### PR TITLE
docs(roadmap): refactor Week 6 scope to episode-only symptoms, standalone health/food logging, and unified delete management surface

### DIFF
--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,34 +96,42 @@
 
 ---
 
-## Week 6: April 20-26 -- Episode Logging, Food Diary, and Wellness Logging
+## Week 6: April 20-26 -- Episode Logging, Food Diary, and Standalone Health Marker Logging
 
-**Goal:** Complete all core daily-use features that patients and caretakers interact with.
+**Goal:** Complete core daily logging flows: episode-first symptom capture, standalone health marker logging, and standalone food diary logging.
+
+**Scope guardrails (product direction):**
+
+- Symptoms such as nausea/vomiting are logged through an **episode flow**, not as standalone symptom entries.
+- Standalone logging paths are limited to **health markers** and **food diary**.
+- Generic mood/wellness note capture is out of scope.
 
 **Tasks:**
 
-- [ ] Complete episode prompt flow:
+- [x] Complete episode prompt flow:
   - All symptom input types functioning (yes/no, severity 1-5, free text)
   - Health marker entry **after** symptoms, using the **health marker preset** stored on the episode row (`health_marker_preset_id`) ([PRD](PRD.md) §4)
-  - "Add additional symptoms/markers" free-text entry at end
+  - "Add additional symptoms/markers" free-text entry at end (episode context only)
   - Episode type selection (ABS / Other) with custom label
   - Episode notes
   - Episode end flow (records `ended_at` timestamp and duration)
-- [ ] Active episode lifecycle and management (no overlap with prompt controls):
+- [x] Active episode lifecycle and management (no overlap with prompt controls):
   - Home screen detects active episode (`ended_at IS NULL`) and shows **Resume episode** as the primary continuation path
   - Prevent accidental duplicate starts when an active episode exists (clear routing/copy for resume vs start-new)
   - Add an **Episodes** management surface for active + recent episodes (secondary navigation, not primary impaired-user path)
   - Add explicit **Cancel accidental episode start** flow for active episodes with destructive confirmation copy
   - Define and implement episode deletion rules + confirmations (what can be deleted, when, and what related rows are removed)
 - [ ] Impaired-user UI polish: large text, large buttons, minimal cognitive load, high contrast mode
-- [ ] Food diary:
-  - Standalone food entry from home screen
+- [x] Food diary:
+  - Standalone food entry from home screen (non-episode path)
   - Food entry during episode prompt (at end of flow)
   - Free text note + meal tag (Breakfast/Lunch/Dinner/Snack/Other) + timestamp
   - Stored as plaintext in PostgreSQL under RLS (`food_diary_entries.food_note` per [PRD](PRD.md))
-- [ ] General wellness: "How are you feeling" mood/wellness entry with optional notes
-- [ ] Ad-hoc symptom logging without starting a full episode
-- [ ] **Standalone vitals:** home or wellness entry to log health markers using **one health marker preset only** (asymptomatic; no symptom preset, no episode)—separate from episode flow ([PRD](PRD.md) §5, [user story](user-stories/episode-and-health-marker-flows.md))
+- [x] **Standalone health marker logging:** home entry path to log markers using **one health marker preset only** with **no episode** (`health_markers.episode_id = null`) ([PRD](PRD.md) §5, [user story](user-stories/episode-and-health-marker-flows.md))
+- [ ] **Unified management surface (web + mobile):** one consolidated place to view/delete all three groups with accessible destructive confirmations:
+  - Episodes
+  - Standalone health entries (`health_markers.episode_id IS NULL`)
+  - Standalone food entries (food diary entries not linked to an episode)
 
 ---
 
@@ -238,7 +246,7 @@ graph TD
     W3[Week 3: Patient Auth + Security Baseline]
     W4[Week 4: UI Components + Presets]
     W5[Week 5: Auth Completion + Episode Foundation]
-    W6[Week 6: Episode Logging + Food Diary + Wellness]
+    W6[Week 6: Episode Logging + Standalone Health + Food Diary]
     W7[Week 7: Media Capture + Offline Sync]
     W8[Week 8: Practitioner App + Caretaker]
     W9[Week 9: Charts + Integration Testing]
@@ -258,7 +266,7 @@ graph TD
 
 ## Notes (constraints, not scope cuts)
 
