### PR TITLE
feat(food-diary): add web and mobile food diary flows with episode integration and CRUD

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -33,7 +33,8 @@
           "resizeMode": "contain",
           "backgroundColor": "#ffffff"
         }
-      ]
+      ],
+      "@react-native-community/datetimepicker"
     ]
   }
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -14,6 +14,7 @@
     "@expo/metro-config": "*",
     "@expo/react-native-action-sheet": "^4.1.1",
     "@expo/vector-icons": "*",
+    "@react-native-community/datetimepicker": "8.4.4",
     "@react-navigation/bottom-tabs": "*",
     "@react-navigation/native": "*",
     "@react-navigation/native-stack": "*",

--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -13,6 +13,7 @@ import type { MainStackParamList } from './navigation/types';
 import { LoginScreen } from './screens/LoginScreen';
 import { EpisodeStartScreen } from './screens/EpisodeStartScreen';
 import { EpisodesScreen } from './screens/EpisodesScreen';
+import { FoodDiaryEntryScreen } from './screens/FoodDiaryEntryScreen';
 import { HealthMarkerPromptScreen } from './screens/HealthMarkerPromptScreen';
 import { SymptomPromptScreen } from './screens/SymptomPromptScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
@@ -414,6 +415,14 @@ function AppBootstrap() {
               component={HealthMarkerPromptScreen}
               options={{
                 title: 'Health markers',
+                headerBackTitle: 'Home',
+              }}
+            />
+            <MainStack.Screen
+              name="FoodDiaryEntry"
+              component={FoodDiaryEntryScreen}
+              options={{
+                title: 'Food diary',
                 headerBackTitle: 'Home',
               }}
             />

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -92,6 +92,19 @@ function navigateFromHomeTabToEpisodes(
   stackNavigation.navigate('Episodes');
 }
 
+function navigateFromHomeTabToFoodDiary(
+  navigation: BottomTabNavigationProp<MainTabParamList, 'Home'>,
+) {
+  const stackNavigation =
+    navigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
+  if (stackNavigation == null) {
+    throw new Error(
+      'MainTabNavigator: expected native stack parent (MainStack) to open FoodDiaryEntry.',
+    );
+  }
+  stackNavigation.navigate('FoodDiaryEntry', {});
+}
+
 type IonName = React.ComponentProps<typeof Ionicons>['name'];
 
 /**
@@ -156,6 +169,9 @@ export function MainTabNavigator() {
               }}
               onGoToEpisodes={() => {
                 navigateFromHomeTabToEpisodes(navigation);
+              }}
+              onGoToFoodDiary={() => {
+                navigateFromHomeTabToFoodDiary(navigation);
               }}
               onStartEpisode={() => {
                 navigateFromHomeTabToEpisodeStart(navigation);

--- a/apps/mobile/src/app/navigation/types.ts
+++ b/apps/mobile/src/app/navigation/types.ts
@@ -49,5 +49,9 @@ export type MainStackParamList = {
     /** When true, initial step is derived from saved marker rows. */
     resume?: boolean;
   };
+  FoodDiaryEntry: {
+    /** Optional episode link for entries logged from inside an episode flow. */
+    episodeId?: string;
+  };
   Settings: undefined;
 };

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.spec.tsx
@@ -1,0 +1,186 @@
+import * as React from 'react';
+import { fireEvent, render, waitFor } from '@testing-library/react-native';
+import { DefaultTheme, useRoute } from '@react-navigation/native';
+import { createFoodDiaryEntry } from '@abstrack/supabase';
+import { announce } from '@abstrack/ui/native';
+import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
+import { useAppTheme } from '../theme/AppThemeContext';
+import { lightAppColors } from '../theme/app-colors';
+import { FoodDiaryEntryScreen } from './FoodDiaryEntryScreen';
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useRoute: jest.fn(),
+}));
+
+jest.mock('@abstrack/supabase', () => {
+  const actual =
+    jest.requireActual<typeof import('@abstrack/supabase')>(
+      '@abstrack/supabase',
+    );
+  return {
+    ...actual,
+    createFoodDiaryEntry: jest.fn(),
+  };
+});
+
+const mockGetUser = jest.fn();
+
+jest.mock('../../lib/supabase-wiring', () => ({
+  getMobileSupabaseClient: jest.fn(() => ({
+    mockClient: true,
+    auth: {
+      getUser: mockGetUser,
+    },
+  })),
+}));
+
+jest.mock('../theme/AppThemeContext', () => ({
+  useAppTheme: jest.fn(),
+}));
+
+jest.mock('@abstrack/ui/native', () => {
+  const actual = jest.requireActual('@abstrack/ui/native');
+  return {
+    ...actual,
+    announce: jest.fn(async () => undefined),
+  };
+});
+
+jest.mock('@react-native-community/datetimepicker', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return function MockDateTimePicker(props: {
+    mode: 'date' | 'time';
+    onChange: (...args: unknown[]) => void;
+  }) {
+    return (
+      <View
+        testID={props.mode === 'date' ? 'mock-date-picker' : 'mock-time-picker'}
+        onChange={props.onChange}
+      />
+    );
+  };
+});
+
+describe('FoodDiaryEntryScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'FoodDiaryEntry',
+      name: 'FoodDiaryEntry',
+      params: { episodeId: 'episode-1' },
+    } as never);
+
+    jest.mocked(useAppTheme).mockReturnValue({
+      colorScheme: 'light',
+      colors: lightAppColors,
+      themePreference: 'system',
+      setThemePreference: jest.fn(async () => undefined),
+      navigationTheme: DefaultTheme,
+      statusBarStyle: 'dark',
+    });
+
+    mockGetUser.mockResolvedValue({
+      data: { user: { id: 'test-user-1' } },
+    });
+
+    jest.mocked(createFoodDiaryEntry).mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'food-1',
+        user_id: 'test-user-1',
+        episode_id: 'episode-1',
+        meal_tag: 'Breakfast',
+        food_note: 'Toast',
+        logged_at: '2026-04-22T15:45:00.000Z',
+        created_at: '2026-04-22T15:45:00.000Z',
+        updated_at: '2026-04-22T15:45:00.000Z',
+      },
+    });
+  });
+
+  test('unauthenticated save shows auth error and does not create entry', async () => {
+    mockGetUser.mockResolvedValueOnce({
+      data: { user: null },
+    });
+    const screen = render(<FoodDiaryEntryScreen />);
+
+    fireEvent.press(screen.getByLabelText('Save food entry'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('You must be signed in to save a food diary entry.'),
+      ).toBeTruthy();
+    });
+    expect(createFoodDiaryEntry).not.toHaveBeenCalled();
+    expect(announce).toHaveBeenCalledWith(
+      'You must be signed in to save a food diary entry.',
+      { politeness: 'assertive' },
+    );
+  });
+
+  test('meal tag validation blocks save when no tag selected', async () => {
+    const screen = render(<FoodDiaryEntryScreen />);
+
+    fireEvent.press(screen.getByLabelText('Save food entry'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Choose a meal tag.')).toBeTruthy();
+    });
+    expect(createFoodDiaryEntry).not.toHaveBeenCalled();
+    expect(announce).toHaveBeenCalledWith('Choose a meal tag.', {
+      politeness: 'assertive',
+    });
+  });
+
+  test('successful save uses picker-updated date/time and resets form', async () => {
+    const screen = render(<FoodDiaryEntryScreen />);
+
+    fireEvent.press(screen.getByLabelText('Breakfast'));
+    fireEvent.changeText(screen.getByLabelText('Food note'), 'Toast');
+
+    fireEvent.press(screen.getByLabelText('Logged date'));
+    fireEvent(
+      screen.getByTestId('mock-date-picker'),
+      'onChange',
+      { type: 'set' },
+      new Date('2026-04-10T00:00:00'),
+    );
+
+    fireEvent.press(screen.getByLabelText('Logged time'));
+    fireEvent(
+      screen.getByTestId('mock-time-picker'),
+      'onChange',
+      { type: 'set' },
+      new Date('2026-04-10T15:45:00'),
+    );
+
+    fireEvent.press(screen.getByLabelText('Save food entry'));
+
+    await waitFor(() => {
+      expect(createFoodDiaryEntry).toHaveBeenCalledTimes(1);
+    });
+    expect(createFoodDiaryEntry).toHaveBeenCalledWith(
+      expect.objectContaining({ mockClient: true }),
+      expect.objectContaining({
+        user_id: 'test-user-1',
+        episode_id: 'episode-1',
+        meal_tag: 'Breakfast',
+        food_note: 'Toast',
+        logged_at: new Date('2026-04-10T15:45').toISOString(),
+      }),
+    );
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Food entry saved and linked to this episode.'),
+      ).toBeTruthy();
+    });
+    expect(screen.getByLabelText('Food note').props.value).toBe('');
+    expect(announce).toHaveBeenCalledWith('Food entry saved.', {
+      politeness: 'polite',
+    });
+  });
+});

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.spec.tsx
@@ -3,7 +3,6 @@ import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { DefaultTheme, useRoute } from '@react-navigation/native';
 import { createFoodDiaryEntry } from '@abstrack/supabase';
 import { announce } from '@abstrack/ui/native';
-import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { useAppTheme } from '../theme/AppThemeContext';
 import { lightAppColors } from '../theme/app-colors';
 import { FoodDiaryEntryScreen } from './FoodDiaryEntryScreen';

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
@@ -100,16 +100,26 @@ export function FoodDiaryEntryScreen() {
     });
   }, [loggedAtValue]);
 
-  const onDateChange = (_event: DateTimePickerEvent, selectedDate?: Date) => {
-    setDatePickerOpen(false);
+  const onDateChange = (event: DateTimePickerEvent, selectedDate?: Date) => {
+    if (Platform.OS === 'android') {
+      setDatePickerOpen(false);
+    }
+    if (event.type === 'dismissed') {
+      return;
+    }
     if (!selectedDate) {
       return;
     }
     setLoggedDate(localDateFromDate(selectedDate));
   };
 
-  const onTimeChange = (_event: DateTimePickerEvent, selectedDate?: Date) => {
-    setTimePickerOpen(false);
+  const onTimeChange = (event: DateTimePickerEvent, selectedDate?: Date) => {
+    if (Platform.OS === 'android') {
+      setTimePickerOpen(false);
+    }
+    if (event.type === 'dismissed') {
+      return;
+    }
     if (!selectedDate) {
       return;
     }
@@ -207,18 +217,14 @@ export function FoodDiaryEntryScreen() {
           >
             Meal tag
           </Text>
-          <View
-            accessibilityRole="radiogroup"
-            accessibilityLabel="Meal tag"
-            className="mb-4 gap-2"
-          >
+          <View accessibilityLabel="Meal tag" className="mb-4 gap-2">
             {MEAL_TAGS.map((tag) => (
               <Pressable
                 key={tag}
-                accessibilityRole="radio"
+                accessibilityRole="button"
                 accessibilityLabel={tag}
                 accessibilityState={{
-                  checked: mealTag === tag,
+                  selected: mealTag === tag,
                   disabled: saving,
                 }}
                 disabled={saving}

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
@@ -69,7 +69,7 @@ export function FoodDiaryEntryScreen() {
   const { colors } = useAppTheme();
   const episodeId = route.params?.episodeId ?? null;
   const supabase = useMemo(() => getMobileSupabaseClient(), []);
-  const [mealTag, setMealTag] = useState<MealTag>('Other');
+  const [mealTag, setMealTag] = useState<MealTag | null>(null);
   const [foodNote, setFoodNote] = useState('');
   const [loggedDate, setLoggedDate] = useState(currentLocalDate);
   const [loggedTime, setLoggedTime] = useState(currentLocalTime);
@@ -143,6 +143,13 @@ export function FoodDiaryEntryScreen() {
       setSaving(false);
       return;
     }
+    if (!mealTag) {
+      const message = 'Choose a meal tag.';
+      setErrorMessage(message);
+      await announce(message, { politeness: 'assertive' });
+      setSaving(false);
+      return;
+    }
 
     const result = await createFoodDiaryEntry(supabase, {
       user_id: user.id,
@@ -158,6 +165,7 @@ export function FoodDiaryEntryScreen() {
       return;
     }
 
+    setMealTag(null);
     setFoodNote('');
     setLoggedDate(currentLocalDate());
     setLoggedTime(currentLocalTime());
@@ -215,7 +223,7 @@ export function FoodDiaryEntryScreen() {
                 }}
                 disabled={saving}
                 onPress={() => {
-                  setMealTag(tag);
+                  setMealTag((prev) => (prev === tag ? null : tag));
                 }}
                 style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
                 className={`w-full items-center justify-center rounded-xl border-2 px-3 py-3 dark:border-app-border-dark ${

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
@@ -260,7 +260,8 @@ export function FoodDiaryEntryScreen() {
             accessibilityState={{ disabled: saving }}
             disabled={saving}
             onPress={() => {
-              setDatePickerOpen(true);
+              setDatePickerOpen((prev) => !prev);
+              setTimePickerOpen(false);
             }}
             style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
             className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
@@ -285,7 +286,8 @@ export function FoodDiaryEntryScreen() {
             accessibilityState={{ disabled: saving }}
             disabled={saving}
             onPress={() => {
-              setTimePickerOpen(true);
+              setTimePickerOpen((prev) => !prev);
+              setDatePickerOpen(false);
             }}
             style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
             className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
@@ -15,6 +15,13 @@ import type { MealTag } from '@abstrack/types';
 import { MEAL_TAGS } from '@abstrack/types';
 import { createFoodDiaryEntry } from '@abstrack/supabase';
 import { announce, COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import {
+  currentLocalDate,
+  currentLocalTime,
+  localDateFromDate,
+  localDateTimeToIso,
+  localTimeFromDate,
+} from '../../lib/food-diary/date-time';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { ScreenShell } from '../components/ScreenShell';
 import type { MainStackParamList } from '../navigation/types';
@@ -22,42 +29,6 @@ import { useAppTheme } from '../theme/AppThemeContext';
 import { nw } from '../theme/app-nativewind-classes';
 
 type FoodDiaryEntryRoute = RouteProp<MainStackParamList, 'FoodDiaryEntry'>;
-
-function pad2(value: number): string {
-  return String(value).padStart(2, '0');
-}
-
-function currentLocalDate(): string {
-  const now = new Date();
-  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())}`;
-}
-
-function currentLocalTime(): string {
-  const now = new Date();
-  return `${pad2(now.getHours())}:${pad2(now.getMinutes())}`;
-}
-
-function localDateTimeToIso(datePart: string, timePart: string): string | null {
-  const date = datePart.trim();
-  const time = timePart.trim();
-  if (!date || !time) {
-    return null;
-  }
-  const parsed = new Date(`${date}T${time}`);
-  const value = parsed.getTime();
-  if (!Number.isFinite(value)) {
-    return null;
-  }
-  return parsed.toISOString();
-}
-
-function localDateFromDate(value: Date): string {
-  return `${value.getFullYear()}-${pad2(value.getMonth() + 1)}-${pad2(value.getDate())}`;
-}
-
-function localTimeFromDate(value: Date): string {
-  return `${pad2(value.getHours())}:${pad2(value.getMinutes())}`;
-}
 
 /**
  * Standalone food diary creation screen (home entry point). Optional episode link can be supplied.

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
@@ -1,5 +1,14 @@
 import React, { useMemo, useState } from 'react';
-import { Pressable, ScrollView, Text, TextInput, View } from 'react-native';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import type { DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import {
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
 import type { RouteProp } from '@react-navigation/native';
 import { useRoute } from '@react-navigation/native';
 import type { MealTag } from '@abstrack/types';
@@ -42,6 +51,14 @@ function localDateTimeToIso(datePart: string, timePart: string): string | null {
   return parsed.toISOString();
 }
 
+function localDateFromDate(value: Date): string {
+  return `${value.getFullYear()}-${pad2(value.getMonth() + 1)}-${pad2(value.getDate())}`;
+}
+
+function localTimeFromDate(value: Date): string {
+  return `${pad2(value.getHours())}:${pad2(value.getMinutes())}`;
+}
+
 /**
  * Standalone food diary creation screen (home entry point). Optional episode link can be supplied.
  *
@@ -56,9 +73,48 @@ export function FoodDiaryEntryScreen() {
   const [foodNote, setFoodNote] = useState('');
   const [loggedDate, setLoggedDate] = useState(currentLocalDate);
   const [loggedTime, setLoggedTime] = useState(currentLocalTime);
+  const [datePickerOpen, setDatePickerOpen] = useState(false);
+  const [timePickerOpen, setTimePickerOpen] = useState(false);
   const [saving, setSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const loggedAtValue = useMemo(() => {
+    const iso = localDateTimeToIso(loggedDate, loggedTime);
+    return iso ? new Date(iso) : new Date();
+  }, [loggedDate, loggedTime]);
+
+  const loggedDateLabel = useMemo(() => {
+    return loggedAtValue.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }, [loggedAtValue]);
+
+  const loggedTimeLabel = useMemo(() => {
+    return loggedAtValue.toLocaleTimeString(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  }, [loggedAtValue]);
+
+  const onDateChange = (_event: DateTimePickerEvent, selectedDate?: Date) => {
+    setDatePickerOpen(false);
+    if (!selectedDate) {
+      return;
+    }
+    setLoggedDate(localDateFromDate(selectedDate));
+  };
+
+  const onTimeChange = (_event: DateTimePickerEvent, selectedDate?: Date) => {
+    setTimePickerOpen(false);
+    if (!selectedDate) {
+      return;
+    }
+    setLoggedTime(localTimeFromDate(selectedDate));
+  };
 
   const onSave = async () => {
     if (saving) {
@@ -105,6 +161,8 @@ export function FoodDiaryEntryScreen() {
     setFoodNote('');
     setLoggedDate(currentLocalDate());
     setLoggedTime(currentLocalTime());
+    setDatePickerOpen(false);
+    setTimePickerOpen(false);
     setSuccessMessage(
       episodeId
         ? 'Food entry saved and linked to this episode.'
@@ -180,35 +238,51 @@ export function FoodDiaryEntryScreen() {
             className={`mb-1 text-base font-medium ${nw.textInk}`}
             maxFontSizeMultiplier={2}
           >
-            Logged date (YYYY-MM-DD)
+            Logged date
           </Text>
-          <TextInput
-            editable={!saving}
+          <Pressable
+            accessibilityRole="button"
             accessibilityLabel="Logged date"
-            value={loggedDate}
-            onChangeText={setLoggedDate}
-            placeholder="YYYY-MM-DD"
-            placeholderTextColor={colors.inputPlaceholder}
-            className={`mb-3 min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-            maxFontSizeMultiplier={2}
-          />
+            accessibilityState={{ disabled: saving }}
+            disabled={saving}
+            onPress={() => {
+              setDatePickerOpen(true);
+            }}
+            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+            className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+          >
+            <Text
+              className={`text-[17px] ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              {loggedDateLabel}
+            </Text>
+          </Pressable>
 
           <Text
             className={`mb-1 text-base font-medium ${nw.textInk}`}
             maxFontSizeMultiplier={2}
           >
-            Logged time (HH:MM)
+            Logged time
           </Text>
-          <TextInput
-            editable={!saving}
+          <Pressable
+            accessibilityRole="button"
             accessibilityLabel="Logged time"
-            value={loggedTime}
-            onChangeText={setLoggedTime}
-            placeholder="HH:MM"
-            placeholderTextColor={colors.inputPlaceholder}
-            className={`mb-4 min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-            maxFontSizeMultiplier={2}
-          />
+            accessibilityState={{ disabled: saving }}
+            disabled={saving}
+            onPress={() => {
+              setTimePickerOpen(true);
+            }}
+            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+            className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+          >
+            <Text
+              className={`text-[17px] ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              {loggedTimeLabel}
+            </Text>
+          </Pressable>
 
           <Text
             className={`mb-1 text-base font-medium ${nw.textInk}`}
@@ -265,6 +339,23 @@ export function FoodDiaryEntryScreen() {
             </Text>
           </Pressable>
         </ScrollView>
+        {datePickerOpen ? (
+          <DateTimePicker
+            value={loggedAtValue}
+            mode="date"
+            display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+            onChange={onDateChange}
+          />
+        ) : null}
+        {timePickerOpen ? (
+          <DateTimePicker
+            value={loggedAtValue}
+            mode="time"
+            is24Hour={false}
+            display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+            onChange={onTimeChange}
+          />
+        ) : null}
       </View>
     </ScreenShell>
   );

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
@@ -1,0 +1,271 @@
+import React, { useMemo, useState } from 'react';
+import { Pressable, ScrollView, Text, TextInput, View } from 'react-native';
+import type { RouteProp } from '@react-navigation/native';
+import { useRoute } from '@react-navigation/native';
+import type { MealTag } from '@abstrack/types';
+import { MEAL_TAGS } from '@abstrack/types';
+import { createFoodDiaryEntry } from '@abstrack/supabase';
+import { announce, COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
+import { ScreenShell } from '../components/ScreenShell';
+import type { MainStackParamList } from '../navigation/types';
+import { useAppTheme } from '../theme/AppThemeContext';
+import { nw } from '../theme/app-nativewind-classes';
+
+type FoodDiaryEntryRoute = RouteProp<MainStackParamList, 'FoodDiaryEntry'>;
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function currentLocalDate(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())}`;
+}
+
+function currentLocalTime(): string {
+  const now = new Date();
+  return `${pad2(now.getHours())}:${pad2(now.getMinutes())}`;
+}
+
+function localDateTimeToIso(datePart: string, timePart: string): string | null {
+  const date = datePart.trim();
+  const time = timePart.trim();
+  if (!date || !time) {
+    return null;
+  }
+  const parsed = new Date(`${date}T${time}`);
+  const value = parsed.getTime();
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  return parsed.toISOString();
+}
+
+/**
+ * Standalone food diary creation screen (home entry point). Optional episode link can be supplied.
+ *
+ * @returns Form for meal tag, log timestamp, and free-text food note.
+ */
+export function FoodDiaryEntryScreen() {
+  const route = useRoute<FoodDiaryEntryRoute>();
+  const { colors } = useAppTheme();
+  const episodeId = route.params?.episodeId ?? null;
+  const supabase = useMemo(() => getMobileSupabaseClient(), []);
+  const [mealTag, setMealTag] = useState<MealTag>('Other');
+  const [foodNote, setFoodNote] = useState('');
+  const [loggedDate, setLoggedDate] = useState(currentLocalDate);
+  const [loggedTime, setLoggedTime] = useState(currentLocalTime);
+  const [saving, setSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const onSave = async () => {
+    if (saving) {
+      return;
+    }
+    setSaving(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      const message = 'You must be signed in to save a food diary entry.';
+      setErrorMessage(message);
+      await announce(message, { politeness: 'assertive' });
+      setSaving(false);
+      return;
+    }
+
+    const loggedAtIso = localDateTimeToIso(loggedDate, loggedTime);
+    if (!loggedAtIso) {
+      const message = 'Enter a valid date and time.';
+      setErrorMessage(message);
+      await announce(message, { politeness: 'assertive' });
+      setSaving(false);
+      return;
+    }
+
+    const result = await createFoodDiaryEntry(supabase, {
+      user_id: user.id,
+      episode_id: episodeId,
+      meal_tag: mealTag,
+      food_note: foodNote,
+      logged_at: loggedAtIso,
+    });
+    setSaving(false);
+    if (!result.ok) {
+      setErrorMessage(result.error.message);
+      await announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+
+    setFoodNote('');
+    setLoggedDate(currentLocalDate());
+    setLoggedTime(currentLocalTime());
+    setSuccessMessage(
+      episodeId
+        ? 'Food entry saved and linked to this episode.'
+        : 'Food entry saved.',
+    );
+    await announce('Food entry saved.', { politeness: 'polite' });
+  };
+
+  return (
+    <ScreenShell contentAlign="stretch">
+      <View className="min-h-0 flex-1 gap-4">
+        <Text
+          accessibilityRole="header"
+          className={`text-[22px] font-semibold ${nw.textInk}`}
+          maxFontSizeMultiplier={2}
+        >
+          Food diary
+        </Text>
+        <Text
+          className={`text-base leading-relaxed ${nw.textMuted}`}
+          maxFontSizeMultiplier={2}
+        >
+          Log what you ate or drank. Time defaults to now and can be adjusted.
+        </Text>
+
+        <ScrollView
+          className="flex-1"
+          keyboardShouldPersistTaps="handled"
+          contentContainerStyle={{ paddingBottom: 24 }}
+        >
+          <Text
+            className={`mb-2 text-base font-medium ${nw.textInk}`}
+            maxFontSizeMultiplier={2}
+          >
+            Meal tag
+          </Text>
+          <View
+            accessibilityRole="radiogroup"
+            accessibilityLabel="Meal tag"
+            className="mb-4 gap-2"
+          >
+            {MEAL_TAGS.map((tag) => (
+              <Pressable
+                key={tag}
+                accessibilityRole="radio"
+                accessibilityLabel={tag}
+                accessibilityState={{
+                  checked: mealTag === tag,
+                  disabled: saving,
+                }}
+                disabled={saving}
+                onPress={() => {
+                  setMealTag(tag);
+                }}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className={`w-full items-center justify-center rounded-xl border-2 px-3 py-3 dark:border-app-border-dark ${
+                  mealTag === tag
+                    ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                    : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
+                }`}
+              >
+                <Text
+                  className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  {tag}
+                </Text>
+              </Pressable>
+            ))}
+          </View>
+
+          <Text
+            className={`mb-1 text-base font-medium ${nw.textInk}`}
+            maxFontSizeMultiplier={2}
+          >
+            Logged date (YYYY-MM-DD)
+          </Text>
+          <TextInput
+            editable={!saving}
+            accessibilityLabel="Logged date"
+            value={loggedDate}
+            onChangeText={setLoggedDate}
+            placeholder="YYYY-MM-DD"
+            placeholderTextColor={colors.inputPlaceholder}
+            className={`mb-3 min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+            maxFontSizeMultiplier={2}
+          />
+
+          <Text
+            className={`mb-1 text-base font-medium ${nw.textInk}`}
+            maxFontSizeMultiplier={2}
+          >
+            Logged time (HH:MM)
+          </Text>
+          <TextInput
+            editable={!saving}
+            accessibilityLabel="Logged time"
+            value={loggedTime}
+            onChangeText={setLoggedTime}
+            placeholder="HH:MM"
+            placeholderTextColor={colors.inputPlaceholder}
+            className={`mb-4 min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+            maxFontSizeMultiplier={2}
+          />
+
+          <Text
+            className={`mb-1 text-base font-medium ${nw.textInk}`}
+            maxFontSizeMultiplier={2}
+          >
+            Food note
+          </Text>
+          <TextInput
+            editable={!saving}
+            accessibilityLabel="Food note"
+            multiline
+            value={foodNote}
+            onChangeText={setFoodNote}
+            placeholder="What did you eat or drink?"
+            placeholderTextColor={colors.inputPlaceholder}
+            className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+            maxFontSizeMultiplier={2}
+          />
+
+          {errorMessage ? (
+            <Text
+              className={`mb-2 text-sm ${nw.textError}`}
+              accessibilityLiveRegion="assertive"
+              maxFontSizeMultiplier={2}
+            >
+              {errorMessage}
+            </Text>
+          ) : null}
+          {successMessage ? (
+            <Text
+              className="mb-2 text-sm text-green-700 dark:text-green-300"
+              accessibilityLiveRegion="polite"
+              maxFontSizeMultiplier={2}
+            >
+              {successMessage}
+            </Text>
+          ) : null}
+
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={
+              saving ? 'Saving food entry' : 'Save food entry'
+            }
+            accessibilityState={{ disabled: saving }}
+            disabled={saving}
+            onPress={() => {
+              void onSave();
+            }}
+            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+            className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 disabled:opacity-60 dark:bg-red-600"
+          >
+            <Text className="text-center text-[17px] font-semibold text-white">
+              {saving ? 'Saving…' : 'Save food entry'}
+            </Text>
+          </Pressable>
+        </ScrollView>
+      </View>
+    </ScreenShell>
+  );
+}

--- a/apps/mobile/src/app/screens/HealthMarkerFoodDiaryStep.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerFoodDiaryStep.tsx
@@ -1,0 +1,652 @@
+import { Ionicons } from '@expo/vector-icons';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import { MEAL_TAGS } from '@abstrack/types';
+import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import {
+  Platform,
+  Pressable,
+  ScrollView,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import type { AppThemeColors } from '../theme/app-colors';
+import { nw } from '../theme/app-nativewind-classes';
+import type { HealthMarkerFoodDiaryHookResult } from './use-health-marker-food-diary';
+
+function formatFoodDiaryLoggedAtForDisplay(iso: string): string {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) {
+    return iso;
+  }
+  const dateStr = d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+  const timeStr = d.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+  return `${dateStr}, ${timeStr}`;
+}
+
+export type HealthMarkerFoodDiaryStepProps = {
+  fd: HealthMarkerFoodDiaryHookResult;
+  colors: AppThemeColors;
+  onCancelEpisodePress: () => void;
+};
+
+export function HealthMarkerFoodDiaryStep({
+  fd,
+  colors,
+  onCancelEpisodePress,
+}: HealthMarkerFoodDiaryStepProps) {
+  return (
+    <>
+      <ScrollView
+        className="flex-1"
+        keyboardShouldPersistTaps="handled"
+        contentContainerStyle={{ paddingBottom: 24 }}
+      >
+        <Text
+          className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
+          maxFontSizeMultiplier={2}
+        >
+          Add one or more meals/snacks for this episode, or skip this step.
+        </Text>
+        <Text
+          accessibilityRole="header"
+          className={`mb-2 text-lg font-semibold ${nw.textInk}`}
+          maxFontSizeMultiplier={2}
+        >
+          Saved entries
+        </Text>
+        {fd.foodEntriesLoading ? (
+          <Text
+            className={`mb-2 text-sm ${nw.textMuted}`}
+            accessibilityLiveRegion="polite"
+            maxFontSizeMultiplier={2}
+          >
+            Loading entries…
+          </Text>
+        ) : null}
+        {fd.foodEntriesError ? (
+          <View className="mb-3">
+            <Text
+              className={`mb-2 text-sm ${nw.textError}`}
+              accessibilityLiveRegion="assertive"
+              maxFontSizeMultiplier={2}
+            >
+              {fd.foodEntriesError}
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Try again to load food diary entries"
+              accessibilityState={{ disabled: fd.foodEntriesLoading }}
+              disabled={fd.foodEntriesLoading}
+              onPress={() => {
+                void fd.loadFoodEntries();
+              }}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 disabled:opacity-50 dark:border-app-border-dark"
+            >
+              <Text
+                className={`text-base font-medium ${nw.textInk}`}
+                maxFontSizeMultiplier={2}
+              >
+                {fd.foodEntriesLoading ? 'Retrying…' : 'Try again'}
+              </Text>
+            </Pressable>
+          </View>
+        ) : null}
+        {!fd.foodEntriesLoading &&
+        !fd.foodEntriesError &&
+        fd.foodEntries.length === 0 ? (
+          <Text
+            className={`mb-3 text-sm ${nw.textMuted}`}
+            maxFontSizeMultiplier={2}
+          >
+            No food entries yet for this episode.
+          </Text>
+        ) : null}
+        {fd.foodEntries.map((entry) => (
+          <View
+            key={entry.id}
+            className="mb-3 rounded-xl border border-app-border bg-app-bg p-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+          >
+            <Text
+              className={`text-base font-semibold ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              {entry.meal_tag}
+            </Text>
+            <Text
+              className={`mt-1 text-sm ${nw.textMuted}`}
+              maxFontSizeMultiplier={2}
+            >
+              {formatFoodDiaryLoggedAtForDisplay(entry.logged_at)}
+            </Text>
+            <Text
+              className={`mt-2 text-sm ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              {entry.food_note}
+            </Text>
+            {fd.editingFoodEntryId !== entry.id ? (
+              <View className="mt-2 flex-row items-center justify-end gap-2">
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Edit ${entry.meal_tag} food entry`}
+                  onPress={() => {
+                    fd.onEditFoodEntry(entry);
+                  }}
+                  style={{
+                    minWidth: COMFORTABLE_TOUCH_TARGET_DP,
+                    minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+                  }}
+                  className="items-center justify-center rounded-lg border border-app-border px-2 active:opacity-80 dark:border-app-border-dark"
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                >
+                  <Ionicons
+                    name="pencil-outline"
+                    size={20}
+                    color={colors.muted}
+                    accessibilityElementsHidden
+                    importantForAccessibility="no"
+                  />
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Discard ${entry.meal_tag} food entry`}
+                  accessibilityState={{
+                    disabled: fd.deletingFoodEntryId != null,
+                  }}
+                  disabled={fd.deletingFoodEntryId != null}
+                  onPress={() => {
+                    fd.onDeleteFoodEntry(entry.id);
+                  }}
+                  style={{
+                    minWidth: COMFORTABLE_TOUCH_TARGET_DP,
+                    minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+                  }}
+                  className="items-center justify-center rounded-lg border border-red-400 px-2 active:opacity-80 disabled:opacity-60 dark:border-red-500/60"
+                  hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                >
+                  {fd.deletingFoodEntryId === entry.id ? (
+                    <Text
+                      className="text-xs font-semibold text-red-700 dark:text-red-300"
+                      maxFontSizeMultiplier={2}
+                    >
+                      ...
+                    </Text>
+                  ) : (
+                    <Ionicons
+                      name="trash-outline"
+                      size={20}
+                      color={colors.error}
+                      accessibilityElementsHidden
+                      importantForAccessibility="no"
+                    />
+                  )}
+                </Pressable>
+              </View>
+            ) : null}
+            {fd.editingFoodEntryId === entry.id ? (
+              <View className="mt-3 rounded-lg border border-app-border p-3 dark:border-app-border-dark">
+                <Text
+                  className={`mb-2 text-base font-semibold ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Edit food entry
+                </Text>
+                <View accessibilityLabel="Meal tag" className="mb-3 gap-2">
+                  {MEAL_TAGS.map((tag) => (
+                    <Pressable
+                      key={`${entry.id}-${tag}`}
+                      accessibilityRole="button"
+                      accessibilityLabel={tag}
+                      accessibilityState={{
+                        selected: fd.mealTag === tag,
+                        disabled: fd.savingFoodDiary,
+                      }}
+                      disabled={fd.savingFoodDiary}
+                      onPress={() => {
+                        fd.setMealTag((prev) => (prev === tag ? null : tag));
+                      }}
+                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                      className={`w-full items-center justify-center rounded-xl border-2 px-3 py-3 dark:border-app-border-dark ${
+                        fd.mealTag === tag
+                          ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                          : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
+                      }`}
+                    >
+                      <Text
+                        className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        {tag}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </View>
+                <Text
+                  className={`mb-1 text-base font-medium ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Logged date
+                </Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Logged date"
+                  accessibilityState={{ disabled: fd.savingFoodDiary }}
+                  disabled={fd.savingFoodDiary}
+                  onPress={() => {
+                    fd.setFoodDatePickerOpen((prev) => !prev);
+                    fd.setFoodTimePickerOpen(false);
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+                >
+                  <Text
+                    className={`text-[17px] ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {fd.foodLoggedDateLabel}
+                  </Text>
+                </Pressable>
+                <Text
+                  className={`mb-1 text-base font-medium ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Logged time
+                </Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Logged time"
+                  accessibilityState={{ disabled: fd.savingFoodDiary }}
+                  disabled={fd.savingFoodDiary}
+                  onPress={() => {
+                    fd.setFoodTimePickerOpen((prev) => !prev);
+                    fd.setFoodDatePickerOpen(false);
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+                >
+                  <Text
+                    className={`text-[17px] ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {fd.foodLoggedTimeLabel}
+                  </Text>
+                </Pressable>
+                <Text
+                  className={`mb-1 text-base font-medium ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Food note
+                </Text>
+                <TextInput
+                  editable={!fd.savingFoodDiary}
+                  accessibilityLabel="Food note"
+                  multiline
+                  value={fd.foodNote}
+                  onChangeText={fd.setFoodNote}
+                  placeholder="What did you eat or drink?"
+                  placeholderTextColor={colors.inputPlaceholder}
+                  className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                />
+                {fd.foodDiaryFeedback ? (
+                  <Text
+                    className={`mb-2 text-sm ${nw.textError}`}
+                    accessibilityLiveRegion="assertive"
+                    maxFontSizeMultiplier={2}
+                  >
+                    {fd.foodDiaryFeedback}
+                  </Text>
+                ) : null}
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    fd.savingFoodDiary
+                      ? 'Saving food diary entry'
+                      : 'Update food entry'
+                  }
+                  accessibilityState={{ disabled: fd.savingFoodDiary }}
+                  disabled={fd.savingFoodDiary}
+                  onPress={() => {
+                    void fd.onSaveFoodDiary();
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 disabled:opacity-60 dark:bg-red-600"
+                >
+                  <Text className="text-center text-[17px] font-semibold text-white">
+                    {fd.savingFoodDiary ? 'Saving…' : 'Update entry'}
+                  </Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Cancel food entry edit"
+                  onPress={fd.onDiscardFoodEditChanges}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="mt-3 w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
+                >
+                  <Text
+                    className={`text-base font-medium ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Discard changes
+                  </Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Discard saved food entry"
+                  accessibilityState={{
+                    disabled: fd.deletingFoodEntryId != null,
+                  }}
+                  disabled={fd.deletingFoodEntryId != null}
+                  onPress={() => {
+                    fd.onDeleteFoodEntry(entry.id);
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="mt-3 w-full items-center justify-center rounded-lg border border-red-400 px-3 py-3 active:opacity-80 disabled:opacity-60 dark:border-red-500/60"
+                >
+                  <Text
+                    className="text-base font-medium text-red-700 dark:text-red-300"
+                    maxFontSizeMultiplier={2}
+                  >
+                    {fd.deletingFoodEntryId === entry.id
+                      ? 'Discarding…'
+                      : 'Discard entry'}
+                  </Text>
+                </Pressable>
+              </View>
+            ) : null}
+          </View>
+        ))}
+        {fd.editingFoodEntryId == null && !fd.isAddFoodEntryOpen ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Add food entry"
+            onPress={fd.onNewFoodEntry}
+            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+            className="w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
+          >
+            <Text
+              className={`text-base font-medium ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              Add food entry
+            </Text>
+          </Pressable>
+        ) : null}
+        {fd.editingFoodEntryId == null && fd.isAddFoodEntryOpen ? (
+          <>
+            <Text
+              accessibilityRole="header"
+              className={`mb-2 text-lg font-semibold ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              Add food entry
+            </Text>
+            <View accessibilityLabel="Meal tag" className="mb-4 gap-2">
+              {MEAL_TAGS.map((tag) => (
+                <Pressable
+                  key={`add-${tag}`}
+                  accessibilityRole="button"
+                  accessibilityLabel={tag}
+                  accessibilityState={{
+                    selected: fd.mealTag === tag,
+                    disabled: fd.savingFoodDiary,
+                  }}
+                  disabled={fd.savingFoodDiary}
+                  onPress={() => {
+                    const nextMealTag = fd.mealTag === tag ? null : tag;
+                    fd.setMealTag(nextMealTag);
+                    fd.setIsAddFoodEntryDirty(
+                      fd.computeIsAddFoodEntryDirty({
+                        mealTag: nextMealTag,
+                        foodNote: fd.foodNote,
+                        foodLoggedDate: fd.foodLoggedDate,
+                        foodLoggedTime: fd.foodLoggedTime,
+                      }),
+                    );
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className={`w-full items-center justify-center rounded-xl border-2 px-3 py-3 dark:border-app-border-dark ${
+                    fd.mealTag === tag
+                      ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                      : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
+                  }`}
+                >
+                  <Text
+                    className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {tag}
+                  </Text>
+                </Pressable>
+              ))}
+            </View>
+            <Text
+              className={`mb-1 text-base font-medium ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              Logged date
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Logged date"
+              accessibilityState={{ disabled: fd.savingFoodDiary }}
+              disabled={fd.savingFoodDiary}
+              onPress={() => {
+                fd.setFoodDatePickerOpen((prev) => !prev);
+                fd.setFoodTimePickerOpen(false);
+              }}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+            >
+              <Text
+                className={`text-[17px] ${nw.textInk}`}
+                maxFontSizeMultiplier={2}
+              >
+                {fd.foodLoggedDateLabel}
+              </Text>
+            </Pressable>
+            <Text
+              className={`mb-1 text-base font-medium ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              Logged time
+            </Text>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Logged time"
+              accessibilityState={{ disabled: fd.savingFoodDiary }}
+              disabled={fd.savingFoodDiary}
+              onPress={() => {
+                fd.setFoodTimePickerOpen((prev) => !prev);
+                fd.setFoodDatePickerOpen(false);
+              }}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+            >
+              <Text
+                className={`text-[17px] ${nw.textInk}`}
+                maxFontSizeMultiplier={2}
+              >
+                {fd.foodLoggedTimeLabel}
+              </Text>
+            </Pressable>
+            <Text
+              className={`mb-1 text-base font-medium ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              Food note
+            </Text>
+            <TextInput
+              editable={!fd.savingFoodDiary}
+              accessibilityLabel="Food note"
+              multiline
+              value={fd.foodNote}
+              onChangeText={(value) => {
+                fd.setFoodNote(value);
+                fd.setIsAddFoodEntryDirty(
+                  fd.computeIsAddFoodEntryDirty({
+                    mealTag: fd.mealTag,
+                    foodNote: value,
+                    foodLoggedDate: fd.foodLoggedDate,
+                    foodLoggedTime: fd.foodLoggedTime,
+                  }),
+                );
+              }}
+              placeholder="What did you eat or drink?"
+              placeholderTextColor={colors.inputPlaceholder}
+              className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            />
+            {fd.foodDiaryFeedback ? (
+              <Text
+                className={`mb-2 text-sm ${nw.textError}`}
+                accessibilityLiveRegion="assertive"
+                maxFontSizeMultiplier={2}
+              >
+                {fd.foodDiaryFeedback}
+              </Text>
+            ) : null}
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={
+                fd.savingFoodDiary
+                  ? 'Saving food diary entry'
+                  : 'Save food entry'
+              }
+              accessibilityState={{ disabled: fd.savingFoodDiary }}
+              disabled={fd.savingFoodDiary}
+              onPress={() => {
+                void fd.onSaveFoodDiary();
+              }}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 disabled:opacity-60 dark:bg-red-600"
+            >
+              <Text className="text-center text-[17px] font-semibold text-white">
+                {fd.savingFoodDiary ? 'Saving…' : 'Save entry'}
+              </Text>
+            </Pressable>
+            {fd.isAddFoodEntryDirty ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Discard food entry"
+                onPress={fd.onDiscardAddFoodDraft}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className="mt-3 w-full items-center justify-center rounded-lg border border-red-400 px-3 py-3 active:opacity-80 dark:border-red-500/60"
+              >
+                <Text
+                  className="text-base font-medium text-red-700 dark:text-red-300"
+                  maxFontSizeMultiplier={2}
+                >
+                  Discard entry
+                </Text>
+              </Pressable>
+            ) : null}
+            {!fd.isAddFoodEntryDirty ? (
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Collapse add food entry"
+                onPress={() => {
+                  fd.setIsAddFoodEntryOpen(false);
+                }}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className="mt-3 w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
+              >
+                <Text
+                  className={`text-base font-medium ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Collapse
+                </Text>
+              </Pressable>
+            ) : null}
+          </>
+        ) : null}
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Back to health markers"
+          onPress={() => {
+            void fd.onBackFromFoodDiary();
+          }}
+          style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+          className="w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
+        >
+          <Text
+            className={`text-base font-medium ${nw.textInk}`}
+            maxFontSizeMultiplier={2}
+          >
+            Back
+          </Text>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel={
+            fd.foodEntries.length === 0
+              ? 'Skip food diary entry'
+              : 'Continue after food diary'
+          }
+          accessibilityState={{ disabled: fd.foodDiaryContinueDisabled }}
+          disabled={fd.foodDiaryContinueDisabled}
+          onPress={() => {
+            void fd.onContinueFromFoodDiary();
+          }}
+          style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+          className={`w-full items-center justify-center rounded-lg bg-red-700 px-3 py-3 active:opacity-90 dark:bg-red-600 ${
+            fd.foodDiaryContinueDisabled ? 'opacity-50' : ''
+          } ${
+            fd.editingFoodEntryId == null && !fd.isAddFoodEntryOpen
+              ? 'mt-5'
+              : 'mt-3'
+          }`}
+        >
+          <Text
+            className="text-center text-base font-semibold text-white"
+            maxFontSizeMultiplier={2}
+          >
+            {fd.foodEntries.length === 0 ? 'Skip for now' : 'Continue'}
+          </Text>
+        </Pressable>
+      </ScrollView>
+      {fd.foodDatePickerOpen ? (
+        <DateTimePicker
+          value={fd.foodLoggedDateTimeValue}
+          mode="date"
+          display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+          onChange={fd.onFoodDatePickerChange}
+        />
+      ) : null}
+      {fd.foodTimePickerOpen ? (
+        <DateTimePicker
+          value={fd.foodLoggedDateTimeValue}
+          mode="time"
+          is24Hour={false}
+          display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+          onChange={fd.onFoodTimePickerChange}
+        />
+      ) : null}
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="Cancel episode"
+        onPress={onCancelEpisodePress}
+        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+        className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
+      >
+        <Text
+          className="text-sm font-medium text-red-700 dark:text-red-300"
+          maxFontSizeMultiplier={2}
+        >
+          Cancel episode
+        </Text>
+      </Pressable>
+    </>
+  );
+}

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
@@ -324,7 +324,7 @@ describe('HealthMarkerPromptScreen', () => {
     const skip = screen.getByLabelText('Skip this marker');
     expect(skip.props.accessibilityState?.disabled).toBe(false);
 
-    fireEvent.press(screen.getByLabelText('Next health marker'));
+    fireEvent.press(screen.getByLabelText('Continue to food diary'));
 
     await waitFor(() => {
       expect(
@@ -349,7 +349,7 @@ describe('HealthMarkerPromptScreen', () => {
     });
 
     fireEvent.changeText(screen.getByLabelText('Marker value'), '100');
-    fireEvent.press(screen.getByLabelText('Next health marker'));
+    fireEvent.press(screen.getByLabelText('Continue to food diary'));
 
     await waitFor(() => {
       expect(screen.getByText('Food diary')).toBeTruthy();
@@ -430,7 +430,7 @@ describe('HealthMarkerPromptScreen', () => {
     });
 
     fireEvent.changeText(screen.getByLabelText('Marker value'), '5');
-    fireEvent.press(screen.getByLabelText('Next health marker'));
+    fireEvent.press(screen.getByLabelText('Continue to food diary'));
 
     await waitFor(() => {
       expect(screen.getByText('Food diary')).toBeTruthy();

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
@@ -5,11 +5,14 @@ import { useNavigation, useRoute } from '@react-navigation/native';
 import {
   cancelActiveEpisodeById,
   completeEpisodePostMarkerStep,
+  createFoodDiaryEntry,
   endEpisodeIfStillActive,
   getEpisodeById,
+  listFoodDiaryEntriesForEpisode,
   listEpisodeHealthMarkersForEpisode,
   listPresetHealthMarkersForPreset,
   PresetDataError,
+  updateFoodDiaryEntry,
   upsertEpisodeHealthMarkerForLine,
 } from '@abstrack/supabase';
 import type { PresetHealthMarkerRow } from '@abstrack/types';
@@ -33,10 +36,13 @@ jest.mock('@abstrack/supabase', () => {
     ...actual,
     cancelActiveEpisodeById: jest.fn(),
     completeEpisodePostMarkerStep: jest.fn(),
+    createFoodDiaryEntry: jest.fn(),
     endEpisodeIfStillActive: jest.fn(),
     getEpisodeById: jest.fn(),
+    listFoodDiaryEntriesForEpisode: jest.fn(),
     listEpisodeHealthMarkersForEpisode: jest.fn(),
     listPresetHealthMarkersForPreset: jest.fn(),
+    updateFoodDiaryEntry: jest.fn(),
     upsertEpisodeHealthMarkerForLine: jest.fn(),
   };
 });
@@ -191,6 +197,36 @@ describe('HealthMarkerPromptScreen', () => {
       ok: true,
       data: { didEnd: true },
     });
+    jest.mocked(createFoodDiaryEntry).mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'food-1',
+        user_id: 'test-user-1',
+        episode_id: episodeId,
+        meal_tag: 'Other',
+        food_note: 'Snack',
+        logged_at: '2020-01-01T01:30:00Z',
+        created_at: '2020-01-01T01:30:00Z',
+        updated_at: '2020-01-01T01:30:00Z',
+      },
+    });
+    jest.mocked(updateFoodDiaryEntry).mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'food-1',
+        user_id: 'test-user-1',
+        episode_id: episodeId,
+        meal_tag: 'Snack',
+        food_note: 'Updated note',
+        logged_at: '2020-01-01T01:30:00Z',
+        created_at: '2020-01-01T01:30:00Z',
+        updated_at: '2020-01-01T01:31:00Z',
+      },
+    });
+    jest.mocked(listFoodDiaryEntriesForEpisode).mockResolvedValue({
+      ok: true,
+      data: [],
+    });
   });
 
   test('loads marker preset lines and shows first step', async () => {
@@ -288,7 +324,7 @@ describe('HealthMarkerPromptScreen', () => {
     const skip = screen.getByLabelText('Skip this marker');
     expect(skip.props.accessibilityState?.disabled).toBe(false);
 
-    fireEvent.press(screen.getByLabelText('Finish health marker list'));
+    fireEvent.press(screen.getByLabelText('Next health marker'));
 
     await waitFor(() => {
       expect(
@@ -300,7 +336,7 @@ describe('HealthMarkerPromptScreen', () => {
     expect(upsertEpisodeHealthMarkerForLine).not.toHaveBeenCalled();
   });
 
-  test('post-marker episode details: save calls Supabase and shows completion UI', async () => {
+  test('food diary comes before episode details, then save shows completion UI', async () => {
     jest.mocked(listPresetHealthMarkersForPreset).mockResolvedValue({
       ok: true,
       data: [lineA],
@@ -313,13 +349,26 @@ describe('HealthMarkerPromptScreen', () => {
     });
 
     fireEvent.changeText(screen.getByLabelText('Marker value'), '100');
-    fireEvent.press(screen.getByLabelText('Finish health marker list'));
+    fireEvent.press(screen.getByLabelText('Next health marker'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Food diary')).toBeTruthy();
+    });
+    expect(
+      screen.getByText(
+        'Add one or more meals/snacks for this episode, or skip this step.',
+      ),
+    ).toBeTruthy();
+
+    fireEvent.press(screen.getByLabelText('Skip food diary entry'));
 
     await waitFor(() => {
       expect(screen.getByText('Episode details')).toBeTruthy();
     });
     expect(
-      screen.getByText('Choose ABS or Other; other fields are optional.'),
+      screen.getByText(
+        'After health markers and food diary, choose ABS or Other; other fields are optional.',
+      ),
     ).toBeTruthy();
 
     fireEvent.press(screen.getByLabelText('Other episode type'));
@@ -381,8 +430,12 @@ describe('HealthMarkerPromptScreen', () => {
     });
 
     fireEvent.changeText(screen.getByLabelText('Marker value'), '5');
-    fireEvent.press(screen.getByLabelText('Finish health marker list'));
+    fireEvent.press(screen.getByLabelText('Next health marker'));
 
+    await waitFor(() => {
+      expect(screen.getByText('Food diary')).toBeTruthy();
+    });
+    fireEvent.press(screen.getByLabelText('Skip food diary entry'));
     await waitFor(() => {
       expect(screen.getByText('Episode details')).toBeTruthy();
     });

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -670,6 +670,8 @@ export function HealthMarkerPromptScreen() {
     if (foodDiaryContinueDisabled) {
       return;
     }
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
     setFoodDiaryDecision(foodEntries.length > 0 ? 'saved' : 'skipped');
     setFoodDiaryFeedback(null);
     setPhase('postMarkers');
@@ -679,6 +681,8 @@ export function HealthMarkerPromptScreen() {
   };
 
   const onBackToHealthMarkersFromFoodDiary = async () => {
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
     setFoodDiaryFeedback(null);
     setPhase('prompting');
     await announce('Returned to health markers.', { politeness: 'polite' });
@@ -701,6 +705,8 @@ export function HealthMarkerPromptScreen() {
   }, [episodeId, episodeRow, navigation]);
 
   const onBackToFoodDiaryFromPostMarkers = async () => {
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
     setPostFeedback(null);
     setPhase('foodDiary');
     await announce('Returned to food diary.', { politeness: 'polite' });

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -5,8 +5,12 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { Ionicons } from '@expo/vector-icons';
+import DateTimePicker from '@react-native-community/datetimepicker';
+import type { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import {
   Alert,
+  Platform,
   Pressable,
   ScrollView,
   Text,
@@ -23,22 +27,29 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type {
   EpisodeRow,
   EpisodeType,
+  FoodDiaryEntryRow,
   HealthMarkerRow,
+  MealTag,
   PresetHealthMarkerRow,
 } from '@abstrack/types';
 import {
   bacReadingSuggestsAbsEpisode,
   formatEpisodeDurationSimple,
+  MEAL_TAGS,
   PRESET_HEALTH_MARKER_KIND_LABELS,
   validatePresetHealthMarkerCustomFields,
 } from '@abstrack/types';
 import {
   cancelActiveEpisodeById,
   completeEpisodePostMarkerStep,
+  createFoodDiaryEntry,
+  deleteFoodDiaryEntry,
   endEpisodeIfStillActive,
   getEpisodeById,
+  listFoodDiaryEntriesForEpisode,
   listEpisodeHealthMarkersForEpisode,
   listPresetHealthMarkersForPreset,
+  updateFoodDiaryEntry,
   upsertEpisodeHealthMarkerForLine,
 } from '@abstrack/supabase';
 import { announce, COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
@@ -171,6 +182,52 @@ function parseOptionalNumber(raw: string | undefined): number | null {
   return Number.isFinite(n) ? n : Number.NaN;
 }
 
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function currentLocalDate(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())}`;
+}
+
+function currentLocalTime(): string {
+  const now = new Date();
+  return `${pad2(now.getHours())}:${pad2(now.getMinutes())}`;
+}
+
+function localDateFromDate(value: Date): string {
+  return `${value.getFullYear()}-${pad2(value.getMonth() + 1)}-${pad2(value.getDate())}`;
+}
+
+function localTimeFromDate(value: Date): string {
+  return `${pad2(value.getHours())}:${pad2(value.getMinutes())}`;
+}
+
+function localDateTimeToIso(datePart: string, timePart: string): string | null {
+  const date = datePart.trim();
+  const time = timePart.trim();
+  if (!date || !time) {
+    return null;
+  }
+  const parsed = new Date(`${date}T${time}`);
+  const value = parsed.getTime();
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  return parsed.toISOString();
+}
+
+function isoToLocalDate(value: string): string {
+  const date = new Date(value);
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+}
+
+function isoToLocalTime(value: string): string {
+  const date = new Date(value);
+  return `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+}
+
 /**
  * Linear in-episode health marker stepper that follows the symptom phase.
  *
@@ -188,9 +245,9 @@ export function HealthMarkerPromptScreen() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [persistFeedback, setPersistFeedback] =
     useState<PersistFeedback | null>(null);
-  const [phase, setPhase] = useState<'prompting' | 'postMarkers' | 'complete'>(
-    'prompting',
-  );
+  const [phase, setPhase] = useState<
+    'prompting' | 'postMarkers' | 'foodDiary' | 'complete'
+  >('prompting');
   const [userId, setUserId] = useState<string | null>(null);
   const [lines, setLines] = useState<PresetHealthMarkerRow[]>([]);
   const [drafts, setDrafts] = useState<Record<string, MarkerDraft>>({});
@@ -204,6 +261,34 @@ export function HealthMarkerPromptScreen() {
   const [postNote, setPostNote] = useState('');
   const [savingPost, setSavingPost] = useState(false);
   const [postFeedback, setPostFeedback] = useState<string | null>(null);
+  const [mealTag, setMealTag] = useState<MealTag | null>(null);
+  const [foodNote, setFoodNote] = useState('');
+  const [foodLoggedDate, setFoodLoggedDate] = useState(currentLocalDate);
+  const [foodLoggedTime, setFoodLoggedTime] = useState(currentLocalTime);
+  const [addFoodInitialDate, setAddFoodInitialDate] =
+    useState(currentLocalDate);
+  const [addFoodInitialTime, setAddFoodInitialTime] =
+    useState(currentLocalTime);
+  const [foodEntries, setFoodEntries] = useState<FoodDiaryEntryRow[]>([]);
+  const [foodEntriesLoading, setFoodEntriesLoading] = useState(false);
+  const [foodEntriesError, setFoodEntriesError] = useState<string | null>(null);
+  const [savingFoodDiary, setSavingFoodDiary] = useState(false);
+  const [foodDiaryFeedback, setFoodDiaryFeedback] = useState<string | null>(
+    null,
+  );
+  const [editingFoodEntryId, setEditingFoodEntryId] = useState<string | null>(
+    null,
+  );
+  const [deletingFoodEntryId, setDeletingFoodEntryId] = useState<string | null>(
+    null,
+  );
+  const [isAddFoodEntryOpen, setIsAddFoodEntryOpen] = useState(true);
+  const [isAddFoodEntryDirty, setIsAddFoodEntryDirty] = useState(false);
+  const [foodDatePickerOpen, setFoodDatePickerOpen] = useState(false);
+  const [foodTimePickerOpen, setFoodTimePickerOpen] = useState(false);
+  const [foodDiaryDecision, setFoodDiaryDecision] = useState<
+    'pending' | 'saved' | 'skipped'
+  >('pending');
   const [endingEpisode, setEndingEpisode] = useState(false);
   const [endFeedback, setEndFeedback] = useState<string | null>(null);
   const [endedSummary, setEndedSummary] = useState<{
@@ -245,6 +330,25 @@ export function HealthMarkerPromptScreen() {
     setPhase('prompting');
     postFormInitRef.current = false;
     setPostFeedback(null);
+    const initialFoodDate = currentLocalDate();
+    const initialFoodTime = currentLocalTime();
+    setMealTag(null);
+    setFoodNote('');
+    setFoodLoggedDate(initialFoodDate);
+    setFoodLoggedTime(initialFoodTime);
+    setAddFoodInitialDate(initialFoodDate);
+    setAddFoodInitialTime(initialFoodTime);
+    setFoodEntries([]);
+    setFoodEntriesLoading(false);
+    setFoodEntriesError(null);
+    setSavingFoodDiary(false);
+    setFoodDiaryFeedback(null);
+    setEditingFoodEntryId(null);
+    setIsAddFoodEntryOpen(true);
+    setIsAddFoodEntryDirty(false);
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+    setFoodDiaryDecision('pending');
     setEndFeedback(null);
     setEndedSummary(null);
 
@@ -330,7 +434,7 @@ export function HealthMarkerPromptScreen() {
       if (episode.data?.post_marker_step_completed_at) {
         setPhase('complete');
       } else {
-        setPhase('postMarkers');
+        setPhase('foodDiary');
       }
     } else if (resume && firstUnanswered >= 0) {
       setActiveIndex(firstUnanswered);
@@ -431,7 +535,7 @@ export function HealthMarkerPromptScreen() {
 
   /**
    * Re-reads saved episode markers so BAC suggestion reflects values logged during this session,
-   * then moves to the post–marker episode details step.
+   * then moves to the food diary step.
    */
   const enterPostMarkerPhaseAfterMarkers = useCallback(async () => {
     const markerRows = await listEpisodeHealthMarkersForEpisode(
@@ -441,7 +545,7 @@ export function HealthMarkerPromptScreen() {
     if (markerRows.ok) {
       setBacSuggestAbs(bacReadingSuggestsAbsEpisode(markerRows.data));
     }
-    setPhase('postMarkers');
+    setPhase('foodDiary');
   }, [episodeId, supabase]);
 
   const goNext = async () => {
@@ -452,7 +556,7 @@ export function HealthMarkerPromptScreen() {
       await enterPostMarkerPhaseAfterMarkers();
       await announce(
         lines.length === 0
-          ? 'No preset health markers to log. Continue to episode details.'
+          ? 'No preset health markers to log. Continue to food diary.'
           : 'Health marker list complete.',
         { politeness: 'polite' },
       );
@@ -507,6 +611,404 @@ export function HealthMarkerPromptScreen() {
     setEndedSummary(null);
     setPhase('complete');
     await announce('Episode details saved.', { politeness: 'polite' });
+  };
+
+  const onSaveFoodDiary = async () => {
+    if (savingFoodDiary || !userId) {
+      return;
+    }
+    setSavingFoodDiary(true);
+    setFoodDiaryFeedback(null);
+    if (!mealTag) {
+      const message = 'Choose a meal tag.';
+      setFoodDiaryFeedback(message);
+      await announce(message, { politeness: 'assertive' });
+      setSavingFoodDiary(false);
+      return;
+    }
+    const loggedAtIso = localDateTimeToIso(foodLoggedDate, foodLoggedTime);
+    if (!loggedAtIso) {
+      const message = 'Enter a valid date and time.';
+      setFoodDiaryFeedback(message);
+      await announce(message, { politeness: 'assertive' });
+      setSavingFoodDiary(false);
+      return;
+    }
+    const result =
+      editingFoodEntryId == null
+        ? await createFoodDiaryEntry(supabase, {
+            user_id: userId,
+            episode_id: episodeId,
+            meal_tag: mealTag,
+            food_note: foodNote,
+            logged_at: loggedAtIso,
+          })
+        : await updateFoodDiaryEntry(supabase, editingFoodEntryId, {
+            meal_tag: mealTag,
+            food_note: foodNote,
+            logged_at: loggedAtIso,
+          });
+    setSavingFoodDiary(false);
+    if (!result.ok) {
+      setFoodDiaryFeedback(result.error.message);
+      await announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    const foodEntriesResult = await listFoodDiaryEntriesForEpisode(
+      supabase,
+      episodeId,
+    );
+    if (foodEntriesResult.ok) {
+      setFoodEntries(foodEntriesResult.data);
+      setFoodEntriesError(null);
+    } else {
+      setFoodEntriesError(foodEntriesResult.error.message);
+    }
+    const initialFoodDate = currentLocalDate();
+    const initialFoodTime = currentLocalTime();
+    setMealTag(null);
+    setFoodNote('');
+    setFoodLoggedDate(initialFoodDate);
+    setFoodLoggedTime(initialFoodTime);
+    setAddFoodInitialDate(initialFoodDate);
+    setAddFoodInitialTime(initialFoodTime);
+    setEditingFoodEntryId(null);
+    setIsAddFoodEntryDirty(false);
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+    if (editingFoodEntryId == null) {
+      setIsAddFoodEntryOpen(false);
+    }
+    setFoodDiaryFeedback(null);
+    await announce(
+      editingFoodEntryId == null ? 'Food entry saved.' : 'Food entry updated.',
+      { politeness: 'polite' },
+    );
+  };
+
+  const onContinueFromFoodDiary = async () => {
+    setFoodDiaryDecision(foodEntries.length > 0 ? 'saved' : 'skipped');
+    setFoodDiaryFeedback(null);
+    setPhase('postMarkers');
+    await announce('Continue to episode details.', {
+      politeness: 'polite',
+    });
+  };
+
+  const onBackToHealthMarkersFromFoodDiary = async () => {
+    setFoodDiaryFeedback(null);
+    setPhase('prompting');
+    await announce('Returned to health markers.', { politeness: 'polite' });
+  };
+
+  const onBackToSymptomsFromHealthMarkers = useCallback(async () => {
+    const symptomPresetId = episodeRow?.symptom_preset_id;
+    if (!symptomPresetId) {
+      await announce(
+        'This episode has no symptom preset linked, so symptoms cannot be reopened.',
+        { politeness: 'assertive' },
+      );
+      return;
+    }
+    navigation.replace('SymptomPrompt', {
+      episodeId,
+      symptomPresetId,
+      resume: true,
+    });
+  }, [episodeId, episodeRow, navigation]);
+
+  const onBackToFoodDiaryFromPostMarkers = async () => {
+    setPostFeedback(null);
+    setPhase('foodDiary');
+    await announce('Returned to food diary.', { politeness: 'polite' });
+  };
+
+  const onEditFoodEntry = (entry: FoodDiaryEntryRow) => {
+    setEditingFoodEntryId(entry.id);
+    setIsAddFoodEntryOpen(false);
+    setIsAddFoodEntryDirty(false);
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+    setMealTag(entry.meal_tag);
+    setFoodNote(entry.food_note);
+    setFoodLoggedDate(isoToLocalDate(entry.logged_at));
+    setFoodLoggedTime(isoToLocalTime(entry.logged_at));
+    setFoodDiaryFeedback(null);
+  };
+
+  const onNewFoodEntry = () => {
+    setEditingFoodEntryId(null);
+    const initialFoodDate = currentLocalDate();
+    const initialFoodTime = currentLocalTime();
+    setMealTag(null);
+    setFoodNote('');
+    setFoodLoggedDate(initialFoodDate);
+    setFoodLoggedTime(initialFoodTime);
+    setAddFoodInitialDate(initialFoodDate);
+    setAddFoodInitialTime(initialFoodTime);
+    setFoodDiaryFeedback(null);
+    setIsAddFoodEntryDirty(false);
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+    setIsAddFoodEntryOpen(true);
+  };
+
+  const onDiscardFoodEditChanges = () => {
+    setEditingFoodEntryId(null);
+    setMealTag(null);
+    setFoodNote('');
+    setFoodLoggedDate(currentLocalDate());
+    setFoodLoggedTime(currentLocalTime());
+    setFoodDiaryFeedback(null);
+    setIsAddFoodEntryDirty(false);
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+    setIsAddFoodEntryOpen(false);
+  };
+
+  const computeIsAddFoodEntryDirty = useCallback(
+    (next: {
+      mealTag: MealTag | null;
+      foodNote: string;
+      foodLoggedDate: string;
+      foodLoggedTime: string;
+    }) => {
+      return (
+        next.mealTag != null ||
+        next.foodNote.trim().length > 0 ||
+        next.foodLoggedDate !== addFoodInitialDate ||
+        next.foodLoggedTime !== addFoodInitialTime
+      );
+    },
+    [addFoodInitialDate, addFoodInitialTime],
+  );
+
+  const onDiscardAddFoodDraft = useCallback(() => {
+    if (!isAddFoodEntryDirty) {
+      setIsAddFoodEntryOpen(false);
+      return;
+    }
+    Alert.alert(
+      'Discard this food entry draft?',
+      'Your unsaved entry will be removed.',
+      [
+        { text: 'Keep editing', style: 'cancel' },
+        {
+          text: 'Discard entry',
+          style: 'destructive',
+          onPress: () => {
+            const initialFoodDate = currentLocalDate();
+            const initialFoodTime = currentLocalTime();
+            setMealTag(null);
+            setFoodNote('');
+            setFoodLoggedDate(initialFoodDate);
+            setFoodLoggedTime(initialFoodTime);
+            setAddFoodInitialDate(initialFoodDate);
+            setAddFoodInitialTime(initialFoodTime);
+            setIsAddFoodEntryDirty(false);
+            setFoodDiaryFeedback(null);
+            setFoodDatePickerOpen(false);
+            setFoodTimePickerOpen(false);
+            setIsAddFoodEntryOpen(false);
+          },
+        },
+      ],
+    );
+  }, [isAddFoodEntryDirty]);
+
+  const foodLoggedDateTimeValue = useMemo(() => {
+    const iso = localDateTimeToIso(foodLoggedDate, foodLoggedTime);
+    return iso ? new Date(iso) : new Date();
+  }, [foodLoggedDate, foodLoggedTime]);
+
+  const foodLoggedDateLabel = useMemo(() => {
+    return foodLoggedDateTimeValue.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }, [foodLoggedDateTimeValue]);
+
+  const foodLoggedTimeLabel = useMemo(() => {
+    return foodLoggedDateTimeValue.toLocaleTimeString(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  }, [foodLoggedDateTimeValue]);
+
+  const onFoodDatePickerChange = useCallback(
+    (_event: DateTimePickerEvent, selectedDate?: Date) => {
+      setFoodDatePickerOpen(false);
+      if (!selectedDate) {
+        return;
+      }
+      const nextDate = localDateFromDate(selectedDate);
+      setFoodLoggedDate(nextDate);
+      if (editingFoodEntryId == null) {
+        setIsAddFoodEntryDirty(
+          computeIsAddFoodEntryDirty({
+            mealTag,
+            foodNote,
+            foodLoggedDate: nextDate,
+            foodLoggedTime,
+          }),
+        );
+      }
+    },
+    [
+      computeIsAddFoodEntryDirty,
+      editingFoodEntryId,
+      foodLoggedTime,
+      foodNote,
+      mealTag,
+    ],
+  );
+
+  const onFoodTimePickerChange = useCallback(
+    (_event: DateTimePickerEvent, selectedDate?: Date) => {
+      setFoodTimePickerOpen(false);
+      if (!selectedDate) {
+        return;
+      }
+      const nextTime = localTimeFromDate(selectedDate);
+      setFoodLoggedTime(nextTime);
+      if (editingFoodEntryId == null) {
+        setIsAddFoodEntryDirty(
+          computeIsAddFoodEntryDirty({
+            mealTag,
+            foodNote,
+            foodLoggedDate,
+            foodLoggedTime: nextTime,
+          }),
+        );
+      }
+    },
+    [
+      computeIsAddFoodEntryDirty,
+      editingFoodEntryId,
+      foodLoggedDate,
+      foodNote,
+      mealTag,
+    ],
+  );
+
+  const loadFoodEntries = useCallback(async () => {
+    setFoodEntriesLoading(true);
+    setFoodEntriesError(null);
+    const result = await listFoodDiaryEntriesForEpisode(supabase, episodeId);
+    setFoodEntriesLoading(false);
+    if (!result.ok) {
+      setFoodEntriesError(result.error.message);
+      return;
+    }
+    setFoodEntries(result.data);
+  }, [episodeId, supabase]);
+
+  const onDeleteFoodEntry = useCallback(
+    (entryId: string) => {
+      if (savingFoodDiary || deletingFoodEntryId) {
+        return;
+      }
+      Alert.alert('Discard this saved food entry?', 'This cannot be undone.', [
+        { text: 'Keep entry', style: 'cancel' },
+        {
+          text: 'Discard entry',
+          style: 'destructive',
+          onPress: () => {
+            void (async () => {
+              setDeletingFoodEntryId(entryId);
+              setFoodDiaryFeedback(null);
+              const result = await deleteFoodDiaryEntry(supabase, entryId);
+              setDeletingFoodEntryId(null);
+              if (!result.ok) {
+                setFoodDiaryFeedback(result.error.message);
+                await announce(result.error.message, {
+                  politeness: 'assertive',
+                });
+                return;
+              }
+              if (editingFoodEntryId === entryId) {
+                onNewFoodEntry();
+                setIsAddFoodEntryOpen(false);
+              }
+              await loadFoodEntries();
+              await announce('Food entry discarded.', { politeness: 'polite' });
+            })();
+          },
+        },
+      ]);
+    },
+    [
+      deletingFoodEntryId,
+      editingFoodEntryId,
+      loadFoodEntries,
+      onNewFoodEntry,
+      savingFoodDiary,
+      supabase,
+    ],
+  );
+
+  useEffect(() => {
+    if (phase !== 'foodDiary') {
+      return;
+    }
+    void loadFoodEntries();
+  }, [phase, loadFoodEntries]);
+
+  const onCancelEpisodePress = () => {
+    if (cancelingEpisode) {
+      return;
+    }
+    Alert.alert(
+      'Cancel this active episode?',
+      'Canceling permanently deletes this in-progress episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone.',
+      [
+        { text: 'Keep episode', style: 'cancel' },
+        {
+          text: 'Cancel episode',
+          style: 'destructive',
+          onPress: () => {
+            void (async () => {
+              setCancelingEpisode(true);
+              try {
+                const result = await cancelActiveEpisodeById(
+                  supabase,
+                  episodeId,
+                );
+                if (!result.ok) {
+                  await announce(result.error.message, {
+                    politeness: 'assertive',
+                  });
+                  return;
+                }
+                clearSymptomPromptSession(episodeId);
+                if (result.data.didCancel) {
+                  await announce(
+                    'Episode canceled. Resume is no longer available.',
+                    {
+                      politeness: 'polite',
+                    },
+                  );
+                } else {
+                  await announce('This episode is no longer active.', {
+                    politeness: 'polite',
+                  });
+                }
+                navigation.dispatch(
+                  CommonActions.reset({
+                    index: 0,
+                    routes: [{ name: 'MainTabs' }],
+                  }),
+                );
+              } finally {
+                setCancelingEpisode(false);
+              }
+            })();
+          },
+        },
+      ],
+    );
   };
 
   const onFinishToHome = () => {
@@ -609,61 +1111,6 @@ export function HealthMarkerPromptScreen() {
     );
   }, [endedSummary, endingEpisode, onEndEpisode]);
 
-  const onCancelEpisodePress = () => {
-    if (cancelingEpisode) {
-      return;
-    }
-    Alert.alert(
-      'Cancel this active episode?',
-      'Canceling permanently deletes this in-progress episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone.',
-      [
-        { text: 'Keep episode', style: 'cancel' },
-        {
-          text: 'Cancel episode',
-          style: 'destructive',
-          onPress: () => {
-            void (async () => {
-              setCancelingEpisode(true);
-              try {
-                const result = await cancelActiveEpisodeById(
-                  supabase,
-                  episodeId,
-                );
-                if (!result.ok) {
-                  await announce(result.error.message, {
-                    politeness: 'assertive',
-                  });
-                  return;
-                }
-                clearSymptomPromptSession(episodeId);
-                if (result.data.didCancel) {
-                  await announce(
-                    'Episode canceled. Resume is no longer available.',
-                    {
-                      politeness: 'polite',
-                    },
-                  );
-                } else {
-                  await announce('This episode is no longer active.', {
-                    politeness: 'polite',
-                  });
-                }
-                navigation.dispatch(
-                  CommonActions.reset({
-                    index: 0,
-                    routes: [{ name: 'MainTabs' }],
-                  }),
-                );
-              } finally {
-                setCancelingEpisode(false);
-              }
-            })();
-          },
-        },
-      ],
-    );
-  };
-
   return (
     <ScreenShell contentAlign="stretch">
       <View className="min-h-0 flex-1 gap-4">
@@ -674,7 +1121,9 @@ export function HealthMarkerPromptScreen() {
         >
           {phase === 'postMarkers'
             ? 'Episode details'
-            : 'Episode health markers'}
+            : phase === 'foodDiary'
+              ? 'Food diary'
+              : 'Episode health markers'}
         </Text>
         {phase === 'prompting' && persistFeedback ? (
           <Text
@@ -716,8 +1165,9 @@ export function HealthMarkerPromptScreen() {
                 className={`text-base leading-relaxed ${nw.textInk}`}
                 maxFontSizeMultiplier={2}
               >
-                Preset prompts and episode details are saved. End this episode
-                to prevent stale resume state.
+                {foodDiaryDecision === 'saved'
+                  ? 'Preset prompts, episode details, and food diary are saved. End this episode to prevent stale resume state.'
+                  : 'Preset prompts and episode details are saved. End this episode to prevent stale resume state.'}
               </Text>
             )}
             {endFeedback ? (
@@ -759,6 +1209,592 @@ export function HealthMarkerPromptScreen() {
               </Pressable>
             )}
           </View>
+        ) : phase === 'foodDiary' ? (
+          <>
+            <ScrollView
+              className="flex-1"
+              keyboardShouldPersistTaps="handled"
+              contentContainerStyle={{ paddingBottom: 24 }}
+            >
+              <Text
+                className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
+                maxFontSizeMultiplier={2}
+              >
+                Add one or more meals/snacks for this episode, or skip this
+                step.
+              </Text>
+              <Text
+                accessibilityRole="header"
+                className={`mb-2 text-lg font-semibold ${nw.textInk}`}
+                maxFontSizeMultiplier={2}
+              >
+                Saved entries
+              </Text>
+              {foodEntriesLoading ? (
+                <Text
+                  className={`mb-2 text-sm ${nw.textMuted}`}
+                  accessibilityLiveRegion="polite"
+                  maxFontSizeMultiplier={2}
+                >
+                  Loading entries…
+                </Text>
+              ) : null}
+              {foodEntriesError ? (
+                <Text
+                  className={`mb-2 text-sm ${nw.textError}`}
+                  accessibilityLiveRegion="assertive"
+                  maxFontSizeMultiplier={2}
+                >
+                  {foodEntriesError}
+                </Text>
+              ) : null}
+              {!foodEntriesLoading &&
+              !foodEntriesError &&
+              foodEntries.length === 0 ? (
+                <Text
+                  className={`mb-3 text-sm ${nw.textMuted}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  No food entries yet for this episode.
+                </Text>
+              ) : null}
+              {foodEntries.map((entry) => (
+                <View
+                  key={entry.id}
+                  className="mb-3 rounded-xl border border-app-border bg-app-bg p-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+                >
+                  <Text
+                    className={`text-base font-semibold ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {entry.meal_tag}
+                  </Text>
+                  <Text
+                    className={`mt-1 text-sm ${nw.textMuted}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {new Date(entry.logged_at).toLocaleString()}
+                  </Text>
+                  <Text
+                    className={`mt-2 text-sm ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {entry.food_note}
+                  </Text>
+                  {editingFoodEntryId !== entry.id ? (
+                    <View className="mt-2 flex-row items-center justify-end gap-2">
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel={`Edit ${entry.meal_tag} food entry`}
+                        onPress={() => {
+                          onEditFoodEntry(entry);
+                        }}
+                        style={{
+                          minWidth: COMFORTABLE_TOUCH_TARGET_DP,
+                          minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+                        }}
+                        className="items-center justify-center rounded-lg border border-app-border px-2 active:opacity-80 dark:border-app-border-dark"
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                      >
+                        <Ionicons
+                          name="pencil-outline"
+                          size={20}
+                          color={colors.muted}
+                          accessibilityElementsHidden
+                          importantForAccessibility="no"
+                        />
+                      </Pressable>
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel={`Discard ${entry.meal_tag} food entry`}
+                        accessibilityState={{
+                          disabled: deletingFoodEntryId != null,
+                        }}
+                        disabled={deletingFoodEntryId != null}
+                        onPress={() => {
+                          onDeleteFoodEntry(entry.id);
+                        }}
+                        style={{
+                          minWidth: COMFORTABLE_TOUCH_TARGET_DP,
+                          minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+                        }}
+                        className="items-center justify-center rounded-lg border border-red-400 px-2 active:opacity-80 disabled:opacity-60 dark:border-red-500/60"
+                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+                      >
+                        {deletingFoodEntryId === entry.id ? (
+                          <Text
+                            className="text-xs font-semibold text-red-700 dark:text-red-300"
+                            maxFontSizeMultiplier={2}
+                          >
+                            ...
+                          </Text>
+                        ) : (
+                          <Ionicons
+                            name="trash-outline"
+                            size={20}
+                            color={colors.error}
+                            accessibilityElementsHidden
+                            importantForAccessibility="no"
+                          />
+                        )}
+                      </Pressable>
+                    </View>
+                  ) : null}
+                  {editingFoodEntryId === entry.id ? (
+                    <View className="mt-3 rounded-lg border border-app-border p-3 dark:border-app-border-dark">
+                      <Text
+                        className={`mb-2 text-base font-semibold ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        Edit food entry
+                      </Text>
+                      <View
+                        accessibilityRole="radiogroup"
+                        accessibilityLabel="Meal tag"
+                        className="mb-3 gap-2"
+                      >
+                        {MEAL_TAGS.map((tag) => (
+                          <Pressable
+                            key={`${entry.id}-${tag}`}
+                            accessibilityRole="radio"
+                            accessibilityLabel={tag}
+                            accessibilityState={{
+                              checked: mealTag === tag,
+                              disabled: savingFoodDiary,
+                            }}
+                            disabled={savingFoodDiary}
+                            onPress={() => {
+                              setMealTag((prev) => (prev === tag ? null : tag));
+                            }}
+                            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                            className={`w-full items-center justify-center rounded-xl border-2 px-3 py-3 dark:border-app-border-dark ${
+                              mealTag === tag
+                                ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                                : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
+                            }`}
+                          >
+                            <Text
+                              className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                              maxFontSizeMultiplier={2}
+                            >
+                              {tag}
+                            </Text>
+                          </Pressable>
+                        ))}
+                      </View>
+                      <Text
+                        className={`mb-1 text-base font-medium ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        Logged date
+                      </Text>
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel="Logged date"
+                        accessibilityState={{ disabled: savingFoodDiary }}
+                        disabled={savingFoodDiary}
+                        onPress={() => {
+                          setFoodDatePickerOpen(true);
+                        }}
+                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                        className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+                      >
+                        <Text
+                          className={`text-[17px] ${nw.textInk}`}
+                          maxFontSizeMultiplier={2}
+                        >
+                          {foodLoggedDateLabel}
+                        </Text>
+                      </Pressable>
+                      <Text
+                        className={`mb-1 text-base font-medium ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        Logged time
+                      </Text>
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel="Logged time"
+                        accessibilityState={{ disabled: savingFoodDiary }}
+                        disabled={savingFoodDiary}
+                        onPress={() => {
+                          setFoodTimePickerOpen(true);
+                        }}
+                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                        className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+                      >
+                        <Text
+                          className={`text-[17px] ${nw.textInk}`}
+                          maxFontSizeMultiplier={2}
+                        >
+                          {foodLoggedTimeLabel}
+                        </Text>
+                      </Pressable>
+                      <Text
+                        className={`mb-1 text-base font-medium ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        Food note
+                      </Text>
+                      <TextInput
+                        editable={!savingFoodDiary}
+                        accessibilityLabel="Food note"
+                        multiline
+                        value={foodNote}
+                        onChangeText={setFoodNote}
+                        placeholder="What did you eat or drink?"
+                        placeholderTextColor={colors.inputPlaceholder}
+                        className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      />
+                      {foodDiaryFeedback ? (
+                        <Text
+                          className={`mb-2 text-sm ${nw.textError}`}
+                          accessibilityLiveRegion="assertive"
+                          maxFontSizeMultiplier={2}
+                        >
+                          {foodDiaryFeedback}
+                        </Text>
+                      ) : null}
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel={
+                          savingFoodDiary
+                            ? 'Saving food diary entry'
+                            : 'Update food entry'
+                        }
+                        accessibilityState={{ disabled: savingFoodDiary }}
+                        disabled={savingFoodDiary}
+                        onPress={() => {
+                          void onSaveFoodDiary();
+                        }}
+                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                        className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 disabled:opacity-60 dark:bg-red-600"
+                      >
+                        <Text className="text-center text-[17px] font-semibold text-white">
+                          {savingFoodDiary ? 'Saving…' : 'Update entry'}
+                        </Text>
+                      </Pressable>
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel="Cancel food entry edit"
+                        onPress={onDiscardFoodEditChanges}
+                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                        className="mt-3 w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
+                      >
+                        <Text
+                          className={`text-base font-medium ${nw.textInk}`}
+                          maxFontSizeMultiplier={2}
+                        >
+                          Discard changes
+                        </Text>
+                      </Pressable>
+                      <Pressable
+                        accessibilityRole="button"
+                        accessibilityLabel="Discard saved food entry"
+                        accessibilityState={{
+                          disabled: deletingFoodEntryId != null,
+                        }}
+                        disabled={deletingFoodEntryId != null}
+                        onPress={() => {
+                          onDeleteFoodEntry(entry.id);
+                        }}
+                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                        className="mt-3 w-full items-center justify-center rounded-lg border border-red-400 px-3 py-3 active:opacity-80 disabled:opacity-60 dark:border-red-500/60"
+                      >
+                        <Text
+                          className="text-base font-medium text-red-700 dark:text-red-300"
+                          maxFontSizeMultiplier={2}
+                        >
+                          {deletingFoodEntryId === entry.id
+                            ? 'Discarding…'
+                            : 'Discard entry'}
+                        </Text>
+                      </Pressable>
+                    </View>
+                  ) : null}
+                </View>
+              ))}
+              {editingFoodEntryId == null && !isAddFoodEntryOpen ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Add food entry"
+                  onPress={onNewFoodEntry}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
+                >
+                  <Text
+                    className={`text-base font-medium ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Add food entry
+                  </Text>
+                </Pressable>
+              ) : null}
+              {editingFoodEntryId == null && isAddFoodEntryOpen ? (
+                <>
+                  <Text
+                    accessibilityRole="header"
+                    className={`mb-2 text-lg font-semibold ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Add food entry
+                  </Text>
+                  <View
+                    accessibilityRole="radiogroup"
+                    accessibilityLabel="Meal tag"
+                    className="mb-4 gap-2"
+                  >
+                    {MEAL_TAGS.map((tag) => (
+                      <Pressable
+                        key={`add-${tag}`}
+                        accessibilityRole="radio"
+                        accessibilityLabel={tag}
+                        accessibilityState={{
+                          checked: mealTag === tag,
+                          disabled: savingFoodDiary,
+                        }}
+                        disabled={savingFoodDiary}
+                        onPress={() => {
+                          const nextMealTag = mealTag === tag ? null : tag;
+                          setMealTag(nextMealTag);
+                          setIsAddFoodEntryDirty(
+                            computeIsAddFoodEntryDirty({
+                              mealTag: nextMealTag,
+                              foodNote,
+                              foodLoggedDate,
+                              foodLoggedTime,
+                            }),
+                          );
+                        }}
+                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                        className={`w-full items-center justify-center rounded-xl border-2 px-3 py-3 dark:border-app-border-dark ${
+                          mealTag === tag
+                            ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                            : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
+                        }`}
+                      >
+                        <Text
+                          className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                          maxFontSizeMultiplier={2}
+                        >
+                          {tag}
+                        </Text>
+                      </Pressable>
+                    ))}
+                  </View>
+                  <Text
+                    className={`mb-1 text-base font-medium ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Logged date
+                  </Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Logged date"
+                    accessibilityState={{ disabled: savingFoodDiary }}
+                    disabled={savingFoodDiary}
+                    onPress={() => {
+                      setFoodDatePickerOpen(true);
+                    }}
+                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                    className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+                  >
+                    <Text
+                      className={`text-[17px] ${nw.textInk}`}
+                      maxFontSizeMultiplier={2}
+                    >
+                      {foodLoggedDateLabel}
+                    </Text>
+                  </Pressable>
+                  <Text
+                    className={`mb-1 text-base font-medium ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Logged time
+                  </Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Logged time"
+                    accessibilityState={{ disabled: savingFoodDiary }}
+                    disabled={savingFoodDiary}
+                    onPress={() => {
+                      setFoodTimePickerOpen(true);
+                    }}
+                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                    className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+                  >
+                    <Text
+                      className={`text-[17px] ${nw.textInk}`}
+                      maxFontSizeMultiplier={2}
+                    >
+                      {foodLoggedTimeLabel}
+                    </Text>
+                  </Pressable>
+                  <Text
+                    className={`mb-1 text-base font-medium ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Food note
+                  </Text>
+                  <TextInput
+                    editable={!savingFoodDiary}
+                    accessibilityLabel="Food note"
+                    multiline
+                    value={foodNote}
+                    onChangeText={(value) => {
+                      setFoodNote(value);
+                      setIsAddFoodEntryDirty(
+                        computeIsAddFoodEntryDirty({
+                          mealTag,
+                          foodNote: value,
+                          foodLoggedDate,
+                          foodLoggedTime,
+                        }),
+                      );
+                    }}
+                    placeholder="What did you eat or drink?"
+                    placeholderTextColor={colors.inputPlaceholder}
+                    className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  />
+                  {foodDiaryFeedback ? (
+                    <Text
+                      className={`mb-2 text-sm ${nw.textError}`}
+                      accessibilityLiveRegion="assertive"
+                      maxFontSizeMultiplier={2}
+                    >
+                      {foodDiaryFeedback}
+                    </Text>
+                  ) : null}
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={
+                      savingFoodDiary
+                        ? 'Saving food diary entry'
+                        : 'Save food entry'
+                    }
+                    accessibilityState={{ disabled: savingFoodDiary }}
+                    disabled={savingFoodDiary}
+                    onPress={() => {
+                      void onSaveFoodDiary();
+                    }}
+                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                    className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 disabled:opacity-60 dark:bg-red-600"
+                  >
+                    <Text className="text-center text-[17px] font-semibold text-white">
+                      {savingFoodDiary ? 'Saving…' : 'Save entry'}
+                    </Text>
+                  </Pressable>
+                  {isAddFoodEntryDirty ? (
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel="Discard food entry"
+                      onPress={onDiscardAddFoodDraft}
+                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                      className="mt-3 w-full items-center justify-center rounded-lg border border-red-400 px-3 py-3 active:opacity-80 dark:border-red-500/60"
+                    >
+                      <Text
+                        className="text-base font-medium text-red-700 dark:text-red-300"
+                        maxFontSizeMultiplier={2}
+                      >
+                        Discard entry
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                  {!isAddFoodEntryDirty ? (
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel="Collapse add food entry"
+                      onPress={() => {
+                        setIsAddFoodEntryOpen(false);
+                      }}
+                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                      className="mt-3 w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
+                    >
+                      <Text
+                        className={`text-base font-medium ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        Collapse
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                </>
+              ) : null}
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Back to health markers"
+                onPress={() => {
+                  void onBackToHealthMarkersFromFoodDiary();
+                }}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className="w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
+              >
+                <Text
+                  className={`text-base font-medium ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Back
+                </Text>
+              </Pressable>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel={
+                  foodEntries.length === 0
+                    ? 'Skip food diary entry'
+                    : 'Continue after food diary'
+                }
+                onPress={() => {
+                  void onContinueFromFoodDiary();
+                }}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className={`w-full items-center justify-center rounded-lg bg-red-700 px-3 py-3 active:opacity-90 dark:bg-red-600 ${
+                  editingFoodEntryId == null && !isAddFoodEntryOpen
+                    ? 'mt-5'
+                    : 'mt-3'
+                }`}
+              >
+                <Text
+                  className="text-center text-base font-semibold text-white"
+                  maxFontSizeMultiplier={2}
+                >
+                  {foodEntries.length === 0 ? 'Skip for now' : 'Continue'}
+                </Text>
+              </Pressable>
+            </ScrollView>
+            {foodDatePickerOpen ? (
+              <DateTimePicker
+                value={foodLoggedDateTimeValue}
+                mode="date"
+                display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                onChange={onFoodDatePickerChange}
+              />
+            ) : null}
+            {foodTimePickerOpen ? (
+              <DateTimePicker
+                value={foodLoggedDateTimeValue}
+                mode="time"
+                is24Hour={false}
+                display={Platform.OS === 'ios' ? 'spinner' : 'default'}
+                onChange={onFoodTimePickerChange}
+              />
+            ) : null}
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Cancel episode"
+              onPress={onCancelEpisodePress}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
+            >
+              <Text
+                className="text-sm font-medium text-red-700 dark:text-red-300"
+                maxFontSizeMultiplier={2}
+              >
+                Cancel episode
+              </Text>
+            </Pressable>
+          </>
         ) : phase === 'postMarkers' ? (
           <>
             <ScrollView
@@ -770,7 +1806,8 @@ export function HealthMarkerPromptScreen() {
                 className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
                 maxFontSizeMultiplier={2}
               >
-                Choose ABS or Other; other fields are optional.
+                After health markers and food diary, choose ABS or Other; other
+                fields are optional.
               </Text>
               <Text
                 accessibilityRole="header"
@@ -907,6 +1944,23 @@ export function HealthMarkerPromptScreen() {
                   {postFeedback}
                 </Text>
               ) : null}
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Back"
+                accessibilityState={{ disabled: savingPost }}
+                disabled={savingPost}
+                onPress={() => {
+                  void onBackToFoodDiaryFromPostMarkers();
+                }}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className="w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
+              >
+                <Text
+                  className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                >
+                  Back
+                </Text>
+              </Pressable>
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel="Save episode details"
@@ -1051,23 +2105,27 @@ export function HealthMarkerPromptScreen() {
                 ) : null}
 
                 <View className="mt-6 gap-3">
-                  {activeIndex > 0 ? (
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel="Previous marker"
-                      onPress={goBackStep}
-                      disabled={saving}
-                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                      className="w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Back"
+                    onPress={() => {
+                      if (activeIndex > 0) {
+                        goBackStep();
+                        return;
+                      }
+                      void onBackToSymptomsFromHealthMarkers();
+                    }}
+                    disabled={saving}
+                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                    className="w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
+                  >
+                    <Text
+                      className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                      maxFontSizeMultiplier={2}
                     >
-                      <Text
-                        className={`text-center text-[17px] font-semibold ${nw.textInk}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        Back
-                      </Text>
-                    </Pressable>
-                  ) : null}
+                      Back
+                    </Text>
+                  </Pressable>
                   {currentLine ? (
                     <Pressable
                       accessibilityRole="button"
@@ -1096,7 +2154,7 @@ export function HealthMarkerPromptScreen() {
                       lines.length === 0
                         ? 'Continue to episode details'
                         : activeIndex >= lines.length - 1
-                          ? 'Finish health marker list'
+                          ? 'Next health marker'
                           : 'Next health marker'
                     }
                     accessibilityState={{ disabled: saving }}
@@ -1113,7 +2171,7 @@ export function HealthMarkerPromptScreen() {
                         : lines.length === 0
                           ? 'Continue to episode details'
                           : activeIndex >= lines.length - 1
-                            ? 'Finish'
+                            ? 'Next'
                             : 'Next'}
                     </Text>
                   </Pressable>

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -54,6 +54,15 @@ import {
 } from '@abstrack/supabase';
 import { announce, COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
+import {
+  currentLocalDate,
+  currentLocalTime,
+  isoToLocalDate,
+  isoToLocalTime,
+  localDateFromDate,
+  localDateTimeToIso,
+  localTimeFromDate,
+} from '../../lib/food-diary/date-time';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
 import { ScreenShell } from '../components/ScreenShell';
@@ -180,52 +189,6 @@ function parseOptionalNumber(raw: string | undefined): number | null {
   }
   const n = Number(trimmed);
   return Number.isFinite(n) ? n : Number.NaN;
-}
-
-function pad2(value: number): string {
-  return String(value).padStart(2, '0');
-}
-
-function currentLocalDate(): string {
-  const now = new Date();
-  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())}`;
-}
-
-function currentLocalTime(): string {
-  const now = new Date();
-  return `${pad2(now.getHours())}:${pad2(now.getMinutes())}`;
-}
-
-function localDateFromDate(value: Date): string {
-  return `${value.getFullYear()}-${pad2(value.getMonth() + 1)}-${pad2(value.getDate())}`;
-}
-
-function localTimeFromDate(value: Date): string {
-  return `${pad2(value.getHours())}:${pad2(value.getMinutes())}`;
-}
-
-function localDateTimeToIso(datePart: string, timePart: string): string | null {
-  const date = datePart.trim();
-  const time = timePart.trim();
-  if (!date || !time) {
-    return null;
-  }
-  const parsed = new Date(`${date}T${time}`);
-  const value = parsed.getTime();
-  if (!Number.isFinite(value)) {
-    return null;
-  }
-  return parsed.toISOString();
-}
-
-function isoToLocalDate(value: string): string {
-  const date = new Date(value);
-  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
-}
-
-function isoToLocalTime(value: string): string {
-  const date = new Date(value);
-  return `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
 }
 
 /**

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -433,7 +433,7 @@ export function HealthMarkerPromptScreen() {
     setDrafts(nextDrafts);
 
     // Initial hydrate / resume; values logged later in this session are picked up in
-    // enterPostMarkerPhaseAfterMarkers before the post-marker step.
+    // enterFoodDiaryPhaseAfterMarkers before the post-marker step.
     setBacSuggestAbs(bacReadingSuggestsAbsEpisode(markerRows.data));
 
     const firstUnanswered = presetLines.data.findIndex((line) => {
@@ -472,6 +472,10 @@ export function HealthMarkerPromptScreen() {
     : false;
   const canSkip = Boolean(currentLine) && !measurementReadyForSave;
   const skipPressable = canSkip && !saving;
+  const continueToFoodDiary =
+    lines.length === 0 || activeIndex >= lines.length - 1;
+  const foodDiaryContinueDisabled =
+    savingFoodDiary || deletingFoodEntryId != null || foodEntriesLoading;
 
   const onUpdateDraft = (patch: Partial<MarkerDraft>) => {
     if (!currentLine) {
@@ -547,7 +551,7 @@ export function HealthMarkerPromptScreen() {
    * Re-reads saved episode markers so BAC suggestion reflects values logged during this session,
    * then moves to the food diary step.
    */
-  const enterPostMarkerPhaseAfterMarkers = useCallback(async () => {
+  const enterFoodDiaryPhaseAfterMarkers = useCallback(async () => {
     const markerRows = await listEpisodeHealthMarkersForEpisode(
       supabase,
       episodeId,
@@ -563,7 +567,7 @@ export function HealthMarkerPromptScreen() {
       return;
     }
     if (!currentLine) {
-      await enterPostMarkerPhaseAfterMarkers();
+      await enterFoodDiaryPhaseAfterMarkers();
       await announce(
         lines.length === 0
           ? 'No preset health markers to log. Continue to food diary.'
@@ -577,7 +581,7 @@ export function HealthMarkerPromptScreen() {
       return;
     }
     if (activeIndex >= lines.length - 1) {
-      await enterPostMarkerPhaseAfterMarkers();
+      await enterFoodDiaryPhaseAfterMarkers();
       await announce('Health marker list complete.', { politeness: 'polite' });
       return;
     }
@@ -589,7 +593,7 @@ export function HealthMarkerPromptScreen() {
       return;
     }
     if (activeIndex >= lines.length - 1) {
-      await enterPostMarkerPhaseAfterMarkers();
+      await enterFoodDiaryPhaseAfterMarkers();
       await announce('Health marker list complete.', { politeness: 'polite' });
       return;
     }
@@ -697,6 +701,9 @@ export function HealthMarkerPromptScreen() {
   };
 
   const onContinueFromFoodDiary = async () => {
+    if (foodDiaryContinueDisabled) {
+      return;
+    }
     setFoodDiaryDecision(foodEntries.length > 0 ? 'saved' : 'skipped');
     setFoodDiaryFeedback(null);
     setPhase('postMarkers');
@@ -1755,11 +1762,15 @@ export function HealthMarkerPromptScreen() {
                     ? 'Skip food diary entry'
                     : 'Continue after food diary'
                 }
+                accessibilityState={{ disabled: foodDiaryContinueDisabled }}
+                disabled={foodDiaryContinueDisabled}
                 onPress={() => {
                   void onContinueFromFoodDiary();
                 }}
                 style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
                 className={`w-full items-center justify-center rounded-lg bg-red-700 px-3 py-3 active:opacity-90 dark:bg-red-600 ${
+                  foodDiaryContinueDisabled ? 'opacity-50' : ''
+                } ${
                   editingFoodEntryId == null && !isAddFoodEntryOpen
                     ? 'mt-5'
                     : 'mt-3'
@@ -2161,11 +2172,9 @@ export function HealthMarkerPromptScreen() {
                   <Pressable
                     accessibilityRole="button"
                     accessibilityLabel={
-                      lines.length === 0
-                        ? 'Continue to episode details'
-                        : activeIndex >= lines.length - 1
-                          ? 'Next health marker'
-                          : 'Next health marker'
+                      continueToFoodDiary
+                        ? 'Continue to food diary'
+                        : 'Next health marker'
                     }
                     accessibilityState={{ disabled: saving }}
                     disabled={saving}
@@ -2178,11 +2187,9 @@ export function HealthMarkerPromptScreen() {
                     <Text className="text-center text-[17px] font-semibold text-white">
                       {saving
                         ? 'Saving…'
-                        : lines.length === 0
-                          ? 'Continue to episode details'
-                          : activeIndex >= lines.length - 1
-                            ? 'Next'
-                            : 'Next'}
+                        : continueToFoodDiary
+                          ? 'Continue to food diary'
+                          : 'Next'}
                     </Text>
                   </Pressable>
                 </View>

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -263,12 +263,22 @@ export function HealthMarkerPromptScreen() {
   const [postFeedback, setPostFeedback] = useState<string | null>(null);
   const [mealTag, setMealTag] = useState<MealTag | null>(null);
   const [foodNote, setFoodNote] = useState('');
-  const [foodLoggedDate, setFoodLoggedDate] = useState(currentLocalDate);
-  const [foodLoggedTime, setFoodLoggedTime] = useState(currentLocalTime);
-  const [addFoodInitialDate, setAddFoodInitialDate] =
-    useState(currentLocalDate);
-  const [addFoodInitialTime, setAddFoodInitialTime] =
-    useState(currentLocalTime);
+  const initialFoodDateTimeRef = useRef({
+    date: currentLocalDate(),
+    time: currentLocalTime(),
+  });
+  const [foodLoggedDate, setFoodLoggedDate] = useState(
+    initialFoodDateTimeRef.current.date,
+  );
+  const [foodLoggedTime, setFoodLoggedTime] = useState(
+    initialFoodDateTimeRef.current.time,
+  );
+  const [addFoodInitialDate, setAddFoodInitialDate] = useState(
+    initialFoodDateTimeRef.current.date,
+  );
+  const [addFoodInitialTime, setAddFoodInitialTime] = useState(
+    initialFoodDateTimeRef.current.time,
+  );
   const [foodEntries, setFoodEntries] = useState<FoodDiaryEntryRow[]>([]);
   const [foodEntriesLoading, setFoodEntriesLoading] = useState(false);
   const [foodEntriesError, setFoodEntriesError] = useState<string | null>(null);

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -438,7 +438,10 @@ export function HealthMarkerPromptScreen() {
   const continueToFoodDiary =
     lines.length === 0 || activeIndex >= lines.length - 1;
   const foodDiaryContinueDisabled =
-    savingFoodDiary || deletingFoodEntryId != null || foodEntriesLoading;
+    savingFoodDiary ||
+    deletingFoodEntryId != null ||
+    foodEntriesLoading ||
+    foodEntriesError != null;
 
   const onUpdateDraft = (patch: Partial<MarkerDraft>) => {
     if (!currentLine) {
@@ -1230,13 +1233,33 @@ export function HealthMarkerPromptScreen() {
                 </Text>
               ) : null}
               {foodEntriesError ? (
-                <Text
-                  className={`mb-2 text-sm ${nw.textError}`}
-                  accessibilityLiveRegion="assertive"
-                  maxFontSizeMultiplier={2}
-                >
-                  {foodEntriesError}
-                </Text>
+                <View className="mb-3">
+                  <Text
+                    className={`mb-2 text-sm ${nw.textError}`}
+                    accessibilityLiveRegion="assertive"
+                    maxFontSizeMultiplier={2}
+                  >
+                    {foodEntriesError}
+                  </Text>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Try again to load food diary entries"
+                    accessibilityState={{ disabled: foodEntriesLoading }}
+                    disabled={foodEntriesLoading}
+                    onPress={() => {
+                      void loadFoodEntries();
+                    }}
+                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                    className="w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 disabled:opacity-50 dark:border-app-border-dark"
+                  >
+                    <Text
+                      className={`text-base font-medium ${nw.textInk}`}
+                      maxFontSizeMultiplier={2}
+                    >
+                      {foodEntriesLoading ? 'Retrying…' : 'Try again'}
+                    </Text>
+                  </Pressable>
+                </View>
               ) : null}
               {!foodEntriesLoading &&
               !foodEntriesError &&
@@ -1730,9 +1753,11 @@ export function HealthMarkerPromptScreen() {
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={
-                  foodEntries.length === 0
-                    ? 'Skip food diary entry'
-                    : 'Continue after food diary'
+                  foodEntriesError != null
+                    ? 'Continue disabled until food entries load successfully'
+                    : foodEntries.length === 0
+                      ? 'Skip food diary entry'
+                      : 'Continue after food diary'
                 }
                 accessibilityState={{ disabled: foodDiaryContinueDisabled }}
                 disabled={foodDiaryContinueDisabled}

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -438,10 +438,7 @@ export function HealthMarkerPromptScreen() {
   const continueToFoodDiary =
     lines.length === 0 || activeIndex >= lines.length - 1;
   const foodDiaryContinueDisabled =
-    savingFoodDiary ||
-    deletingFoodEntryId != null ||
-    foodEntriesLoading ||
-    foodEntriesError != null;
+    savingFoodDiary || deletingFoodEntryId != null || foodEntriesLoading;
 
   const onUpdateDraft = (patch: Partial<MarkerDraft>) => {
     if (!currentLine) {
@@ -672,7 +669,13 @@ export function HealthMarkerPromptScreen() {
     }
     setFoodDatePickerOpen(false);
     setFoodTimePickerOpen(false);
-    setFoodDiaryDecision(foodEntries.length > 0 ? 'saved' : 'skipped');
+    setFoodDiaryDecision(
+      foodEntriesError != null
+        ? 'skipped'
+        : foodEntries.length > 0
+          ? 'saved'
+          : 'skipped',
+    );
     setFoodDiaryFeedback(null);
     setPhase('postMarkers');
     await announce('Continue to episode details.', {
@@ -1759,11 +1762,9 @@ export function HealthMarkerPromptScreen() {
               <Pressable
                 accessibilityRole="button"
                 accessibilityLabel={
-                  foodEntriesError != null
-                    ? 'Continue disabled until food entries load successfully'
-                    : foodEntries.length === 0
-                      ? 'Skip food diary entry'
-                      : 'Continue after food diary'
+                  foodEntries.length === 0
+                    ? 'Skip food diary entry'
+                    : 'Continue after food diary'
                 }
                 accessibilityState={{ disabled: foodDiaryContinueDisabled }}
                 disabled={foodDiaryContinueDisabled}

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -855,8 +855,13 @@ export function HealthMarkerPromptScreen() {
   }, [foodLoggedDateTimeValue]);
 
   const onFoodDatePickerChange = useCallback(
-    (_event: DateTimePickerEvent, selectedDate?: Date) => {
-      setFoodDatePickerOpen(false);
+    (event: DateTimePickerEvent, selectedDate?: Date) => {
+      if (Platform.OS === 'android') {
+        setFoodDatePickerOpen(false);
+      }
+      if (event.type === 'dismissed') {
+        return;
+      }
       if (!selectedDate) {
         return;
       }
@@ -883,8 +888,13 @@ export function HealthMarkerPromptScreen() {
   );
 
   const onFoodTimePickerChange = useCallback(
-    (_event: DateTimePickerEvent, selectedDate?: Date) => {
-      setFoodTimePickerOpen(false);
+    (event: DateTimePickerEvent, selectedDate?: Date) => {
+      if (Platform.OS === 'android') {
+        setFoodTimePickerOpen(false);
+      }
+      if (event.type === 'dismissed') {
+        return;
+      }
       if (!selectedDate) {
         return;
       }
@@ -1366,17 +1376,16 @@ export function HealthMarkerPromptScreen() {
                         Edit food entry
                       </Text>
                       <View
-                        accessibilityRole="radiogroup"
                         accessibilityLabel="Meal tag"
                         className="mb-3 gap-2"
                       >
                         {MEAL_TAGS.map((tag) => (
                           <Pressable
                             key={`${entry.id}-${tag}`}
-                            accessibilityRole="radio"
+                            accessibilityRole="button"
                             accessibilityLabel={tag}
                             accessibilityState={{
-                              checked: mealTag === tag,
+                              selected: mealTag === tag,
                               disabled: savingFoodDiary,
                             }}
                             disabled={savingFoodDiary}
@@ -1557,18 +1566,14 @@ export function HealthMarkerPromptScreen() {
                   >
                     Add food entry
                   </Text>
-                  <View
-                    accessibilityRole="radiogroup"
-                    accessibilityLabel="Meal tag"
-                    className="mb-4 gap-2"
-                  >
+                  <View accessibilityLabel="Meal tag" className="mb-4 gap-2">
                     {MEAL_TAGS.map((tag) => (
                       <Pressable
                         key={`add-${tag}`}
-                        accessibilityRole="radio"
+                        accessibilityRole="button"
                         accessibilityLabel={tag}
                         accessibilityState={{
-                          checked: mealTag === tag,
+                          selected: mealTag === tag,
                           disabled: savingFoodDiary,
                         }}
                         disabled={savingFoodDiary}

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -192,6 +192,28 @@ function parseOptionalNumber(raw: string | undefined): number | null {
 }
 
 /**
+ * Formats a stored `logged_at` instant for list display: short date + 12-hour time
+ * (aligned with food diary picker labels in this screen).
+ */
+function formatFoodDiaryLoggedAtForDisplay(iso: string): string {
+  const d = new Date(iso);
+  if (!Number.isFinite(d.getTime())) {
+    return iso;
+  }
+  const dateStr = d.toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+  const timeStr = d.toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+    hour12: true,
+  });
+  return `${dateStr}, ${timeStr}`;
+}
+
+/**
  * Linear in-episode health marker stepper that follows the symptom phase.
  *
  * @returns One marker at a time with manual numeric entry and persistence.
@@ -1295,7 +1317,7 @@ export function HealthMarkerPromptScreen() {
                     className={`mt-1 text-sm ${nw.textMuted}`}
                     maxFontSizeMultiplier={2}
                   >
-                    {new Date(entry.logged_at).toLocaleString()}
+                    {formatFoodDiaryLoggedAtForDisplay(entry.logged_at)}
                   </Text>
                   <Text
                     className={`mt-2 text-sm ${nw.textInk}`}

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -5,12 +5,8 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import { Ionicons } from '@expo/vector-icons';
-import DateTimePicker from '@react-native-community/datetimepicker';
-import type { DateTimePickerEvent } from '@react-native-community/datetimepicker';
 import {
   Alert,
-  Platform,
   Pressable,
   ScrollView,
   Text,
@@ -27,48 +23,34 @@ import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type {
   EpisodeRow,
   EpisodeType,
-  FoodDiaryEntryRow,
   HealthMarkerRow,
-  MealTag,
   PresetHealthMarkerRow,
 } from '@abstrack/types';
 import {
   bacReadingSuggestsAbsEpisode,
   formatEpisodeDurationSimple,
-  MEAL_TAGS,
   PRESET_HEALTH_MARKER_KIND_LABELS,
   validatePresetHealthMarkerCustomFields,
 } from '@abstrack/types';
 import {
   cancelActiveEpisodeById,
   completeEpisodePostMarkerStep,
-  createFoodDiaryEntry,
-  deleteFoodDiaryEntry,
   endEpisodeIfStillActive,
   getEpisodeById,
-  listFoodDiaryEntriesForEpisode,
   listEpisodeHealthMarkersForEpisode,
   listPresetHealthMarkersForPreset,
-  updateFoodDiaryEntry,
   upsertEpisodeHealthMarkerForLine,
 } from '@abstrack/supabase';
 import { announce, COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
-import {
-  currentLocalDate,
-  currentLocalTime,
-  isoToLocalDate,
-  isoToLocalTime,
-  localDateFromDate,
-  localDateTimeToIso,
-  localTimeFromDate,
-} from '../../lib/food-diary/date-time';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
 import { ScreenShell } from '../components/ScreenShell';
 import type { MainStackParamList } from '../navigation/types';
 import { useAppTheme } from '../theme/AppThemeContext';
 import { nw } from '../theme/app-nativewind-classes';
+import { HealthMarkerFoodDiaryStep } from './HealthMarkerFoodDiaryStep';
+import { useHealthMarkerFoodDiary } from './use-health-marker-food-diary';
 
 type HealthMarkerPromptRoute = RouteProp<
   MainStackParamList,
@@ -192,28 +174,6 @@ function parseOptionalNumber(raw: string | undefined): number | null {
 }
 
 /**
- * Formats a stored `logged_at` instant for list display: short date + 12-hour time
- * (aligned with food diary picker labels in this screen).
- */
-function formatFoodDiaryLoggedAtForDisplay(iso: string): string {
-  const d = new Date(iso);
-  if (!Number.isFinite(d.getTime())) {
-    return iso;
-  }
-  const dateStr = d.toLocaleDateString(undefined, {
-    year: 'numeric',
-    month: 'short',
-    day: 'numeric',
-  });
-  const timeStr = d.toLocaleTimeString(undefined, {
-    hour: 'numeric',
-    minute: '2-digit',
-    hour12: true,
-  });
-  return `${dateStr}, ${timeStr}`;
-}
-
-/**
  * Linear in-episode health marker stepper that follows the symptom phase.
  *
  * @returns One marker at a time with manual numeric entry and persistence.
@@ -246,41 +206,6 @@ export function HealthMarkerPromptScreen() {
   const [postNote, setPostNote] = useState('');
   const [savingPost, setSavingPost] = useState(false);
   const [postFeedback, setPostFeedback] = useState<string | null>(null);
-  const [mealTag, setMealTag] = useState<MealTag | null>(null);
-  const [foodNote, setFoodNote] = useState('');
-  const initialFoodDateTimeRef = useRef({
-    date: currentLocalDate(),
-    time: currentLocalTime(),
-  });
-  const [foodLoggedDate, setFoodLoggedDate] = useState(
-    initialFoodDateTimeRef.current.date,
-  );
-  const [foodLoggedTime, setFoodLoggedTime] = useState(
-    initialFoodDateTimeRef.current.time,
-  );
-  const [addFoodInitialDate, setAddFoodInitialDate] = useState(
-    initialFoodDateTimeRef.current.date,
-  );
-  const [addFoodInitialTime, setAddFoodInitialTime] = useState(
-    initialFoodDateTimeRef.current.time,
-  );
-  const [foodEntries, setFoodEntries] = useState<FoodDiaryEntryRow[]>([]);
-  const [foodEntriesLoading, setFoodEntriesLoading] = useState(false);
-  const [foodEntriesError, setFoodEntriesError] = useState<string | null>(null);
-  const [savingFoodDiary, setSavingFoodDiary] = useState(false);
-  const [foodDiaryFeedback, setFoodDiaryFeedback] = useState<string | null>(
-    null,
-  );
-  const [editingFoodEntryId, setEditingFoodEntryId] = useState<string | null>(
-    null,
-  );
-  const [deletingFoodEntryId, setDeletingFoodEntryId] = useState<string | null>(
-    null,
-  );
-  const [isAddFoodEntryOpen, setIsAddFoodEntryOpen] = useState(true);
-  const [isAddFoodEntryDirty, setIsAddFoodEntryDirty] = useState(false);
-  const [foodDatePickerOpen, setFoodDatePickerOpen] = useState(false);
-  const [foodTimePickerOpen, setFoodTimePickerOpen] = useState(false);
   const [foodDiaryDecision, setFoodDiaryDecision] = useState<
     'pending' | 'saved' | 'skipped'
   >('pending');
@@ -292,6 +217,33 @@ export function HealthMarkerPromptScreen() {
   } | null>(null);
   const postFormInitRef = useRef(false);
   const [cancelingEpisode, setCancelingEpisode] = useState(false);
+
+  const supabase = useMemo(() => getMobileSupabaseClient(), []);
+  /** Bumps when the screen unmounts or `load` deps change so stale async work does not setState. */
+  const loadGenerationRef = useRef(0);
+
+  const onLeaveFoodDiary = useCallback(
+    async (decision: 'saved' | 'skipped') => {
+      setFoodDiaryDecision(decision);
+      setPhase('postMarkers');
+    },
+    [],
+  );
+
+  const onBackToHealthMarkersFromFoodDiaryBody = useCallback(async () => {
+    setPhase('prompting');
+    await announce('Returned to health markers.', { politeness: 'polite' });
+  }, []);
+
+  const foodDiary = useHealthMarkerFoodDiary({
+    episodeId,
+    userId,
+    supabase,
+    enabled: phase === 'foodDiary',
+    onLeaveFoodDiary,
+    onBack: onBackToHealthMarkersFromFoodDiaryBody,
+  });
+  const resetFoodDiaryState = foodDiary.reset;
 
   useEffect(() => {
     setPersistFeedback(null);
@@ -311,10 +263,6 @@ export function HealthMarkerPromptScreen() {
     setPostNote(episodeRow.note ?? '');
   }, [phase, episodeRow, bacSuggestAbs]);
 
-  const supabase = useMemo(() => getMobileSupabaseClient(), []);
-  /** Bumps when the screen unmounts or `load` deps change so stale async work does not setState. */
-  const loadGenerationRef = useRef(0);
-
   const load = useCallback(async () => {
     const generation = ++loadGenerationRef.current;
     const stale = () => generation !== loadGenerationRef.current;
@@ -325,24 +273,7 @@ export function HealthMarkerPromptScreen() {
     setPhase('prompting');
     postFormInitRef.current = false;
     setPostFeedback(null);
-    const initialFoodDate = currentLocalDate();
-    const initialFoodTime = currentLocalTime();
-    setMealTag(null);
-    setFoodNote('');
-    setFoodLoggedDate(initialFoodDate);
-    setFoodLoggedTime(initialFoodTime);
-    setAddFoodInitialDate(initialFoodDate);
-    setAddFoodInitialTime(initialFoodTime);
-    setFoodEntries([]);
-    setFoodEntriesLoading(false);
-    setFoodEntriesError(null);
-    setSavingFoodDiary(false);
-    setFoodDiaryFeedback(null);
-    setEditingFoodEntryId(null);
-    setIsAddFoodEntryOpen(true);
-    setIsAddFoodEntryDirty(false);
-    setFoodDatePickerOpen(false);
-    setFoodTimePickerOpen(false);
+    resetFoodDiaryState();
     setFoodDiaryDecision('pending');
     setEndFeedback(null);
     setEndedSummary(null);
@@ -437,7 +368,7 @@ export function HealthMarkerPromptScreen() {
       setActiveIndex(0);
     }
     setStatus('ready');
-  }, [episodeId, resume, supabase]);
+  }, [episodeId, resetFoodDiaryState, resume, supabase]);
 
   useEffect(() => {
     void load();
@@ -459,8 +390,6 @@ export function HealthMarkerPromptScreen() {
   const skipPressable = canSkip && !saving;
   const continueToFoodDiary =
     lines.length === 0 || activeIndex >= lines.length - 1;
-  const foodDiaryContinueDisabled =
-    savingFoodDiary || deletingFoodEntryId != null || foodEntriesLoading;
 
   const onUpdateDraft = (patch: Partial<MarkerDraft>) => {
     if (!currentLine) {
@@ -612,107 +541,6 @@ export function HealthMarkerPromptScreen() {
     await announce('Episode details saved.', { politeness: 'polite' });
   };
 
-  const onSaveFoodDiary = async () => {
-    if (savingFoodDiary || !userId) {
-      return;
-    }
-    setSavingFoodDiary(true);
-    setFoodDiaryFeedback(null);
-    if (!mealTag) {
-      const message = 'Choose a meal tag.';
-      setFoodDiaryFeedback(message);
-      await announce(message, { politeness: 'assertive' });
-      setSavingFoodDiary(false);
-      return;
-    }
-    const loggedAtIso = localDateTimeToIso(foodLoggedDate, foodLoggedTime);
-    if (!loggedAtIso) {
-      const message = 'Enter a valid date and time.';
-      setFoodDiaryFeedback(message);
-      await announce(message, { politeness: 'assertive' });
-      setSavingFoodDiary(false);
-      return;
-    }
-    const result =
-      editingFoodEntryId == null
-        ? await createFoodDiaryEntry(supabase, {
-            user_id: userId,
-            episode_id: episodeId,
-            meal_tag: mealTag,
-            food_note: foodNote,
-            logged_at: loggedAtIso,
-          })
-        : await updateFoodDiaryEntry(supabase, editingFoodEntryId, {
-            meal_tag: mealTag,
-            food_note: foodNote,
-            logged_at: loggedAtIso,
-          });
-    setSavingFoodDiary(false);
-    if (!result.ok) {
-      setFoodDiaryFeedback(result.error.message);
-      await announce(result.error.message, { politeness: 'assertive' });
-      return;
-    }
-    const foodEntriesResult = await listFoodDiaryEntriesForEpisode(
-      supabase,
-      episodeId,
-    );
-    if (foodEntriesResult.ok) {
-      setFoodEntries(foodEntriesResult.data);
-      setFoodEntriesError(null);
-    } else {
-      setFoodEntriesError(foodEntriesResult.error.message);
-    }
-    const initialFoodDate = currentLocalDate();
-    const initialFoodTime = currentLocalTime();
-    setMealTag(null);
-    setFoodNote('');
-    setFoodLoggedDate(initialFoodDate);
-    setFoodLoggedTime(initialFoodTime);
-    setAddFoodInitialDate(initialFoodDate);
-    setAddFoodInitialTime(initialFoodTime);
-    setEditingFoodEntryId(null);
-    setIsAddFoodEntryDirty(false);
-    setFoodDatePickerOpen(false);
-    setFoodTimePickerOpen(false);
-    if (editingFoodEntryId == null) {
-      setIsAddFoodEntryOpen(false);
-    }
-    setFoodDiaryFeedback(null);
-    await announce(
-      editingFoodEntryId == null ? 'Food entry saved.' : 'Food entry updated.',
-      { politeness: 'polite' },
-    );
-  };
-
-  const onContinueFromFoodDiary = async () => {
-    if (foodDiaryContinueDisabled) {
-      return;
-    }
-    setFoodDatePickerOpen(false);
-    setFoodTimePickerOpen(false);
-    setFoodDiaryDecision(
-      foodEntriesError != null
-        ? 'skipped'
-        : foodEntries.length > 0
-          ? 'saved'
-          : 'skipped',
-    );
-    setFoodDiaryFeedback(null);
-    setPhase('postMarkers');
-    await announce('Continue to episode details.', {
-      politeness: 'polite',
-    });
-  };
-
-  const onBackToHealthMarkersFromFoodDiary = async () => {
-    setFoodDatePickerOpen(false);
-    setFoodTimePickerOpen(false);
-    setFoodDiaryFeedback(null);
-    setPhase('prompting');
-    await announce('Returned to health markers.', { politeness: 'polite' });
-  };
-
   const onBackToSymptomsFromHealthMarkers = useCallback(async () => {
     const symptomPresetId = episodeRow?.symptom_preset_id;
     if (!symptomPresetId) {
@@ -730,255 +558,10 @@ export function HealthMarkerPromptScreen() {
   }, [episodeId, episodeRow, navigation]);
 
   const onBackToFoodDiaryFromPostMarkers = async () => {
-    setFoodDatePickerOpen(false);
-    setFoodTimePickerOpen(false);
     setPostFeedback(null);
     setPhase('foodDiary');
     await announce('Returned to food diary.', { politeness: 'polite' });
   };
-
-  const onEditFoodEntry = (entry: FoodDiaryEntryRow) => {
-    setEditingFoodEntryId(entry.id);
-    setIsAddFoodEntryOpen(false);
-    setIsAddFoodEntryDirty(false);
-    setFoodDatePickerOpen(false);
-    setFoodTimePickerOpen(false);
-    setMealTag(entry.meal_tag);
-    setFoodNote(entry.food_note);
-    setFoodLoggedDate(isoToLocalDate(entry.logged_at));
-    setFoodLoggedTime(isoToLocalTime(entry.logged_at));
-    setFoodDiaryFeedback(null);
-  };
-
-  const onNewFoodEntry = () => {
-    setEditingFoodEntryId(null);
-    const initialFoodDate = currentLocalDate();
-    const initialFoodTime = currentLocalTime();
-    setMealTag(null);
-    setFoodNote('');
-    setFoodLoggedDate(initialFoodDate);
-    setFoodLoggedTime(initialFoodTime);
-    setAddFoodInitialDate(initialFoodDate);
-    setAddFoodInitialTime(initialFoodTime);
-    setFoodDiaryFeedback(null);
-    setIsAddFoodEntryDirty(false);
-    setFoodDatePickerOpen(false);
-    setFoodTimePickerOpen(false);
-    setIsAddFoodEntryOpen(true);
-  };
-
-  const onDiscardFoodEditChanges = () => {
-    setEditingFoodEntryId(null);
-    setMealTag(null);
-    setFoodNote('');
-    setFoodLoggedDate(currentLocalDate());
-    setFoodLoggedTime(currentLocalTime());
-    setFoodDiaryFeedback(null);
-    setIsAddFoodEntryDirty(false);
-    setFoodDatePickerOpen(false);
-    setFoodTimePickerOpen(false);
-    setIsAddFoodEntryOpen(false);
-  };
-
-  const computeIsAddFoodEntryDirty = useCallback(
-    (next: {
-      mealTag: MealTag | null;
-      foodNote: string;
-      foodLoggedDate: string;
-      foodLoggedTime: string;
-    }) => {
-      return (
-        next.mealTag != null ||
-        next.foodNote.trim().length > 0 ||
-        next.foodLoggedDate !== addFoodInitialDate ||
-        next.foodLoggedTime !== addFoodInitialTime
-      );
-    },
-    [addFoodInitialDate, addFoodInitialTime],
-  );
-
-  const onDiscardAddFoodDraft = useCallback(() => {
-    if (!isAddFoodEntryDirty) {
-      setIsAddFoodEntryOpen(false);
-      return;
-    }
-    Alert.alert(
-      'Discard this food entry draft?',
-      'Your unsaved entry will be removed.',
-      [
-        { text: 'Keep editing', style: 'cancel' },
-        {
-          text: 'Discard entry',
-          style: 'destructive',
-          onPress: () => {
-            const initialFoodDate = currentLocalDate();
-            const initialFoodTime = currentLocalTime();
-            setMealTag(null);
-            setFoodNote('');
-            setFoodLoggedDate(initialFoodDate);
-            setFoodLoggedTime(initialFoodTime);
-            setAddFoodInitialDate(initialFoodDate);
-            setAddFoodInitialTime(initialFoodTime);
-            setIsAddFoodEntryDirty(false);
-            setFoodDiaryFeedback(null);
-            setFoodDatePickerOpen(false);
-            setFoodTimePickerOpen(false);
-            setIsAddFoodEntryOpen(false);
-          },
-        },
-      ],
-    );
-  }, [isAddFoodEntryDirty]);
-
-  const foodLoggedDateTimeValue = useMemo(() => {
-    const iso = localDateTimeToIso(foodLoggedDate, foodLoggedTime);
-    return iso ? new Date(iso) : new Date();
-  }, [foodLoggedDate, foodLoggedTime]);
-
-  const foodLoggedDateLabel = useMemo(() => {
-    return foodLoggedDateTimeValue.toLocaleDateString(undefined, {
-      year: 'numeric',
-      month: 'short',
-      day: 'numeric',
-    });
-  }, [foodLoggedDateTimeValue]);
-
-  const foodLoggedTimeLabel = useMemo(() => {
-    return foodLoggedDateTimeValue.toLocaleTimeString(undefined, {
-      hour: 'numeric',
-      minute: '2-digit',
-      hour12: true,
-    });
-  }, [foodLoggedDateTimeValue]);
-
-  const onFoodDatePickerChange = useCallback(
-    (event: DateTimePickerEvent, selectedDate?: Date) => {
-      if (Platform.OS === 'android') {
-        setFoodDatePickerOpen(false);
-      }
-      if (event.type === 'dismissed') {
-        return;
-      }
-      if (!selectedDate) {
-        return;
-      }
-      const nextDate = localDateFromDate(selectedDate);
-      setFoodLoggedDate(nextDate);
-      if (editingFoodEntryId == null) {
-        setIsAddFoodEntryDirty(
-          computeIsAddFoodEntryDirty({
-            mealTag,
-            foodNote,
-            foodLoggedDate: nextDate,
-            foodLoggedTime,
-          }),
-        );
-      }
-    },
-    [
-      computeIsAddFoodEntryDirty,
-      editingFoodEntryId,
-      foodLoggedTime,
-      foodNote,
-      mealTag,
-    ],
-  );
-
-  const onFoodTimePickerChange = useCallback(
-    (event: DateTimePickerEvent, selectedDate?: Date) => {
-      if (Platform.OS === 'android') {
-        setFoodTimePickerOpen(false);
-      }
-      if (event.type === 'dismissed') {
-        return;
-      }
-      if (!selectedDate) {
-        return;
-      }
-      const nextTime = localTimeFromDate(selectedDate);
-      setFoodLoggedTime(nextTime);
-      if (editingFoodEntryId == null) {
-        setIsAddFoodEntryDirty(
-          computeIsAddFoodEntryDirty({
-            mealTag,
-            foodNote,
-            foodLoggedDate,
-            foodLoggedTime: nextTime,
-          }),
-        );
-      }
-    },
-    [
-      computeIsAddFoodEntryDirty,
-      editingFoodEntryId,
-      foodLoggedDate,
-      foodNote,
-      mealTag,
-    ],
-  );
-
-  const loadFoodEntries = useCallback(async () => {
-    setFoodEntriesLoading(true);
-    setFoodEntriesError(null);
-    const result = await listFoodDiaryEntriesForEpisode(supabase, episodeId);
-    setFoodEntriesLoading(false);
-    if (!result.ok) {
-      setFoodEntriesError(result.error.message);
-      return;
-    }
-    setFoodEntries(result.data);
-  }, [episodeId, supabase]);
-
-  const onDeleteFoodEntry = useCallback(
-    (entryId: string) => {
-      if (savingFoodDiary || deletingFoodEntryId) {
-        return;
-      }
-      Alert.alert('Discard this saved food entry?', 'This cannot be undone.', [
-        { text: 'Keep entry', style: 'cancel' },
-        {
-          text: 'Discard entry',
-          style: 'destructive',
-          onPress: () => {
-            void (async () => {
-              setDeletingFoodEntryId(entryId);
-              setFoodDiaryFeedback(null);
-              const result = await deleteFoodDiaryEntry(supabase, entryId);
-              setDeletingFoodEntryId(null);
-              if (!result.ok) {
-                setFoodDiaryFeedback(result.error.message);
-                await announce(result.error.message, {
-                  politeness: 'assertive',
-                });
-                return;
-              }
-              if (editingFoodEntryId === entryId) {
-                onNewFoodEntry();
-                setIsAddFoodEntryOpen(false);
-              }
-              await loadFoodEntries();
-              await announce('Food entry discarded.', { politeness: 'polite' });
-            })();
-          },
-        },
-      ]);
-    },
-    [
-      deletingFoodEntryId,
-      editingFoodEntryId,
-      loadFoodEntries,
-      onNewFoodEntry,
-      savingFoodDiary,
-      supabase,
-    ],
-  );
-
-  useEffect(() => {
-    if (phase !== 'foodDiary') {
-      return;
-    }
-    void loadFoodEntries();
-  }, [phase, loadFoodEntries]);
 
   const onCancelEpisodePress = () => {
     if (cancelingEpisode) {
@@ -1234,614 +817,11 @@ export function HealthMarkerPromptScreen() {
             )}
           </View>
         ) : phase === 'foodDiary' ? (
-          <>
-            <ScrollView
-              className="flex-1"
-              keyboardShouldPersistTaps="handled"
-              contentContainerStyle={{ paddingBottom: 24 }}
-            >
-              <Text
-                className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
-                maxFontSizeMultiplier={2}
-              >
-                Add one or more meals/snacks for this episode, or skip this
-                step.
-              </Text>
-              <Text
-                accessibilityRole="header"
-                className={`mb-2 text-lg font-semibold ${nw.textInk}`}
-                maxFontSizeMultiplier={2}
-              >
-                Saved entries
-              </Text>
-              {foodEntriesLoading ? (
-                <Text
-                  className={`mb-2 text-sm ${nw.textMuted}`}
-                  accessibilityLiveRegion="polite"
-                  maxFontSizeMultiplier={2}
-                >
-                  Loading entries…
-                </Text>
-              ) : null}
-              {foodEntriesError ? (
-                <View className="mb-3">
-                  <Text
-                    className={`mb-2 text-sm ${nw.textError}`}
-                    accessibilityLiveRegion="assertive"
-                    maxFontSizeMultiplier={2}
-                  >
-                    {foodEntriesError}
-                  </Text>
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel="Try again to load food diary entries"
-                    accessibilityState={{ disabled: foodEntriesLoading }}
-                    disabled={foodEntriesLoading}
-                    onPress={() => {
-                      void loadFoodEntries();
-                    }}
-                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                    className="w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 disabled:opacity-50 dark:border-app-border-dark"
-                  >
-                    <Text
-                      className={`text-base font-medium ${nw.textInk}`}
-                      maxFontSizeMultiplier={2}
-                    >
-                      {foodEntriesLoading ? 'Retrying…' : 'Try again'}
-                    </Text>
-                  </Pressable>
-                </View>
-              ) : null}
-              {!foodEntriesLoading &&
-              !foodEntriesError &&
-              foodEntries.length === 0 ? (
-                <Text
-                  className={`mb-3 text-sm ${nw.textMuted}`}
-                  maxFontSizeMultiplier={2}
-                >
-                  No food entries yet for this episode.
-                </Text>
-              ) : null}
-              {foodEntries.map((entry) => (
-                <View
-                  key={entry.id}
-                  className="mb-3 rounded-xl border border-app-border bg-app-bg p-3 dark:border-app-border-dark dark:bg-app-bg-dark"
-                >
-                  <Text
-                    className={`text-base font-semibold ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
-                  >
-                    {entry.meal_tag}
-                  </Text>
-                  <Text
-                    className={`mt-1 text-sm ${nw.textMuted}`}
-                    maxFontSizeMultiplier={2}
-                  >
-                    {formatFoodDiaryLoggedAtForDisplay(entry.logged_at)}
-                  </Text>
-                  <Text
-                    className={`mt-2 text-sm ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
-                  >
-                    {entry.food_note}
-                  </Text>
-                  {editingFoodEntryId !== entry.id ? (
-                    <View className="mt-2 flex-row items-center justify-end gap-2">
-                      <Pressable
-                        accessibilityRole="button"
-                        accessibilityLabel={`Edit ${entry.meal_tag} food entry`}
-                        onPress={() => {
-                          onEditFoodEntry(entry);
-                        }}
-                        style={{
-                          minWidth: COMFORTABLE_TOUCH_TARGET_DP,
-                          minHeight: COMFORTABLE_TOUCH_TARGET_DP,
-                        }}
-                        className="items-center justify-center rounded-lg border border-app-border px-2 active:opacity-80 dark:border-app-border-dark"
-                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                      >
-                        <Ionicons
-                          name="pencil-outline"
-                          size={20}
-                          color={colors.muted}
-                          accessibilityElementsHidden
-                          importantForAccessibility="no"
-                        />
-                      </Pressable>
-                      <Pressable
-                        accessibilityRole="button"
-                        accessibilityLabel={`Discard ${entry.meal_tag} food entry`}
-                        accessibilityState={{
-                          disabled: deletingFoodEntryId != null,
-                        }}
-                        disabled={deletingFoodEntryId != null}
-                        onPress={() => {
-                          onDeleteFoodEntry(entry.id);
-                        }}
-                        style={{
-                          minWidth: COMFORTABLE_TOUCH_TARGET_DP,
-                          minHeight: COMFORTABLE_TOUCH_TARGET_DP,
-                        }}
-                        className="items-center justify-center rounded-lg border border-red-400 px-2 active:opacity-80 disabled:opacity-60 dark:border-red-500/60"
-                        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-                      >
-                        {deletingFoodEntryId === entry.id ? (
-                          <Text
-                            className="text-xs font-semibold text-red-700 dark:text-red-300"
-                            maxFontSizeMultiplier={2}
-                          >
-                            ...
-                          </Text>
-                        ) : (
-                          <Ionicons
-                            name="trash-outline"
-                            size={20}
-                            color={colors.error}
-                            accessibilityElementsHidden
-                            importantForAccessibility="no"
-                          />
-                        )}
-                      </Pressable>
-                    </View>
-                  ) : null}
-                  {editingFoodEntryId === entry.id ? (
-                    <View className="mt-3 rounded-lg border border-app-border p-3 dark:border-app-border-dark">
-                      <Text
-                        className={`mb-2 text-base font-semibold ${nw.textInk}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        Edit food entry
-                      </Text>
-                      <View
-                        accessibilityLabel="Meal tag"
-                        className="mb-3 gap-2"
-                      >
-                        {MEAL_TAGS.map((tag) => (
-                          <Pressable
-                            key={`${entry.id}-${tag}`}
-                            accessibilityRole="button"
-                            accessibilityLabel={tag}
-                            accessibilityState={{
-                              selected: mealTag === tag,
-                              disabled: savingFoodDiary,
-                            }}
-                            disabled={savingFoodDiary}
-                            onPress={() => {
-                              setMealTag((prev) => (prev === tag ? null : tag));
-                            }}
-                            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                            className={`w-full items-center justify-center rounded-xl border-2 px-3 py-3 dark:border-app-border-dark ${
-                              mealTag === tag
-                                ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
-                                : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
-                            }`}
-                          >
-                            <Text
-                              className={`text-center text-[17px] font-semibold ${nw.textInk}`}
-                              maxFontSizeMultiplier={2}
-                            >
-                              {tag}
-                            </Text>
-                          </Pressable>
-                        ))}
-                      </View>
-                      <Text
-                        className={`mb-1 text-base font-medium ${nw.textInk}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        Logged date
-                      </Text>
-                      <Pressable
-                        accessibilityRole="button"
-                        accessibilityLabel="Logged date"
-                        accessibilityState={{ disabled: savingFoodDiary }}
-                        disabled={savingFoodDiary}
-                        onPress={() => {
-                          setFoodDatePickerOpen((prev) => !prev);
-                          setFoodTimePickerOpen(false);
-                        }}
-                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                        className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
-                      >
-                        <Text
-                          className={`text-[17px] ${nw.textInk}`}
-                          maxFontSizeMultiplier={2}
-                        >
-                          {foodLoggedDateLabel}
-                        </Text>
-                      </Pressable>
-                      <Text
-                        className={`mb-1 text-base font-medium ${nw.textInk}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        Logged time
-                      </Text>
-                      <Pressable
-                        accessibilityRole="button"
-                        accessibilityLabel="Logged time"
-                        accessibilityState={{ disabled: savingFoodDiary }}
-                        disabled={savingFoodDiary}
-                        onPress={() => {
-                          setFoodTimePickerOpen((prev) => !prev);
-                          setFoodDatePickerOpen(false);
-                        }}
-                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                        className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
-                      >
-                        <Text
-                          className={`text-[17px] ${nw.textInk}`}
-                          maxFontSizeMultiplier={2}
-                        >
-                          {foodLoggedTimeLabel}
-                        </Text>
-                      </Pressable>
-                      <Text
-                        className={`mb-1 text-base font-medium ${nw.textInk}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        Food note
-                      </Text>
-                      <TextInput
-                        editable={!savingFoodDiary}
-                        accessibilityLabel="Food note"
-                        multiline
-                        value={foodNote}
-                        onChangeText={setFoodNote}
-                        placeholder="What did you eat or drink?"
-                        placeholderTextColor={colors.inputPlaceholder}
-                        className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-                        maxFontSizeMultiplier={2}
-                      />
-                      {foodDiaryFeedback ? (
-                        <Text
-                          className={`mb-2 text-sm ${nw.textError}`}
-                          accessibilityLiveRegion="assertive"
-                          maxFontSizeMultiplier={2}
-                        >
-                          {foodDiaryFeedback}
-                        </Text>
-                      ) : null}
-                      <Pressable
-                        accessibilityRole="button"
-                        accessibilityLabel={
-                          savingFoodDiary
-                            ? 'Saving food diary entry'
-                            : 'Update food entry'
-                        }
-                        accessibilityState={{ disabled: savingFoodDiary }}
-                        disabled={savingFoodDiary}
-                        onPress={() => {
-                          void onSaveFoodDiary();
-                        }}
-                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                        className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 disabled:opacity-60 dark:bg-red-600"
-                      >
-                        <Text className="text-center text-[17px] font-semibold text-white">
-                          {savingFoodDiary ? 'Saving…' : 'Update entry'}
-                        </Text>
-                      </Pressable>
-                      <Pressable
-                        accessibilityRole="button"
-                        accessibilityLabel="Cancel food entry edit"
-                        onPress={onDiscardFoodEditChanges}
-                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                        className="mt-3 w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
-                      >
-                        <Text
-                          className={`text-base font-medium ${nw.textInk}`}
-                          maxFontSizeMultiplier={2}
-                        >
-                          Discard changes
-                        </Text>
-                      </Pressable>
-                      <Pressable
-                        accessibilityRole="button"
-                        accessibilityLabel="Discard saved food entry"
-                        accessibilityState={{
-                          disabled: deletingFoodEntryId != null,
-                        }}
-                        disabled={deletingFoodEntryId != null}
-                        onPress={() => {
-                          onDeleteFoodEntry(entry.id);
-                        }}
-                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                        className="mt-3 w-full items-center justify-center rounded-lg border border-red-400 px-3 py-3 active:opacity-80 disabled:opacity-60 dark:border-red-500/60"
-                      >
-                        <Text
-                          className="text-base font-medium text-red-700 dark:text-red-300"
-                          maxFontSizeMultiplier={2}
-                        >
-                          {deletingFoodEntryId === entry.id
-                            ? 'Discarding…'
-                            : 'Discard entry'}
-                        </Text>
-                      </Pressable>
-                    </View>
-                  ) : null}
-                </View>
-              ))}
-              {editingFoodEntryId == null && !isAddFoodEntryOpen ? (
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel="Add food entry"
-                  onPress={onNewFoodEntry}
-                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                  className="w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
-                >
-                  <Text
-                    className={`text-base font-medium ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
-                  >
-                    Add food entry
-                  </Text>
-                </Pressable>
-              ) : null}
-              {editingFoodEntryId == null && isAddFoodEntryOpen ? (
-                <>
-                  <Text
-                    accessibilityRole="header"
-                    className={`mb-2 text-lg font-semibold ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
-                  >
-                    Add food entry
-                  </Text>
-                  <View accessibilityLabel="Meal tag" className="mb-4 gap-2">
-                    {MEAL_TAGS.map((tag) => (
-                      <Pressable
-                        key={`add-${tag}`}
-                        accessibilityRole="button"
-                        accessibilityLabel={tag}
-                        accessibilityState={{
-                          selected: mealTag === tag,
-                          disabled: savingFoodDiary,
-                        }}
-                        disabled={savingFoodDiary}
-                        onPress={() => {
-                          const nextMealTag = mealTag === tag ? null : tag;
-                          setMealTag(nextMealTag);
-                          setIsAddFoodEntryDirty(
-                            computeIsAddFoodEntryDirty({
-                              mealTag: nextMealTag,
-                              foodNote,
-                              foodLoggedDate,
-                              foodLoggedTime,
-                            }),
-                          );
-                        }}
-                        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                        className={`w-full items-center justify-center rounded-xl border-2 px-3 py-3 dark:border-app-border-dark ${
-                          mealTag === tag
-                            ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
-                            : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
-                        }`}
-                      >
-                        <Text
-                          className={`text-center text-[17px] font-semibold ${nw.textInk}`}
-                          maxFontSizeMultiplier={2}
-                        >
-                          {tag}
-                        </Text>
-                      </Pressable>
-                    ))}
-                  </View>
-                  <Text
-                    className={`mb-1 text-base font-medium ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
-                  >
-                    Logged date
-                  </Text>
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel="Logged date"
-                    accessibilityState={{ disabled: savingFoodDiary }}
-                    disabled={savingFoodDiary}
-                    onPress={() => {
-                      setFoodDatePickerOpen((prev) => !prev);
-                      setFoodTimePickerOpen(false);
-                    }}
-                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                    className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
-                  >
-                    <Text
-                      className={`text-[17px] ${nw.textInk}`}
-                      maxFontSizeMultiplier={2}
-                    >
-                      {foodLoggedDateLabel}
-                    </Text>
-                  </Pressable>
-                  <Text
-                    className={`mb-1 text-base font-medium ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
-                  >
-                    Logged time
-                  </Text>
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel="Logged time"
-                    accessibilityState={{ disabled: savingFoodDiary }}
-                    disabled={savingFoodDiary}
-                    onPress={() => {
-                      setFoodTimePickerOpen((prev) => !prev);
-                      setFoodDatePickerOpen(false);
-                    }}
-                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                    className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
-                  >
-                    <Text
-                      className={`text-[17px] ${nw.textInk}`}
-                      maxFontSizeMultiplier={2}
-                    >
-                      {foodLoggedTimeLabel}
-                    </Text>
-                  </Pressable>
-                  <Text
-                    className={`mb-1 text-base font-medium ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
-                  >
-                    Food note
-                  </Text>
-                  <TextInput
-                    editable={!savingFoodDiary}
-                    accessibilityLabel="Food note"
-                    multiline
-                    value={foodNote}
-                    onChangeText={(value) => {
-                      setFoodNote(value);
-                      setIsAddFoodEntryDirty(
-                        computeIsAddFoodEntryDirty({
-                          mealTag,
-                          foodNote: value,
-                          foodLoggedDate,
-                          foodLoggedTime,
-                        }),
-                      );
-                    }}
-                    placeholder="What did you eat or drink?"
-                    placeholderTextColor={colors.inputPlaceholder}
-                    className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
-                  />
-                  {foodDiaryFeedback ? (
-                    <Text
-                      className={`mb-2 text-sm ${nw.textError}`}
-                      accessibilityLiveRegion="assertive"
-                      maxFontSizeMultiplier={2}
-                    >
-                      {foodDiaryFeedback}
-                    </Text>
-                  ) : null}
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel={
-                      savingFoodDiary
-                        ? 'Saving food diary entry'
-                        : 'Save food entry'
-                    }
-                    accessibilityState={{ disabled: savingFoodDiary }}
-                    disabled={savingFoodDiary}
-                    onPress={() => {
-                      void onSaveFoodDiary();
-                    }}
-                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                    className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 disabled:opacity-60 dark:bg-red-600"
-                  >
-                    <Text className="text-center text-[17px] font-semibold text-white">
-                      {savingFoodDiary ? 'Saving…' : 'Save entry'}
-                    </Text>
-                  </Pressable>
-                  {isAddFoodEntryDirty ? (
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel="Discard food entry"
-                      onPress={onDiscardAddFoodDraft}
-                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                      className="mt-3 w-full items-center justify-center rounded-lg border border-red-400 px-3 py-3 active:opacity-80 dark:border-red-500/60"
-                    >
-                      <Text
-                        className="text-base font-medium text-red-700 dark:text-red-300"
-                        maxFontSizeMultiplier={2}
-                      >
-                        Discard entry
-                      </Text>
-                    </Pressable>
-                  ) : null}
-                  {!isAddFoodEntryDirty ? (
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel="Collapse add food entry"
-                      onPress={() => {
-                        setIsAddFoodEntryOpen(false);
-                      }}
-                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                      className="mt-3 w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
-                    >
-                      <Text
-                        className={`text-base font-medium ${nw.textInk}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        Collapse
-                      </Text>
-                    </Pressable>
-                  ) : null}
-                </>
-              ) : null}
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Back to health markers"
-                onPress={() => {
-                  void onBackToHealthMarkersFromFoodDiary();
-                }}
-                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                className="w-full items-center justify-center rounded-lg border border-app-border px-3 py-3 active:opacity-80 dark:border-app-border-dark"
-              >
-                <Text
-                  className={`text-base font-medium ${nw.textInk}`}
-                  maxFontSizeMultiplier={2}
-                >
-                  Back
-                </Text>
-              </Pressable>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={
-                  foodEntries.length === 0
-                    ? 'Skip food diary entry'
-                    : 'Continue after food diary'
-                }
-                accessibilityState={{ disabled: foodDiaryContinueDisabled }}
-                disabled={foodDiaryContinueDisabled}
-                onPress={() => {
-                  void onContinueFromFoodDiary();
-                }}
-                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                className={`w-full items-center justify-center rounded-lg bg-red-700 px-3 py-3 active:opacity-90 dark:bg-red-600 ${
-                  foodDiaryContinueDisabled ? 'opacity-50' : ''
-                } ${
-                  editingFoodEntryId == null && !isAddFoodEntryOpen
-                    ? 'mt-5'
-                    : 'mt-3'
-                }`}
-              >
-                <Text
-                  className="text-center text-base font-semibold text-white"
-                  maxFontSizeMultiplier={2}
-                >
-                  {foodEntries.length === 0 ? 'Skip for now' : 'Continue'}
-                </Text>
-              </Pressable>
-            </ScrollView>
-            {foodDatePickerOpen ? (
-              <DateTimePicker
-                value={foodLoggedDateTimeValue}
-                mode="date"
-                display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-                onChange={onFoodDatePickerChange}
-              />
-            ) : null}
-            {foodTimePickerOpen ? (
-              <DateTimePicker
-                value={foodLoggedDateTimeValue}
-                mode="time"
-                is24Hour={false}
-                display={Platform.OS === 'ios' ? 'spinner' : 'default'}
-                onChange={onFoodTimePickerChange}
-              />
-            ) : null}
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Cancel episode"
-              onPress={onCancelEpisodePress}
-              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-              className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
-            >
-              <Text
-                className="text-sm font-medium text-red-700 dark:text-red-300"
-                maxFontSizeMultiplier={2}
-              >
-                Cancel episode
-              </Text>
-            </Pressable>
-          </>
+          <HealthMarkerFoodDiaryStep
+            fd={foodDiary}
+            colors={colors}
+            onCancelEpisodePress={onCancelEpisodePress}
+          />
         ) : phase === 'postMarkers' ? (
           <>
             <ScrollView

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -1420,7 +1420,8 @@ export function HealthMarkerPromptScreen() {
                         accessibilityState={{ disabled: savingFoodDiary }}
                         disabled={savingFoodDiary}
                         onPress={() => {
-                          setFoodDatePickerOpen(true);
+                          setFoodDatePickerOpen((prev) => !prev);
+                          setFoodTimePickerOpen(false);
                         }}
                         style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
                         className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
@@ -1444,7 +1445,8 @@ export function HealthMarkerPromptScreen() {
                         accessibilityState={{ disabled: savingFoodDiary }}
                         disabled={savingFoodDiary}
                         onPress={() => {
-                          setFoodTimePickerOpen(true);
+                          setFoodTimePickerOpen((prev) => !prev);
+                          setFoodDatePickerOpen(false);
                         }}
                         style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
                         className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
@@ -1617,7 +1619,8 @@ export function HealthMarkerPromptScreen() {
                     accessibilityState={{ disabled: savingFoodDiary }}
                     disabled={savingFoodDiary}
                     onPress={() => {
-                      setFoodDatePickerOpen(true);
+                      setFoodDatePickerOpen((prev) => !prev);
+                      setFoodTimePickerOpen(false);
                     }}
                     style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
                     className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
@@ -1641,7 +1644,8 @@ export function HealthMarkerPromptScreen() {
                     accessibilityState={{ disabled: savingFoodDiary }}
                     disabled={savingFoodDiary}
                     onPress={() => {
-                      setFoodTimePickerOpen(true);
+                      setFoodTimePickerOpen((prev) => !prev);
+                      setFoodDatePickerOpen(false);
                     }}
                     style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
                     className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -25,6 +25,7 @@ interface HealthCheckResult {
 type HomeScreenProps = {
   onGoToSettings: () => void;
   onGoToEpisodes: () => void;
+  onGoToFoodDiary: () => void;
   onStartEpisode: () => void;
   onResumeEpisode: (episode: ActiveEpisodeHomeSummary) => void;
 };
@@ -32,6 +33,7 @@ type HomeScreenProps = {
 export function HomeScreen({
   onGoToSettings,
   onGoToEpisodes,
+  onGoToFoodDiary,
   onStartEpisode,
   onResumeEpisode,
 }: HomeScreenProps) {
@@ -254,6 +256,19 @@ export function HomeScreen({
             maxFontSizeMultiplier={2}
           >
             Episodes
+          </Text>
+        </Pressable>
+        <Pressable
+          accessibilityRole="button"
+          accessibilityLabel="Add food diary entry"
+          onPress={onGoToFoodDiary}
+          className={`mb-1 min-h-[48px] justify-center rounded-xl border border-app-border bg-app-surface px-4 py-3 dark:border-app-border-dark dark:bg-app-surface-dark`}
+        >
+          <Text
+            className={`text-center text-base font-semibold ${nw.textPrimary}`}
+            maxFontSizeMultiplier={2}
+          >
+            Food diary
           </Text>
         </Pressable>
 

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -752,7 +752,7 @@ describe('SymptomPromptScreen', () => {
     );
   });
 
-  test('Next on last symptom transitions to health marker prompt and clears symptom session', async () => {
+  test('Next on last symptom transitions to health marker prompt and persists symptom session', async () => {
     const screen = render(<SymptomPromptScreen />);
 
     await waitFor(() => {
@@ -769,7 +769,13 @@ describe('SymptomPromptScreen', () => {
     fireEvent.press(screen.getByLabelText('Severity 1'));
     fireEvent.press(screen.getByLabelText('Next symptom'));
 
-    expect(clearSymptomPromptSession).toHaveBeenCalledWith(episodeId);
+    expect(setSymptomPromptSession).toHaveBeenCalledWith(episodeId, {
+      activeIndex: 1,
+      answers: {
+        [lineA.id]: { type: 'yes_no', value: true },
+        [lineB.id]: { type: 'severity_scale', value: 1 },
+      },
+    });
     expect(mockReplace).toHaveBeenCalledWith('HealthMarkerPrompt', {
       episodeId,
       resume: undefined,

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -640,7 +640,10 @@ export function SymptomPromptScreen() {
 
   const advanceToNextStep = () => {
     if (lines.length === 0) {
-      clearSymptomPromptSession(episodeIdRef.current);
+      setSymptomPromptSession(episodeIdRef.current, {
+        activeIndex: activeIndexRef.current,
+        answers: answersRef.current,
+      });
       allowRemovalRef.current = true;
       navigation.replace('HealthMarkerPrompt', {
         episodeId: episodeIdRef.current,
@@ -656,7 +659,10 @@ export function SymptomPromptScreen() {
       persist(next, answersRef.current);
       return;
     }
-    clearSymptomPromptSession(episodeIdRef.current);
+    setSymptomPromptSession(episodeIdRef.current, {
+      activeIndex: activeIndexRef.current,
+      answers: answersRef.current,
+    });
     allowRemovalRef.current = true;
     navigation.replace('HealthMarkerPrompt', {
       episodeId: episodeIdRef.current,

--- a/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
+++ b/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
@@ -159,7 +159,19 @@ export function useHealthMarkerFoodDiary({
     }
     setFoodDatePickerOpen(false);
     setFoodTimePickerOpen(false);
-  }, [enabled]);
+    // Hook mounts before the food-diary phase; refresh "now" when entering the step
+    // so defaults are not stale after time on health markers (skip in-flight add/edit).
+    if (editingFoodEntryId != null || isAddFoodEntryDirty) {
+      return;
+    }
+    const d = currentLocalDate();
+    const t = currentLocalTime();
+    initialFoodDateTimeRef.current = { date: d, time: t };
+    setFoodLoggedDate(d);
+    setFoodLoggedTime(t);
+    setAddFoodInitialDate(d);
+    setAddFoodInitialTime(t);
+  }, [enabled, editingFoodEntryId, isAddFoodEntryDirty]);
 
   const computeIsAddFoodEntryDirty = useCallback(
     (next: {

--- a/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
+++ b/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
@@ -326,23 +326,13 @@ export function useHealthMarkerFoodDiary({
     }
     setFoodDatePickerOpen(false);
     setFoodTimePickerOpen(false);
-    const decision =
-      foodEntriesError != null
-        ? 'skipped'
-        : foodEntries.length > 0
-          ? 'saved'
-          : 'skipped';
+    const decision = foodEntries.length > 0 ? 'saved' : 'skipped';
     setFoodDiaryFeedback(null);
     await onLeaveFoodDiary(decision);
     await announce('Continue to episode details.', {
       politeness: 'polite',
     });
-  }, [
-    foodDiaryContinueDisabled,
-    foodEntries.length,
-    foodEntriesError,
-    onLeaveFoodDiary,
-  ]);
+  }, [foodDiaryContinueDisabled, foodEntries.length, onLeaveFoodDiary]);
 
   const onBackFromFoodDiary = useCallback(async () => {
     setFoodDatePickerOpen(false);

--- a/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
+++ b/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
@@ -1,0 +1,567 @@
+import type { DateTimePickerEvent } from '@react-native-community/datetimepicker';
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { Alert, Platform } from 'react-native';
+import type { FoodDiaryEntryRow, MealTag } from '@abstrack/types';
+import type { AbstrackSupabaseClient } from '@abstrack/supabase';
+import {
+  createFoodDiaryEntry,
+  deleteFoodDiaryEntry,
+  listFoodDiaryEntriesForEpisode,
+  updateFoodDiaryEntry,
+} from '@abstrack/supabase';
+import { announce } from '@abstrack/ui/native';
+import {
+  currentLocalDate,
+  currentLocalTime,
+  isoToLocalDate,
+  isoToLocalTime,
+  localDateFromDate,
+  localDateTimeToIso,
+  localTimeFromDate,
+} from '../../lib/food-diary/date-time';
+
+export type UseHealthMarkerFoodDiaryArgs = {
+  episodeId: string;
+  userId: string | null;
+  supabase: AbstrackSupabaseClient;
+  enabled: boolean;
+  onLeaveFoodDiary: (decision: 'saved' | 'skipped') => void | Promise<void>;
+  onBack: () => void | Promise<void>;
+};
+
+export type HealthMarkerFoodDiaryHookResult = {
+  reset: () => void;
+  mealTag: MealTag | null;
+  setMealTag: Dispatch<SetStateAction<MealTag | null>>;
+  foodNote: string;
+  setFoodNote: Dispatch<SetStateAction<string>>;
+  foodLoggedDate: string;
+  setFoodLoggedDate: Dispatch<SetStateAction<string>>;
+  foodLoggedTime: string;
+  setFoodLoggedTime: Dispatch<SetStateAction<string>>;
+  foodEntries: FoodDiaryEntryRow[];
+  foodEntriesLoading: boolean;
+  foodEntriesError: string | null;
+  savingFoodDiary: boolean;
+  foodDiaryFeedback: string | null;
+  editingFoodEntryId: string | null;
+  deletingFoodEntryId: string | null;
+  isAddFoodEntryOpen: boolean;
+  setIsAddFoodEntryOpen: Dispatch<SetStateAction<boolean>>;
+  isAddFoodEntryDirty: boolean;
+  setIsAddFoodEntryDirty: Dispatch<SetStateAction<boolean>>;
+  foodDatePickerOpen: boolean;
+  setFoodDatePickerOpen: Dispatch<SetStateAction<boolean>>;
+  foodTimePickerOpen: boolean;
+  setFoodTimePickerOpen: Dispatch<SetStateAction<boolean>>;
+  foodDiaryContinueDisabled: boolean;
+  foodLoggedDateTimeValue: Date;
+  foodLoggedDateLabel: string;
+  foodLoggedTimeLabel: string;
+  computeIsAddFoodEntryDirty: (next: {
+    mealTag: MealTag | null;
+    foodNote: string;
+    foodLoggedDate: string;
+    foodLoggedTime: string;
+  }) => boolean;
+  loadFoodEntries: () => Promise<void>;
+  onSaveFoodDiary: () => Promise<void>;
+  onContinueFromFoodDiary: () => Promise<void>;
+  onBackFromFoodDiary: () => Promise<void>;
+  onEditFoodEntry: (entry: FoodDiaryEntryRow) => void;
+  onNewFoodEntry: () => void;
+  onDiscardFoodEditChanges: () => void;
+  onDiscardAddFoodDraft: () => void;
+  onFoodDatePickerChange: (
+    event: DateTimePickerEvent,
+    selectedDate?: Date,
+  ) => void;
+  onFoodTimePickerChange: (
+    event: DateTimePickerEvent,
+    selectedDate?: Date,
+  ) => void;
+  onDeleteFoodEntry: (entryId: string) => void;
+};
+
+/**
+ * Food diary list / add / edit / delete for the in-episode health marker flow (mobile).
+ */
+export function useHealthMarkerFoodDiary({
+  episodeId,
+  userId,
+  supabase,
+  enabled,
+  onLeaveFoodDiary,
+  onBack,
+}: UseHealthMarkerFoodDiaryArgs): HealthMarkerFoodDiaryHookResult {
+  const initialFoodDateTimeRef = useRef({
+    date: currentLocalDate(),
+    time: currentLocalTime(),
+  });
+  const [mealTag, setMealTag] = useState<MealTag | null>(null);
+  const [foodNote, setFoodNote] = useState('');
+  const [foodLoggedDate, setFoodLoggedDate] = useState(
+    initialFoodDateTimeRef.current.date,
+  );
+  const [foodLoggedTime, setFoodLoggedTime] = useState(
+    initialFoodDateTimeRef.current.time,
+  );
+  const [addFoodInitialDate, setAddFoodInitialDate] = useState(
+    initialFoodDateTimeRef.current.date,
+  );
+  const [addFoodInitialTime, setAddFoodInitialTime] = useState(
+    initialFoodDateTimeRef.current.time,
+  );
+  const [foodEntries, setFoodEntries] = useState<FoodDiaryEntryRow[]>([]);
+  const [foodEntriesLoading, setFoodEntriesLoading] = useState(false);
+  const [foodEntriesError, setFoodEntriesError] = useState<string | null>(null);
+  const [savingFoodDiary, setSavingFoodDiary] = useState(false);
+  const [foodDiaryFeedback, setFoodDiaryFeedback] = useState<string | null>(
+    null,
+  );
+  const [editingFoodEntryId, setEditingFoodEntryId] = useState<string | null>(
+    null,
+  );
+  const [deletingFoodEntryId, setDeletingFoodEntryId] = useState<string | null>(
+    null,
+  );
+  const [isAddFoodEntryOpen, setIsAddFoodEntryOpen] = useState(true);
+  const [isAddFoodEntryDirty, setIsAddFoodEntryDirty] = useState(false);
+  const [foodDatePickerOpen, setFoodDatePickerOpen] = useState(false);
+  const [foodTimePickerOpen, setFoodTimePickerOpen] = useState(false);
+
+  const reset = useCallback(() => {
+    const initialFoodDate = currentLocalDate();
+    const initialFoodTime = currentLocalTime();
+    setMealTag(null);
+    setFoodNote('');
+    setFoodLoggedDate(initialFoodDate);
+    setFoodLoggedTime(initialFoodTime);
+    setAddFoodInitialDate(initialFoodDate);
+    setAddFoodInitialTime(initialFoodTime);
+    setFoodEntries([]);
+    setFoodEntriesLoading(false);
+    setFoodEntriesError(null);
+    setSavingFoodDiary(false);
+    setFoodDiaryFeedback(null);
+    setEditingFoodEntryId(null);
+    setDeletingFoodEntryId(null);
+    setIsAddFoodEntryOpen(true);
+    setIsAddFoodEntryDirty(false);
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+  }, []);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+  }, [enabled]);
+
+  const computeIsAddFoodEntryDirty = useCallback(
+    (next: {
+      mealTag: MealTag | null;
+      foodNote: string;
+      foodLoggedDate: string;
+      foodLoggedTime: string;
+    }) => {
+      return (
+        next.mealTag != null ||
+        next.foodNote.trim().length > 0 ||
+        next.foodLoggedDate !== addFoodInitialDate ||
+        next.foodLoggedTime !== addFoodInitialTime
+      );
+    },
+    [addFoodInitialDate, addFoodInitialTime],
+  );
+
+  const onNewFoodEntry = useCallback(() => {
+    setEditingFoodEntryId(null);
+    const initialFoodDate = currentLocalDate();
+    const initialFoodTime = currentLocalTime();
+    setMealTag(null);
+    setFoodNote('');
+    setFoodLoggedDate(initialFoodDate);
+    setFoodLoggedTime(initialFoodTime);
+    setAddFoodInitialDate(initialFoodDate);
+    setAddFoodInitialTime(initialFoodTime);
+    setFoodDiaryFeedback(null);
+    setIsAddFoodEntryDirty(false);
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+    setIsAddFoodEntryOpen(true);
+  }, []);
+
+  const loadFoodEntries = useCallback(async () => {
+    setFoodEntriesLoading(true);
+    setFoodEntriesError(null);
+    const result = await listFoodDiaryEntriesForEpisode(supabase, episodeId);
+    setFoodEntriesLoading(false);
+    if (!result.ok) {
+      setFoodEntriesError(result.error.message);
+      return;
+    }
+    setFoodEntries(result.data);
+  }, [episodeId, supabase]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    void loadFoodEntries();
+  }, [enabled, loadFoodEntries]);
+
+  const onEditFoodEntry = useCallback((entry: FoodDiaryEntryRow) => {
+    setEditingFoodEntryId(entry.id);
+    setIsAddFoodEntryOpen(false);
+    setIsAddFoodEntryDirty(false);
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+    setMealTag(entry.meal_tag);
+    setFoodNote(entry.food_note);
+    setFoodLoggedDate(isoToLocalDate(entry.logged_at));
+    setFoodLoggedTime(isoToLocalTime(entry.logged_at));
+    setFoodDiaryFeedback(null);
+  }, []);
+
+  const onDiscardFoodEditChanges = useCallback(() => {
+    setEditingFoodEntryId(null);
+    setMealTag(null);
+    setFoodNote('');
+    setFoodLoggedDate(currentLocalDate());
+    setFoodLoggedTime(currentLocalTime());
+    setFoodDiaryFeedback(null);
+    setIsAddFoodEntryDirty(false);
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+    setIsAddFoodEntryOpen(false);
+  }, []);
+
+  const onSaveFoodDiary = useCallback(async () => {
+    if (savingFoodDiary || !userId) {
+      return;
+    }
+    setSavingFoodDiary(true);
+    setFoodDiaryFeedback(null);
+    if (!mealTag) {
+      const message = 'Choose a meal tag.';
+      setFoodDiaryFeedback(message);
+      await announce(message, { politeness: 'assertive' });
+      setSavingFoodDiary(false);
+      return;
+    }
+    const loggedAtIso = localDateTimeToIso(foodLoggedDate, foodLoggedTime);
+    if (!loggedAtIso) {
+      const message = 'Enter a valid date and time.';
+      setFoodDiaryFeedback(message);
+      await announce(message, { politeness: 'assertive' });
+      setSavingFoodDiary(false);
+      return;
+    }
+    const editingId = editingFoodEntryId;
+    const result =
+      editingId == null
+        ? await createFoodDiaryEntry(supabase, {
+            user_id: userId,
+            episode_id: episodeId,
+            meal_tag: mealTag,
+            food_note: foodNote,
+            logged_at: loggedAtIso,
+          })
+        : await updateFoodDiaryEntry(supabase, editingId, {
+            meal_tag: mealTag,
+            food_note: foodNote,
+            logged_at: loggedAtIso,
+          });
+    setSavingFoodDiary(false);
+    if (!result.ok) {
+      setFoodDiaryFeedback(result.error.message);
+      await announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    const foodEntriesResult = await listFoodDiaryEntriesForEpisode(
+      supabase,
+      episodeId,
+    );
+    if (foodEntriesResult.ok) {
+      setFoodEntries(foodEntriesResult.data);
+      setFoodEntriesError(null);
+    } else {
+      setFoodEntriesError(foodEntriesResult.error.message);
+    }
+    const initialFoodDate = currentLocalDate();
+    const initialFoodTime = currentLocalTime();
+    setMealTag(null);
+    setFoodNote('');
+    setFoodLoggedDate(initialFoodDate);
+    setFoodLoggedTime(initialFoodTime);
+    setAddFoodInitialDate(initialFoodDate);
+    setAddFoodInitialTime(initialFoodTime);
+    setEditingFoodEntryId(null);
+    setIsAddFoodEntryDirty(false);
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+    if (editingId == null) {
+      setIsAddFoodEntryOpen(false);
+    }
+    setFoodDiaryFeedback(null);
+    await announce(
+      editingId == null ? 'Food entry saved.' : 'Food entry updated.',
+      { politeness: 'polite' },
+    );
+  }, [
+    editingFoodEntryId,
+    episodeId,
+    foodLoggedDate,
+    foodLoggedTime,
+    foodNote,
+    mealTag,
+    savingFoodDiary,
+    supabase,
+    userId,
+  ]);
+
+  const foodDiaryContinueDisabled =
+    savingFoodDiary || deletingFoodEntryId != null || foodEntriesLoading;
+
+  const onContinueFromFoodDiary = useCallback(async () => {
+    if (foodDiaryContinueDisabled) {
+      return;
+    }
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+    const decision =
+      foodEntriesError != null
+        ? 'skipped'
+        : foodEntries.length > 0
+          ? 'saved'
+          : 'skipped';
+    setFoodDiaryFeedback(null);
+    await onLeaveFoodDiary(decision);
+    await announce('Continue to episode details.', {
+      politeness: 'polite',
+    });
+  }, [
+    foodDiaryContinueDisabled,
+    foodEntries.length,
+    foodEntriesError,
+    onLeaveFoodDiary,
+  ]);
+
+  const onBackFromFoodDiary = useCallback(async () => {
+    setFoodDatePickerOpen(false);
+    setFoodTimePickerOpen(false);
+    setFoodDiaryFeedback(null);
+    await onBack();
+  }, [onBack]);
+
+  const onDiscardAddFoodDraft = useCallback(() => {
+    if (!isAddFoodEntryDirty) {
+      setIsAddFoodEntryOpen(false);
+      return;
+    }
+    Alert.alert(
+      'Discard this food entry draft?',
+      'Your unsaved entry will be removed.',
+      [
+        { text: 'Keep editing', style: 'cancel' },
+        {
+          text: 'Discard entry',
+          style: 'destructive',
+          onPress: () => {
+            const initialFoodDate = currentLocalDate();
+            const initialFoodTime = currentLocalTime();
+            setMealTag(null);
+            setFoodNote('');
+            setFoodLoggedDate(initialFoodDate);
+            setFoodLoggedTime(initialFoodTime);
+            setAddFoodInitialDate(initialFoodDate);
+            setAddFoodInitialTime(initialFoodTime);
+            setIsAddFoodEntryDirty(false);
+            setFoodDiaryFeedback(null);
+            setFoodDatePickerOpen(false);
+            setFoodTimePickerOpen(false);
+            setIsAddFoodEntryOpen(false);
+          },
+        },
+      ],
+    );
+  }, [isAddFoodEntryDirty]);
+
+  const foodLoggedDateTimeValue = useMemo(() => {
+    const iso = localDateTimeToIso(foodLoggedDate, foodLoggedTime);
+    return iso ? new Date(iso) : new Date();
+  }, [foodLoggedDate, foodLoggedTime]);
+
+  const foodLoggedDateLabel = useMemo(() => {
+    return foodLoggedDateTimeValue.toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric',
+    });
+  }, [foodLoggedDateTimeValue]);
+
+  const foodLoggedTimeLabel = useMemo(() => {
+    return foodLoggedDateTimeValue.toLocaleTimeString(undefined, {
+      hour: 'numeric',
+      minute: '2-digit',
+      hour12: true,
+    });
+  }, [foodLoggedDateTimeValue]);
+
+  const onFoodDatePickerChange = useCallback(
+    (event: DateTimePickerEvent, selectedDate?: Date) => {
+      if (Platform.OS === 'android') {
+        setFoodDatePickerOpen(false);
+      }
+      if (event.type === 'dismissed') {
+        return;
+      }
+      if (!selectedDate) {
+        return;
+      }
+      const nextDate = localDateFromDate(selectedDate);
+      setFoodLoggedDate(nextDate);
+      if (editingFoodEntryId == null) {
+        setIsAddFoodEntryDirty(
+          computeIsAddFoodEntryDirty({
+            mealTag,
+            foodNote,
+            foodLoggedDate: nextDate,
+            foodLoggedTime,
+          }),
+        );
+      }
+    },
+    [
+      computeIsAddFoodEntryDirty,
+      editingFoodEntryId,
+      foodLoggedTime,
+      foodNote,
+      mealTag,
+    ],
+  );
+
+  const onFoodTimePickerChange = useCallback(
+    (event: DateTimePickerEvent, selectedDate?: Date) => {
+      if (Platform.OS === 'android') {
+        setFoodTimePickerOpen(false);
+      }
+      if (event.type === 'dismissed') {
+        return;
+      }
+      if (!selectedDate) {
+        return;
+      }
+      const nextTime = localTimeFromDate(selectedDate);
+      setFoodLoggedTime(nextTime);
+      if (editingFoodEntryId == null) {
+        setIsAddFoodEntryDirty(
+          computeIsAddFoodEntryDirty({
+            mealTag,
+            foodNote,
+            foodLoggedDate,
+            foodLoggedTime: nextTime,
+          }),
+        );
+      }
+    },
+    [
+      computeIsAddFoodEntryDirty,
+      editingFoodEntryId,
+      foodLoggedDate,
+      foodNote,
+      mealTag,
+    ],
+  );
+
+  const onDeleteFoodEntry = useCallback(
+    (entryId: string) => {
+      if (savingFoodDiary || deletingFoodEntryId) {
+        return;
+      }
+      Alert.alert('Discard this saved food entry?', 'This cannot be undone.', [
+        { text: 'Keep entry', style: 'cancel' },
+        {
+          text: 'Discard entry',
+          style: 'destructive',
+          onPress: () => {
+            void (async () => {
+              setDeletingFoodEntryId(entryId);
+              setFoodDiaryFeedback(null);
+              const result = await deleteFoodDiaryEntry(supabase, entryId);
+              setDeletingFoodEntryId(null);
+              if (!result.ok) {
+                setFoodDiaryFeedback(result.error.message);
+                await announce(result.error.message, {
+                  politeness: 'assertive',
+                });
+                return;
+              }
+              if (editingFoodEntryId === entryId) {
+                onNewFoodEntry();
+                setIsAddFoodEntryOpen(false);
+              }
+              await loadFoodEntries();
+              await announce('Food entry discarded.', { politeness: 'polite' });
+            })();
+          },
+        },
+      ]);
+    },
+    [
+      deletingFoodEntryId,
+      editingFoodEntryId,
+      loadFoodEntries,
+      onNewFoodEntry,
+      savingFoodDiary,
+      supabase,
+    ],
+  );
+
+  return {
+    reset,
+    mealTag,
+    setMealTag,
+    foodNote,
+    setFoodNote,
+    foodLoggedDate,
+    setFoodLoggedDate,
+    foodLoggedTime,
+    setFoodLoggedTime,
+    foodEntries,
+    foodEntriesLoading,
+    foodEntriesError,
+    savingFoodDiary,
+    foodDiaryFeedback,
+    editingFoodEntryId,
+    deletingFoodEntryId,
+    isAddFoodEntryOpen,
+    setIsAddFoodEntryOpen,
+    isAddFoodEntryDirty,
+    setIsAddFoodEntryDirty,
+    foodDatePickerOpen,
+    setFoodDatePickerOpen,
+    foodTimePickerOpen,
+    setFoodTimePickerOpen,
+    foodDiaryContinueDisabled,
+    foodLoggedDateTimeValue,
+    foodLoggedDateLabel,
+    foodLoggedTimeLabel,
+    computeIsAddFoodEntryDirty,
+    loadFoodEntries,
+    onSaveFoodDiary,
+    onContinueFromFoodDiary,
+    onBackFromFoodDiary,
+    onEditFoodEntry,
+    onNewFoodEntry,
+    onDiscardFoodEditChanges,
+    onDiscardAddFoodDraft,
+    onFoodDatePickerChange,
+    onFoodTimePickerChange,
+    onDeleteFoodEntry,
+  };
+}

--- a/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
+++ b/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
@@ -276,22 +276,13 @@ export function useHealthMarkerFoodDiary({
             food_note: foodNote,
             logged_at: loggedAtIso,
           });
-    setSavingFoodDiary(false);
     if (!result.ok) {
+      setSavingFoodDiary(false);
       setFoodDiaryFeedback(result.error.message);
       await announce(result.error.message, { politeness: 'assertive' });
       return;
     }
-    const foodEntriesResult = await listFoodDiaryEntriesForEpisode(
-      supabase,
-      episodeId,
-    );
-    if (foodEntriesResult.ok) {
-      setFoodEntries(foodEntriesResult.data);
-      setFoodEntriesError(null);
-    } else {
-      setFoodEntriesError(foodEntriesResult.error.message);
-    }
+    await loadFoodEntries();
     const initialFoodDate = currentLocalDate();
     const initialFoodTime = currentLocalTime();
     setMealTag(null);
@@ -312,6 +303,7 @@ export function useHealthMarkerFoodDiary({
       editingId == null ? 'Food entry saved.' : 'Food entry updated.',
       { politeness: 'polite' },
     );
+    setSavingFoodDiary(false);
   }, [
     editingFoodEntryId,
     episodeId,
@@ -320,6 +312,7 @@ export function useHealthMarkerFoodDiary({
     foodNote,
     mealTag,
     savingFoodDiary,
+    loadFoodEntries,
     supabase,
     userId,
   ]);

--- a/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
+++ b/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
@@ -21,6 +21,32 @@ import {
   localTimeFromDate,
 } from '../../lib/food-diary/date-time';
 
+/** Same ordering as `listFoodDiaryEntriesForEpisode` (newest first). */
+function compareFoodDiaryEntriesDesc(
+  a: FoodDiaryEntryRow,
+  b: FoodDiaryEntryRow,
+): number {
+  let c = b.logged_at.localeCompare(a.logged_at);
+  if (c !== 0) {
+    return c;
+  }
+  c = b.created_at.localeCompare(a.created_at);
+  if (c !== 0) {
+    return c;
+  }
+  return b.id.localeCompare(a.id);
+}
+
+function upsertFoodEntrySorted(
+  prev: FoodDiaryEntryRow[],
+  row: FoodDiaryEntryRow,
+): FoodDiaryEntryRow[] {
+  const next = prev.filter((e) => e.id !== row.id);
+  next.push(row);
+  next.sort(compareFoodDiaryEntriesDesc);
+  return next;
+}
+
 export type UseHealthMarkerFoodDiaryArgs = {
   episodeId: string;
   userId: string | null;
@@ -294,6 +320,7 @@ export function useHealthMarkerFoodDiary({
       await announce(result.error.message, { politeness: 'assertive' });
       return;
     }
+    setFoodEntries((prev) => upsertFoodEntrySorted(prev, result.data));
     await loadFoodEntries();
     const initialFoodDate = currentLocalDate();
     const initialFoodTime = currentLocalTime();

--- a/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
+++ b/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
@@ -321,7 +321,7 @@ export function useHealthMarkerFoodDiary({
       return;
     }
     setFoodEntries((prev) => upsertFoodEntrySorted(prev, result.data));
-    await loadFoodEntries();
+    setFoodEntriesError(null);
     const initialFoodDate = currentLocalDate();
     const initialFoodTime = currentLocalTime();
     setMealTag(null);
@@ -351,7 +351,6 @@ export function useHealthMarkerFoodDiary({
     foodNote,
     mealTag,
     savingFoodDiary,
-    loadFoodEntries,
     supabase,
     userId,
   ]);

--- a/apps/mobile/src/lib/food-diary/date-time.spec.ts
+++ b/apps/mobile/src/lib/food-diary/date-time.spec.ts
@@ -1,0 +1,85 @@
+import {
+  isoToLocalDate,
+  isoToLocalTime,
+  localDateTimeToIso,
+} from './date-time';
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+function toDatePart(year: number, month1: number, day: number): string {
+  return `${year}-${pad2(month1)}-${pad2(day)}`;
+}
+
+function toTimePart(hour: number, minute: number): string {
+  return `${pad2(hour)}:${pad2(minute)}`;
+}
+
+function findSpringForwardGap(): {
+  year: number;
+  month1: number;
+  day: number;
+  hour: number;
+  minute: number;
+} | null {
+  for (let year = 2020; year <= 2032; year += 1) {
+    for (let month0 = 0; month0 < 12; month0 += 1) {
+      const daysInMonth = new Date(year, month0 + 1, 0).getDate();
+      for (let day = 1; day <= daysInMonth; day += 1) {
+        for (let hour = 1; hour <= 22; hour += 1) {
+          const minute = 30;
+          const local = new Date(year, month0, day, hour, minute, 0, 0);
+          const sameCalendarDay =
+            local.getFullYear() === year &&
+            local.getMonth() === month0 &&
+            local.getDate() === day;
+          if (sameCalendarDay && local.getHours() > hour) {
+            return { year, month1: month0 + 1, day, hour, minute };
+          }
+        }
+      }
+    }
+  }
+  return null;
+}
+
+describe('food diary mobile date-time helpers', () => {
+  it('round-trips local date/time through ISO helpers', () => {
+    const datePart = '2026-01-15';
+    const timePart = '13:45';
+    const iso = localDateTimeToIso(datePart, timePart);
+
+    expect(iso).not.toBeNull();
+    expect(isoToLocalDate(iso ?? '')).toBe(datePart);
+    expect(isoToLocalTime(iso ?? '')).toBe(timePart);
+  });
+
+  it('parses optional seconds in local time', () => {
+    const iso = localDateTimeToIso('2026-01-15', '08:09:10');
+    const expected = new Date(2026, 0, 15, 8, 9, 10, 0).toISOString();
+
+    expect(iso).toBe(expected);
+  });
+
+  it('returns null for invalid or out-of-range date/time parts', () => {
+    expect(localDateTimeToIso('', '08:09')).toBeNull();
+    expect(localDateTimeToIso('2026-01-15', '')).toBeNull();
+    expect(localDateTimeToIso('2026-13-15', '08:09')).toBeNull();
+    expect(localDateTimeToIso('2026-02-30', '08:09')).toBeNull();
+    expect(localDateTimeToIso('2026-01-15', '24:00')).toBeNull();
+    expect(localDateTimeToIso('2026-01-15', '08:60')).toBeNull();
+    expect(localDateTimeToIso('2026-01-15', '08:09:99')).toBeNull();
+  });
+
+  it('rejects a nonexistent local time in a spring-forward DST gap', () => {
+    const gap = findSpringForwardGap();
+    if (!gap) {
+      expect(localDateTimeToIso('2026-01-15', '08:09')).not.toBeNull();
+      return;
+    }
+    const datePart = toDatePart(gap.year, gap.month1, gap.day);
+    const timePart = toTimePart(gap.hour, gap.minute);
+    expect(localDateTimeToIso(datePart, timePart)).toBeNull();
+  });
+});

--- a/apps/mobile/src/lib/food-diary/date-time.ts
+++ b/apps/mobile/src/lib/food-diary/date-time.ts
@@ -23,27 +23,76 @@ export function currentLocalTime(): string {
   return `${pad2(now.getHours())}:${pad2(now.getMinutes())}`;
 }
 
+const LOCAL_DATE_PART_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+const LOCAL_TIME_PART_RE = /^(\d{2}):(\d{2})(?::(\d{2}))?$/;
+
 /**
  * Combines local date and time strings into an ISO timestamp, or `null` if invalid.
+ * Parses components and uses the local `Date` constructor (not `new Date(string)`) so
+ * wall time is consistent across Hermes/JSC.
  *
  * @param datePart - `YYYY-MM-DD`
- * @param timePart - `HH:mm`
+ * @param timePart - `HH:mm` (optional `:ss`)
  */
 export function localDateTimeToIso(
   datePart: string,
   timePart: string,
 ): string | null {
-  const date = datePart.trim();
-  const time = timePart.trim();
-  if (!date || !time) {
+  const dTrim = datePart.trim();
+  const tTrim = timePart.trim();
+  if (!dTrim || !tTrim) {
     return null;
   }
-  const parsed = new Date(`${date}T${time}`);
-  const value = parsed.getTime();
+  const dateMatch = LOCAL_DATE_PART_RE.exec(dTrim);
+  const timeMatch = LOCAL_TIME_PART_RE.exec(tTrim);
+  if (!dateMatch || !timeMatch) {
+    return null;
+  }
+  const year = Number(dateMatch[1]);
+  const month = Number(dateMatch[2]);
+  const day = Number(dateMatch[3]);
+  const hour = Number(timeMatch[1]);
+  const minute = Number(timeMatch[2]);
+  const second = timeMatch[3] != null ? Number(timeMatch[3]) : 0;
+
+  if (
+    !Number.isFinite(year) ||
+    !Number.isFinite(month) ||
+    !Number.isFinite(day) ||
+    !Number.isFinite(hour) ||
+    !Number.isFinite(minute) ||
+    !Number.isFinite(second) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31 ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59 ||
+    second < 0 ||
+    second > 59
+  ) {
+    return null;
+  }
+
+  const local = new Date(year, month - 1, day, hour, minute, second, 0);
+  if (
+    local.getFullYear() !== year ||
+    local.getMonth() !== month - 1 ||
+    local.getDate() !== day ||
+    local.getHours() !== hour ||
+    local.getMinutes() !== minute ||
+    local.getSeconds() !== second
+  ) {
+    return null;
+  }
+
+  const value = local.getTime();
   if (!Number.isFinite(value)) {
     return null;
   }
-  return parsed.toISOString();
+  return local.toISOString();
 }
 
 /**

--- a/apps/mobile/src/lib/food-diary/date-time.ts
+++ b/apps/mobile/src/lib/food-diary/date-time.ts
@@ -1,0 +1,81 @@
+/**
+ * Shared local date/time helpers for food diary flows (string parts + picker wiring).
+ * Keeps parsing and formatting consistent across standalone and in-episode screens.
+ */
+
+function pad2(value: number): string {
+  return String(value).padStart(2, '0');
+}
+
+/**
+ * @returns Local calendar date as `YYYY-MM-DD` for the current instant.
+ */
+export function currentLocalDate(): string {
+  const now = new Date();
+  return `${now.getFullYear()}-${pad2(now.getMonth() + 1)}-${pad2(now.getDate())}`;
+}
+
+/**
+ * @returns Local time as `HH:mm` for the current instant.
+ */
+export function currentLocalTime(): string {
+  const now = new Date();
+  return `${pad2(now.getHours())}:${pad2(now.getMinutes())}`;
+}
+
+/**
+ * Combines local date and time strings into an ISO timestamp, or `null` if invalid.
+ *
+ * @param datePart - `YYYY-MM-DD`
+ * @param timePart - `HH:mm`
+ */
+export function localDateTimeToIso(
+  datePart: string,
+  timePart: string,
+): string | null {
+  const date = datePart.trim();
+  const time = timePart.trim();
+  if (!date || !time) {
+    return null;
+  }
+  const parsed = new Date(`${date}T${time}`);
+  const value = parsed.getTime();
+  if (!Number.isFinite(value)) {
+    return null;
+  }
+  return parsed.toISOString();
+}
+
+/**
+ * @param value - Picked date
+ * @returns Local date string `YYYY-MM-DD`
+ */
+export function localDateFromDate(value: Date): string {
+  return `${value.getFullYear()}-${pad2(value.getMonth() + 1)}-${pad2(value.getDate())}`;
+}
+
+/**
+ * @param value - Picked date/time
+ * @returns Local time string `HH:mm`
+ */
+export function localTimeFromDate(value: Date): string {
+  return `${pad2(value.getHours())}:${pad2(value.getMinutes())}`;
+}
+
+/**
+ * @param iso - ISO timestamp
+ * @returns Local calendar date `YYYY-MM-DD` in the device timezone
+ */
+export function isoToLocalDate(iso: string): string {
+  const date = new Date(iso);
+  return `${date.getFullYear()}-${pad2(date.getMonth() + 1)}-${pad2(date.getDate())}`;
+}
+
+/**
+ * @param iso - ISO timestamp
+ * @returns Local time `HH:mm` in the device timezone
+ */
+export function isoToLocalTime(iso: string): string {
+  const date = new Date(iso);
+  return `${pad2(date.getHours())}:${pad2(date.getMinutes())}`;
+}

--- a/apps/web-e2e/playwright.config.ts
+++ b/apps/web-e2e/playwright.config.ts
@@ -2,7 +2,13 @@ import { defineConfig, devices } from '@playwright/test';
 import { nxE2EPreset } from '@nx/playwright/preset';
 import { workspaceRoot } from '@nx/devkit';
 
-const localBaseURL = 'http://localhost:3000';
+/**
+ * Dedicated port for Playwright’s `webServer` so local runs do not accidentally reuse
+ * whatever is already bound to :3000 (common default for other stacks). Override with
+ * `PLAYWRIGHT_WEB_PORT` if needed.
+ */
+const localWebPort = process.env['PLAYWRIGHT_WEB_PORT'] ?? '4310';
+const localBaseURL = `http://localhost:${localWebPort}`;
 /** When set (e.g. deployed preview), tests hit this origin and `webServer` is not started. */
 const isRemote = Boolean(process.env['BASE_URL']);
 const baseURL = process.env['BASE_URL'] || localBaseURL;
@@ -38,6 +44,9 @@ export default defineConfig({
           reuseExistingServer: !process.env.CI,
           cwd: workspaceRoot,
           timeout: 180_000,
+          env: {
+            PORT: localWebPort,
+          },
         },
       }),
   projects: [

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -1,4 +1,5 @@
 import { redirect } from 'next/navigation';
+import Link from 'next/link';
 import { EpisodeStartHomeCta } from '@/components/episode-flow/EpisodeStartHomeCta';
 import { createServerClient } from '@/lib/supabase/server-client';
 import { healthCheckProfilesLimit1 } from '@abstrack/supabase';
@@ -127,6 +128,15 @@ export default async function DashboardPage() {
         )}
 
         <div className="space-y-4">
+          <div>
+            <p className="text-sm text-app-muted">Food diary</p>
+            <Link
+              href="/food-diary/new"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-app-border bg-app-surface px-3 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            >
+              Add a food diary entry
+            </Link>
+          </div>
           {user ? (
             <>
               <div>

--- a/apps/web/src/app/(app)/food-diary/new/page.tsx
+++ b/apps/web/src/app/(app)/food-diary/new/page.tsx
@@ -1,0 +1,22 @@
+import { FoodDiaryEntryForm } from '@/components/food-diary/FoodDiaryEntryForm';
+
+/**
+ * Standalone food diary entry page from the dashboard/home surface.
+ *
+ * @returns Food diary form without an episode link.
+ */
+export default function FoodDiaryNewPage() {
+  return (
+    <div className="w-full space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          New food diary entry
+        </h1>
+        <p className="mt-1 text-sm text-app-muted">
+          Use this when you want to log food outside an active episode.
+        </p>
+      </div>
+      <FoodDiaryEntryForm />
+    </div>
+  );
+}

--- a/apps/web/src/components/episode-flow/EpisodeFoodDiaryStep.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeFoodDiaryStep.tsx
@@ -1,0 +1,433 @@
+'use client';
+
+import { MEAL_TAGS } from '@abstrack/types';
+import { EpisodeLocaleInstant } from '@/components/episodes/EpisodeLocaleInstant';
+import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
+import type { EpisodeFoodDiaryHookResult } from './use-episode-food-diary';
+
+export type EpisodeFoodDiaryStepProps = {
+  fd: EpisodeFoodDiaryHookResult;
+  onBack: () => void;
+  cancelDialogOpen: boolean;
+  setCancelDialogOpen: (open: boolean) => void;
+  onCancelEpisodeConfirm: () => void | false | Promise<void | false>;
+  cancelingEpisode: boolean;
+};
+
+/**
+ * Food diary step UI for the episode health-marker flow (list, add, edit, delete).
+ * State and effects live in {@link useEpisodeFoodDiary}.
+ */
+export function EpisodeFoodDiaryStep({
+  fd,
+  onBack,
+  cancelDialogOpen,
+  setCancelDialogOpen,
+  onCancelEpisodeConfirm,
+  cancelingEpisode,
+}: EpisodeFoodDiaryStepProps) {
+  return (
+    <>
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+            Food diary
+          </h1>
+          <p className="mt-2 text-base text-app-muted">
+            Add one or more meals/snacks for this episode, or skip this step.
+          </p>
+        </div>
+
+        <section className="space-y-3 rounded-2xl border border-app-border/90 bg-app-surface p-5 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+          <h2 className="text-base font-semibold text-app-ink">
+            Saved entries
+          </h2>
+          {fd.foodEntriesLoading ? (
+            <p className="text-sm text-app-muted" role="status">
+              Loading entries…
+            </p>
+          ) : null}
+          {fd.foodEntriesError ? (
+            <div className="space-y-2">
+              <p
+                className="text-sm text-red-700 dark:text-red-300"
+                role="alert"
+              >
+                {fd.foodEntriesError}
+              </p>
+              <button
+                type="button"
+                className="inline-flex min-h-[40px] items-center justify-center rounded-lg border border-app-border px-3 py-2 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={fd.foodEntriesLoading}
+                onClick={() => {
+                  void fd.loadFoodEntries();
+                }}
+              >
+                {fd.foodEntriesLoading ? 'Retrying…' : 'Try again'}
+              </button>
+            </div>
+          ) : null}
+          {!fd.foodEntriesLoading &&
+          !fd.foodEntriesError &&
+          fd.foodEntries.length === 0 ? (
+            <p className="text-sm text-app-muted">
+              No food entries yet for this episode.
+            </p>
+          ) : null}
+          {!fd.foodEntriesLoading && fd.foodEntries.length > 0 ? (
+            <div className="space-y-2">
+              {fd.foodEntries.map((entry) => (
+                <div
+                  key={entry.id}
+                  className="rounded-xl border border-app-border bg-app-surface px-3 py-3"
+                >
+                  <p className="text-sm font-semibold text-app-ink">
+                    {entry.meal_tag} -{' '}
+                    <EpisodeLocaleInstant iso={entry.logged_at} />
+                  </p>
+                  <p className="mt-1 whitespace-pre-wrap text-sm text-app-muted">
+                    {entry.food_note}
+                  </p>
+                  {fd.editingFoodEntryId === entry.id ? (
+                    <div className="mt-3 space-y-3 rounded-lg border border-app-border/80 p-3">
+                      <fieldset className="space-y-2" disabled={fd.foodSaving}>
+                        <legend className="text-xs font-medium text-app-ink">
+                          Meal tag
+                        </legend>
+                        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                          {MEAL_TAGS.map((tag) => {
+                            const selected = fd.foodMealTag === tag;
+                            return (
+                              <button
+                                type="button"
+                                key={`edit-${entry.id}-${tag}`}
+                                aria-pressed={selected}
+                                className={`flex min-h-[40px] items-center justify-center rounded-lg border px-3 py-2 text-xs font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 ${
+                                  selected
+                                    ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
+                                    : 'cursor-pointer border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
+                                }`}
+                                disabled={fd.foodSaving}
+                                onClick={() => {
+                                  if (!fd.foodSaving) {
+                                    fd.setFoodMealTag(selected ? null : tag);
+                                  }
+                                }}
+                              >
+                                {tag}
+                              </button>
+                            );
+                          })}
+                        </div>
+                      </fieldset>
+                      <label className="block space-y-1 text-xs font-medium text-app-ink">
+                        <span>Logged at</span>
+                        <input
+                          type="datetime-local"
+                          value={fd.foodLoggedAtLocal}
+                          disabled={fd.foodSaving}
+                          onChange={(e) => {
+                            fd.setFoodLoggedAtLocal(e.target.value);
+                          }}
+                          className="min-h-[40px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+                        />
+                      </label>
+                      <label className="block space-y-1 text-xs font-medium text-app-ink">
+                        <span>Food note</span>
+                        <textarea
+                          rows={3}
+                          value={fd.foodNote}
+                          disabled={fd.foodSaving}
+                          onChange={(e) => {
+                            fd.setFoodNote(e.target.value);
+                          }}
+                          className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+                        />
+                      </label>
+                      {fd.foodSaveError ? (
+                        <p
+                          className="text-xs text-red-700 dark:text-red-300"
+                          role="alert"
+                        >
+                          {fd.foodSaveError}
+                        </p>
+                      ) : null}
+                      <div className="flex gap-2">
+                        <button
+                          type="button"
+                          className="inline-flex min-h-[40px] items-center justify-center rounded-lg bg-red-700 px-3 text-xs font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
+                          disabled={fd.foodSaving}
+                          onClick={() => {
+                            void fd.onSaveFoodEntry();
+                          }}
+                        >
+                          {fd.foodSaving ? 'Saving…' : 'Update'}
+                        </button>
+                        <button
+                          type="button"
+                          className="inline-flex min-h-[40px] items-center justify-center rounded-lg border border-app-border px-3 text-xs font-semibold text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                          onClick={fd.resetFoodForm}
+                        >
+                          Discard changes
+                        </button>
+                        <button
+                          type="button"
+                          className="inline-flex min-h-[40px] items-center justify-center rounded-lg border border-red-400 px-3 text-xs font-semibold text-red-700 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-500/60 dark:text-red-300 dark:hover:bg-red-950/30"
+                          disabled={fd.deletingFoodEntryId != null}
+                          onClick={() => {
+                            fd.requestDeleteFoodEntry(entry.id);
+                          }}
+                        >
+                          {fd.deletingFoodEntryId === entry.id
+                            ? 'Discarding…'
+                            : 'Discard entry'}
+                        </button>
+                      </div>
+                    </div>
+                  ) : null}
+                  {fd.editingFoodEntryId !== entry.id ? (
+                    <div className="mt-2 flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className="inline-flex min-h-[36px] items-center justify-center rounded-lg border border-app-border px-3 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                        onClick={() => {
+                          fd.onEditFoodEntry(entry);
+                        }}
+                      >
+                        Edit
+                      </button>
+                      <button
+                        type="button"
+                        className="inline-flex min-h-[36px] items-center justify-center rounded-lg border border-red-400 px-3 text-sm font-medium text-red-700 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-500/60 dark:text-red-300 dark:hover:bg-red-950/30"
+                        disabled={fd.deletingFoodEntryId != null}
+                        onClick={() => {
+                          fd.requestDeleteFoodEntry(entry.id);
+                        }}
+                      >
+                        {fd.deletingFoodEntryId === entry.id
+                          ? 'Discarding…'
+                          : 'Discard entry'}
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+          ) : null}
+        </section>
+
+        {fd.editingFoodEntryId == null && fd.isAddFoodEntryOpen ? (
+          <section className="space-y-4 rounded-2xl border border-app-border/90 bg-app-surface p-5 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+            <h2 className="text-base font-semibold text-app-ink">
+              Add food entry
+            </h2>
+            <fieldset className="space-y-2" disabled={fd.foodSaving}>
+              <legend className="text-sm font-medium text-app-ink">
+                Meal tag
+              </legend>
+              <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                {MEAL_TAGS.map((tag) => {
+                  const selected = fd.foodMealTag === tag;
+                  return (
+                    <button
+                      type="button"
+                      key={`add-${tag}`}
+                      aria-pressed={selected}
+                      className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 ${
+                        selected
+                          ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
+                          : 'cursor-pointer border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
+                      }`}
+                      disabled={fd.foodSaving}
+                      onClick={() => {
+                        if (!fd.foodSaving) {
+                          const nextMealTag = selected ? null : tag;
+                          fd.setFoodMealTag(nextMealTag);
+                          fd.setIsAddFoodEntryDirty(
+                            fd.computeIsAddFoodEntryDirty({
+                              mealTag: nextMealTag,
+                              note: fd.foodNote,
+                              loggedAtLocal: fd.foodLoggedAtLocal,
+                            }),
+                          );
+                        }
+                      }}
+                    >
+                      {tag}
+                    </button>
+                  );
+                })}
+              </div>
+            </fieldset>
+            <label className="block space-y-1 text-sm font-medium text-app-ink">
+              <span>Logged at</span>
+              <input
+                type="datetime-local"
+                value={fd.foodLoggedAtLocal}
+                disabled={fd.foodSaving}
+                onChange={(e) => {
+                  const nextLoggedAtLocal = e.target.value;
+                  fd.setFoodLoggedAtLocal(nextLoggedAtLocal);
+                  fd.setIsAddFoodEntryDirty(
+                    fd.computeIsAddFoodEntryDirty({
+                      mealTag: fd.foodMealTag,
+                      note: fd.foodNote,
+                      loggedAtLocal: nextLoggedAtLocal,
+                    }),
+                  );
+                }}
+                className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+              />
+            </label>
+            <label className="block space-y-1 text-sm font-medium text-app-ink">
+              <span>Food note</span>
+              <textarea
+                rows={3}
+                value={fd.foodNote}
+                disabled={fd.foodSaving}
+                onChange={(e) => {
+                  const nextFoodNote = e.target.value;
+                  fd.setFoodNote(nextFoodNote);
+                  fd.setIsAddFoodEntryDirty(
+                    fd.computeIsAddFoodEntryDirty({
+                      mealTag: fd.foodMealTag,
+                      note: nextFoodNote,
+                      loggedAtLocal: fd.foodLoggedAtLocal,
+                    }),
+                  );
+                }}
+                placeholder="What did you eat or drink?"
+                className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+              />
+            </label>
+            {fd.foodSaveError ? (
+              <p
+                className="text-sm text-red-700 dark:text-red-300"
+                role="alert"
+              >
+                {fd.foodSaveError}
+              </p>
+            ) : null}
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <button
+                type="button"
+                className="inline-flex min-h-[48px] items-center justify-center rounded-xl bg-red-700 px-4 text-sm font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
+                disabled={fd.foodSaving}
+                onClick={() => {
+                  void fd.onSaveFoodEntry();
+                }}
+              >
+                {fd.foodSaving ? 'Saving…' : 'Save entry'}
+              </button>
+              {fd.isAddFoodEntryDirty ? (
+                <button
+                  type="button"
+                  className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-red-400 px-4 text-sm font-semibold text-red-700 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-500/60 dark:text-red-300 dark:hover:bg-red-950/30"
+                  onClick={fd.onDiscardAddFoodDraft}
+                >
+                  Discard entry
+                </button>
+              ) : null}
+              {!fd.isAddFoodEntryDirty ? (
+                <button
+                  type="button"
+                  className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-app-border px-4 text-sm font-semibold text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                  onClick={() => {
+                    fd.setIsAddFoodEntryOpen(false);
+                  }}
+                >
+                  Collapse
+                </button>
+              ) : null}
+            </div>
+          </section>
+        ) : null}
+
+        <div
+          className={`flex flex-wrap items-center gap-3 ${
+            fd.editingFoodEntryId == null && !fd.isAddFoodEntryOpen
+              ? 'mt-6'
+              : 'mt-3'
+          }`}
+        >
+          <button
+            type="button"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-app-border px-3 py-2 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            onClick={onBack}
+          >
+            Back
+          </button>
+          {fd.editingFoodEntryId == null && !fd.isAddFoodEntryOpen ? (
+            <button
+              type="button"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-app-border px-3 py-2 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+              onClick={() => {
+                fd.resetFoodForm();
+                fd.setIsAddFoodEntryOpen(true);
+              }}
+            >
+              Add food entry
+            </button>
+          ) : null}
+          <button
+            type="button"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-red-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
+            onClick={fd.onContinueFromFoodDiary}
+            disabled={
+              fd.foodSaving ||
+              fd.deletingFoodEntryId != null ||
+              fd.foodEntriesLoading
+            }
+          >
+            {fd.foodEntries.length > 0 ? 'Continue' : 'Skip for now'}
+          </button>
+        </div>
+        <button
+          type="button"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-3 py-2 text-sm font-medium text-red-700 transition hover:text-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:text-red-300 dark:hover:text-red-200"
+          onClick={() => {
+            setCancelDialogOpen(true);
+          }}
+          disabled={cancelingEpisode}
+        >
+          Cancel episode
+        </button>
+      </div>
+      <ConfirmDialog
+        open={cancelDialogOpen}
+        title="Cancel this active episode?"
+        description="Canceling permanently deletes this in-progress episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone."
+        confirmLabel="Cancel episode"
+        confirmBusyLabel="Canceling episode…"
+        cancelLabel="Keep episode"
+        onConfirm={onCancelEpisodeConfirm}
+        onClose={() => {
+          setCancelDialogOpen(false);
+        }}
+      />
+      <ConfirmDialog
+        open={fd.discardAddFoodDraftDialogOpen}
+        title="Discard this food entry draft?"
+        description="Your unsaved entry will be removed."
+        confirmLabel="Discard draft"
+        cancelLabel="Keep editing"
+        onConfirm={fd.onConfirmDiscardAddFoodDraft}
+        onClose={() => {
+          fd.setDiscardAddFoodDraftDialogOpen(false);
+        }}
+      />
+      <ConfirmDialog
+        open={fd.foodEntryDeleteConfirmEntryId != null}
+        title="Discard this saved food entry?"
+        description="This cannot be undone."
+        confirmLabel="Discard entry"
+        confirmBusyLabel="Discarding…"
+        cancelLabel="Keep entry"
+        onConfirm={fd.onConfirmDeleteFoodEntry}
+        onClose={() => {
+          fd.setFoodEntryDeleteConfirmEntryId(null);
+        }}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -5,23 +5,30 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   EpisodeRow,
   EpisodeType,
+  FoodDiaryEntryRow,
   HealthMarkerRow,
+  MealTag,
   PresetHealthMarkerKind,
   PresetHealthMarkerRow,
 } from '@abstrack/types';
 import {
   bacReadingSuggestsAbsEpisode,
   formatEpisodeDurationSimple,
+  MEAL_TAGS,
   PRESET_HEALTH_MARKER_KIND_LABELS,
   validatePresetHealthMarkerCustomFields,
 } from '@abstrack/types';
 import {
   cancelActiveEpisodeById,
   completeEpisodePostMarkerStep,
+  createFoodDiaryEntry,
+  deleteFoodDiaryEntry,
   endEpisodeIfStillActive,
   getEpisodeById,
+  listFoodDiaryEntriesForEpisode,
   listEpisodeHealthMarkersForEpisode,
   listPresetHealthMarkersForPreset,
+  updateFoodDiaryEntry,
   upsertEpisodeHealthMarkerForLine,
 } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
@@ -152,6 +159,25 @@ function parseOptionalNumber(raw: string | undefined): number | null {
   return Number.isFinite(n) ? n : Number.NaN;
 }
 
+function toLocalDateTimeInputValue(iso: string): string {
+  const date = new Date(iso);
+  const offsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+function localInputValueToIso(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const date = new Date(trimmed);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) {
+    return null;
+  }
+  return date.toISOString();
+}
+
 export type HealthMarkerPromptFlowProps = {
   episodeId: string;
   resumeFromEntry?: boolean;
@@ -177,9 +203,9 @@ export function HealthMarkerPromptFlow({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [persistFeedback, setPersistFeedback] =
     useState<PersistFeedback | null>(null);
-  const [phase, setPhase] = useState<'prompting' | 'postMarkers' | 'complete'>(
-    'prompting',
-  );
+  const [phase, setPhase] = useState<
+    'prompting' | 'postMarkers' | 'foodDiary' | 'complete'
+  >('prompting');
   const [userId, setUserId] = useState<string | null>(null);
   const [lines, setLines] = useState<PresetHealthMarkerRow[]>([]);
   const [drafts, setDrafts] = useState<Record<string, MarkerDraft>>({});
@@ -192,6 +218,29 @@ export function HealthMarkerPromptFlow({
   const [postNote, setPostNote] = useState('');
   const [savingPost, setSavingPost] = useState(false);
   const [postFeedback, setPostFeedback] = useState<string | null>(null);
+  const [foodDiaryDecision, setFoodDiaryDecision] = useState<
+    'pending' | 'saved' | 'skipped'
+  >('pending');
+  const [foodEntries, setFoodEntries] = useState<FoodDiaryEntryRow[]>([]);
+  const [foodEntriesLoading, setFoodEntriesLoading] = useState(false);
+  const [foodEntriesError, setFoodEntriesError] = useState<string | null>(null);
+  const [foodMealTag, setFoodMealTag] = useState<MealTag | null>(null);
+  const [foodNote, setFoodNote] = useState('');
+  const [foodLoggedAtLocal, setFoodLoggedAtLocal] = useState(() =>
+    toLocalDateTimeInputValue(new Date().toISOString()),
+  );
+  const [addFoodInitialLoggedAtLocal, setAddFoodInitialLoggedAtLocal] =
+    useState(() => toLocalDateTimeInputValue(new Date().toISOString()));
+  const [foodSaving, setFoodSaving] = useState(false);
+  const [foodSaveError, setFoodSaveError] = useState<string | null>(null);
+  const [editingFoodEntryId, setEditingFoodEntryId] = useState<string | null>(
+    null,
+  );
+  const [deletingFoodEntryId, setDeletingFoodEntryId] = useState<string | null>(
+    null,
+  );
+  const [isAddFoodEntryOpen, setIsAddFoodEntryOpen] = useState(true);
+  const [isAddFoodEntryDirty, setIsAddFoodEntryDirty] = useState(false);
   const [endingEpisode, setEndingEpisode] = useState(false);
   const [endDialogOpen, setEndDialogOpen] = useState(false);
   const [endFeedback, setEndFeedback] = useState<string | null>(null);
@@ -233,6 +282,21 @@ export function HealthMarkerPromptFlow({
     setPhase('prompting');
     postFormInitRef.current = false;
     setPostFeedback(null);
+    setFoodDiaryDecision('pending');
+    setFoodEntries([]);
+    setFoodEntriesError(null);
+    setFoodEntriesLoading(false);
+    setFoodMealTag(null);
+    setFoodNote('');
+    const initialFoodLoggedAtLocal = toLocalDateTimeInputValue(
+      new Date().toISOString(),
+    );
+    setFoodLoggedAtLocal(initialFoodLoggedAtLocal);
+    setAddFoodInitialLoggedAtLocal(initialFoodLoggedAtLocal);
+    setFoodSaving(false);
+    setFoodSaveError(null);
+    setEditingFoodEntryId(null);
+    setIsAddFoodEntryOpen(true);
     setEndFeedback(null);
     setEndedSummary(null);
     const {
@@ -317,7 +381,7 @@ export function HealthMarkerPromptFlow({
         if (episode.data?.post_marker_step_completed_at) {
           setPhase('complete');
         } else {
-          setPhase('postMarkers');
+          setPhase('foodDiary');
         }
       } else {
         setActiveIndex(firstUnanswered);
@@ -415,7 +479,7 @@ export function HealthMarkerPromptFlow({
 
   /**
    * Re-reads saved episode markers so BAC suggestion reflects values logged during this session,
-   * then moves to the post–marker episode details step.
+   * then moves to the food diary step.
    */
   const enterPostMarkerPhaseAfterMarkers = useCallback(async () => {
     const markerRows = await listEpisodeHealthMarkersForEpisode(
@@ -425,7 +489,7 @@ export function HealthMarkerPromptFlow({
     if (markerRows.ok) {
       setBacSuggestAbs(bacReadingSuggestsAbsEpisode(markerRows.data));
     }
-    setPhase('postMarkers');
+    setPhase('foodDiary');
   }, [episodeId, supabase]);
 
   const goNext = async () => {
@@ -436,7 +500,7 @@ export function HealthMarkerPromptFlow({
       await enterPostMarkerPhaseAfterMarkers();
       announce(
         lines.length === 0
-          ? 'No preset health markers to log. Continue to episode details.'
+          ? 'No preset health markers to log. Continue to food diary.'
           : 'Health marker list complete.',
         { politeness: 'polite' },
       );
@@ -491,6 +555,185 @@ export function HealthMarkerPromptFlow({
     setEndedSummary(null);
     setPhase('complete');
     announce('Episode details saved.', { politeness: 'polite' });
+  };
+
+  const resetFoodForm = useCallback(() => {
+    const initialFoodLoggedAtLocal = toLocalDateTimeInputValue(
+      new Date().toISOString(),
+    );
+    setEditingFoodEntryId(null);
+    setFoodMealTag(null);
+    setFoodNote('');
+    setFoodLoggedAtLocal(initialFoodLoggedAtLocal);
+    setAddFoodInitialLoggedAtLocal(initialFoodLoggedAtLocal);
+    setFoodSaveError(null);
+    setIsAddFoodEntryDirty(false);
+  }, []);
+
+  const computeIsAddFoodEntryDirty = useCallback(
+    (next: {
+      mealTag: MealTag | null;
+      note: string;
+      loggedAtLocal: string;
+    }) => {
+      return (
+        next.mealTag != null ||
+        next.note.trim().length > 0 ||
+        next.loggedAtLocal !== addFoodInitialLoggedAtLocal
+      );
+    },
+    [addFoodInitialLoggedAtLocal],
+  );
+
+  const onDiscardAddFoodDraft = () => {
+    if (!isAddFoodEntryDirty) {
+      setIsAddFoodEntryOpen(false);
+      return;
+    }
+    const shouldDiscard = window.confirm(
+      'Discard this food entry draft? Your unsaved entry will be removed.',
+    );
+    if (!shouldDiscard) {
+      return;
+    }
+    resetFoodForm();
+    setIsAddFoodEntryOpen(false);
+  };
+
+  const loadFoodEntries = useCallback(async () => {
+    setFoodEntriesLoading(true);
+    setFoodEntriesError(null);
+    const result = await listFoodDiaryEntriesForEpisode(supabase, episodeId);
+    setFoodEntriesLoading(false);
+    if (!result.ok) {
+      setFoodEntriesError(result.error.message);
+      return;
+    }
+    setFoodEntries(result.data);
+  }, [episodeId, supabase]);
+
+  useEffect(() => {
+    if (phase !== 'foodDiary') {
+      return;
+    }
+    void loadFoodEntries();
+  }, [phase, loadFoodEntries]);
+
+  const onEditFoodEntry = (entry: FoodDiaryEntryRow) => {
+    setEditingFoodEntryId(entry.id);
+    setIsAddFoodEntryOpen(false);
+    setFoodMealTag(entry.meal_tag);
+    setFoodNote(entry.food_note);
+    setFoodLoggedAtLocal(toLocalDateTimeInputValue(entry.logged_at));
+    setFoodSaveError(null);
+  };
+
+  const onSaveFoodEntry = async () => {
+    if (foodSaving || !userId) {
+      return;
+    }
+    setFoodSaving(true);
+    setFoodSaveError(null);
+    if (!foodMealTag) {
+      const message = 'Choose a meal tag.';
+      setFoodSaveError(message);
+      announce(message, { politeness: 'assertive' });
+      setFoodSaving(false);
+      return;
+    }
+    const loggedAtIso = localInputValueToIso(foodLoggedAtLocal);
+    if (!loggedAtIso) {
+      const message = 'Enter a valid date and time.';
+      setFoodSaveError(message);
+      announce(message, { politeness: 'assertive' });
+      setFoodSaving(false);
+      return;
+    }
+
+    const result =
+      editingFoodEntryId == null
+        ? await createFoodDiaryEntry(supabase, {
+            user_id: userId,
+            episode_id: episodeId,
+            meal_tag: foodMealTag,
+            food_note: foodNote,
+            logged_at: loggedAtIso,
+          })
+        : await updateFoodDiaryEntry(supabase, editingFoodEntryId, {
+            meal_tag: foodMealTag,
+            food_note: foodNote,
+            logged_at: loggedAtIso,
+          });
+    setFoodSaving(false);
+    if (!result.ok) {
+      setFoodSaveError(result.error.message);
+      announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    await loadFoodEntries();
+    resetFoodForm();
+    if (editingFoodEntryId == null) {
+      setIsAddFoodEntryOpen(false);
+    }
+    announce(
+      editingFoodEntryId == null ? 'Food entry saved.' : 'Food entry updated.',
+      { politeness: 'polite' },
+    );
+  };
+
+  const onDeleteFoodEntry = async (entryId: string) => {
+    if (foodSaving || deletingFoodEntryId) {
+      return;
+    }
+    const shouldDelete = window.confirm(
+      'Discard this saved food entry? This cannot be undone.',
+    );
+    if (!shouldDelete) {
+      return;
+    }
+    setDeletingFoodEntryId(entryId);
+    setFoodSaveError(null);
+    const result = await deleteFoodDiaryEntry(supabase, entryId);
+    setDeletingFoodEntryId(null);
+    if (!result.ok) {
+      setFoodSaveError(result.error.message);
+      announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    if (editingFoodEntryId === entryId) {
+      resetFoodForm();
+    }
+    await loadFoodEntries();
+    announce('Food entry discarded.', { politeness: 'polite' });
+  };
+
+  const onContinueFromFoodDiary = () => {
+    setFoodDiaryDecision(foodEntries.length > 0 ? 'saved' : 'skipped');
+    setPhase('postMarkers');
+  };
+
+  const onBackToHealthMarkersFromFoodDiary = () => {
+    setPhase('prompting');
+    announce('Returned to health markers.', { politeness: 'polite' });
+  };
+
+  const onBackToSymptomsFromHealthMarkers = useCallback(() => {
+    const symptomPresetId = episodeRow?.symptom_preset_id;
+    if (!symptomPresetId) {
+      const message =
+        'This episode has no symptom preset linked, so symptoms cannot be reopened.';
+      announce(message, { politeness: 'assertive' });
+      return;
+    }
+    const query = new URLSearchParams();
+    query.set('symptomPresetId', symptomPresetId);
+    query.set('resume', '1');
+    router.push(`/episode/${episodeId}/symptoms?${query.toString()}`);
+  }, [announce, episodeId, episodeRow, router]);
+
+  const onBackToFoodDiaryFromPostMarkers = () => {
+    setPhase('foodDiary');
+    announce('Returned to food diary.', { politeness: 'polite' });
   };
 
   const onFinishToDashboard = () => {
@@ -640,7 +883,7 @@ export function HealthMarkerPromptFlow({
               Episode details
             </h1>
             <p className="mt-2 text-base text-app-muted">
-              After your preset health markers, add any extra context. Choose
+              After health markers and food diary, add any extra context. Choose
               ABS or Other; other fields are optional.
             </p>
           </div>
@@ -751,16 +994,26 @@ export function HealthMarkerPromptFlow({
             </p>
           ) : null}
 
-          <button
-            type="button"
-            className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500 sm:w-auto"
-            disabled={savingPost}
-            onClick={() => {
-              void onSubmitPostMarkers();
-            }}
-          >
-            {savingPost ? 'Saving…' : 'Save and continue'}
-          </button>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <button
+              type="button"
+              className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg sm:w-auto"
+              disabled={savingPost}
+              onClick={onBackToFoodDiaryFromPostMarkers}
+            >
+              Back
+            </button>
+            <button
+              type="button"
+              className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500 sm:w-auto"
+              disabled={savingPost}
+              onClick={() => {
+                void onSubmitPostMarkers();
+              }}
+            >
+              {savingPost ? 'Saving…' : 'Save and continue'}
+            </button>
+          </div>
 
           <button
             type="button"
@@ -815,8 +1068,9 @@ export function HealthMarkerPromptFlow({
               </div>
             ) : (
               <p className="text-sm leading-relaxed text-app-ink">
-                Preset prompts and episode details are saved. End this episode
-                to prevent stale resume state.
+                {foodDiaryDecision === 'saved'
+                  ? 'Preset prompts, episode details, and food diary are saved. End this episode to prevent stale resume state.'
+                  : 'Preset prompts and episode details are saved. End this episode to prevent stale resume state.'}
               </p>
             )}
           </div>
@@ -856,6 +1110,375 @@ export function HealthMarkerPromptFlow({
           onConfirm={onEndEpisode}
           onClose={() => {
             setEndDialogOpen(false);
+          }}
+        />
+      </>
+    );
+  }
+
+  if (phase === 'foodDiary') {
+    return (
+      <>
+        <div className="space-y-6">
+          <div>
+            <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+              Food diary
+            </h1>
+            <p className="mt-2 text-base text-app-muted">
+              Add one or more meals/snacks for this episode, or skip this step.
+            </p>
+          </div>
+
+          <section className="space-y-3 rounded-2xl border border-app-border/90 bg-app-surface p-5 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+            <h2 className="text-base font-semibold text-app-ink">
+              Saved entries
+            </h2>
+            {foodEntriesLoading ? (
+              <p className="text-sm text-app-muted" role="status">
+                Loading entries…
+              </p>
+            ) : null}
+            {foodEntriesError ? (
+              <p
+                className="text-sm text-red-700 dark:text-red-300"
+                role="alert"
+              >
+                {foodEntriesError}
+              </p>
+            ) : null}
+            {!foodEntriesLoading &&
+            !foodEntriesError &&
+            foodEntries.length === 0 ? (
+              <p className="text-sm text-app-muted">
+                No food entries yet for this episode.
+              </p>
+            ) : null}
+            {!foodEntriesLoading && foodEntries.length > 0 ? (
+              <div className="space-y-2">
+                {foodEntries.map((entry) => (
+                  <div
+                    key={entry.id}
+                    className="rounded-xl border border-app-border bg-app-surface px-3 py-3"
+                  >
+                    <p className="text-sm font-semibold text-app-ink">
+                      {entry.meal_tag} -{' '}
+                      <EpisodeLocaleInstant iso={entry.logged_at} />
+                    </p>
+                    <p className="mt-1 whitespace-pre-wrap text-sm text-app-muted">
+                      {entry.food_note}
+                    </p>
+                    {editingFoodEntryId === entry.id ? (
+                      <div className="mt-3 space-y-3 rounded-lg border border-app-border/80 p-3">
+                        <fieldset className="space-y-2" disabled={foodSaving}>
+                          <legend className="text-xs font-medium text-app-ink">
+                            Meal tag
+                          </legend>
+                          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                            {MEAL_TAGS.map((tag) => (
+                              <button
+                                type="button"
+                                key={`edit-${entry.id}-${tag}`}
+                                className={`flex min-h-[40px] items-center justify-center rounded-lg border px-3 py-2 text-xs font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
+                                  foodMealTag === tag
+                                    ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
+                                    : 'border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
+                                } ${
+                                  foodSaving
+                                    ? 'cursor-not-allowed opacity-60'
+                                    : 'cursor-pointer'
+                                }`}
+                                disabled={foodSaving}
+                                onClick={() => {
+                                  if (!foodSaving) {
+                                    setFoodMealTag((prev) =>
+                                      prev === tag ? null : tag,
+                                    );
+                                  }
+                                }}
+                              >
+                                {tag}
+                              </button>
+                            ))}
+                          </div>
+                        </fieldset>
+                        <label className="block space-y-1 text-xs font-medium text-app-ink">
+                          <span>Logged at</span>
+                          <input
+                            type="datetime-local"
+                            value={foodLoggedAtLocal}
+                            disabled={foodSaving}
+                            onChange={(e) => {
+                              setFoodLoggedAtLocal(e.target.value);
+                            }}
+                            className="min-h-[40px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+                          />
+                        </label>
+                        <label className="block space-y-1 text-xs font-medium text-app-ink">
+                          <span>Food note</span>
+                          <textarea
+                            rows={3}
+                            value={foodNote}
+                            disabled={foodSaving}
+                            onChange={(e) => {
+                              setFoodNote(e.target.value);
+                            }}
+                            className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+                          />
+                        </label>
+                        {foodSaveError ? (
+                          <p
+                            className="text-xs text-red-700 dark:text-red-300"
+                            role="alert"
+                          >
+                            {foodSaveError}
+                          </p>
+                        ) : null}
+                        <div className="flex gap-2">
+                          <button
+                            type="button"
+                            className="inline-flex min-h-[40px] items-center justify-center rounded-lg bg-red-700 px-3 text-xs font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
+                            disabled={foodSaving}
+                            onClick={() => {
+                              void onSaveFoodEntry();
+                            }}
+                          >
+                            {foodSaving ? 'Saving…' : 'Update'}
+                          </button>
+                          <button
+                            type="button"
+                            className="inline-flex min-h-[40px] items-center justify-center rounded-lg border border-app-border px-3 text-xs font-semibold text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                            onClick={resetFoodForm}
+                          >
+                            Discard changes
+                          </button>
+                          <button
+                            type="button"
+                            className="inline-flex min-h-[40px] items-center justify-center rounded-lg border border-red-400 px-3 text-xs font-semibold text-red-700 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-500/60 dark:text-red-300 dark:hover:bg-red-950/30"
+                            disabled={deletingFoodEntryId != null}
+                            onClick={() => {
+                              void onDeleteFoodEntry(entry.id);
+                            }}
+                          >
+                            {deletingFoodEntryId === entry.id
+                              ? 'Discarding…'
+                              : 'Discard entry'}
+                          </button>
+                        </div>
+                      </div>
+                    ) : null}
+                    {editingFoodEntryId !== entry.id ? (
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        <button
+                          type="button"
+                          className="inline-flex min-h-[36px] items-center justify-center rounded-lg border border-app-border px-3 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                          onClick={() => {
+                            onEditFoodEntry(entry);
+                          }}
+                        >
+                          Edit
+                        </button>
+                        <button
+                          type="button"
+                          className="inline-flex min-h-[36px] items-center justify-center rounded-lg border border-red-400 px-3 text-sm font-medium text-red-700 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-500/60 dark:text-red-300 dark:hover:bg-red-950/30"
+                          disabled={deletingFoodEntryId != null}
+                          onClick={() => {
+                            void onDeleteFoodEntry(entry.id);
+                          }}
+                        >
+                          {deletingFoodEntryId === entry.id
+                            ? 'Discarding…'
+                            : 'Discard entry'}
+                        </button>
+                      </div>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+            ) : null}
+          </section>
+
+          {editingFoodEntryId == null && isAddFoodEntryOpen ? (
+            <section className="space-y-4 rounded-2xl border border-app-border/90 bg-app-surface p-5 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+              <h2 className="text-base font-semibold text-app-ink">
+                Add food entry
+              </h2>
+              <fieldset className="space-y-2" disabled={foodSaving}>
+                <legend className="text-sm font-medium text-app-ink">
+                  Meal tag
+                </legend>
+                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                  {MEAL_TAGS.map((tag) => (
+                    <button
+                      type="button"
+                      key={`add-${tag}`}
+                      className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
+                        foodMealTag === tag
+                          ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
+                          : 'border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
+                      } ${
+                        foodSaving
+                          ? 'cursor-not-allowed opacity-60'
+                          : 'cursor-pointer'
+                      }`}
+                      disabled={foodSaving}
+                      onClick={() => {
+                        if (!foodSaving) {
+                          const nextMealTag = foodMealTag === tag ? null : tag;
+                          setFoodMealTag(nextMealTag);
+                          setIsAddFoodEntryDirty(
+                            computeIsAddFoodEntryDirty({
+                              mealTag: nextMealTag,
+                              note: foodNote,
+                              loggedAtLocal: foodLoggedAtLocal,
+                            }),
+                          );
+                        }
+                      }}
+                    >
+                      {tag}
+                    </button>
+                  ))}
+                </div>
+              </fieldset>
+              <label className="block space-y-1 text-sm font-medium text-app-ink">
+                <span>Logged at</span>
+                <input
+                  type="datetime-local"
+                  value={foodLoggedAtLocal}
+                  disabled={foodSaving}
+                  onChange={(e) => {
+                    const nextLoggedAtLocal = e.target.value;
+                    setFoodLoggedAtLocal(nextLoggedAtLocal);
+                    setIsAddFoodEntryDirty(
+                      computeIsAddFoodEntryDirty({
+                        mealTag: foodMealTag,
+                        note: foodNote,
+                        loggedAtLocal: nextLoggedAtLocal,
+                      }),
+                    );
+                  }}
+                  className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+                />
+              </label>
+              <label className="block space-y-1 text-sm font-medium text-app-ink">
+                <span>Food note</span>
+                <textarea
+                  rows={3}
+                  value={foodNote}
+                  disabled={foodSaving}
+                  onChange={(e) => {
+                    const nextFoodNote = e.target.value;
+                    setFoodNote(nextFoodNote);
+                    setIsAddFoodEntryDirty(
+                      computeIsAddFoodEntryDirty({
+                        mealTag: foodMealTag,
+                        note: nextFoodNote,
+                        loggedAtLocal: foodLoggedAtLocal,
+                      }),
+                    );
+                  }}
+                  placeholder="What did you eat or drink?"
+                  className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+                />
+              </label>
+              {foodSaveError ? (
+                <p
+                  className="text-sm text-red-700 dark:text-red-300"
+                  role="alert"
+                >
+                  {foodSaveError}
+                </p>
+              ) : null}
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <button
+                  type="button"
+                  className="inline-flex min-h-[48px] items-center justify-center rounded-xl bg-red-700 px-4 text-sm font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
+                  disabled={foodSaving}
+                  onClick={() => {
+                    void onSaveFoodEntry();
+                  }}
+                >
+                  {foodSaving ? 'Saving…' : 'Save entry'}
+                </button>
+                {isAddFoodEntryDirty ? (
+                  <button
+                    type="button"
+                    className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-red-400 px-4 text-sm font-semibold text-red-700 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-500/60 dark:text-red-300 dark:hover:bg-red-950/30"
+                    onClick={onDiscardAddFoodDraft}
+                  >
+                    Discard entry
+                  </button>
+                ) : null}
+                {!isAddFoodEntryDirty ? (
+                  <button
+                    type="button"
+                    className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-app-border px-4 text-sm font-semibold text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                    onClick={() => {
+                      setIsAddFoodEntryOpen(false);
+                    }}
+                  >
+                    Collapse
+                  </button>
+                ) : null}
+              </div>
+            </section>
+          ) : null}
+
+          <div
+            className={`flex flex-wrap items-center gap-3 ${
+              editingFoodEntryId == null && !isAddFoodEntryOpen
+                ? 'mt-6'
+                : 'mt-3'
+            }`}
+          >
+            <button
+              type="button"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-app-border px-3 py-2 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+              onClick={onBackToHealthMarkersFromFoodDiary}
+            >
+              Back
+            </button>
+            {editingFoodEntryId == null && !isAddFoodEntryOpen ? (
+              <button
+                type="button"
+                className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-app-border px-3 py-2 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                onClick={() => {
+                  resetFoodForm();
+                  setIsAddFoodEntryOpen(true);
+                }}
+              >
+                Add food entry
+              </button>
+            ) : null}
+            <button
+              type="button"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-red-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 dark:hover:bg-red-500"
+              onClick={onContinueFromFoodDiary}
+            >
+              {foodEntries.length > 0 ? 'Continue' : 'Skip for now'}
+            </button>
+          </div>
+          <button
+            type="button"
+            className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-3 py-2 text-sm font-medium text-red-700 transition hover:text-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:text-red-300 dark:hover:text-red-200"
+            onClick={() => {
+              setCancelDialogOpen(true);
+            }}
+            disabled={cancelingEpisode}
+          >
+            Cancel episode
+          </button>
+        </div>
+        <ConfirmDialog
+          open={cancelDialogOpen}
+          title="Cancel this active episode?"
+          description="Canceling permanently deletes this in-progress episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone."
+          confirmLabel="Cancel episode"
+          confirmBusyLabel="Canceling episode…"
+          cancelLabel="Keep episode"
+          onConfirm={onCancelEpisodeConfirm}
+          onClose={() => {
+            setCancelDialogOpen(false);
           }}
         />
       </>
@@ -980,16 +1603,20 @@ export function HealthMarkerPromptFlow({
         ) : null}
 
         <div className="flex flex-col gap-3 sm:flex-row">
-          {activeIndex > 0 ? (
-            <button
-              type="button"
-              className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-              onClick={goBackStep}
-              disabled={saving}
-            >
-              Back
-            </button>
-          ) : null}
+          <button
+            type="button"
+            className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            onClick={() => {
+              if (activeIndex > 0) {
+                goBackStep();
+                return;
+              }
+              onBackToSymptomsFromHealthMarkers();
+            }}
+            disabled={saving}
+          >
+            Back
+          </button>
           {currentLine ? (
             <button
               type="button"
@@ -1017,7 +1644,7 @@ export function HealthMarkerPromptFlow({
               lines.length === 0
                 ? 'Continue to episode details'
                 : activeIndex >= lines.length - 1
-                  ? 'Finish health marker list'
+                  ? 'Next health marker'
                   : 'Next health marker'
             }
           >
@@ -1026,7 +1653,7 @@ export function HealthMarkerPromptFlow({
               : lines.length === 0
                 ? 'Continue to episode details'
                 : activeIndex >= lines.length - 1
-                  ? 'Finish'
+                  ? 'Next'
                   : 'Next'}
           </button>
         </div>

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -698,15 +698,17 @@ export function HealthMarkerPromptFlow({
   };
 
   const onContinueFromFoodDiary = () => {
-    if (
-      foodSaving ||
-      deletingFoodEntryId != null ||
-      foodEntriesLoading ||
-      foodEntriesError != null
-    ) {
+    if (foodSaving || deletingFoodEntryId != null || foodEntriesLoading) {
       return;
     }
-    setFoodDiaryDecision(foodEntries.length > 0 ? 'saved' : 'skipped');
+    // If listing failed we cannot assert saved entries; treat as skipped for completion copy.
+    setFoodDiaryDecision(
+      foodEntriesError != null
+        ? 'skipped'
+        : foodEntries.length > 0
+          ? 'saved'
+          : 'skipped',
+    );
     setPhase('postMarkers');
   };
 
@@ -1489,10 +1491,7 @@ export function HealthMarkerPromptFlow({
               className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-red-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
               onClick={onContinueFromFoodDiary}
               disabled={
-                foodSaving ||
-                deletingFoodEntryId != null ||
-                foodEntriesLoading ||
-                foodEntriesError != null
+                foodSaving || deletingFoodEntryId != null || foodEntriesLoading
               }
             >
               {foodEntries.length > 0 ? 'Continue' : 'Skip for now'}

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -34,6 +34,10 @@ import {
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { clearSymptomPromptSession } from '@/lib/episode-flow/symptom-prompt-session-store';
+import {
+  localInputValueToIso,
+  toLocalDateTimeInputValue,
+} from '@/lib/food-diary/date-time';
 import { EpisodeLocaleInstant } from '@/components/episodes/EpisodeLocaleInstant';
 import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
 
@@ -157,25 +161,6 @@ function parseOptionalNumber(raw: string | undefined): number | null {
   }
   const n = Number(trimmed);
   return Number.isFinite(n) ? n : Number.NaN;
-}
-
-function toLocalDateTimeInputValue(iso: string): string {
-  const date = new Date(iso);
-  const offsetMs = date.getTimezoneOffset() * 60_000;
-  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
-}
-
-function localInputValueToIso(value: string): string | null {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const date = new Date(trimmed);
-  const time = date.getTime();
-  if (!Number.isFinite(time)) {
-    return null;
-  }
-  return date.toISOString();
 }
 
 export type HealthMarkerPromptFlowProps = {
@@ -1182,35 +1167,39 @@ export function HealthMarkerPromptFlow({
                             Meal tag
                           </legend>
                           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                            {MEAL_TAGS.map((tag) => (
-                              <label
-                                key={`edit-${entry.id}-${tag}`}
-                                className={`flex min-h-[40px] items-center justify-center rounded-lg border px-3 py-2 text-xs font-medium shadow-sm transition focus-within:outline-none focus-within:ring-2 focus-within:ring-app-ring focus-within:ring-offset-2 focus-within:ring-offset-app-bg ${
-                                  foodMealTag === tag
-                                    ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
-                                    : 'border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
-                                } ${
-                                  foodSaving
-                                    ? 'cursor-not-allowed opacity-60'
-                                    : 'cursor-pointer'
-                                }`}
-                              >
-                                <input
-                                  type="checkbox"
-                                  className="sr-only"
-                                  checked={foodMealTag === tag}
+                            {MEAL_TAGS.map((tag) =>
+                              foodMealTag === tag ? (
+                                <button
+                                  type="button"
+                                  key={`edit-${entry.id}-${tag}`}
+                                  aria-pressed="true"
+                                  className="flex min-h-[40px] items-center justify-center rounded-lg border border-red-700 bg-red-50 px-3 py-2 text-xs font-medium text-red-900 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100"
                                   disabled={foodSaving}
-                                  onChange={() => {
+                                  onClick={() => {
                                     if (!foodSaving) {
-                                      setFoodMealTag((prev) =>
-                                        prev === tag ? null : tag,
-                                      );
+                                      setFoodMealTag(null);
                                     }
                                   }}
-                                />
-                                <span>{tag}</span>
-                              </label>
-                            ))}
+                                >
+                                  {tag}
+                                </button>
+                              ) : (
+                                <button
+                                  type="button"
+                                  key={`edit-${entry.id}-${tag}`}
+                                  aria-pressed="false"
+                                  className="flex min-h-[40px] cursor-pointer items-center justify-center rounded-lg border border-app-border bg-app-surface px-3 py-2 text-xs font-medium text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                                  disabled={foodSaving}
+                                  onClick={() => {
+                                    if (!foodSaving) {
+                                      setFoodMealTag(tag);
+                                    }
+                                  }}
+                                >
+                                  {tag}
+                                </button>
+                              ),
+                            )}
                           </div>
                         </fieldset>
                         <label className="block space-y-1 text-xs font-medium text-app-ink">
@@ -1319,42 +1308,53 @@ export function HealthMarkerPromptFlow({
                   Meal tag
                 </legend>
                 <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                  {MEAL_TAGS.map((tag) => (
-                    <label
-                      key={`add-${tag}`}
-                      className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-within:outline-none focus-within:ring-2 focus-within:ring-app-ring focus-within:ring-offset-2 focus-within:ring-offset-app-bg ${
-                        foodMealTag === tag
-                          ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
-                          : 'border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
-                      } ${
-                        foodSaving
-                          ? 'cursor-not-allowed opacity-60'
-                          : 'cursor-pointer'
-                      }`}
-                    >
-                      <input
-                        type="checkbox"
-                        className="sr-only"
-                        checked={foodMealTag === tag}
+                  {MEAL_TAGS.map((tag) =>
+                    foodMealTag === tag ? (
+                      <button
+                        type="button"
+                        key={`add-${tag}`}
+                        aria-pressed="true"
+                        className="flex min-h-[44px] items-center justify-center rounded-lg border border-red-700 bg-red-50 px-3 py-2 text-sm font-medium text-red-900 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100"
                         disabled={foodSaving}
-                        onChange={() => {
+                        onClick={() => {
                           if (!foodSaving) {
-                            const nextMealTag =
-                              foodMealTag === tag ? null : tag;
-                            setFoodMealTag(nextMealTag);
+                            setFoodMealTag(null);
                             setIsAddFoodEntryDirty(
                               computeIsAddFoodEntryDirty({
-                                mealTag: nextMealTag,
+                                mealTag: null,
                                 note: foodNote,
                                 loggedAtLocal: foodLoggedAtLocal,
                               }),
                             );
                           }
                         }}
-                      />
-                      <span>{tag}</span>
-                    </label>
-                  ))}
+                      >
+                        {tag}
+                      </button>
+                    ) : (
+                      <button
+                        type="button"
+                        key={`add-${tag}`}
+                        aria-pressed="false"
+                        className="flex min-h-[44px] cursor-pointer items-center justify-center rounded-lg border border-app-border bg-app-surface px-3 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                        disabled={foodSaving}
+                        onClick={() => {
+                          if (!foodSaving) {
+                            setFoodMealTag(tag);
+                            setIsAddFoodEntryDirty(
+                              computeIsAddFoodEntryDirty({
+                                mealTag: tag,
+                                note: foodNote,
+                                loggedAtLocal: foodLoggedAtLocal,
+                              }),
+                            );
+                          }
+                        }}
+                      >
+                        {tag}
+                      </button>
+                    ),
+                  )}
                 </div>
               </fieldset>
               <label className="block space-y-1 text-sm font-medium text-app-ink">

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -5,41 +5,32 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type {
   EpisodeRow,
   EpisodeType,
-  FoodDiaryEntryRow,
   HealthMarkerRow,
-  MealTag,
   PresetHealthMarkerKind,
   PresetHealthMarkerRow,
 } from '@abstrack/types';
 import {
   bacReadingSuggestsAbsEpisode,
   formatEpisodeDurationSimple,
-  MEAL_TAGS,
   PRESET_HEALTH_MARKER_KIND_LABELS,
   validatePresetHealthMarkerCustomFields,
 } from '@abstrack/types';
 import {
   cancelActiveEpisodeById,
   completeEpisodePostMarkerStep,
-  createFoodDiaryEntry,
-  deleteFoodDiaryEntry,
   endEpisodeIfStillActive,
   getEpisodeById,
-  listFoodDiaryEntriesForEpisode,
   listEpisodeHealthMarkersForEpisode,
   listPresetHealthMarkersForPreset,
-  updateFoodDiaryEntry,
   upsertEpisodeHealthMarkerForLine,
 } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { clearSymptomPromptSession } from '@/lib/episode-flow/symptom-prompt-session-store';
-import {
-  localInputValueToIso,
-  toLocalDateTimeInputValue,
-} from '@/lib/food-diary/date-time';
 import { EpisodeLocaleInstant } from '@/components/episodes/EpisodeLocaleInstant';
 import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
+import { EpisodeFoodDiaryStep } from './EpisodeFoodDiaryStep';
+import { useEpisodeFoodDiary } from './use-episode-food-diary';
 
 type MarkerDraft = {
   value: string;
@@ -206,33 +197,6 @@ export function HealthMarkerPromptFlow({
   const [foodDiaryDecision, setFoodDiaryDecision] = useState<
     'pending' | 'saved' | 'skipped'
   >('pending');
-  const [foodEntries, setFoodEntries] = useState<FoodDiaryEntryRow[]>([]);
-  const [foodEntriesLoading, setFoodEntriesLoading] = useState(false);
-  const [foodEntriesError, setFoodEntriesError] = useState<string | null>(null);
-  const [foodMealTag, setFoodMealTag] = useState<MealTag | null>(null);
-  const [foodNote, setFoodNote] = useState('');
-  const initialFoodLoggedAtLocalRef = useRef(
-    toLocalDateTimeInputValue(new Date().toISOString()),
-  );
-  const [foodLoggedAtLocal, setFoodLoggedAtLocal] = useState(
-    initialFoodLoggedAtLocalRef.current,
-  );
-  const [addFoodInitialLoggedAtLocal, setAddFoodInitialLoggedAtLocal] =
-    useState(initialFoodLoggedAtLocalRef.current);
-  const [foodSaving, setFoodSaving] = useState(false);
-  const [foodSaveError, setFoodSaveError] = useState<string | null>(null);
-  const [editingFoodEntryId, setEditingFoodEntryId] = useState<string | null>(
-    null,
-  );
-  const [deletingFoodEntryId, setDeletingFoodEntryId] = useState<string | null>(
-    null,
-  );
-  const [isAddFoodEntryOpen, setIsAddFoodEntryOpen] = useState(true);
-  const [isAddFoodEntryDirty, setIsAddFoodEntryDirty] = useState(false);
-  const [discardAddFoodDraftDialogOpen, setDiscardAddFoodDraftDialogOpen] =
-    useState(false);
-  const [foodEntryDeleteConfirmEntryId, setFoodEntryDeleteConfirmEntryId] =
-    useState<string | null>(null);
   const [endingEpisode, setEndingEpisode] = useState(false);
   const [endDialogOpen, setEndDialogOpen] = useState(false);
   const [endFeedback, setEndFeedback] = useState<string | null>(null);
@@ -245,6 +209,20 @@ export function HealthMarkerPromptFlow({
   const [cancelingEpisode, setCancelingEpisode] = useState(false);
   const [episodeRow, setEpisodeRow] = useState<EpisodeRow | null>(null);
   const loadGenRef = useRef(0);
+
+  const onLeaveFoodDiary = useCallback((decision: 'saved' | 'skipped') => {
+    setFoodDiaryDecision(decision);
+    setPhase('postMarkers');
+  }, []);
+
+  const foodDiary = useEpisodeFoodDiary({
+    episodeId,
+    userId,
+    supabase,
+    announce,
+    enabled: phase === 'foodDiary',
+    onLeaveFoodDiary,
+  });
 
   useEffect(() => {
     setPersistFeedback(null);
@@ -275,24 +253,7 @@ export function HealthMarkerPromptFlow({
     postFormInitRef.current = false;
     setPostFeedback(null);
     setFoodDiaryDecision('pending');
-    setFoodEntries([]);
-    setFoodEntriesError(null);
-    setFoodEntriesLoading(false);
-    setFoodMealTag(null);
-    setFoodNote('');
-    const initialFoodLoggedAtLocal = toLocalDateTimeInputValue(
-      new Date().toISOString(),
-    );
-    setFoodLoggedAtLocal(initialFoodLoggedAtLocal);
-    setAddFoodInitialLoggedAtLocal(initialFoodLoggedAtLocal);
-    setFoodSaving(false);
-    setFoodSaveError(null);
-    setEditingFoodEntryId(null);
-    setDeletingFoodEntryId(null);
-    setDiscardAddFoodDraftDialogOpen(false);
-    setFoodEntryDeleteConfirmEntryId(null);
-    setIsAddFoodEntryOpen(true);
-    setIsAddFoodEntryDirty(false);
+    foodDiary.reset();
     setEndFeedback(null);
     setEndedSummary(null);
     const {
@@ -386,7 +347,7 @@ export function HealthMarkerPromptFlow({
       setActiveIndex(0);
     }
     setStatus('ready');
-  }, [episodeId, resumeFromEntry, supabase]);
+  }, [episodeId, foodDiary.reset, resumeFromEntry, supabase]);
 
   useEffect(() => {
     void load();
@@ -553,172 +514,6 @@ export function HealthMarkerPromptFlow({
     setEndedSummary(null);
     setPhase('complete');
     announce('Episode details saved.', { politeness: 'polite' });
-  };
-
-  const resetFoodForm = useCallback(() => {
-    const initialFoodLoggedAtLocal = toLocalDateTimeInputValue(
-      new Date().toISOString(),
-    );
-    setEditingFoodEntryId(null);
-    setFoodMealTag(null);
-    setFoodNote('');
-    setFoodLoggedAtLocal(initialFoodLoggedAtLocal);
-    setAddFoodInitialLoggedAtLocal(initialFoodLoggedAtLocal);
-    setFoodSaveError(null);
-    setIsAddFoodEntryDirty(false);
-  }, []);
-
-  const computeIsAddFoodEntryDirty = useCallback(
-    (next: {
-      mealTag: MealTag | null;
-      note: string;
-      loggedAtLocal: string;
-    }) => {
-      return (
-        next.mealTag != null ||
-        next.note.trim().length > 0 ||
-        next.loggedAtLocal !== addFoodInitialLoggedAtLocal
-      );
-    },
-    [addFoodInitialLoggedAtLocal],
-  );
-
-  const onDiscardAddFoodDraft = () => {
-    if (!isAddFoodEntryDirty) {
-      setIsAddFoodEntryOpen(false);
-      return;
-    }
-    setDiscardAddFoodDraftDialogOpen(true);
-  };
-
-  const onConfirmDiscardAddFoodDraft = () => {
-    resetFoodForm();
-    setIsAddFoodEntryOpen(false);
-  };
-
-  const loadFoodEntries = useCallback(async () => {
-    setFoodEntriesLoading(true);
-    setFoodEntriesError(null);
-    const result = await listFoodDiaryEntriesForEpisode(supabase, episodeId);
-    setFoodEntriesLoading(false);
-    if (!result.ok) {
-      setFoodEntriesError(result.error.message);
-      return;
-    }
-    setFoodEntries(result.data);
-  }, [episodeId, supabase]);
-
-  useEffect(() => {
-    if (phase !== 'foodDiary') {
-      return;
-    }
-    void loadFoodEntries();
-  }, [phase, loadFoodEntries]);
-
-  const onEditFoodEntry = (entry: FoodDiaryEntryRow) => {
-    setEditingFoodEntryId(entry.id);
-    setIsAddFoodEntryOpen(false);
-    setFoodMealTag(entry.meal_tag);
-    setFoodNote(entry.food_note);
-    setFoodLoggedAtLocal(toLocalDateTimeInputValue(entry.logged_at));
-    setFoodSaveError(null);
-  };
-
-  const onSaveFoodEntry = async () => {
-    if (foodSaving || !userId) {
-      return;
-    }
-    setFoodSaving(true);
-    setFoodSaveError(null);
-    if (!foodMealTag) {
-      const message = 'Choose a meal tag.';
-      setFoodSaveError(message);
-      announce(message, { politeness: 'assertive' });
-      setFoodSaving(false);
-      return;
-    }
-    const loggedAtIso = localInputValueToIso(foodLoggedAtLocal);
-    if (!loggedAtIso) {
-      const message = 'Enter a valid date and time.';
-      setFoodSaveError(message);
-      announce(message, { politeness: 'assertive' });
-      setFoodSaving(false);
-      return;
-    }
-
-    const result =
-      editingFoodEntryId == null
-        ? await createFoodDiaryEntry(supabase, {
-            user_id: userId,
-            episode_id: episodeId,
-            meal_tag: foodMealTag,
-            food_note: foodNote,
-            logged_at: loggedAtIso,
-          })
-        : await updateFoodDiaryEntry(supabase, editingFoodEntryId, {
-            meal_tag: foodMealTag,
-            food_note: foodNote,
-            logged_at: loggedAtIso,
-          });
-    setFoodSaving(false);
-    if (!result.ok) {
-      setFoodSaveError(result.error.message);
-      announce(result.error.message, { politeness: 'assertive' });
-      return;
-    }
-    await loadFoodEntries();
-    resetFoodForm();
-    if (editingFoodEntryId == null) {
-      setIsAddFoodEntryOpen(false);
-    }
-    announce(
-      editingFoodEntryId == null ? 'Food entry saved.' : 'Food entry updated.',
-      { politeness: 'polite' },
-    );
-  };
-
-  const requestDeleteFoodEntry = (entryId: string) => {
-    if (foodSaving || deletingFoodEntryId) {
-      return;
-    }
-    setFoodEntryDeleteConfirmEntryId(entryId);
-  };
-
-  const onConfirmDeleteFoodEntry = async () => {
-    const entryId = foodEntryDeleteConfirmEntryId;
-    if (!entryId || foodSaving || deletingFoodEntryId) {
-      return false;
-    }
-    setDeletingFoodEntryId(entryId);
-    setFoodSaveError(null);
-    const result = await deleteFoodDiaryEntry(supabase, entryId);
-    setDeletingFoodEntryId(null);
-    if (!result.ok) {
-      setFoodSaveError(result.error.message);
-      announce(result.error.message, { politeness: 'assertive' });
-      return false;
-    }
-    if (editingFoodEntryId === entryId) {
-      resetFoodForm();
-    }
-    await loadFoodEntries();
-    announce('Food entry discarded.', { politeness: 'polite' });
-    return;
-  };
-
-  const onContinueFromFoodDiary = () => {
-    if (foodSaving || deletingFoodEntryId != null || foodEntriesLoading) {
-      return;
-    }
-    // If listing failed we cannot assert saved entries; treat as skipped for completion copy.
-    setFoodDiaryDecision(
-      foodEntriesError != null
-        ? 'skipped'
-        : foodEntries.length > 0
-          ? 'saved'
-          : 'skipped',
-    );
-    setPhase('postMarkers');
   };
 
   const onBackToHealthMarkersFromFoodDiary = () => {
@@ -1127,406 +922,14 @@ export function HealthMarkerPromptFlow({
 
   if (phase === 'foodDiary') {
     return (
-      <>
-        <div className="space-y-6">
-          <div>
-            <h1 className="text-2xl font-bold tracking-tight text-app-ink">
-              Food diary
-            </h1>
-            <p className="mt-2 text-base text-app-muted">
-              Add one or more meals/snacks for this episode, or skip this step.
-            </p>
-          </div>
-
-          <section className="space-y-3 rounded-2xl border border-app-border/90 bg-app-surface p-5 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
-            <h2 className="text-base font-semibold text-app-ink">
-              Saved entries
-            </h2>
-            {foodEntriesLoading ? (
-              <p className="text-sm text-app-muted" role="status">
-                Loading entries…
-              </p>
-            ) : null}
-            {foodEntriesError ? (
-              <div className="space-y-2">
-                <p
-                  className="text-sm text-red-700 dark:text-red-300"
-                  role="alert"
-                >
-                  {foodEntriesError}
-                </p>
-                <button
-                  type="button"
-                  className="inline-flex min-h-[40px] items-center justify-center rounded-lg border border-app-border px-3 py-2 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
-                  disabled={foodEntriesLoading}
-                  onClick={() => {
-                    void loadFoodEntries();
-                  }}
-                >
-                  {foodEntriesLoading ? 'Retrying…' : 'Try again'}
-                </button>
-              </div>
-            ) : null}
-            {!foodEntriesLoading &&
-            !foodEntriesError &&
-            foodEntries.length === 0 ? (
-              <p className="text-sm text-app-muted">
-                No food entries yet for this episode.
-              </p>
-            ) : null}
-            {!foodEntriesLoading && foodEntries.length > 0 ? (
-              <div className="space-y-2">
-                {foodEntries.map((entry) => (
-                  <div
-                    key={entry.id}
-                    className="rounded-xl border border-app-border bg-app-surface px-3 py-3"
-                  >
-                    <p className="text-sm font-semibold text-app-ink">
-                      {entry.meal_tag} -{' '}
-                      <EpisodeLocaleInstant iso={entry.logged_at} />
-                    </p>
-                    <p className="mt-1 whitespace-pre-wrap text-sm text-app-muted">
-                      {entry.food_note}
-                    </p>
-                    {editingFoodEntryId === entry.id ? (
-                      <div className="mt-3 space-y-3 rounded-lg border border-app-border/80 p-3">
-                        <fieldset className="space-y-2" disabled={foodSaving}>
-                          <legend className="text-xs font-medium text-app-ink">
-                            Meal tag
-                          </legend>
-                          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                            {MEAL_TAGS.map((tag) => {
-                              const selected = foodMealTag === tag;
-                              return (
-                                <button
-                                  type="button"
-                                  key={`edit-${entry.id}-${tag}`}
-                                  aria-pressed={selected}
-                                  className={`flex min-h-[40px] items-center justify-center rounded-lg border px-3 py-2 text-xs font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 ${
-                                    selected
-                                      ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
-                                      : 'cursor-pointer border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
-                                  }`}
-                                  disabled={foodSaving}
-                                  onClick={() => {
-                                    if (!foodSaving) {
-                                      setFoodMealTag(selected ? null : tag);
-                                    }
-                                  }}
-                                >
-                                  {tag}
-                                </button>
-                              );
-                            })}
-                          </div>
-                        </fieldset>
-                        <label className="block space-y-1 text-xs font-medium text-app-ink">
-                          <span>Logged at</span>
-                          <input
-                            type="datetime-local"
-                            value={foodLoggedAtLocal}
-                            disabled={foodSaving}
-                            onChange={(e) => {
-                              setFoodLoggedAtLocal(e.target.value);
-                            }}
-                            className="min-h-[40px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
-                          />
-                        </label>
-                        <label className="block space-y-1 text-xs font-medium text-app-ink">
-                          <span>Food note</span>
-                          <textarea
-                            rows={3}
-                            value={foodNote}
-                            disabled={foodSaving}
-                            onChange={(e) => {
-                              setFoodNote(e.target.value);
-                            }}
-                            className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
-                          />
-                        </label>
-                        {foodSaveError ? (
-                          <p
-                            className="text-xs text-red-700 dark:text-red-300"
-                            role="alert"
-                          >
-                            {foodSaveError}
-                          </p>
-                        ) : null}
-                        <div className="flex gap-2">
-                          <button
-                            type="button"
-                            className="inline-flex min-h-[40px] items-center justify-center rounded-lg bg-red-700 px-3 text-xs font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
-                            disabled={foodSaving}
-                            onClick={() => {
-                              void onSaveFoodEntry();
-                            }}
-                          >
-                            {foodSaving ? 'Saving…' : 'Update'}
-                          </button>
-                          <button
-                            type="button"
-                            className="inline-flex min-h-[40px] items-center justify-center rounded-lg border border-app-border px-3 text-xs font-semibold text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-                            onClick={resetFoodForm}
-                          >
-                            Discard changes
-                          </button>
-                          <button
-                            type="button"
-                            className="inline-flex min-h-[40px] items-center justify-center rounded-lg border border-red-400 px-3 text-xs font-semibold text-red-700 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-500/60 dark:text-red-300 dark:hover:bg-red-950/30"
-                            disabled={deletingFoodEntryId != null}
-                            onClick={() => {
-                              requestDeleteFoodEntry(entry.id);
-                            }}
-                          >
-                            {deletingFoodEntryId === entry.id
-                              ? 'Discarding…'
-                              : 'Discard entry'}
-                          </button>
-                        </div>
-                      </div>
-                    ) : null}
-                    {editingFoodEntryId !== entry.id ? (
-                      <div className="mt-2 flex flex-wrap gap-2">
-                        <button
-                          type="button"
-                          className="inline-flex min-h-[36px] items-center justify-center rounded-lg border border-app-border px-3 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-                          onClick={() => {
-                            onEditFoodEntry(entry);
-                          }}
-                        >
-                          Edit
-                        </button>
-                        <button
-                          type="button"
-                          className="inline-flex min-h-[36px] items-center justify-center rounded-lg border border-red-400 px-3 text-sm font-medium text-red-700 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-500/60 dark:text-red-300 dark:hover:bg-red-950/30"
-                          disabled={deletingFoodEntryId != null}
-                          onClick={() => {
-                            requestDeleteFoodEntry(entry.id);
-                          }}
-                        >
-                          {deletingFoodEntryId === entry.id
-                            ? 'Discarding…'
-                            : 'Discard entry'}
-                        </button>
-                      </div>
-                    ) : null}
-                  </div>
-                ))}
-              </div>
-            ) : null}
-          </section>
-
-          {editingFoodEntryId == null && isAddFoodEntryOpen ? (
-            <section className="space-y-4 rounded-2xl border border-app-border/90 bg-app-surface p-5 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
-              <h2 className="text-base font-semibold text-app-ink">
-                Add food entry
-              </h2>
-              <fieldset className="space-y-2" disabled={foodSaving}>
-                <legend className="text-sm font-medium text-app-ink">
-                  Meal tag
-                </legend>
-                <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                  {MEAL_TAGS.map((tag) => {
-                    const selected = foodMealTag === tag;
-                    return (
-                      <button
-                        type="button"
-                        key={`add-${tag}`}
-                        aria-pressed={selected}
-                        className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 ${
-                          selected
-                            ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
-                            : 'cursor-pointer border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
-                        }`}
-                        disabled={foodSaving}
-                        onClick={() => {
-                          if (!foodSaving) {
-                            const nextMealTag = selected ? null : tag;
-                            setFoodMealTag(nextMealTag);
-                            setIsAddFoodEntryDirty(
-                              computeIsAddFoodEntryDirty({
-                                mealTag: nextMealTag,
-                                note: foodNote,
-                                loggedAtLocal: foodLoggedAtLocal,
-                              }),
-                            );
-                          }
-                        }}
-                      >
-                        {tag}
-                      </button>
-                    );
-                  })}
-                </div>
-              </fieldset>
-              <label className="block space-y-1 text-sm font-medium text-app-ink">
-                <span>Logged at</span>
-                <input
-                  type="datetime-local"
-                  value={foodLoggedAtLocal}
-                  disabled={foodSaving}
-                  onChange={(e) => {
-                    const nextLoggedAtLocal = e.target.value;
-                    setFoodLoggedAtLocal(nextLoggedAtLocal);
-                    setIsAddFoodEntryDirty(
-                      computeIsAddFoodEntryDirty({
-                        mealTag: foodMealTag,
-                        note: foodNote,
-                        loggedAtLocal: nextLoggedAtLocal,
-                      }),
-                    );
-                  }}
-                  className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
-                />
-              </label>
-              <label className="block space-y-1 text-sm font-medium text-app-ink">
-                <span>Food note</span>
-                <textarea
-                  rows={3}
-                  value={foodNote}
-                  disabled={foodSaving}
-                  onChange={(e) => {
-                    const nextFoodNote = e.target.value;
-                    setFoodNote(nextFoodNote);
-                    setIsAddFoodEntryDirty(
-                      computeIsAddFoodEntryDirty({
-                        mealTag: foodMealTag,
-                        note: nextFoodNote,
-                        loggedAtLocal: foodLoggedAtLocal,
-                      }),
-                    );
-                  }}
-                  placeholder="What did you eat or drink?"
-                  className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
-                />
-              </label>
-              {foodSaveError ? (
-                <p
-                  className="text-sm text-red-700 dark:text-red-300"
-                  role="alert"
-                >
-                  {foodSaveError}
-                </p>
-              ) : null}
-              <div className="flex flex-col gap-2 sm:flex-row">
-                <button
-                  type="button"
-                  className="inline-flex min-h-[48px] items-center justify-center rounded-xl bg-red-700 px-4 text-sm font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
-                  disabled={foodSaving}
-                  onClick={() => {
-                    void onSaveFoodEntry();
-                  }}
-                >
-                  {foodSaving ? 'Saving…' : 'Save entry'}
-                </button>
-                {isAddFoodEntryDirty ? (
-                  <button
-                    type="button"
-                    className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-red-400 px-4 text-sm font-semibold text-red-700 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-500/60 dark:text-red-300 dark:hover:bg-red-950/30"
-                    onClick={onDiscardAddFoodDraft}
-                  >
-                    Discard entry
-                  </button>
-                ) : null}
-                {!isAddFoodEntryDirty ? (
-                  <button
-                    type="button"
-                    className="inline-flex min-h-[48px] items-center justify-center rounded-xl border border-app-border px-4 text-sm font-semibold text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-                    onClick={() => {
-                      setIsAddFoodEntryOpen(false);
-                    }}
-                  >
-                    Collapse
-                  </button>
-                ) : null}
-              </div>
-            </section>
-          ) : null}
-
-          <div
-            className={`flex flex-wrap items-center gap-3 ${
-              editingFoodEntryId == null && !isAddFoodEntryOpen
-                ? 'mt-6'
-                : 'mt-3'
-            }`}
-          >
-            <button
-              type="button"
-              className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-app-border px-3 py-2 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-              onClick={onBackToHealthMarkersFromFoodDiary}
-            >
-              Back
-            </button>
-            {editingFoodEntryId == null && !isAddFoodEntryOpen ? (
-              <button
-                type="button"
-                className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-app-border px-3 py-2 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-                onClick={() => {
-                  resetFoodForm();
-                  setIsAddFoodEntryOpen(true);
-                }}
-              >
-                Add food entry
-              </button>
-            ) : null}
-            <button
-              type="button"
-              className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-red-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
-              onClick={onContinueFromFoodDiary}
-              disabled={
-                foodSaving || deletingFoodEntryId != null || foodEntriesLoading
-              }
-            >
-              {foodEntries.length > 0 ? 'Continue' : 'Skip for now'}
-            </button>
-          </div>
-          <button
-            type="button"
-            className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-3 py-2 text-sm font-medium text-red-700 transition hover:text-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:text-red-300 dark:hover:text-red-200"
-            onClick={() => {
-              setCancelDialogOpen(true);
-            }}
-            disabled={cancelingEpisode}
-          >
-            Cancel episode
-          </button>
-        </div>
-        <ConfirmDialog
-          open={cancelDialogOpen}
-          title="Cancel this active episode?"
-          description="Canceling permanently deletes this in-progress episode, its symptom answers, health markers, and media metadata. Food diary entries are kept, but this episode link is removed. This cannot be undone."
-          confirmLabel="Cancel episode"
-          confirmBusyLabel="Canceling episode…"
-          cancelLabel="Keep episode"
-          onConfirm={onCancelEpisodeConfirm}
-          onClose={() => {
-            setCancelDialogOpen(false);
-          }}
-        />
-        <ConfirmDialog
-          open={discardAddFoodDraftDialogOpen}
-          title="Discard this food entry draft?"
-          description="Your unsaved entry will be removed."
-          confirmLabel="Discard draft"
-          cancelLabel="Keep editing"
-          onConfirm={onConfirmDiscardAddFoodDraft}
-          onClose={() => {
-            setDiscardAddFoodDraftDialogOpen(false);
-          }}
-        />
-        <ConfirmDialog
-          open={foodEntryDeleteConfirmEntryId != null}
-          title="Discard this saved food entry?"
-          description="This cannot be undone."
-          confirmLabel="Discard entry"
-          confirmBusyLabel="Discarding…"
-          cancelLabel="Keep entry"
-          onConfirm={onConfirmDeleteFoodEntry}
-          onClose={() => {
-            setFoodEntryDeleteConfirmEntryId(null);
-          }}
-        />
-      </>
+      <EpisodeFoodDiaryStep
+        fd={foodDiary}
+        onBack={onBackToHealthMarkersFromFoodDiary}
+        cancelDialogOpen={cancelDialogOpen}
+        setCancelDialogOpen={setCancelDialogOpen}
+        onCancelEpisodeConfirm={onCancelEpisodeConfirm}
+        cancelingEpisode={cancelingEpisode}
+      />
     );
   }
 

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -698,7 +698,12 @@ export function HealthMarkerPromptFlow({
   };
 
   const onContinueFromFoodDiary = () => {
-    if (foodSaving || deletingFoodEntryId != null || foodEntriesLoading) {
+    if (
+      foodSaving ||
+      deletingFoodEntryId != null ||
+      foodEntriesLoading ||
+      foodEntriesError != null
+    ) {
       return;
     }
     setFoodDiaryDecision(foodEntries.length > 0 ? 'saved' : 'skipped');
@@ -1132,12 +1137,24 @@ export function HealthMarkerPromptFlow({
               </p>
             ) : null}
             {foodEntriesError ? (
-              <p
-                className="text-sm text-red-700 dark:text-red-300"
-                role="alert"
-              >
-                {foodEntriesError}
-              </p>
+              <div className="space-y-2">
+                <p
+                  className="text-sm text-red-700 dark:text-red-300"
+                  role="alert"
+                >
+                  {foodEntriesError}
+                </p>
+                <button
+                  type="button"
+                  className="inline-flex min-h-[40px] items-center justify-center rounded-lg border border-app-border px-3 py-2 text-sm font-medium text-app-ink transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                  disabled={foodEntriesLoading}
+                  onClick={() => {
+                    void loadFoodEntries();
+                  }}
+                >
+                  {foodEntriesLoading ? 'Retrying…' : 'Try again'}
+                </button>
+              </div>
             ) : null}
             {!foodEntriesLoading &&
             !foodEntriesError &&
@@ -1472,7 +1489,10 @@ export function HealthMarkerPromptFlow({
               className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-red-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
               onClick={onContinueFromFoodDiary}
               disabled={
-                foodSaving || deletingFoodEntryId != null || foodEntriesLoading
+                foodSaving ||
+                deletingFoodEntryId != null ||
+                foodEntriesLoading ||
+                foodEntriesError != null
               }
             >
               {foodEntries.length > 0 ? 'Continue' : 'Skip for now'}

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -226,11 +226,14 @@ export function HealthMarkerPromptFlow({
   const [foodEntriesError, setFoodEntriesError] = useState<string | null>(null);
   const [foodMealTag, setFoodMealTag] = useState<MealTag | null>(null);
   const [foodNote, setFoodNote] = useState('');
-  const [foodLoggedAtLocal, setFoodLoggedAtLocal] = useState(() =>
+  const initialFoodLoggedAtLocalRef = useRef(
     toLocalDateTimeInputValue(new Date().toISOString()),
   );
+  const [foodLoggedAtLocal, setFoodLoggedAtLocal] = useState(
+    initialFoodLoggedAtLocalRef.current,
+  );
   const [addFoodInitialLoggedAtLocal, setAddFoodInitialLoggedAtLocal] =
-    useState(() => toLocalDateTimeInputValue(new Date().toISOString()));
+    useState(initialFoodLoggedAtLocalRef.current);
   const [foodSaving, setFoodSaving] = useState(false);
   const [foodSaveError, setFoodSaveError] = useState<string | null>(null);
   const [editingFoodEntryId, setEditingFoodEntryId] = useState<string | null>(

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -229,6 +229,10 @@ export function HealthMarkerPromptFlow({
   );
   const [isAddFoodEntryOpen, setIsAddFoodEntryOpen] = useState(true);
   const [isAddFoodEntryDirty, setIsAddFoodEntryDirty] = useState(false);
+  const [discardAddFoodDraftDialogOpen, setDiscardAddFoodDraftDialogOpen] =
+    useState(false);
+  const [foodEntryDeleteConfirmEntryId, setFoodEntryDeleteConfirmEntryId] =
+    useState<string | null>(null);
   const [endingEpisode, setEndingEpisode] = useState(false);
   const [endDialogOpen, setEndDialogOpen] = useState(false);
   const [endFeedback, setEndFeedback] = useState<string | null>(null);
@@ -284,7 +288,11 @@ export function HealthMarkerPromptFlow({
     setFoodSaving(false);
     setFoodSaveError(null);
     setEditingFoodEntryId(null);
+    setDeletingFoodEntryId(null);
+    setDiscardAddFoodDraftDialogOpen(false);
+    setFoodEntryDeleteConfirmEntryId(null);
     setIsAddFoodEntryOpen(true);
+    setIsAddFoodEntryDirty(false);
     setEndFeedback(null);
     setEndedSummary(null);
     const {
@@ -580,12 +588,10 @@ export function HealthMarkerPromptFlow({
       setIsAddFoodEntryOpen(false);
       return;
     }
-    const shouldDiscard = window.confirm(
-      'Discard this food entry draft? Your unsaved entry will be removed.',
-    );
-    if (!shouldDiscard) {
-      return;
-    }
+    setDiscardAddFoodDraftDialogOpen(true);
+  };
+
+  const onConfirmDiscardAddFoodDraft = () => {
     resetFoodForm();
     setIsAddFoodEntryOpen(false);
   };
@@ -671,15 +677,17 @@ export function HealthMarkerPromptFlow({
     );
   };
 
-  const onDeleteFoodEntry = async (entryId: string) => {
+  const requestDeleteFoodEntry = (entryId: string) => {
     if (foodSaving || deletingFoodEntryId) {
       return;
     }
-    const shouldDelete = window.confirm(
-      'Discard this saved food entry? This cannot be undone.',
-    );
-    if (!shouldDelete) {
-      return;
+    setFoodEntryDeleteConfirmEntryId(entryId);
+  };
+
+  const onConfirmDeleteFoodEntry = async () => {
+    const entryId = foodEntryDeleteConfirmEntryId;
+    if (!entryId || foodSaving || deletingFoodEntryId) {
+      return false;
     }
     setDeletingFoodEntryId(entryId);
     setFoodSaveError(null);
@@ -688,13 +696,14 @@ export function HealthMarkerPromptFlow({
     if (!result.ok) {
       setFoodSaveError(result.error.message);
       announce(result.error.message, { politeness: 'assertive' });
-      return;
+      return false;
     }
     if (editingFoodEntryId === entryId) {
       resetFoodForm();
     }
     await loadFoodEntries();
     announce('Food entry discarded.', { politeness: 'polite' });
+    return;
   };
 
   const onContinueFromFoodDiary = () => {
@@ -1186,39 +1195,29 @@ export function HealthMarkerPromptFlow({
                             Meal tag
                           </legend>
                           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                            {MEAL_TAGS.map((tag) =>
-                              foodMealTag === tag ? (
+                            {MEAL_TAGS.map((tag) => {
+                              const selected = foodMealTag === tag;
+                              return (
                                 <button
                                   type="button"
                                   key={`edit-${entry.id}-${tag}`}
-                                  aria-pressed="true"
-                                  className="flex min-h-[40px] items-center justify-center rounded-lg border border-red-700 bg-red-50 px-3 py-2 text-xs font-medium text-red-900 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100"
+                                  aria-pressed={selected}
+                                  className={`flex min-h-[40px] items-center justify-center rounded-lg border px-3 py-2 text-xs font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 ${
+                                    selected
+                                      ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
+                                      : 'cursor-pointer border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
+                                  }`}
                                   disabled={foodSaving}
                                   onClick={() => {
                                     if (!foodSaving) {
-                                      setFoodMealTag(null);
+                                      setFoodMealTag(selected ? null : tag);
                                     }
                                   }}
                                 >
                                   {tag}
                                 </button>
-                              ) : (
-                                <button
-                                  type="button"
-                                  key={`edit-${entry.id}-${tag}`}
-                                  aria-pressed="false"
-                                  className="flex min-h-[40px] cursor-pointer items-center justify-center rounded-lg border border-app-border bg-app-surface px-3 py-2 text-xs font-medium text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
-                                  disabled={foodSaving}
-                                  onClick={() => {
-                                    if (!foodSaving) {
-                                      setFoodMealTag(tag);
-                                    }
-                                  }}
-                                >
-                                  {tag}
-                                </button>
-                              ),
-                            )}
+                              );
+                            })}
                           </div>
                         </fieldset>
                         <label className="block space-y-1 text-xs font-medium text-app-ink">
@@ -1276,7 +1275,7 @@ export function HealthMarkerPromptFlow({
                             className="inline-flex min-h-[40px] items-center justify-center rounded-lg border border-red-400 px-3 text-xs font-semibold text-red-700 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-500/60 dark:text-red-300 dark:hover:bg-red-950/30"
                             disabled={deletingFoodEntryId != null}
                             onClick={() => {
-                              void onDeleteFoodEntry(entry.id);
+                              requestDeleteFoodEntry(entry.id);
                             }}
                           >
                             {deletingFoodEntryId === entry.id
@@ -1302,7 +1301,7 @@ export function HealthMarkerPromptFlow({
                           className="inline-flex min-h-[36px] items-center justify-center rounded-lg border border-red-400 px-3 text-sm font-medium text-red-700 transition hover:bg-red-50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-red-500/60 dark:text-red-300 dark:hover:bg-red-950/30"
                           disabled={deletingFoodEntryId != null}
                           onClick={() => {
-                            void onDeleteFoodEntry(entry.id);
+                            requestDeleteFoodEntry(entry.id);
                           }}
                         >
                           {deletingFoodEntryId === entry.id
@@ -1327,20 +1326,26 @@ export function HealthMarkerPromptFlow({
                   Meal tag
                 </legend>
                 <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-                  {MEAL_TAGS.map((tag) =>
-                    foodMealTag === tag ? (
+                  {MEAL_TAGS.map((tag) => {
+                    const selected = foodMealTag === tag;
+                    return (
                       <button
                         type="button"
                         key={`add-${tag}`}
-                        aria-pressed="true"
-                        className="flex min-h-[44px] items-center justify-center rounded-lg border border-red-700 bg-red-50 px-3 py-2 text-sm font-medium text-red-900 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100"
+                        aria-pressed={selected}
+                        className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 ${
+                          selected
+                            ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
+                            : 'cursor-pointer border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
+                        }`}
                         disabled={foodSaving}
                         onClick={() => {
                           if (!foodSaving) {
-                            setFoodMealTag(null);
+                            const nextMealTag = selected ? null : tag;
+                            setFoodMealTag(nextMealTag);
                             setIsAddFoodEntryDirty(
                               computeIsAddFoodEntryDirty({
-                                mealTag: null,
+                                mealTag: nextMealTag,
                                 note: foodNote,
                                 loggedAtLocal: foodLoggedAtLocal,
                               }),
@@ -1350,30 +1355,8 @@ export function HealthMarkerPromptFlow({
                       >
                         {tag}
                       </button>
-                    ) : (
-                      <button
-                        type="button"
-                        key={`add-${tag}`}
-                        aria-pressed="false"
-                        className="flex min-h-[44px] cursor-pointer items-center justify-center rounded-lg border border-app-border bg-app-surface px-3 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
-                        disabled={foodSaving}
-                        onClick={() => {
-                          if (!foodSaving) {
-                            setFoodMealTag(tag);
-                            setIsAddFoodEntryDirty(
-                              computeIsAddFoodEntryDirty({
-                                mealTag: tag,
-                                note: foodNote,
-                                loggedAtLocal: foodLoggedAtLocal,
-                              }),
-                            );
-                          }
-                        }}
-                      >
-                        {tag}
-                      </button>
-                    ),
-                  )}
+                    );
+                  })}
                 </div>
               </fieldset>
               <label className="block space-y-1 text-sm font-medium text-app-ink">
@@ -1518,6 +1501,29 @@ export function HealthMarkerPromptFlow({
           onConfirm={onCancelEpisodeConfirm}
           onClose={() => {
             setCancelDialogOpen(false);
+          }}
+        />
+        <ConfirmDialog
+          open={discardAddFoodDraftDialogOpen}
+          title="Discard this food entry draft?"
+          description="Your unsaved entry will be removed."
+          confirmLabel="Discard draft"
+          cancelLabel="Keep editing"
+          onConfirm={onConfirmDiscardAddFoodDraft}
+          onClose={() => {
+            setDiscardAddFoodDraftDialogOpen(false);
+          }}
+        />
+        <ConfirmDialog
+          open={foodEntryDeleteConfirmEntryId != null}
+          title="Discard this saved food entry?"
+          description="This cannot be undone."
+          confirmLabel="Discard entry"
+          confirmBusyLabel="Discarding…"
+          cancelLabel="Keep entry"
+          onConfirm={onConfirmDeleteFoodEntry}
+          onClose={() => {
+            setFoodEntryDeleteConfirmEntryId(null);
           }}
         />
       </>

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -372,7 +372,7 @@ export function HealthMarkerPromptFlow({
     setDrafts(nextDrafts);
 
     // Initial hydrate / resume; values logged later in this session are picked up in
-    // enterPostMarkerPhaseAfterMarkers before the post-marker step.
+    // enterFoodDiaryPhaseAfterMarkers before the food diary step.
     setBacSuggestAbs(bacReadingSuggestsAbsEpisode(markerRows.data));
 
     const firstUnanswered = presetLines.data.findIndex((line) => {
@@ -411,6 +411,8 @@ export function HealthMarkerPromptFlow({
     : false;
   const canSkip = Boolean(currentLine) && !measurementReadyForSave;
   const skipPressable = canSkip && !saving;
+  const continueToFoodDiary =
+    lines.length === 0 || activeIndex >= lines.length - 1;
 
   const onUpdateDraft = (patch: Partial<MarkerDraft>) => {
     if (!currentLine) {
@@ -484,7 +486,7 @@ export function HealthMarkerPromptFlow({
    * Re-reads saved episode markers so BAC suggestion reflects values logged during this session,
    * then moves to the food diary step.
    */
-  const enterPostMarkerPhaseAfterMarkers = useCallback(async () => {
+  const enterFoodDiaryPhaseAfterMarkers = useCallback(async () => {
     const markerRows = await listEpisodeHealthMarkersForEpisode(
       supabase,
       episodeId,
@@ -500,7 +502,7 @@ export function HealthMarkerPromptFlow({
       return;
     }
     if (!currentLine) {
-      await enterPostMarkerPhaseAfterMarkers();
+      await enterFoodDiaryPhaseAfterMarkers();
       announce(
         lines.length === 0
           ? 'No preset health markers to log. Continue to food diary.'
@@ -514,7 +516,7 @@ export function HealthMarkerPromptFlow({
       return;
     }
     if (activeIndex >= lines.length - 1) {
-      await enterPostMarkerPhaseAfterMarkers();
+      await enterFoodDiaryPhaseAfterMarkers();
       announce('Health marker list complete.', { politeness: 'polite' });
       return;
     }
@@ -526,7 +528,7 @@ export function HealthMarkerPromptFlow({
       return;
     }
     if (activeIndex >= lines.length - 1) {
-      await enterPostMarkerPhaseAfterMarkers();
+      await enterFoodDiaryPhaseAfterMarkers();
       announce('Health marker list complete.', { politeness: 'polite' });
       return;
     }
@@ -711,6 +713,9 @@ export function HealthMarkerPromptFlow({
   };
 
   const onContinueFromFoodDiary = () => {
+    if (foodSaving || deletingFoodEntryId != null || foodEntriesLoading) {
+      return;
+    }
     setFoodDiaryDecision(foodEntries.length > 0 ? 'saved' : 'skipped');
     setPhase('postMarkers');
   };
@@ -1178,10 +1183,9 @@ export function HealthMarkerPromptFlow({
                           </legend>
                           <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
                             {MEAL_TAGS.map((tag) => (
-                              <button
-                                type="button"
+                              <label
                                 key={`edit-${entry.id}-${tag}`}
-                                className={`flex min-h-[40px] items-center justify-center rounded-lg border px-3 py-2 text-xs font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
+                                className={`flex min-h-[40px] items-center justify-center rounded-lg border px-3 py-2 text-xs font-medium shadow-sm transition focus-within:outline-none focus-within:ring-2 focus-within:ring-app-ring focus-within:ring-offset-2 focus-within:ring-offset-app-bg ${
                                   foodMealTag === tag
                                     ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
                                     : 'border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
@@ -1190,17 +1194,22 @@ export function HealthMarkerPromptFlow({
                                     ? 'cursor-not-allowed opacity-60'
                                     : 'cursor-pointer'
                                 }`}
-                                disabled={foodSaving}
-                                onClick={() => {
-                                  if (!foodSaving) {
-                                    setFoodMealTag((prev) =>
-                                      prev === tag ? null : tag,
-                                    );
-                                  }
-                                }}
                               >
-                                {tag}
-                              </button>
+                                <input
+                                  type="checkbox"
+                                  className="sr-only"
+                                  checked={foodMealTag === tag}
+                                  disabled={foodSaving}
+                                  onChange={() => {
+                                    if (!foodSaving) {
+                                      setFoodMealTag((prev) =>
+                                        prev === tag ? null : tag,
+                                      );
+                                    }
+                                  }}
+                                />
+                                <span>{tag}</span>
+                              </label>
                             ))}
                           </div>
                         </fieldset>
@@ -1311,10 +1320,9 @@ export function HealthMarkerPromptFlow({
                 </legend>
                 <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
                   {MEAL_TAGS.map((tag) => (
-                    <button
-                      type="button"
+                    <label
                       key={`add-${tag}`}
-                      className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
+                      className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-within:outline-none focus-within:ring-2 focus-within:ring-app-ring focus-within:ring-offset-2 focus-within:ring-offset-app-bg ${
                         foodMealTag === tag
                           ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
                           : 'border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
@@ -1323,23 +1331,29 @@ export function HealthMarkerPromptFlow({
                           ? 'cursor-not-allowed opacity-60'
                           : 'cursor-pointer'
                       }`}
-                      disabled={foodSaving}
-                      onClick={() => {
-                        if (!foodSaving) {
-                          const nextMealTag = foodMealTag === tag ? null : tag;
-                          setFoodMealTag(nextMealTag);
-                          setIsAddFoodEntryDirty(
-                            computeIsAddFoodEntryDirty({
-                              mealTag: nextMealTag,
-                              note: foodNote,
-                              loggedAtLocal: foodLoggedAtLocal,
-                            }),
-                          );
-                        }
-                      }}
                     >
-                      {tag}
-                    </button>
+                      <input
+                        type="checkbox"
+                        className="sr-only"
+                        checked={foodMealTag === tag}
+                        disabled={foodSaving}
+                        onChange={() => {
+                          if (!foodSaving) {
+                            const nextMealTag =
+                              foodMealTag === tag ? null : tag;
+                            setFoodMealTag(nextMealTag);
+                            setIsAddFoodEntryDirty(
+                              computeIsAddFoodEntryDirty({
+                                mealTag: nextMealTag,
+                                note: foodNote,
+                                loggedAtLocal: foodLoggedAtLocal,
+                              }),
+                            );
+                          }
+                        }}
+                      />
+                      <span>{tag}</span>
+                    </label>
                   ))}
                 </div>
               </fieldset>
@@ -1455,8 +1469,11 @@ export function HealthMarkerPromptFlow({
             ) : null}
             <button
               type="button"
-              className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-red-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 dark:hover:bg-red-500"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-lg bg-red-700 px-4 py-2.5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
               onClick={onContinueFromFoodDiary}
+              disabled={
+                foodSaving || deletingFoodEntryId != null || foodEntriesLoading
+              }
             >
               {foodEntries.length > 0 ? 'Continue' : 'Skip for now'}
             </button>
@@ -1644,20 +1661,16 @@ export function HealthMarkerPromptFlow({
             }}
             disabled={saving}
             aria-label={
-              lines.length === 0
-                ? 'Continue to episode details'
-                : activeIndex >= lines.length - 1
-                  ? 'Next health marker'
-                  : 'Next health marker'
+              continueToFoodDiary
+                ? 'Continue to food diary'
+                : 'Next health marker'
             }
           >
             {saving
               ? 'Saving…'
-              : lines.length === 0
-                ? 'Continue to episode details'
-                : activeIndex >= lines.length - 1
-                  ? 'Next'
-                  : 'Next'}
+              : continueToFoodDiary
+                ? 'Continue to food diary'
+                : 'Next'}
           </button>
         </div>
         <button

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -673,7 +673,11 @@ export function SymptomPromptFlow({
 
   const continueToHealthMarkers = useCallback(() => {
     omitSymptomPromptSnapshotOnUnmountRef.current = true;
-    clearSymptomPromptSession(episodeIdRef.current);
+    // Preserve symptom step position so health-marker "Back" returns here.
+    setSymptomPromptSession(episodeIdRef.current, {
+      activeIndex: activeIndexRef.current,
+      answers: answersRef.current,
+    });
     const q = new URLSearchParams();
     if (resumeFromHomeIntentRef.current) {
       q.set('resume', '1');

--- a/apps/web/src/components/episode-flow/use-episode-food-diary.ts
+++ b/apps/web/src/components/episode-flow/use-episode-food-diary.ts
@@ -193,6 +193,21 @@ export function useEpisodeFoodDiary({
     void loadFoodEntries();
   }, [enabled, loadFoodEntries]);
 
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    // Hook mounts before the food-diary step; refresh default logged-at when entering
+    // so it matches "now" after time on health markers (skip in-flight add/edit).
+    if (editingFoodEntryId != null || isAddFoodEntryDirty) {
+      return;
+    }
+    const nowLocal = toLocalDateTimeInputValue(new Date().toISOString());
+    initialFoodLoggedAtLocalRef.current = nowLocal;
+    setFoodLoggedAtLocal(nowLocal);
+    setAddFoodInitialLoggedAtLocal(nowLocal);
+  }, [enabled, editingFoodEntryId, isAddFoodEntryDirty]);
+
   const onEditFoodEntry = useCallback((entry: FoodDiaryEntryRow) => {
     setEditingFoodEntryId(entry.id);
     setIsAddFoodEntryOpen(false);

--- a/apps/web/src/components/episode-flow/use-episode-food-diary.ts
+++ b/apps/web/src/components/episode-flow/use-episode-food-diary.ts
@@ -312,17 +312,10 @@ export function useEpisodeFoodDiary({
     if (foodSaving || deletingFoodEntryId != null || foodEntriesLoading) {
       return;
     }
-    onLeaveFoodDiary(
-      foodEntriesError != null
-        ? 'skipped'
-        : foodEntries.length > 0
-          ? 'saved'
-          : 'skipped',
-    );
+    onLeaveFoodDiary(foodEntries.length > 0 ? 'saved' : 'skipped');
   }, [
     deletingFoodEntryId,
     foodEntries.length,
-    foodEntriesError,
     foodEntriesLoading,
     foodSaving,
     onLeaveFoodDiary,

--- a/apps/web/src/components/episode-flow/use-episode-food-diary.ts
+++ b/apps/web/src/components/episode-flow/use-episode-food-diary.ts
@@ -15,6 +15,32 @@ import {
   toLocalDateTimeInputValue,
 } from '@/lib/food-diary/date-time';
 
+/** Same ordering as `listFoodDiaryEntriesForEpisode` (newest first). */
+function compareFoodDiaryEntriesDesc(
+  a: FoodDiaryEntryRow,
+  b: FoodDiaryEntryRow,
+): number {
+  let c = b.logged_at.localeCompare(a.logged_at);
+  if (c !== 0) {
+    return c;
+  }
+  c = b.created_at.localeCompare(a.created_at);
+  if (c !== 0) {
+    return c;
+  }
+  return b.id.localeCompare(a.id);
+}
+
+function upsertFoodEntrySorted(
+  prev: FoodDiaryEntryRow[],
+  row: FoodDiaryEntryRow,
+): FoodDiaryEntryRow[] {
+  const next = prev.filter((e) => e.id !== row.id);
+  next.push(row);
+  next.sort(compareFoodDiaryEntriesDesc);
+  return next;
+}
+
 type AnnouncePoliteness = 'polite' | 'assertive';
 
 export type EpisodeFoodDiaryAnnounce = (
@@ -260,6 +286,7 @@ export function useEpisodeFoodDiary({
       announce(result.error.message, { politeness: 'assertive' });
       return;
     }
+    setFoodEntries((prev) => upsertFoodEntrySorted(prev, result.data));
     await loadFoodEntries();
     resetFoodForm();
     if (editingId == null) {

--- a/apps/web/src/components/episode-flow/use-episode-food-diary.ts
+++ b/apps/web/src/components/episode-flow/use-episode-food-diary.ts
@@ -287,7 +287,7 @@ export function useEpisodeFoodDiary({
       return;
     }
     setFoodEntries((prev) => upsertFoodEntrySorted(prev, result.data));
-    await loadFoodEntries();
+    setFoodEntriesError(null);
     resetFoodForm();
     if (editingId == null) {
       setIsAddFoodEntryOpen(false);
@@ -303,7 +303,6 @@ export function useEpisodeFoodDiary({
     foodMealTag,
     foodNote,
     foodSaving,
-    loadFoodEntries,
     resetFoodForm,
     supabase,
     userId,

--- a/apps/web/src/components/episode-flow/use-episode-food-diary.ts
+++ b/apps/web/src/components/episode-flow/use-episode-food-diary.ts
@@ -1,0 +1,365 @@
+'use client';
+
+import type { Dispatch, SetStateAction } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import type { FoodDiaryEntryRow, MealTag } from '@abstrack/types';
+import type { AbstrackSupabaseClient } from '@abstrack/supabase';
+import {
+  createFoodDiaryEntry,
+  deleteFoodDiaryEntry,
+  listFoodDiaryEntriesForEpisode,
+  updateFoodDiaryEntry,
+} from '@abstrack/supabase';
+import {
+  localInputValueToIso,
+  toLocalDateTimeInputValue,
+} from '@/lib/food-diary/date-time';
+
+type AnnouncePoliteness = 'polite' | 'assertive';
+
+export type EpisodeFoodDiaryAnnounce = (
+  message: string,
+  options?: { politeness: AnnouncePoliteness },
+) => void;
+
+export type UseEpisodeFoodDiaryArgs = {
+  episodeId: string;
+  userId: string | null;
+  supabase: AbstrackSupabaseClient;
+  announce: EpisodeFoodDiaryAnnounce;
+  /** When true, loads entries on mount and when this flips to true. */
+  enabled: boolean;
+  /** Called after user taps Continue / Skip with how saved entries should be summarized. */
+  onLeaveFoodDiary: (decision: 'saved' | 'skipped') => void;
+};
+
+export type EpisodeFoodDiaryHookResult = {
+  reset: () => void;
+  foodEntries: FoodDiaryEntryRow[];
+  foodEntriesLoading: boolean;
+  foodEntriesError: string | null;
+  foodMealTag: MealTag | null;
+  setFoodMealTag: Dispatch<SetStateAction<MealTag | null>>;
+  foodNote: string;
+  setFoodNote: Dispatch<SetStateAction<string>>;
+  foodLoggedAtLocal: string;
+  setFoodLoggedAtLocal: Dispatch<SetStateAction<string>>;
+  foodSaving: boolean;
+  foodSaveError: string | null;
+  editingFoodEntryId: string | null;
+  deletingFoodEntryId: string | null;
+  isAddFoodEntryOpen: boolean;
+  setIsAddFoodEntryOpen: Dispatch<SetStateAction<boolean>>;
+  isAddFoodEntryDirty: boolean;
+  setIsAddFoodEntryDirty: Dispatch<SetStateAction<boolean>>;
+  discardAddFoodDraftDialogOpen: boolean;
+  setDiscardAddFoodDraftDialogOpen: Dispatch<SetStateAction<boolean>>;
+  foodEntryDeleteConfirmEntryId: string | null;
+  setFoodEntryDeleteConfirmEntryId: Dispatch<SetStateAction<string | null>>;
+  computeIsAddFoodEntryDirty: (next: {
+    mealTag: MealTag | null;
+    note: string;
+    loggedAtLocal: string;
+  }) => boolean;
+  resetFoodForm: () => void;
+  loadFoodEntries: () => Promise<void>;
+  onDiscardAddFoodDraft: () => void;
+  onConfirmDiscardAddFoodDraft: () => void;
+  onEditFoodEntry: (entry: FoodDiaryEntryRow) => void;
+  onSaveFoodEntry: () => Promise<void>;
+  requestDeleteFoodEntry: (entryId: string) => void;
+  onConfirmDeleteFoodEntry: () => Promise<void | false>;
+  onContinueFromFoodDiary: () => void;
+};
+
+/**
+ * Food diary list / add / edit / delete for the episode health-marker flow.
+ * Keeps loading, dirty tracking, and confirm dialogs out of the parent stepper.
+ */
+export function useEpisodeFoodDiary({
+  episodeId,
+  userId,
+  supabase,
+  announce,
+  enabled,
+  onLeaveFoodDiary,
+}: UseEpisodeFoodDiaryArgs): EpisodeFoodDiaryHookResult {
+  const [foodEntries, setFoodEntries] = useState<FoodDiaryEntryRow[]>([]);
+  const [foodEntriesLoading, setFoodEntriesLoading] = useState(false);
+  const [foodEntriesError, setFoodEntriesError] = useState<string | null>(null);
+  const [foodMealTag, setFoodMealTag] = useState<MealTag | null>(null);
+  const [foodNote, setFoodNote] = useState('');
+  const initialFoodLoggedAtLocalRef = useRef(
+    toLocalDateTimeInputValue(new Date().toISOString()),
+  );
+  const [foodLoggedAtLocal, setFoodLoggedAtLocal] = useState(
+    initialFoodLoggedAtLocalRef.current,
+  );
+  const [addFoodInitialLoggedAtLocal, setAddFoodInitialLoggedAtLocal] =
+    useState(initialFoodLoggedAtLocalRef.current);
+  const [foodSaving, setFoodSaving] = useState(false);
+  const [foodSaveError, setFoodSaveError] = useState<string | null>(null);
+  const [editingFoodEntryId, setEditingFoodEntryId] = useState<string | null>(
+    null,
+  );
+  const [deletingFoodEntryId, setDeletingFoodEntryId] = useState<string | null>(
+    null,
+  );
+  const [isAddFoodEntryOpen, setIsAddFoodEntryOpen] = useState(true);
+  const [isAddFoodEntryDirty, setIsAddFoodEntryDirty] = useState(false);
+  const [discardAddFoodDraftDialogOpen, setDiscardAddFoodDraftDialogOpen] =
+    useState(false);
+  const [foodEntryDeleteConfirmEntryId, setFoodEntryDeleteConfirmEntryId] =
+    useState<string | null>(null);
+
+  const resetFoodForm = useCallback(() => {
+    const initialFoodLoggedAtLocal = toLocalDateTimeInputValue(
+      new Date().toISOString(),
+    );
+    setEditingFoodEntryId(null);
+    setFoodMealTag(null);
+    setFoodNote('');
+    setFoodLoggedAtLocal(initialFoodLoggedAtLocal);
+    setAddFoodInitialLoggedAtLocal(initialFoodLoggedAtLocal);
+    setFoodSaveError(null);
+    setIsAddFoodEntryDirty(false);
+  }, []);
+
+  const reset = useCallback(() => {
+    setFoodEntries([]);
+    setFoodEntriesError(null);
+    setFoodEntriesLoading(false);
+    setFoodMealTag(null);
+    setFoodNote('');
+    const initialFoodLoggedAtLocal = toLocalDateTimeInputValue(
+      new Date().toISOString(),
+    );
+    setFoodLoggedAtLocal(initialFoodLoggedAtLocal);
+    setAddFoodInitialLoggedAtLocal(initialFoodLoggedAtLocal);
+    setFoodSaving(false);
+    setFoodSaveError(null);
+    setEditingFoodEntryId(null);
+    setDeletingFoodEntryId(null);
+    setDiscardAddFoodDraftDialogOpen(false);
+    setFoodEntryDeleteConfirmEntryId(null);
+    setIsAddFoodEntryOpen(true);
+    setIsAddFoodEntryDirty(false);
+  }, []);
+
+  const computeIsAddFoodEntryDirty = useCallback(
+    (next: {
+      mealTag: MealTag | null;
+      note: string;
+      loggedAtLocal: string;
+    }) => {
+      return (
+        next.mealTag != null ||
+        next.note.trim().length > 0 ||
+        next.loggedAtLocal !== addFoodInitialLoggedAtLocal
+      );
+    },
+    [addFoodInitialLoggedAtLocal],
+  );
+
+  const onDiscardAddFoodDraft = useCallback(() => {
+    if (!isAddFoodEntryDirty) {
+      setIsAddFoodEntryOpen(false);
+      return;
+    }
+    setDiscardAddFoodDraftDialogOpen(true);
+  }, [isAddFoodEntryDirty]);
+
+  const onConfirmDiscardAddFoodDraft = useCallback(() => {
+    resetFoodForm();
+    setIsAddFoodEntryOpen(false);
+  }, [resetFoodForm]);
+
+  const loadFoodEntries = useCallback(async () => {
+    setFoodEntriesLoading(true);
+    setFoodEntriesError(null);
+    const result = await listFoodDiaryEntriesForEpisode(supabase, episodeId);
+    setFoodEntriesLoading(false);
+    if (!result.ok) {
+      setFoodEntriesError(result.error.message);
+      return;
+    }
+    setFoodEntries(result.data);
+  }, [episodeId, supabase]);
+
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
+    void loadFoodEntries();
+  }, [enabled, loadFoodEntries]);
+
+  const onEditFoodEntry = useCallback((entry: FoodDiaryEntryRow) => {
+    setEditingFoodEntryId(entry.id);
+    setIsAddFoodEntryOpen(false);
+    setFoodMealTag(entry.meal_tag);
+    setFoodNote(entry.food_note);
+    setFoodLoggedAtLocal(toLocalDateTimeInputValue(entry.logged_at));
+    setFoodSaveError(null);
+  }, []);
+
+  const onSaveFoodEntry = useCallback(async () => {
+    if (foodSaving || !userId) {
+      return;
+    }
+    setFoodSaving(true);
+    setFoodSaveError(null);
+    if (!foodMealTag) {
+      const message = 'Choose a meal tag.';
+      setFoodSaveError(message);
+      announce(message, { politeness: 'assertive' });
+      setFoodSaving(false);
+      return;
+    }
+    const loggedAtIso = localInputValueToIso(foodLoggedAtLocal);
+    if (!loggedAtIso) {
+      const message = 'Enter a valid date and time.';
+      setFoodSaveError(message);
+      announce(message, { politeness: 'assertive' });
+      setFoodSaving(false);
+      return;
+    }
+
+    const editingId = editingFoodEntryId;
+    const result =
+      editingId == null
+        ? await createFoodDiaryEntry(supabase, {
+            user_id: userId,
+            episode_id: episodeId,
+            meal_tag: foodMealTag,
+            food_note: foodNote,
+            logged_at: loggedAtIso,
+          })
+        : await updateFoodDiaryEntry(supabase, editingId, {
+            meal_tag: foodMealTag,
+            food_note: foodNote,
+            logged_at: loggedAtIso,
+          });
+    setFoodSaving(false);
+    if (!result.ok) {
+      setFoodSaveError(result.error.message);
+      announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    await loadFoodEntries();
+    resetFoodForm();
+    if (editingId == null) {
+      setIsAddFoodEntryOpen(false);
+    }
+    announce(editingId == null ? 'Food entry saved.' : 'Food entry updated.', {
+      politeness: 'polite',
+    });
+  }, [
+    announce,
+    editingFoodEntryId,
+    episodeId,
+    foodLoggedAtLocal,
+    foodMealTag,
+    foodNote,
+    foodSaving,
+    loadFoodEntries,
+    resetFoodForm,
+    supabase,
+    userId,
+  ]);
+
+  const requestDeleteFoodEntry = useCallback(
+    (entryId: string) => {
+      if (foodSaving || deletingFoodEntryId) {
+        return;
+      }
+      setFoodEntryDeleteConfirmEntryId(entryId);
+    },
+    [deletingFoodEntryId, foodSaving],
+  );
+
+  const onConfirmDeleteFoodEntry = useCallback(async () => {
+    const entryId = foodEntryDeleteConfirmEntryId;
+    if (!entryId || foodSaving || deletingFoodEntryId) {
+      return false;
+    }
+    setDeletingFoodEntryId(entryId);
+    setFoodSaveError(null);
+    const result = await deleteFoodDiaryEntry(supabase, entryId);
+    setDeletingFoodEntryId(null);
+    if (!result.ok) {
+      setFoodSaveError(result.error.message);
+      announce(result.error.message, { politeness: 'assertive' });
+      return false;
+    }
+    if (editingFoodEntryId === entryId) {
+      resetFoodForm();
+    }
+    await loadFoodEntries();
+    announce('Food entry discarded.', { politeness: 'polite' });
+    return;
+  }, [
+    announce,
+    deletingFoodEntryId,
+    editingFoodEntryId,
+    foodEntryDeleteConfirmEntryId,
+    foodSaving,
+    loadFoodEntries,
+    resetFoodForm,
+    supabase,
+  ]);
+
+  const onContinueFromFoodDiary = useCallback(() => {
+    if (foodSaving || deletingFoodEntryId != null || foodEntriesLoading) {
+      return;
+    }
+    onLeaveFoodDiary(
+      foodEntriesError != null
+        ? 'skipped'
+        : foodEntries.length > 0
+          ? 'saved'
+          : 'skipped',
+    );
+  }, [
+    deletingFoodEntryId,
+    foodEntries.length,
+    foodEntriesError,
+    foodEntriesLoading,
+    foodSaving,
+    onLeaveFoodDiary,
+  ]);
+
+  return {
+    reset,
+    foodEntries,
+    foodEntriesLoading,
+    foodEntriesError,
+    foodMealTag,
+    setFoodMealTag,
+    foodNote,
+    setFoodNote,
+    foodLoggedAtLocal,
+    setFoodLoggedAtLocal,
+    foodSaving,
+    foodSaveError,
+    editingFoodEntryId,
+    deletingFoodEntryId,
+    isAddFoodEntryOpen,
+    setIsAddFoodEntryOpen,
+    isAddFoodEntryDirty,
+    setIsAddFoodEntryDirty,
+    discardAddFoodDraftDialogOpen,
+    setDiscardAddFoodDraftDialogOpen,
+    foodEntryDeleteConfirmEntryId,
+    setFoodEntryDeleteConfirmEntryId,
+    computeIsAddFoodEntryDirty,
+    resetFoodForm,
+    loadFoodEntries,
+    onDiscardAddFoodDraft,
+    onConfirmDiscardAddFoodDraft,
+    onEditFoodEntry,
+    onSaveFoodEntry,
+    requestDeleteFoodEntry,
+    onConfirmDeleteFoodEntry,
+    onContinueFromFoodDiary,
+  };
+}

--- a/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
+++ b/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
@@ -131,23 +131,27 @@ export function FoodDiaryEntryForm({
         <legend className="text-sm font-medium text-app-ink">Meal tag</legend>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
           {MEAL_TAGS.map((tag) => (
-            <button
-              type="button"
+            <label
               key={tag}
-              className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
+              className={`flex min-h-[44px] cursor-pointer items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-within:outline-none focus-within:ring-2 focus-within:ring-app-ring focus-within:ring-offset-2 focus-within:ring-offset-app-bg ${
                 mealTag === tag
                   ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
                   : 'border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
-              } ${saving ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
-              disabled={saving}
-              onClick={() => {
-                if (!saving) {
-                  setMealTag((prev) => (prev === tag ? null : tag));
-                }
-              }}
+              } ${saving ? 'cursor-not-allowed opacity-60' : ''}`}
             >
-              {tag}
-            </button>
+              <input
+                type="checkbox"
+                className="sr-only"
+                checked={mealTag === tag}
+                disabled={saving}
+                onChange={() => {
+                  if (!saving) {
+                    setMealTag((prev) => (prev === tag ? null : tag));
+                  }
+                }}
+              />
+              <span>{tag}</span>
+            </label>
           ))}
         </div>
       </fieldset>

--- a/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
+++ b/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
@@ -49,7 +49,7 @@ export function FoodDiaryEntryForm({
 }: FoodDiaryEntryFormProps) {
   const { announce } = useAnnounce();
   const supabase = useMemo(() => createBrowserClient(), []);
-  const [mealTag, setMealTag] = useState<MealTag>('Other');
+  const [mealTag, setMealTag] = useState<MealTag | null>(null);
   const [foodNote, setFoodNote] = useState('');
   const [loggedAtLocal, setLoggedAtLocal] = useState(() =>
     toLocalDateTimeInputValue(new Date().toISOString()),
@@ -78,6 +78,13 @@ export function FoodDiaryEntryForm({
     }
 
     const loggedAtIso = localInputValueToIso(loggedAtLocal);
+    if (!mealTag) {
+      const message = 'Choose a meal tag.';
+      setErrorMessage(message);
+      announce(message, { politeness: 'assertive' });
+      setSaving(false);
+      return;
+    }
     if (!loggedAtIso) {
       const message = 'Enter a valid date and time.';
       setErrorMessage(message);
@@ -124,26 +131,23 @@ export function FoodDiaryEntryForm({
         <legend className="text-sm font-medium text-app-ink">Meal tag</legend>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
           {MEAL_TAGS.map((tag) => (
-            <label
+            <button
+              type="button"
               key={tag}
-              className={`flex min-h-[44px] items-center gap-2 rounded-lg border border-app-border bg-app-surface px-3 py-2 text-sm shadow-sm has-[:checked]:ring-2 has-[:checked]:ring-app-ring ${
-                saving ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
-              }`}
+              className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
+                mealTag === tag
+                  ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
+                  : 'border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
+              } ${saving ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
+              disabled={saving}
+              onClick={() => {
+                if (!saving) {
+                  setMealTag((prev) => (prev === tag ? null : tag));
+                }
+              }}
             >
-              <input
-                type="radio"
-                className="h-4 w-4"
-                name="food-diary-meal-tag"
-                checked={mealTag === tag}
-                disabled={saving}
-                onChange={() => {
-                  if (!saving) {
-                    setMealTag(tag);
-                  }
-                }}
-              />
-              <span className="text-app-ink">{tag}</span>
-            </label>
+              {tag}
+            </button>
           ))}
         </div>
       </fieldset>

--- a/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
+++ b/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
@@ -6,6 +6,10 @@ import { MEAL_TAGS } from '@abstrack/types';
 import { createFoodDiaryEntry } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
+import {
+  localInputValueToIso,
+  toLocalDateTimeInputValue,
+} from '@/lib/food-diary/date-time';
 
 type FoodDiaryEntryFormProps = {
   episodeId?: string | null;
@@ -14,25 +18,6 @@ type FoodDiaryEntryFormProps = {
   submitLabel?: string;
   onSaved?: () => void;
 };
-
-function toLocalDateTimeInputValue(iso: string): string {
-  const date = new Date(iso);
-  const offsetMs = date.getTimezoneOffset() * 60_000;
-  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
-}
-
-function localInputValueToIso(value: string): string | null {
-  const trimmed = value.trim();
-  if (!trimmed) {
-    return null;
-  }
-  const date = new Date(trimmed);
-  const time = date.getTime();
-  if (!Number.isFinite(time)) {
-    return null;
-  }
-  return date.toISOString();
-}
 
 /**
  * Food diary entry form used from home and episode-end flow.
@@ -130,29 +115,39 @@ export function FoodDiaryEntryForm({
       <fieldset className="space-y-2" disabled={saving}>
         <legend className="text-sm font-medium text-app-ink">Meal tag</legend>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-          {MEAL_TAGS.map((tag) => (
-            <label
-              key={tag}
-              className={`flex min-h-[44px] cursor-pointer items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-within:outline-none focus-within:ring-2 focus-within:ring-app-ring focus-within:ring-offset-2 focus-within:ring-offset-app-bg ${
-                mealTag === tag
-                  ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
-                  : 'border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
-              } ${saving ? 'cursor-not-allowed opacity-60' : ''}`}
-            >
-              <input
-                type="checkbox"
-                className="sr-only"
-                checked={mealTag === tag}
+          {MEAL_TAGS.map((tag) =>
+            mealTag === tag ? (
+              <button
+                type="button"
+                key={tag}
+                aria-pressed="true"
+                className="flex min-h-[44px] items-center justify-center rounded-lg border border-red-700 bg-red-50 px-3 py-2 text-sm font-medium text-red-900 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100"
                 disabled={saving}
-                onChange={() => {
+                onClick={() => {
                   if (!saving) {
-                    setMealTag((prev) => (prev === tag ? null : tag));
+                    setMealTag(null);
                   }
                 }}
-              />
-              <span>{tag}</span>
-            </label>
-          ))}
+              >
+                {tag}
+              </button>
+            ) : (
+              <button
+                type="button"
+                key={tag}
+                aria-pressed="false"
+                className="flex min-h-[44px] cursor-pointer items-center justify-center rounded-lg border border-app-border bg-app-surface px-3 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={saving}
+                onClick={() => {
+                  if (!saving) {
+                    setMealTag(tag);
+                  }
+                }}
+              >
+                {tag}
+              </button>
+            ),
+          )}
         </div>
       </fieldset>
 

--- a/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
+++ b/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
@@ -1,0 +1,201 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import type { MealTag } from '@abstrack/types';
+import { MEAL_TAGS } from '@abstrack/types';
+import { createFoodDiaryEntry } from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+
+type FoodDiaryEntryFormProps = {
+  episodeId?: string | null;
+  heading?: string;
+  description?: string;
+  submitLabel?: string;
+  onSaved?: () => void;
+};
+
+function toLocalDateTimeInputValue(iso: string): string {
+  const date = new Date(iso);
+  const offsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+function localInputValueToIso(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const date = new Date(trimmed);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) {
+    return null;
+  }
+  return date.toISOString();
+}
+
+/**
+ * Food diary entry form used from home and episode-end flow.
+ *
+ * @param props - Form settings and completion callback.
+ * @returns Accessible form for meal tag, note, and logged timestamp.
+ */
+export function FoodDiaryEntryForm({
+  episodeId = null,
+  heading = 'Food diary',
+  description = 'Log what you ate or drank. Time defaults to now and can be adjusted.',
+  submitLabel = 'Save food entry',
+  onSaved,
+}: FoodDiaryEntryFormProps) {
+  const { announce } = useAnnounce();
+  const supabase = useMemo(() => createBrowserClient(), []);
+  const [mealTag, setMealTag] = useState<MealTag>('Other');
+  const [foodNote, setFoodNote] = useState('');
+  const [loggedAtLocal, setLoggedAtLocal] = useState(() =>
+    toLocalDateTimeInputValue(new Date().toISOString()),
+  );
+  const [saving, setSaving] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+
+  const onSubmit = async () => {
+    if (saving) {
+      return;
+    }
+    setSaving(true);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      const message = 'You must be signed in to save a food diary entry.';
+      setErrorMessage(message);
+      announce(message, { politeness: 'assertive' });
+      setSaving(false);
+      return;
+    }
+
+    const loggedAtIso = localInputValueToIso(loggedAtLocal);
+    if (!loggedAtIso) {
+      const message = 'Enter a valid date and time.';
+      setErrorMessage(message);
+      announce(message, { politeness: 'assertive' });
+      setSaving(false);
+      return;
+    }
+
+    const result = await createFoodDiaryEntry(supabase, {
+      user_id: user.id,
+      episode_id: episodeId,
+      meal_tag: mealTag,
+      food_note: foodNote,
+      logged_at: loggedAtIso,
+    });
+    setSaving(false);
+    if (!result.ok) {
+      setErrorMessage(result.error.message);
+      announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+
+    setSuccessMessage(
+      episodeId
+        ? 'Food entry saved and linked to this episode.'
+        : 'Food entry saved.',
+    );
+    setFoodNote('');
+    setLoggedAtLocal(toLocalDateTimeInputValue(new Date().toISOString()));
+    announce('Food entry saved.', { politeness: 'polite' });
+    onSaved?.();
+  };
+
+  return (
+    <section className="space-y-5 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8">
+      <div>
+        <h2 className="text-xl font-semibold tracking-tight text-app-ink">
+          {heading}
+        </h2>
+        <p className="mt-1 text-sm text-app-muted">{description}</p>
+      </div>
+
+      <fieldset className="space-y-2" disabled={saving}>
+        <legend className="text-sm font-medium text-app-ink">Meal tag</legend>
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+          {MEAL_TAGS.map((tag) => (
+            <label
+              key={tag}
+              className={`flex min-h-[44px] items-center gap-2 rounded-lg border border-app-border bg-app-surface px-3 py-2 text-sm shadow-sm has-[:checked]:ring-2 has-[:checked]:ring-app-ring ${
+                saving ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
+              }`}
+            >
+              <input
+                type="radio"
+                className="h-4 w-4"
+                name="food-diary-meal-tag"
+                checked={mealTag === tag}
+                disabled={saving}
+                onChange={() => {
+                  if (!saving) {
+                    setMealTag(tag);
+                  }
+                }}
+              />
+              <span className="text-app-ink">{tag}</span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
+
+      <label className="block space-y-1 text-sm font-medium text-app-ink">
+        <span>Logged at</span>
+        <input
+          type="datetime-local"
+          value={loggedAtLocal}
+          disabled={saving}
+          onChange={(e) => {
+            setLoggedAtLocal(e.target.value);
+          }}
+          className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+        />
+      </label>
+
+      <label className="block space-y-1 text-sm font-medium text-app-ink">
+        <span>Food note</span>
+        <textarea
+          rows={4}
+          value={foodNote}
+          disabled={saving}
+          onChange={(e) => {
+            setFoodNote(e.target.value);
+          }}
+          placeholder="What did you eat or drink?"
+          className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+        />
+      </label>
+
+      {errorMessage ? (
+        <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+          {errorMessage}
+        </p>
+      ) : null}
+      {successMessage ? (
+        <p className="text-sm text-green-700 dark:text-green-300" role="status">
+          {successMessage}
+        </p>
+      ) : null}
+
+      <button
+        type="button"
+        className="inline-flex min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
+        disabled={saving}
+        onClick={() => {
+          void onSubmit();
+        }}
+      >
+        {saving ? 'Saving…' : submitLabel}
+      </button>
+    </section>
+  );
+}

--- a/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
+++ b/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
@@ -115,39 +115,29 @@ export function FoodDiaryEntryForm({
       <fieldset className="space-y-2" disabled={saving}>
         <legend className="text-sm font-medium text-app-ink">Meal tag</legend>
         <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-          {MEAL_TAGS.map((tag) =>
-            mealTag === tag ? (
+          {MEAL_TAGS.map((tag) => {
+            const selected = mealTag === tag;
+            return (
               <button
                 type="button"
                 key={tag}
-                aria-pressed="true"
-                className="flex min-h-[44px] items-center justify-center rounded-lg border border-red-700 bg-red-50 px-3 py-2 text-sm font-medium text-red-900 shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100"
+                aria-pressed={selected}
+                className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
+                  selected
+                    ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
+                    : 'cursor-pointer border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
+                } ${saving ? 'cursor-not-allowed opacity-60' : ''}`}
                 disabled={saving}
                 onClick={() => {
                   if (!saving) {
-                    setMealTag(null);
+                    setMealTag(selected ? null : tag);
                   }
                 }}
               >
                 {tag}
               </button>
-            ) : (
-              <button
-                type="button"
-                key={tag}
-                aria-pressed="false"
-                className="flex min-h-[44px] cursor-pointer items-center justify-center rounded-lg border border-app-border bg-app-surface px-3 py-2 text-sm font-medium text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
-                disabled={saving}
-                onClick={() => {
-                  if (!saving) {
-                    setMealTag(tag);
-                  }
-                }}
-              >
-                {tag}
-              </button>
-            ),
-          )}
+            );
+          })}
         </div>
       </fieldset>
 

--- a/apps/web/src/lib/food-diary/date-time.spec.ts
+++ b/apps/web/src/lib/food-diary/date-time.spec.ts
@@ -1,0 +1,132 @@
+import { localInputValueToIso, toLocalDateTimeInputValue } from './date-time';
+
+describe('food diary date-time helpers', () => {
+  it('round-trips an ISO value through datetime-local format', () => {
+    const iso = '2026-01-15T13:45:00.000Z';
+    const local = toLocalDateTimeInputValue(iso);
+
+    expect(local).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}$/);
+    expect(localInputValueToIso(local)).toBe(iso);
+  });
+
+  it('parses optional seconds in datetime-local input', () => {
+    const value = '2026-01-15T08:09:10';
+    const expected = new Date(2026, 0, 15, 8, 9, 10, 0).toISOString();
+
+    expect(localInputValueToIso(value)).toBe(expected);
+  });
+
+  it('returns null for malformed or out-of-range inputs', () => {
+    expect(localInputValueToIso('')).toBeNull();
+    expect(localInputValueToIso('not-a-date')).toBeNull();
+    expect(localInputValueToIso('2026-13-15T08:09')).toBeNull();
+    expect(localInputValueToIso('2026-02-30T08:09')).toBeNull();
+    expect(localInputValueToIso('2026-01-15T24:00')).toBeNull();
+    expect(localInputValueToIso('2026-01-15T08:60')).toBeNull();
+    expect(localInputValueToIso('2026-01-15T08:09:99')).toBeNull();
+  });
+});
+
+describe('food diary date-time DST gap handling', () => {
+  function pad2(value: number): string {
+    return String(value).padStart(2, '0');
+  }
+
+  function toLocalInput(
+    year: number,
+    month1: number,
+    day: number,
+    hour: number,
+    minute: number,
+  ): string {
+    return `${year}-${pad2(month1)}-${pad2(day)}T${pad2(hour)}:${pad2(minute)}`;
+  }
+
+  function findSpringForwardGap(): {
+    year: number;
+    month1: number;
+    day: number;
+    hour: number;
+    minute: number;
+  } | null {
+    for (let year = 2020; year <= 2032; year += 1) {
+      for (let month0 = 0; month0 < 12; month0 += 1) {
+        const daysInMonth = new Date(year, month0 + 1, 0).getDate();
+        for (let day = 1; day <= daysInMonth; day += 1) {
+          for (let hour = 1; hour <= 22; hour += 1) {
+            const minute = 30;
+            const local = new Date(year, month0, day, hour, minute, 0, 0);
+            const sameCalendarDay =
+              local.getFullYear() === year &&
+              local.getMonth() === month0 &&
+              local.getDate() === day;
+            if (sameCalendarDay && local.getHours() > hour) {
+              return { year, month1: month0 + 1, day, hour, minute };
+            }
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  it('rejects nonexistent local times in the spring-forward gap', () => {
+    const gap = findSpringForwardGap();
+    if (!gap) {
+      // Some environments run in non-DST zones; ensure helper still parses valid local input.
+      expect(localInputValueToIso('2026-01-15T08:09')).not.toBeNull();
+      return;
+    }
+    const value = toLocalInput(
+      gap.year,
+      gap.month1,
+      gap.day,
+      gap.hour,
+      gap.minute,
+    );
+    expect(localInputValueToIso(value)).toBeNull();
+  });
+
+  it('accepts valid local times adjacent to the DST gap', () => {
+    const gap = findSpringForwardGap();
+    if (!gap) {
+      expect(localInputValueToIso('2026-01-15T08:09')).not.toBeNull();
+      return;
+    }
+    const beforeValue = toLocalInput(
+      gap.year,
+      gap.month1,
+      gap.day,
+      gap.hour - 1,
+      gap.minute,
+    );
+    const afterValue = toLocalInput(
+      gap.year,
+      gap.month1,
+      gap.day,
+      gap.hour + 1,
+      gap.minute,
+    );
+    const beforeExpected = new Date(
+      gap.year,
+      gap.month1 - 1,
+      gap.day,
+      gap.hour - 1,
+      gap.minute,
+      0,
+      0,
+    ).toISOString();
+    const afterExpected = new Date(
+      gap.year,
+      gap.month1 - 1,
+      gap.day,
+      gap.hour + 1,
+      gap.minute,
+      0,
+      0,
+    ).toISOString();
+
+    expect(localInputValueToIso(beforeValue)).toBe(beforeExpected);
+    expect(localInputValueToIso(afterValue)).toBe(afterExpected);
+  });
+});

--- a/apps/web/src/lib/food-diary/date-time.spec.ts
+++ b/apps/web/src/lib/food-diary/date-time.spec.ts
@@ -1,6 +1,10 @@
 import { localInputValueToIso, toLocalDateTimeInputValue } from './date-time';
 
 describe('food diary date-time helpers', () => {
+  it('returns empty string for an invalid ISO input', () => {
+    expect(toLocalDateTimeInputValue('not-a-real-iso')).toBe('');
+  });
+
   it('round-trips an ISO value through datetime-local format', () => {
     const iso = '2026-01-15T13:45:00.000Z';
     const local = toLocalDateTimeInputValue(iso);

--- a/apps/web/src/lib/food-diary/date-time.ts
+++ b/apps/web/src/lib/food-diary/date-time.ts
@@ -2,10 +2,13 @@
  * Converts an ISO timestamp into an HTML `datetime-local` value using local time.
  *
  * @param iso - ISO timestamp to convert.
- * @returns Local datetime input string in `YYYY-MM-DDTHH:mm` format.
+ * @returns Local datetime input string in `YYYY-MM-DDTHH:mm` format, or empty string when invalid.
  */
 export function toLocalDateTimeInputValue(iso: string): string {
   const date = new Date(iso);
+  if (!Number.isFinite(date.getTime())) {
+    return '';
+  }
   const offsetMs = date.getTimezoneOffset() * 60_000;
   return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
 }

--- a/apps/web/src/lib/food-diary/date-time.ts
+++ b/apps/web/src/lib/food-diary/date-time.ts
@@ -10,8 +10,14 @@ export function toLocalDateTimeInputValue(iso: string): string {
   return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
 }
 
+const LOCAL_DATETIME_INPUT_RE =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?$/;
+
 /**
  * Converts an HTML `datetime-local` input value to ISO.
+ * Parses `YYYY-MM-DDTHH:mm` (optional `:ss`) with explicit numeric fields and
+ * {@link Date}’s local constructor so behavior matches local wall time across engines
+ * (avoids `new Date(string)` ambiguity in Safari and others).
  *
  * @param value - Local datetime input string.
  * @returns ISO timestamp when valid; otherwise `null`.
@@ -21,10 +27,53 @@ export function localInputValueToIso(value: string): string | null {
   if (!trimmed) {
     return null;
   }
-  const date = new Date(trimmed);
-  const time = date.getTime();
+  const match = LOCAL_DATETIME_INPUT_RE.exec(trimmed);
+  if (!match) {
+    return null;
+  }
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = match[6] != null ? Number(match[6]) : 0;
+
+  if (
+    !Number.isFinite(year) ||
+    !Number.isFinite(month) ||
+    !Number.isFinite(day) ||
+    !Number.isFinite(hour) ||
+    !Number.isFinite(minute) ||
+    !Number.isFinite(second) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31 ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59 ||
+    second < 0 ||
+    second > 59
+  ) {
+    return null;
+  }
+
+  const local = new Date(year, month - 1, day, hour, minute, second, 0);
+  if (
+    local.getFullYear() !== year ||
+    local.getMonth() !== month - 1 ||
+    local.getDate() !== day ||
+    local.getHours() !== hour ||
+    local.getMinutes() !== minute ||
+    local.getSeconds() !== second
+  ) {
+    return null;
+  }
+
+  const time = local.getTime();
   if (!Number.isFinite(time)) {
     return null;
   }
-  return date.toISOString();
+  return local.toISOString();
 }

--- a/apps/web/src/lib/food-diary/date-time.ts
+++ b/apps/web/src/lib/food-diary/date-time.ts
@@ -1,0 +1,30 @@
+/**
+ * Converts an ISO timestamp into an HTML `datetime-local` value using local time.
+ *
+ * @param iso - ISO timestamp to convert.
+ * @returns Local datetime input string in `YYYY-MM-DDTHH:mm` format.
+ */
+export function toLocalDateTimeInputValue(iso: string): string {
+  const date = new Date(iso);
+  const offsetMs = date.getTimezoneOffset() * 60_000;
+  return new Date(date.getTime() - offsetMs).toISOString().slice(0, 16);
+}
+
+/**
+ * Converts an HTML `datetime-local` input value to ISO.
+ *
+ * @param value - Local datetime input string.
+ * @returns ISO timestamp when valid; otherwise `null`.
+ */
+export function localInputValueToIso(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) {
+    return null;
+  }
+  const date = new Date(trimmed);
+  const time = date.getTime();
+  if (!Number.isFinite(time)) {
+    return null;
+  }
+  return date.toISOString();
+}

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -99,3 +99,10 @@ export {
   listEpisodeHealthMarkersForEpisode,
   upsertEpisodeHealthMarkerForLine,
 } from './lib/episode-health-marker-data.js';
+export {
+  createFoodDiaryEntry,
+  deleteFoodDiaryEntry,
+  listFoodDiaryEntriesForEpisode,
+  listFoodDiaryEntriesForUser,
+  updateFoodDiaryEntry,
+} from './lib/food-diary-data.js';

--- a/packages/supabase/src/lib/food-diary-data.spec.ts
+++ b/packages/supabase/src/lib/food-diary-data.spec.ts
@@ -151,6 +151,52 @@ describe('createFoodDiaryEntry', () => {
     expect(client.from).not.toHaveBeenCalled();
   });
 
+  it('returns validation_error for date-only logged_at (no time / offset)', async () => {
+    const client = {
+      from: vi.fn(() => {
+        throw new Error('should not query');
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await createFoodDiaryEntry(client, {
+      user_id: 'user-1',
+      episode_id: 'ep-1',
+      meal_tag: 'Dinner',
+      food_note: 'Soup',
+      logged_at: '2026-04-22',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('validation_error');
+      expect(result.error.message).toContain('valid date and time');
+    }
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('returns validation_error when logged_at has time but no Z or offset', async () => {
+    const client = {
+      from: vi.fn(() => {
+        throw new Error('should not query');
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await createFoodDiaryEntry(client, {
+      user_id: 'user-1',
+      episode_id: 'ep-1',
+      meal_tag: 'Dinner',
+      food_note: 'Soup',
+      logged_at: '2026-04-22T12:30',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('validation_error');
+      expect(result.error.message).toContain('valid date and time');
+    }
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
   it('normalizes food_note and logged_at before insert', async () => {
     const inserted: FoodDiaryEntryRow = {
       ...baseRow,

--- a/packages/supabase/src/lib/food-diary-data.spec.ts
+++ b/packages/supabase/src/lib/food-diary-data.spec.ts
@@ -1,0 +1,344 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { FoodDiaryEntryRow } from '@abstrack/types';
+import {
+  createFoodDiaryEntry,
+  deleteFoodDiaryEntry,
+  listFoodDiaryEntriesForEpisode,
+  listFoodDiaryEntriesForUser,
+  updateFoodDiaryEntry,
+} from './food-diary-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+const baseRow: FoodDiaryEntryRow = {
+  id: 'food-1',
+  user_id: 'user-1',
+  episode_id: 'ep-1',
+  meal_tag: 'Breakfast',
+  food_note: 'Eggs and toast',
+  logged_at: '2026-04-22T10:00:00.000Z',
+  created_at: '2026-04-22T10:00:00.000Z',
+  updated_at: '2026-04-22T10:00:00.000Z',
+};
+
+describe('listFoodDiaryEntriesForUser', () => {
+  it('orders by logged_at desc, created_at desc, id desc and applies default limit', async () => {
+    const rows: FoodDiaryEntryRow[] = [baseRow];
+    const limit = vi.fn(async () => ({ data: rows, error: null }));
+    const orderBuilder = {
+      order: vi.fn(() => orderBuilder),
+      limit,
+    };
+    const client = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq: vi.fn(() => orderBuilder),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await listFoodDiaryEntriesForUser(client, 'user-1');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual(rows);
+    }
+    expect(orderBuilder.order).toHaveBeenNthCalledWith(1, 'logged_at', {
+      ascending: false,
+    });
+    expect(orderBuilder.order).toHaveBeenNthCalledWith(2, 'created_at', {
+      ascending: false,
+    });
+    expect(orderBuilder.order).toHaveBeenNthCalledWith(3, 'id', {
+      ascending: false,
+    });
+    expect(limit).toHaveBeenCalledWith(50);
+  });
+});
+
+describe('listFoodDiaryEntriesForEpisode', () => {
+  it('filters by episode and applies explicit limit', async () => {
+    const limit = vi.fn(async () => ({ data: [baseRow], error: null }));
+    const orderBuilder = {
+      order: vi.fn(() => orderBuilder),
+      limit,
+    };
+    const eq = vi.fn(() => orderBuilder);
+    const client = {
+      from: vi.fn(() => ({
+        select: vi.fn(() => ({
+          eq,
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await listFoodDiaryEntriesForEpisode(client, 'ep-1', {
+      limit: 10,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(eq).toHaveBeenCalledWith('episode_id', 'ep-1');
+    expect(limit).toHaveBeenCalledWith(10);
+  });
+});
+
+describe('createFoodDiaryEntry', () => {
+  it('returns validation_error for invalid meal tag', async () => {
+    const client = {
+      from: vi.fn(() => {
+        throw new Error('should not query');
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await createFoodDiaryEntry(client, {
+      user_id: 'user-1',
+      episode_id: 'ep-1',
+      meal_tag: 'Brunch' as never,
+      food_note: 'Toast',
+      logged_at: '2026-04-22T10:00:00.000Z',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('validation_error');
+      expect(result.error.message).toContain('valid meal tag');
+    }
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('returns validation_error for blank food_note', async () => {
+    const client = {
+      from: vi.fn(() => {
+        throw new Error('should not query');
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await createFoodDiaryEntry(client, {
+      user_id: 'user-1',
+      episode_id: 'ep-1',
+      meal_tag: 'Lunch',
+      food_note: '   ',
+      logged_at: '2026-04-22T10:00:00.000Z',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('validation_error');
+      expect(result.error.message).toContain('Enter what you ate');
+    }
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('returns validation_error for invalid logged_at', async () => {
+    const client = {
+      from: vi.fn(() => {
+        throw new Error('should not query');
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await createFoodDiaryEntry(client, {
+      user_id: 'user-1',
+      episode_id: 'ep-1',
+      meal_tag: 'Dinner',
+      food_note: 'Soup',
+      logged_at: 'not-a-date',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('validation_error');
+      expect(result.error.message).toContain('valid date and time');
+    }
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('normalizes food_note and logged_at before insert', async () => {
+    const inserted: FoodDiaryEntryRow = {
+      ...baseRow,
+      meal_tag: 'Snack',
+      food_note: 'Apple slices',
+      logged_at: '2026-04-22T14:05:00.000Z',
+    };
+    const insert = vi.fn((payload: Record<string, unknown>) => {
+      expect(payload).toEqual(
+        expect.objectContaining({
+          meal_tag: 'Snack',
+          food_note: 'Apple slices',
+          logged_at: '2026-04-22T14:05:00.000Z',
+        }),
+      );
+      return {
+        select: vi.fn(() => ({
+          single: vi.fn(async () => ({ data: inserted, error: null })),
+        })),
+      };
+    });
+    const client = {
+      from: vi.fn(() => ({
+        insert,
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await createFoodDiaryEntry(client, {
+      user_id: 'user-1',
+      episode_id: 'ep-1',
+      meal_tag: 'Snack',
+      food_note: '  Apple slices  ',
+      logged_at: '2026-04-22T10:05:00-04:00',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.food_note).toBe('Apple slices');
+      expect(result.data.logged_at).toBe('2026-04-22T14:05:00.000Z');
+    }
+  });
+});
+
+describe('updateFoodDiaryEntry', () => {
+  it('returns validation_error when meal_tag is invalid', async () => {
+    const client = {
+      from: vi.fn(() => {
+        throw new Error('should not query');
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await updateFoodDiaryEntry(client, 'food-1', {
+      meal_tag: 'Brunch' as never,
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('validation_error');
+      expect(result.error.message).toContain('valid meal tag');
+    }
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('returns validation_error when food_note is blank', async () => {
+    const client = {
+      from: vi.fn(() => {
+        throw new Error('should not query');
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await updateFoodDiaryEntry(client, 'food-1', {
+      food_note: '   ',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('validation_error');
+      expect(result.error.message).toContain('Enter what you ate');
+    }
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('returns validation_error when logged_at is invalid', async () => {
+    const client = {
+      from: vi.fn(() => {
+        throw new Error('should not query');
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await updateFoodDiaryEntry(client, 'food-1', {
+      logged_at: 'bad-value',
+    });
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.error.code).toBe('validation_error');
+      expect(result.error.message).toContain('valid date and time');
+    }
+    expect(client.from).not.toHaveBeenCalled();
+  });
+
+  it('normalizes update patch before writing', async () => {
+    const updated: FoodDiaryEntryRow = {
+      ...baseRow,
+      meal_tag: 'Other',
+      food_note: 'Protein shake',
+      logged_at: '2026-04-22T20:15:00.000Z',
+    };
+    const update = vi.fn((patch: Record<string, unknown>) => {
+      expect(patch).toEqual({
+        meal_tag: 'Other',
+        food_note: 'Protein shake',
+        logged_at: '2026-04-22T20:15:00.000Z',
+      });
+      return {
+        eq: vi.fn(() => ({
+          select: vi.fn(() => ({
+            single: vi.fn(async () => ({ data: updated, error: null })),
+          })),
+        })),
+      };
+    });
+    const client = {
+      from: vi.fn(() => ({
+        update,
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await updateFoodDiaryEntry(client, 'food-1', {
+      meal_tag: 'Other',
+      food_note: '  Protein shake  ',
+      logged_at: '2026-04-22T15:15:00-05:00',
+    });
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data.food_note).toBe('Protein shake');
+      expect(result.data.logged_at).toBe('2026-04-22T20:15:00.000Z');
+    }
+    expect(client.from).toHaveBeenCalledWith('food_diary_entries');
+  });
+});
+
+describe('deleteFoodDiaryEntry', () => {
+  it('returns true when a row was deleted', async () => {
+    const maybeSingle = vi.fn(async () => ({
+      data: { id: 'food-1' },
+      error: null,
+    }));
+    const client = {
+      from: vi.fn(() => ({
+        delete: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              maybeSingle,
+            })),
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await deleteFoodDiaryEntry(client, 'food-1');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toBe(true);
+    }
+  });
+
+  it('returns false when no row matched', async () => {
+    const maybeSingle = vi.fn(async () => ({ data: null, error: null }));
+    const client = {
+      from: vi.fn(() => ({
+        delete: vi.fn(() => ({
+          eq: vi.fn(() => ({
+            select: vi.fn(() => ({
+              maybeSingle,
+            })),
+          })),
+        })),
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await deleteFoodDiaryEntry(client, 'food-missing');
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toBe(false);
+    }
+  });
+});

--- a/packages/supabase/src/lib/food-diary-data.ts
+++ b/packages/supabase/src/lib/food-diary-data.ts
@@ -30,28 +30,52 @@ function normalizeOptionalIso(value: string | null | undefined): string | null {
   return new Date(time).toISOString();
 }
 
-function validateFoodDiaryPayload(
-  payload: Pick<FoodDiaryEntryInsert, 'meal_tag' | 'food_note' | 'logged_at'>,
-): PresetDataError | null {
+type FoodDiaryCreateCore = Pick<
+  FoodDiaryEntryInsert,
+  'meal_tag' | 'food_note' | 'logged_at'
+>;
+
+type ValidateCreateCoreResult =
+  | { ok: true; food_note: string; logged_at: string }
+  | { ok: false; error: PresetDataError };
+
+/**
+ * Validates meal tag / note / logged_at and returns normalized strings for insert
+ * (single pass — avoids re-parsing after validation).
+ */
+function validateAndNormalizeFoodDiaryCreateCore(
+  payload: FoodDiaryCreateCore,
+): ValidateCreateCoreResult {
   if (!isMealTag(payload.meal_tag)) {
-    return new PresetDataError(
-      'validation_error',
-      'Choose a valid meal tag (Breakfast, Lunch, Dinner, Snack, or Other).',
-    );
+    return {
+      ok: false,
+      error: new PresetDataError(
+        'validation_error',
+        'Choose a valid meal tag (Breakfast, Lunch, Dinner, Snack, or Other).',
+      ),
+    };
   }
-  if (!normalizeFoodNote(payload.food_note)) {
-    return new PresetDataError(
-      'validation_error',
-      'Enter what you ate or drank before saving.',
-    );
+  const foodNote = normalizeFoodNote(payload.food_note);
+  if (!foodNote) {
+    return {
+      ok: false,
+      error: new PresetDataError(
+        'validation_error',
+        'Enter what you ate or drank before saving.',
+      ),
+    };
   }
-  if (!normalizeOptionalIso(payload.logged_at)) {
-    return new PresetDataError(
-      'validation_error',
-      'Enter a valid date and time.',
-    );
+  const loggedAt = normalizeOptionalIso(payload.logged_at);
+  if (!loggedAt) {
+    return {
+      ok: false,
+      error: new PresetDataError(
+        'validation_error',
+        'Enter a valid date and time.',
+      ),
+    };
   }
-  return null;
+  return { ok: true, food_note: foodNote, logged_at: loggedAt };
 }
 
 /**
@@ -122,28 +146,17 @@ export async function createFoodDiaryEntry(
   client: AbstrackSupabaseClient,
   row: FoodDiaryEntryInsert,
 ): Promise<PresetDataResult<FoodDiaryEntryRow>> {
-  const validation = validateFoodDiaryPayload(row);
-  if (validation) {
-    return { ok: false, error: validation };
-  }
-  const loggedAt = normalizeOptionalIso(row.logged_at);
-  const foodNote = normalizeFoodNote(row.food_note);
-  if (!loggedAt || !foodNote) {
-    return {
-      ok: false,
-      error: new PresetDataError(
-        'validation_error',
-        'Invalid food diary entry.',
-      ),
-    };
+  const core = validateAndNormalizeFoodDiaryCreateCore(row);
+  if (!core.ok) {
+    return { ok: false, error: core.error };
   }
   return wrap(async () => {
     const r = await client
       .from('food_diary_entries')
       .insert({
         ...row,
-        food_note: foodNote,
-        logged_at: loggedAt,
+        food_note: core.food_note,
+        logged_at: core.logged_at,
       })
       .select('*')
       .single();

--- a/packages/supabase/src/lib/food-diary-data.ts
+++ b/packages/supabase/src/lib/food-diary-data.ts
@@ -1,0 +1,245 @@
+import type {
+  FoodDiaryEntryInsert,
+  FoodDiaryEntryRow,
+  FoodDiaryEntryUpdate,
+  Uuid,
+} from '@abstrack/types';
+import { isMealTag } from '@abstrack/types';
+import { PresetDataError } from './preset-data-error.js';
+import type { PresetDataResult } from './preset-data.js';
+import { wrap } from './preset-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+function normalizeFoodNote(note: string): string | null {
+  const next = note.trim();
+  return next.length > 0 ? next : null;
+}
+
+function normalizeOptionalIso(value: string | null | undefined): string | null {
+  if (value == null) {
+    return null;
+  }
+  const next = value.trim();
+  if (!next) {
+    return null;
+  }
+  const time = Date.parse(next);
+  if (!Number.isFinite(time)) {
+    return null;
+  }
+  return new Date(time).toISOString();
+}
+
+function validateFoodDiaryPayload(
+  payload: Pick<FoodDiaryEntryInsert, 'meal_tag' | 'food_note' | 'logged_at'>,
+): PresetDataError | null {
+  if (!isMealTag(payload.meal_tag)) {
+    return new PresetDataError(
+      'validation_error',
+      'Choose a valid meal tag (Breakfast, Lunch, Dinner, Snack, or Other).',
+    );
+  }
+  if (!normalizeFoodNote(payload.food_note)) {
+    return new PresetDataError(
+      'validation_error',
+      'Enter what you ate or drank before saving.',
+    );
+  }
+  if (!normalizeOptionalIso(payload.logged_at)) {
+    return new PresetDataError(
+      'validation_error',
+      'Enter a valid date and time.',
+    );
+  }
+  return null;
+}
+
+/**
+ * Lists food diary entries for one user (newest first).
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param userId - `auth.users.id` / `food_diary_entries.user_id`.
+ * @param options - Optional result cap (`limit`, default `50`).
+ */
+export async function listFoodDiaryEntriesForUser(
+  client: AbstrackSupabaseClient,
+  userId: Uuid,
+  options: { limit?: number } = {},
+): Promise<PresetDataResult<FoodDiaryEntryRow[]>> {
+  const limit = options.limit ?? 50;
+  return wrap(async () => {
+    const r = await client
+      .from('food_diary_entries')
+      .select('*')
+      .eq('user_id', userId)
+      .order('logged_at', { ascending: false })
+      .order('created_at', { ascending: false })
+      .order('id', { ascending: false })
+      .limit(limit);
+    return {
+      data: (r.data ?? []) as FoodDiaryEntryRow[],
+      error: r.error,
+    };
+  });
+}
+
+/**
+ * Lists food diary entries linked to one episode (newest first).
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param episodeId - `episodes.id` linked from `food_diary_entries.episode_id`.
+ * @param options - Optional result cap (`limit`, default `50`).
+ */
+export async function listFoodDiaryEntriesForEpisode(
+  client: AbstrackSupabaseClient,
+  episodeId: Uuid,
+  options: { limit?: number } = {},
+): Promise<PresetDataResult<FoodDiaryEntryRow[]>> {
+  const limit = options.limit ?? 50;
+  return wrap(async () => {
+    const r = await client
+      .from('food_diary_entries')
+      .select('*')
+      .eq('episode_id', episodeId)
+      .order('logged_at', { ascending: false })
+      .order('created_at', { ascending: false })
+      .order('id', { ascending: false })
+      .limit(limit);
+    return {
+      data: (r.data ?? []) as FoodDiaryEntryRow[],
+      error: r.error,
+    };
+  });
+}
+
+/**
+ * Creates one food diary entry. `episode_id` can be `null` for standalone home entries.
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param row - Insert payload.
+ */
+export async function createFoodDiaryEntry(
+  client: AbstrackSupabaseClient,
+  row: FoodDiaryEntryInsert,
+): Promise<PresetDataResult<FoodDiaryEntryRow>> {
+  const validation = validateFoodDiaryPayload(row);
+  if (validation) {
+    return { ok: false, error: validation };
+  }
+  const loggedAt = normalizeOptionalIso(row.logged_at);
+  const foodNote = normalizeFoodNote(row.food_note);
+  if (!loggedAt || !foodNote) {
+    return {
+      ok: false,
+      error: new PresetDataError(
+        'validation_error',
+        'Invalid food diary entry.',
+      ),
+    };
+  }
+  return wrap(async () => {
+    const r = await client
+      .from('food_diary_entries')
+      .insert({
+        ...row,
+        food_note: foodNote,
+        logged_at: loggedAt,
+      })
+      .select('*')
+      .single();
+    return {
+      data: r.data as FoodDiaryEntryRow | null,
+      error: r.error,
+    };
+  });
+}
+
+/**
+ * Updates one food diary entry.
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param entryId - `food_diary_entries.id`.
+ * @param patch - Fields to change.
+ */
+export async function updateFoodDiaryEntry(
+  client: AbstrackSupabaseClient,
+  entryId: Uuid,
+  patch: FoodDiaryEntryUpdate,
+): Promise<PresetDataResult<FoodDiaryEntryRow>> {
+  const normalizedPatch: FoodDiaryEntryUpdate = { ...patch };
+  if (normalizedPatch.food_note !== undefined) {
+    const next = normalizeFoodNote(normalizedPatch.food_note);
+    if (!next) {
+      return {
+        ok: false,
+        error: new PresetDataError(
+          'validation_error',
+          'Enter what you ate or drank before saving.',
+        ),
+      };
+    }
+    normalizedPatch.food_note = next;
+  }
+  if (
+    normalizedPatch.meal_tag !== undefined &&
+    !isMealTag(normalizedPatch.meal_tag)
+  ) {
+    return {
+      ok: false,
+      error: new PresetDataError(
+        'validation_error',
+        'Choose a valid meal tag (Breakfast, Lunch, Dinner, Snack, or Other).',
+      ),
+    };
+  }
+  if (normalizedPatch.logged_at !== undefined) {
+    const loggedAt = normalizeOptionalIso(normalizedPatch.logged_at);
+    if (!loggedAt) {
+      return {
+        ok: false,
+        error: new PresetDataError(
+          'validation_error',
+          'Enter a valid date and time.',
+        ),
+      };
+    }
+    normalizedPatch.logged_at = loggedAt;
+  }
+
+  return wrap(async () => {
+    const r = await client
+      .from('food_diary_entries')
+      .update(normalizedPatch)
+      .eq('id', entryId)
+      .select('*')
+      .single();
+    return {
+      data: r.data as FoodDiaryEntryRow | null,
+      error: r.error,
+    };
+  });
+}
+
+/**
+ * Deletes one food diary entry by id.
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param entryId - `food_diary_entries.id`.
+ */
+export async function deleteFoodDiaryEntry(
+  client: AbstrackSupabaseClient,
+  entryId: Uuid,
+): Promise<PresetDataResult<boolean>> {
+  return wrap(async () => {
+    const r = await client
+      .from('food_diary_entries')
+      .delete()
+      .eq('id', entryId)
+      .select('id')
+      .maybeSingle();
+    return {
+      data: r.data != null,
+      error: r.error,
+    };
+  });
+}

--- a/packages/supabase/src/lib/food-diary-data.ts
+++ b/packages/supabase/src/lib/food-diary-data.ts
@@ -15,19 +15,139 @@ function normalizeFoodNote(note: string): string | null {
   return next.length > 0 ? next : null;
 }
 
+/**
+ * Fractional-second digits from ISO (e.g. `007` or `7`) to 0–999 ms, matching typical
+ * `Date` / `toISOString` millisecond precision.
+ */
+function isoFractionToMs(frac: string | undefined): number {
+  if (frac == null || frac === '') {
+    return 0;
+  }
+  const n = Number(`0.${frac}`);
+  if (!Number.isFinite(n)) {
+    return 0;
+  }
+  return Math.min(999, Math.max(0, Math.floor(n * 1000)));
+}
+
+function civilDayExistsInUtcCalendar(
+  year: number,
+  month: number,
+  day: number,
+): boolean {
+  const probe = Date.UTC(year, month - 1, day, 12, 0, 0, 0);
+  const d = new Date(probe);
+  return (
+    d.getUTCFullYear() === year &&
+    d.getUTCMonth() === month - 1 &&
+    d.getUTCDate() === day
+  );
+}
+
+/** ISO-8601 instant with required clock time and explicit `Z` or `±HH:MM` (not date-only). */
+const STRICT_LOGGED_AT_ISO_RE =
+  /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(Z|([+-])(\d{2}):(\d{2}))$/;
+
 function normalizeOptionalIso(value: string | null | undefined): string | null {
   if (value == null) {
     return null;
   }
-  const next = value.trim();
-  if (!next) {
+  const trimmed = value.trim();
+  if (!trimmed) {
     return null;
   }
-  const time = Date.parse(next);
-  if (!Number.isFinite(time)) {
+
+  const match = STRICT_LOGGED_AT_ISO_RE.exec(trimmed);
+  if (!match) {
     return null;
   }
-  return new Date(time).toISOString();
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = match[6] != null && match[6] !== '' ? Number(match[6]) : 0;
+  const ms = isoFractionToMs(match[7]);
+  const tz = match[8];
+
+  if (
+    !Number.isFinite(year) ||
+    !Number.isFinite(month) ||
+    !Number.isFinite(day) ||
+    !Number.isFinite(hour) ||
+    !Number.isFinite(minute) ||
+    !Number.isFinite(second) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31 ||
+    hour < 0 ||
+    hour > 23 ||
+    minute < 0 ||
+    minute > 59 ||
+    second < 0 ||
+    second > 59
+  ) {
+    return null;
+  }
+
+  if (!civilDayExistsInUtcCalendar(year, month, day)) {
+    return null;
+  }
+
+  let utcMs: number;
+
+  if (tz === 'Z') {
+    utcMs = Date.UTC(year, month - 1, day, hour, minute, second, ms);
+    const check = new Date(utcMs);
+    if (
+      check.getUTCFullYear() !== year ||
+      check.getUTCMonth() !== month - 1 ||
+      check.getUTCDate() !== day ||
+      check.getUTCHours() !== hour ||
+      check.getUTCMinutes() !== minute ||
+      check.getUTCSeconds() !== second ||
+      check.getUTCMilliseconds() !== ms
+    ) {
+      return null;
+    }
+  } else {
+    const sign = match[9];
+    const offH = Number(match[10]);
+    const offM = Number(match[11]);
+    if (
+      !Number.isFinite(offH) ||
+      !Number.isFinite(offM) ||
+      offH > 23 ||
+      offM > 59
+    ) {
+      return null;
+    }
+    const offsetMinutesEast =
+      sign === '+' ? offH * 60 + offM : -(offH * 60 + offM);
+    utcMs =
+      Date.UTC(year, month - 1, day, hour, minute, second, ms) -
+      offsetMinutesEast * 60 * 1000;
+    if (!Number.isFinite(utcMs)) {
+      return null;
+    }
+    const civilAsUtcTicks = utcMs + offsetMinutesEast * 60 * 1000;
+    const check = new Date(civilAsUtcTicks);
+    if (
+      check.getUTCFullYear() !== year ||
+      check.getUTCMonth() !== month - 1 ||
+      check.getUTCDate() !== day ||
+      check.getUTCHours() !== hour ||
+      check.getUTCMinutes() !== minute ||
+      check.getUTCSeconds() !== second ||
+      check.getUTCMilliseconds() !== ms
+    ) {
+      return null;
+    }
+  }
+
+  return new Date(utcMs).toISOString();
 }
 
 type FoodDiaryCreateCore = Pick<

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -255,6 +255,9 @@ importers:
       '@expo/vector-icons':
         specifier: '*'
         version: 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-native-community/datetimepicker':
+        specifier: 8.4.4
+        version: 8.4.4(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@react-navigation/bottom-tabs':
         specifier: '*'
         version: 7.15.9(@react-navigation/native@7.2.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -4140,6 +4143,22 @@ packages:
       }
     engines: { node: '>=18' }
     hasBin: true
+
+  '@react-native-community/datetimepicker@8.4.4':
+    resolution:
+      {
+        integrity: sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==,
+      }
+    peerDependencies:
+      expo: '>=52.0.0'
+      react: '*'
+      react-native: '*'
+      react-native-windows: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      react-native-windows:
+        optional: true
 
   '@react-native/assets-registry@0.81.5':
     resolution:
@@ -20201,6 +20220,14 @@ snapshots:
   '@playwright/test@1.58.2':
     dependencies:
       playwright: 1.58.2
+
+  '@react-native-community/datetimepicker@8.4.4(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
+    optionalDependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
   '@react-native/assets-registry@0.81.5': {}
 


### PR DESCRIPTION
Closes #96

## Summary

This PR implements the Food Diary feature across web and mobile, including standalone entry points and in-episode integration, with Supabase-backed CRUD and episode linkage.

## What changed

- Added a new shared Supabase data layer for food diary entries:
  - `listFoodDiaryEntriesForUser`
  - `listFoodDiaryEntriesForEpisode`
  - `createFoodDiaryEntry`
  - `updateFoodDiaryEntry`
  - `deleteFoodDiaryEntry`
  - input normalization/validation helpers for `meal_tag`, `food_note`, and `logged_at`
- Exported the new food diary data APIs from `packages/supabase/src/index.ts`.

- Added standalone Food Diary entry flows:
  - **Web:** `/food-diary/new`
  - **Mobile:** `FoodDiaryEntryScreen` + navigation wiring from Home/Main tabs

- Integrated Food Diary into the episode flow on both platforms:
  - flow now supports multiple food entries per episode (list + add + edit + delete/discard)
  - entries are linked to `episode_id` when logged in-episode
  - users can continue without logging food (`Skip for now` path)

- Reworked episode-step sequencing and navigation:
  - health markers → food diary → episode details → completion
  - added seamless back navigation between steps (including back from food diary to health markers and from episode details to food diary)
  - preserved symptom progress when transitioning to health markers so returning back does not reset to the first symptom

- Dashboard/home entry points:
  - added Food Diary access from dashboard/home
  - reduced prominence of food-diary CTA relative to primary episode CTA for clarity/accessibility

## UX / accessibility refinements

- Food diary meal tag selection supports select/deselect behavior (single active choice, toggle off).
- Add/edit UX improved with clearer affordances:
  - inline edit for saved entries
  - hide redundant edit controls while editing
  - add-card collapse behavior after save
  - discard protections/confirmations to prevent accidental loss
  - icon-based compact entry actions on mobile (edit/discard)
- Mobile food diary now uses native date/time pickers instead of manual typing.
  - time display is shown in 12-hour format in-app.

## Tests

- Updated mobile tests to match new episode flow order and persistence behavior.
- Verified targeted mobile suites:
  - `HealthMarkerPromptScreen.spec.tsx` (pass)
  - `SymptomPromptScreen.spec.tsx` (pass)

## Notes

- Scope is focused on food diary logging and episode-flow integration (CRUD + UX), without AI parsing/charting changes.