-- **Episode + health marker presets:** Week 5 ships migrations for `episodes.health_marker_preset_id`, the **episode preset templates** table, template **settings** UI, and **I'm having an episode** → template picker → insert with both preset IDs. Week 6 completes the full prompt flow (symptoms + markers), wellness, and standalone vitals—see week checkboxes and [user story](user-stories/episode-and-health-marker-flows.md).
+- **Episode + health marker presets:** Week 5 ships migrations for `episodes.health_marker_preset_id`, the **episode preset templates** table, template **settings** UI, and **I'm having an episode** → template picker → insert with both preset IDs. Week 6 completes the full prompt flow (symptoms + markers), standalone health marker logging (`health_markers.episode_id = null`), standalone food diary, and defines the unified management surface requirements—see week checkboxes and [user story](user-stories/episode-and-health-marker-flows.md).
 - **PowerSync + RLS consistency:** Sync Rules must mirror grant logic (patient / caretaker / practitioner). Treat RLS as authoritative for API access; validate rule changes in tests ([PRD](PRD.md) Architecture). Week 7 delivers online media upload and the offline queue + PowerSync work as listed in that week’s tasks.
 - **Practitioner MFA fail-closed:** Use an Edge Function (or equivalent) that verifies MFA before returning patient data; do not rely on JWT hooks alone if they can omit claims. This is part of Week 5’s practitioner MFA work, not a downgrade path.
 - **SQLCipher / offline queue:** Week 7 pairs media and offline sync. Device-bound encryption for queued blobs matches the PRD; it is separate from server-side PHI encryption and does not involve sharing keys between users.

--- a/docs/user-stories/episode-and-health-marker-flows.md
+++ b/docs/user-stories/episode-and-health-marker-flows.md
@@ -1,14 +1,23 @@
-# User story: Episode logging vs standalone vitals (symptom + health marker presets)
+# User story: Episode flows + standalone health and food logging
 
-**Status:** Draft (product intent; schedule on [ROADMAP.md](../ROADMAP.md) — **Week 5:** migrations (`health_marker_preset_id` + episode templates table), template settings UI, **I'm having an episode** + template picker; **Week 6:** full symptom + marker prompt flow, standalone vitals, food diary, wellness)  
+**Status:** Draft (product intent; schedule on [ROADMAP.md](../ROADMAP.md) — **Week 5:** migrations (`health_marker_preset_id` + episode templates table), template settings UI, **I'm having an episode** + template picker; **Week 6:** full symptom + marker prompt flow, standalone health markers, standalone food diary, and consolidated management requirements)  
 **Related PRD:** [PRD.md](../PRD.md) — §3 Health Marker Presets, §4 Episode Logging, §5 General Wellness Logging
 
 This document expands the **user-facing flows** for:
 
 1. Starting an **episode** when the user may be **cognitively impaired** — the UI must not dump many choices on them at once ([PRD](../PRD.md) impaired-user requirements).
-2. **Asymptomatic** use: the user only wants to **track vitals** using a health marker preset, with **no** symptom episode.
+2. **Asymptomatic** use: the user wants to **track health markers** using a preset, with **no** symptom episode.
+3. Standalone **food diary** logging outside episode prompts.
 
 The PRD states the **order** of prompts (symptoms first, then health markers). This story adds **how** pairing is chosen without overwhelming the user at episode start.
+
+## Product scope guardrails
+
+- Symptoms (including nausea/vomiting and related episode symptoms) are captured through the **episode flow**, not a standalone symptom path.
+- Standalone logging in this scope is limited to:
+  - health marker entries
+  - food diary entries
+- Generic "How are you feeling" mood/wellness capture is out of scope for these flows.
 
 ---
 
@@ -29,7 +38,7 @@ At episode start, the experience is: **pick what kind of episode this is** using
 
 So Eric needs **more than one named episode type** at start — not more complexity on one screen. He should see a **short list of big buttons** (or an equally accessible control), e.g. **“ABS Episode”** and **“CVS Episode”**, each backed by its own episode template (different symptom lines, different marker lines, or both). One tap → into the combined flow.
 
-Eric also wants to log glucose or other markers on a **good day** without starting any episode — that is **standalone vitals** (Story B).
+Eric also wants to log glucose or other markers on a **good day** without starting any episode — that is **standalone health marker logging** (Story B). He may also add food diary entries without an episode (Story C).
 
 ---
 
@@ -57,7 +66,7 @@ Naming a symptom preset and a health marker preset the same string does **not** 
 
 ---
 
-## Story B — Asymptomatic, “just checking vitals”
+## Story B — Asymptomatic, “just checking health markers”
 
 ### Setup
 
@@ -67,12 +76,39 @@ Naming a symptom preset and a health marker preset the same string does **not** 
 
 1. Eric taps something like **“Log vitals”** / **“Health markers”** from home (**not** “I'm having an episode”).
 2. Eric picks **one health marker preset** only.
-3. The app walks **only** those markers in preset order and saves readings **without** symptom prompts and **without** an episode template.
+3. The app walks **only** those markers in preset order and saves readings **without** symptom prompts and **without** an episode template (`health_markers.episode_id = null`).
 
 ### Outcome
 
 - The same health marker preset can appear inside an episode template (Story A) and **alone** (Story B).
-- Standalone vitals stay **first-class** — no requirement to link markers to symptoms for users who only need that path.
+- Standalone health marker logging stays **first-class** — no requirement to link markers to symptoms for users who only need that path.
+
+---
+
+## Story C — Standalone food diary (non-episode path)
+
+### When Eric wants to log food outside an episode
+
+1. Eric opens a dedicated **Food diary** entry path from home or secondary navigation.
+2. Eric records free-text food notes, meal tag, and timestamp without starting an episode.
+3. If Eric is already in an episode flow, food diary can still be logged at the designated episode step; this standalone path remains available outside episode context.
+
+### Outcome
+
+- Food diary logging works both **during episode flow** and **as a standalone path**.
+- Standalone food entries remain separate from symptom-only assumptions and do not imply an episode.
+
+---
+
+## Unified management concept (product-level)
+
+The product includes one consolidated management surface (implemented accessibly on web + mobile) where users can review and delete entries across three groups:
+
+- Episodes
+- Standalone health marker entries (`health_markers.episode_id IS NULL`)
+- Standalone food diary entries (entries not linked to an episode)
+
+This story defines the scope boundary only; it does not prescribe exact layout, navigation hierarchy, or component-level UI patterns.
 
 ---
 
@@ -84,10 +120,11 @@ Naming a symptom preset and a health marker preset the same string does **not** 
 | **Independent preset lists in the DB** | Symptom presets and health marker presets remain separate editable lists; **templates** are how we pair them for logging without cognitive overload. |
 | **Explicit pairing**                   | The app must not guess; the **episode template** resolves which marker list goes with which symptom list.                                            |
 | **Persist both IDs on the episode**    | For auditability, the episode row should store both `symptom_preset_id` and `health_marker_preset_id` once the schema supports it.                   |
-| **Standalone vitals**                  | Separate entry point; health marker preset only.                                                                                                     |
+| **Standalone health markers**          | Separate entry point; health marker preset only (`health_markers.episode_id = null`).                                                                |
+| **Standalone food diary**              | Separate non-episode entry path is allowed in addition to the in-episode food step.                                                                  |
 
 ---
 
 ## Implementation note
 
-Database migrations, RLS, and typed client updates for `episodes.health_marker_preset_id` and for the **episode preset templates** (bundle) table are **not** specified in this user story file. Concrete tasks live as checkboxes under **[ROADMAP.md](../ROADMAP.md)** (episode template schema + picker in **Week 5**; full prompts and standalone vitals in **Week 6**).
+Database migrations, RLS, and typed client updates for `episodes.health_marker_preset_id` and for the **episode preset templates** (bundle) table are **not** specified in this user story file. Concrete tasks live as checkboxes under **[ROADMAP.md](../ROADMAP.md)** (episode template schema + picker in **Week 5**; full prompts, standalone health markers, standalone food diary, and unified management requirements in **Week 6**).


### PR DESCRIPTION
Closes #97

## Summary
- Refactors Week 6 roadmap requirements to match the new product direction: symptoms are episode-only, with standalone logging limited to health markers and food diary.
- Removes wellness/ad-hoc standalone symptom language from planning docs and adds explicit scope guardrails to prevent ambiguous downstream implementation.
- Adds a consolidated management-surface requirement (web + mobile) for viewing/deleting Episodes, Standalone Health entries, and Standalone Food entries.
- Updates the related user story to align Story A/B wording with episode-only symptom flows, adds standalone food diary coverage, and introduces a concise product-level unified management concept note.

## Why
Planning docs were still describing legacy wellness/ad-hoc symptom behavior, which risked causing follow-up AI implementation work to build the wrong flows. This change makes requirements implementation-ready and unambiguous before coding tasks proceed.

## Scope of changes
- `docs/ROADMAP.md`
  - Week 6 heading/goal/scope guardrails updated
  - wellness + ad-hoc standalone symptom tasks removed
  - standalone health marker logging clarified with `health_markers.episode_id = null`
  - standalone food diary clarified as non-episode path
  - unified management surface requirement added (Episodes / Standalone Health / Standalone Food, with delete)
  - Week 6 dependency graph label and notes text updated to remove wellness implication
  - Week 6 checkboxes updated to reflect completed vs remaining items
- `docs/user-stories/episode-and-health-marker-flows.md`
  - status/intro wording aligned with new scope
  - explicit product guardrails added (episode-only symptoms, no wellness flow)
  - Story B updated to standalone health marker language (`episode_id = null`)
  - Story C added for standalone food diary (non-episode path)
  - concise unified management concept section added (product-level, non-prescriptive UI)

## Acceptance criteria mapping
- [x] `docs/ROADMAP.md` no longer includes Week 6 wellness mood logging or ad-hoc standalone symptom logging.
- [x] Week 6 clearly includes standalone health marker logging (`health_markers.episode_id = null`) and standalone food diary logging.
- [x] Week 6 includes one consolidated management surface for Episodes, Health, and Food with delete support.
- [x] `docs/user-stories/episode-and-health-marker-flows.md` reviewed and updated to match scope.
- [x] No conflicting language remains between roadmap and user story docs.

## Out of scope
- No feature/UI/DB implementation changes.
- No edit/update management actions introduced beyond delete requirements.