### PR TITLE
OLD: feat(health-markers,food-diary): standalone marker logging and post-save food diary UX on web and mobile

### DIFF
--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.spec.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react';
 import { fireEvent, render, waitFor } from '@testing-library/react-native';
 import { DefaultTheme, useRoute } from '@react-navigation/native';
 import { createFoodDiaryEntry } from '@abstrack/supabase';
@@ -181,5 +180,61 @@ describe('FoodDiaryEntryScreen', () => {
     expect(announce).toHaveBeenCalledWith('Food entry saved.', {
       politeness: 'polite',
     });
+  });
+
+  test('standalone save collapses form and add new entry restores fresh form', async () => {
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'FoodDiaryEntry',
+      name: 'FoodDiaryEntry',
+      params: {},
+    } as never);
+
+    jest.mocked(createFoodDiaryEntry).mockResolvedValue({
+      ok: true,
+      data: {
+        id: 'food-standalone-1',
+        user_id: 'test-user-1',
+        episode_id: null,
+        meal_tag: 'Lunch',
+        food_note: 'Salad',
+        logged_at: '2026-04-22T12:00:00.000Z',
+        created_at: '2026-04-22T12:00:00.000Z',
+        updated_at: '2026-04-22T12:00:00.000Z',
+      },
+    });
+
+    const screen = render(<FoodDiaryEntryScreen />);
+
+    fireEvent.press(screen.getByLabelText('Lunch'));
+    fireEvent.changeText(screen.getByLabelText('Food note'), 'Salad');
+    fireEvent.press(screen.getByLabelText('Save food entry'));
+
+    await waitFor(() => {
+      expect(createFoodDiaryEntry).toHaveBeenCalledWith(
+        expect.objectContaining({ mockClient: true }),
+        expect.objectContaining({
+          user_id: 'test-user-1',
+          episode_id: null,
+          meal_tag: 'Lunch',
+          food_note: 'Salad',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Food entry saved.')).toBeTruthy();
+    });
+    expect(screen.queryByText('Meal tag')).toBeNull();
+
+    fireEvent.press(screen.getByLabelText('Add a new food diary entry'));
+
+    await waitFor(() => {
+      expect(screen.getByText('Meal tag')).toBeTruthy();
+    });
+    expect(screen.getByLabelText('Food note').props.value).toBe('');
+    expect(announce).toHaveBeenCalledWith(
+      'Ready to add another food diary entry.',
+      { politeness: 'polite' },
+    );
   });
 });

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
@@ -30,8 +30,17 @@ import { nw } from '../theme/app-nativewind-classes';
 
 type FoodDiaryEntryRoute = RouteProp<MainStackParamList, 'FoodDiaryEntry'>;
 
+type LastSavedSummary = {
+  mealTag: MealTag;
+  loggedAtIso: string;
+};
+
 /**
- * Standalone food diary creation screen (home entry point). Optional episode link can be supplied.
+ * Food diary creation screen (home entry point or optional episode link).
+ *
+ * Standalone entries (`episodeId` absent) collapse after save with a
+ * confirmation and an action to start a fresh entry. Episode-linked saves
+ * keep the form visible with inline success text.
  *
  * @returns Form for meal tag, log timestamp, and free-text food note.
  */
@@ -39,6 +48,7 @@ export function FoodDiaryEntryScreen() {
   const route = useRoute<FoodDiaryEntryRoute>();
   const { colors } = useAppTheme();
   const episodeId = route.params?.episodeId ?? null;
+  const isStandalone = episodeId == null;
   const supabase = useMemo(() => getMobileSupabaseClient(), []);
   const [mealTag, setMealTag] = useState<MealTag | null>(null);
   const [foodNote, setFoodNote] = useState('');
@@ -49,6 +59,10 @@ export function FoodDiaryEntryScreen() {
   const [saving, setSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [standaloneSaved, setStandaloneSaved] = useState(false);
+  const [lastSaved, setLastSaved] = useState<LastSavedSummary | null>(null);
+  /** Remount form fields after “Add a new entry” so state matches a fresh screen. */
+  const [formInstanceKey, setFormInstanceKey] = useState(0);
 
   const loggedAtValue = useMemo(() => {
     const iso = localDateTimeToIso(loggedDate, loggedTime);
@@ -95,6 +109,20 @@ export function FoodDiaryEntryScreen() {
       return;
     }
     setLoggedTime(localTimeFromDate(selectedDate));
+  };
+
+  const resetToFreshEntry = () => {
+    setMealTag(null);
+    setFoodNote('');
+    setLoggedDate(currentLocalDate());
+    setLoggedTime(currentLocalTime());
+    setDatePickerOpen(false);
+    setTimePickerOpen(false);
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setStandaloneSaved(false);
+    setLastSaved(null);
+    setFormInstanceKey((k) => k + 1);
   };
 
   const onSave = async () => {
@@ -146,19 +174,33 @@ export function FoodDiaryEntryScreen() {
       return;
     }
 
-    setMealTag(null);
-    setFoodNote('');
-    setLoggedDate(currentLocalDate());
-    setLoggedTime(currentLocalTime());
     setDatePickerOpen(false);
     setTimePickerOpen(false);
-    setSuccessMessage(
-      episodeId
-        ? 'Food entry saved and linked to this episode.'
-        : 'Food entry saved.',
-    );
+
+    if (isStandalone) {
+      setLastSaved({ mealTag, loggedAtIso });
+      setMealTag(null);
+      setFoodNote('');
+      setLoggedDate(currentLocalDate());
+      setLoggedTime(currentLocalTime());
+      setStandaloneSaved(true);
+    } else {
+      setMealTag(null);
+      setFoodNote('');
+      setLoggedDate(currentLocalDate());
+      setLoggedTime(currentLocalTime());
+      setSuccessMessage('Food entry saved and linked to this episode.');
+    }
     await announce('Food entry saved.', { politeness: 'polite' });
   };
+
+  const savedLoggedAtDisplay =
+    lastSaved != null
+      ? new Date(lastSaved.loggedAtIso).toLocaleString(undefined, {
+          dateStyle: 'medium',
+          timeStyle: 'short',
+        })
+      : '';
 
   return (
     <ScreenShell contentAlign="stretch">
@@ -170,162 +212,205 @@ export function FoodDiaryEntryScreen() {
         >
           Food diary
         </Text>
-        <Text
-          className={`text-base leading-relaxed ${nw.textMuted}`}
-          maxFontSizeMultiplier={2}
-        >
-          Log what you ate or drank. Time defaults to now and can be adjusted.
-        </Text>
-
-        <ScrollView
-          className="flex-1"
-          keyboardShouldPersistTaps="handled"
-          contentContainerStyle={{ paddingBottom: 24 }}
-        >
-          <Text
-            className={`mb-2 text-base font-medium ${nw.textInk}`}
-            maxFontSizeMultiplier={2}
-          >
-            Meal tag
-          </Text>
-          <View accessibilityLabel="Meal tag" className="mb-4 gap-2">
-            {MEAL_TAGS.map((tag) => (
-              <Pressable
-                key={tag}
-                accessibilityRole="button"
-                accessibilityLabel={tag}
-                accessibilityState={{
-                  selected: mealTag === tag,
-                  disabled: saving,
-                }}
-                disabled={saving}
-                onPress={() => {
-                  setMealTag((prev) => (prev === tag ? null : tag));
-                }}
-                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                className={`w-full items-center justify-center rounded-xl border-2 px-3 py-3 dark:border-app-border-dark ${
-                  mealTag === tag
-                    ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
-                    : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
-                }`}
+        {isStandalone && standaloneSaved && lastSaved != null ? (
+          <>
+            <View
+              className="rounded-xl border border-emerald-200/90 bg-emerald-50 p-4 dark:border-emerald-800/60 dark:bg-emerald-950/40"
+              accessibilityLiveRegion="polite"
+            >
+              <Text
+                className={`text-base font-semibold ${nw.textInk}`}
+                maxFontSizeMultiplier={2}
               >
+                Food entry saved.
+              </Text>
+              <Text
+                className={`mt-2 text-sm leading-relaxed ${nw.textMuted}`}
+                maxFontSizeMultiplier={2}
+              >
+                {lastSaved.mealTag} · {savedLoggedAtDisplay}
+              </Text>
+            </View>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Add a new food diary entry"
+              onPress={() => {
+                resetToFreshEntry();
+                void announce('Ready to add another food diary entry.', {
+                  politeness: 'polite',
+                });
+              }}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 dark:bg-red-600"
+            >
+              <Text className="text-center text-[17px] font-semibold text-white">
+                Add a new entry
+              </Text>
+            </Pressable>
+          </>
+        ) : (
+          <>
+            <Text
+              className={`text-base leading-relaxed ${nw.textMuted}`}
+              maxFontSizeMultiplier={2}
+            >
+              Log what you ate or drank. Time defaults to now and can be
+              adjusted.
+            </Text>
+
+            <ScrollView
+              className="flex-1"
+              keyboardShouldPersistTaps="handled"
+              contentContainerStyle={{ paddingBottom: 24 }}
+            >
+              <View key={formInstanceKey} className="gap-0">
                 <Text
-                  className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                  className={`mb-2 text-base font-medium ${nw.textInk}`}
                   maxFontSizeMultiplier={2}
                 >
-                  {tag}
+                  Meal tag
                 </Text>
-              </Pressable>
-            ))}
-          </View>
+                <View accessibilityLabel="Meal tag" className="mb-4 gap-2">
+                  {MEAL_TAGS.map((tag) => (
+                    <Pressable
+                      key={tag}
+                      accessibilityRole="button"
+                      accessibilityLabel={tag}
+                      accessibilityState={{
+                        selected: mealTag === tag,
+                        disabled: saving,
+                      }}
+                      disabled={saving}
+                      onPress={() => {
+                        setMealTag((prev) => (prev === tag ? null : tag));
+                      }}
+                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                      className={`w-full items-center justify-center rounded-xl border-2 px-3 py-3 dark:border-app-border-dark ${
+                        mealTag === tag
+                          ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                          : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
+                      }`}
+                    >
+                      <Text
+                        className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        {tag}
+                      </Text>
+                    </Pressable>
+                  ))}
+                </View>
 
-          <Text
-            className={`mb-1 text-base font-medium ${nw.textInk}`}
-            maxFontSizeMultiplier={2}
-          >
-            Logged date
-          </Text>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Logged date"
-            accessibilityState={{ disabled: saving }}
-            disabled={saving}
-            onPress={() => {
-              setDatePickerOpen((prev) => !prev);
-              setTimePickerOpen(false);
-            }}
-            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-            className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
-          >
-            <Text
-              className={`text-[17px] ${nw.textInk}`}
-              maxFontSizeMultiplier={2}
-            >
-              {loggedDateLabel}
-            </Text>
-          </Pressable>
+                <Text
+                  className={`mb-1 text-base font-medium ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Logged date
+                </Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Logged date"
+                  accessibilityState={{ disabled: saving }}
+                  disabled={saving}
+                  onPress={() => {
+                    setDatePickerOpen((prev) => !prev);
+                    setTimePickerOpen(false);
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="mb-3 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+                >
+                  <Text
+                    className={`text-[17px] ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {loggedDateLabel}
+                  </Text>
+                </Pressable>
 
-          <Text
-            className={`mb-1 text-base font-medium ${nw.textInk}`}
-            maxFontSizeMultiplier={2}
-          >
-            Logged time
-          </Text>
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Logged time"
-            accessibilityState={{ disabled: saving }}
-            disabled={saving}
-            onPress={() => {
-              setTimePickerOpen((prev) => !prev);
-              setDatePickerOpen(false);
-            }}
-            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-            className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
-          >
-            <Text
-              className={`text-[17px] ${nw.textInk}`}
-              maxFontSizeMultiplier={2}
-            >
-              {loggedTimeLabel}
-            </Text>
-          </Pressable>
+                <Text
+                  className={`mb-1 text-base font-medium ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Logged time
+                </Text>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Logged time"
+                  accessibilityState={{ disabled: saving }}
+                  disabled={saving}
+                  onPress={() => {
+                    setTimePickerOpen((prev) => !prev);
+                    setDatePickerOpen(false);
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="mb-4 items-center justify-center rounded-xl border border-app-border bg-white px-4 py-3 dark:border-app-border-dark dark:bg-app-bg-dark"
+                >
+                  <Text
+                    className={`text-[17px] ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {loggedTimeLabel}
+                  </Text>
+                </Pressable>
 
-          <Text
-            className={`mb-1 text-base font-medium ${nw.textInk}`}
-            maxFontSizeMultiplier={2}
-          >
-            Food note
-          </Text>
-          <TextInput
-            editable={!saving}
-            accessibilityLabel="Food note"
-            multiline
-            value={foodNote}
-            onChangeText={setFoodNote}
-            placeholder="What did you eat or drink?"
-            placeholderTextColor={colors.inputPlaceholder}
-            className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-            maxFontSizeMultiplier={2}
-          />
+                <Text
+                  className={`mb-1 text-base font-medium ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Food note
+                </Text>
+                <TextInput
+                  editable={!saving}
+                  accessibilityLabel="Food note"
+                  multiline
+                  value={foodNote}
+                  onChangeText={setFoodNote}
+                  placeholder="What did you eat or drink?"
+                  placeholderTextColor={colors.inputPlaceholder}
+                  className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                />
 
-          {errorMessage ? (
-            <Text
-              className={`mb-2 text-sm ${nw.textError}`}
-              accessibilityLiveRegion="assertive"
-              maxFontSizeMultiplier={2}
-            >
-              {errorMessage}
-            </Text>
-          ) : null}
-          {successMessage ? (
-            <Text
-              className="mb-2 text-sm text-green-700 dark:text-green-300"
-              accessibilityLiveRegion="polite"
-              maxFontSizeMultiplier={2}
-            >
-              {successMessage}
-            </Text>
-          ) : null}
+                {errorMessage ? (
+                  <Text
+                    className={`mb-2 text-sm ${nw.textError}`}
+                    accessibilityLiveRegion="assertive"
+                    maxFontSizeMultiplier={2}
+                  >
+                    {errorMessage}
+                  </Text>
+                ) : null}
+                {!isStandalone && successMessage ? (
+                  <Text
+                    className="mb-2 text-sm text-green-700 dark:text-green-300"
+                    accessibilityLiveRegion="polite"
+                    maxFontSizeMultiplier={2}
+                  >
+                    {successMessage}
+                  </Text>
+                ) : null}
 
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={
-              saving ? 'Saving food entry' : 'Save food entry'
-            }
-            accessibilityState={{ disabled: saving }}
-            disabled={saving}
-            onPress={() => {
-              void onSave();
-            }}
-            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-            className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 disabled:opacity-60 dark:bg-red-600"
-          >
-            <Text className="text-center text-[17px] font-semibold text-white">
-              {saving ? 'Saving…' : 'Save food entry'}
-            </Text>
-          </Pressable>
-        </ScrollView>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    saving ? 'Saving food entry' : 'Save food entry'
+                  }
+                  accessibilityState={{ disabled: saving }}
+                  disabled={saving}
+                  onPress={() => {
+                    void onSave();
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 disabled:opacity-60 dark:bg-red-600"
+                >
+                  <Text className="text-center text-[17px] font-semibold text-white">
+                    {saving ? 'Saving…' : 'Save food entry'}
+                  </Text>
+                </Pressable>
+              </View>
+            </ScrollView>
+          </>
+        )}
         {datePickerOpen ? (
           <DateTimePicker
             value={loggedAtValue}

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -129,6 +129,15 @@ export default async function DashboardPage() {
 
         <div className="space-y-4">
           <div>
+            <p className="text-sm text-app-muted">Health markers</p>
+            <Link
+              href="/health-markers/new"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-app-border bg-app-surface px-3 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            >
+              Log health markers
+            </Link>
+          </div>
+          <div>
             <p className="text-sm text-app-muted">Food diary</p>
             <Link
               href="/food-diary/new"

--- a/apps/web/src/app/(app)/health-markers/new/page.tsx
+++ b/apps/web/src/app/(app)/health-markers/new/page.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link';
+import { StandaloneHealthMarkerFlow } from '@/components/health-markers/StandaloneHealthMarkerFlow';
+
+/**
+ * Standalone health-marker logging route (no episode).
+ *
+ * @returns Marker preset picker and prompt flow.
+ */
+export default function StandaloneHealthMarkersPage() {
+  return (
+    <div className="w-full space-y-8">
+      <div>
+        <p className="text-sm font-medium text-app-muted">
+          <Link
+            href="/dashboard"
+            className="rounded-md text-app-primary underline decoration-app-primary/40 underline-offset-2 outline-none transition hover:text-app-ink hover:decoration-app-primary focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            ← Back to dashboard
+          </Link>
+        </p>
+      </div>
+      <StandaloneHealthMarkerFlow />
+    </div>
+  );
+}

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -6,13 +6,11 @@ import type {
   EpisodeRow,
   EpisodeType,
   HealthMarkerRow,
-  PresetHealthMarkerKind,
   PresetHealthMarkerRow,
 } from '@abstrack/types';
 import {
   bacReadingSuggestsAbsEpisode,
   formatEpisodeDurationSimple,
-  PRESET_HEALTH_MARKER_KIND_LABELS,
   validatePresetHealthMarkerCustomFields,
 } from '@abstrack/types';
 import {
@@ -31,54 +29,21 @@ import { EpisodeLocaleInstant } from '@/components/episodes/EpisodeLocaleInstant
 import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
 import { EpisodeFoodDiaryStep } from './EpisodeFoodDiaryStep';
 import { useEpisodeFoodDiary } from './use-episode-food-diary';
-
-type MarkerDraft = {
-  value: string;
-  systolic: string;
-  diastolic: string;
-  notes: string;
-};
+import {
+  createDraftFromMarker,
+  markerLineTitle,
+  minForPresetMarkerValueInput,
+  parseMeasurementDraftForSave,
+  type MarkerDraft,
+} from '../health-markers/marker-draft';
 
 type PersistFeedback =
   | { source: 'validation'; message: string }
   | { source: 'sync'; message: string };
 
-function normalizeNullable(value: string | null | undefined): string | null {
-  const next = value?.trim() ?? '';
-  return next.length > 0 ? next : null;
-}
-
 function trimToNull(value: string): string | null {
   const t = value.trim();
   return t.length > 0 ? t : null;
-}
-
-/**
- * HTML `min` for preset kinds with non-negative vitals; `custom` stays unconstrained (scales vary).
- * Pair with `step="any"` so decimals still validate in browsers.
- */
-function minForPresetMarkerValueInput(
-  kind: PresetHealthMarkerKind,
-): number | undefined {
-  return kind === 'custom' ? undefined : 0;
-}
-
-function markerLineTitle(line: PresetHealthMarkerRow): string {
-  if (line.marker_kind !== 'custom') {
-    return PRESET_HEALTH_MARKER_KIND_LABELS[line.marker_kind];
-  }
-  const customName = normalizeNullable(line.custom_name);
-  return customName ?? PRESET_HEALTH_MARKER_KIND_LABELS.custom;
-}
-
-function createDraftFromMarker(row: HealthMarkerRow | null): MarkerDraft {
-  return {
-    value: row?.value_numeric != null ? String(row.value_numeric) : '',
-    systolic: row?.systolic_numeric != null ? String(row.systolic_numeric) : '',
-    diastolic:
-      row?.diastolic_numeric != null ? String(row.diastolic_numeric) : '',
-    notes: row?.notes ?? '',
-  };
 }
 
 function findExistingMarkerForLine(
@@ -86,72 +51,6 @@ function findExistingMarkerForLine(
   line: PresetHealthMarkerRow,
 ): HealthMarkerRow | null {
   return rows.find((row) => row.preset_health_marker_id === line.id) ?? null;
-}
-
-type MeasurementDraftResult =
-  | {
-      ok: true;
-      valueNumeric: number | null;
-      systolicNumeric: number | null;
-      diastolicNumeric: number | null;
-    }
-  | { ok: false; message: string };
-
-/**
- * Parses numeric fields the same way as {@link saveCurrentLine} (single source of truth).
- * Skip is allowed whenever this returns `ok: false` (incomplete or invalid measurement).
- */
-function parseMeasurementDraftForSave(
-  line: PresetHealthMarkerRow,
-  draft: MarkerDraft,
-): MeasurementDraftResult {
-  const value = parseOptionalNumber(draft.value);
-  const systolic = parseOptionalNumber(draft.systolic);
-  const diastolic = parseOptionalNumber(draft.diastolic);
-
-  if (line.marker_kind === 'blood_pressure') {
-    if (systolic == null || diastolic == null) {
-      return {
-        ok: false,
-        message:
-          'Enter both systolic and diastolic blood pressure values to continue.',
-      };
-    }
-    if (Number.isNaN(systolic) || Number.isNaN(diastolic)) {
-      return {
-        ok: false,
-        message:
-          'Blood pressure values must be valid numbers (for example 120 and 80).',
-      };
-    }
-    return {
-      ok: true,
-      valueNumeric: null,
-      systolicNumeric: systolic,
-      diastolicNumeric: diastolic,
-    };
-  }
-  if (value == null) {
-    return { ok: false, message: 'Enter a numeric value to continue.' };
-  }
-  if (Number.isNaN(value)) {
-    return { ok: false, message: 'Value must be a valid number.' };
-  }
-  return {
-    ok: true,
-    valueNumeric: value,
-    systolicNumeric: null,
-    diastolicNumeric: null,
-  };
-}
-
-function parseOptionalNumber(raw: string | undefined): number | null {
-  const trimmed = (raw ?? '').trim();
-  if (!trimmed) {
-    return null;
-  }
-  const n = Number(trimmed);
-  return Number.isFinite(n) ? n : Number.NaN;
 }
 
 export type HealthMarkerPromptFlowProps = {

--- a/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
+++ b/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
@@ -196,7 +196,7 @@ export function FoodDiaryEntryForm({
                 <button
                   type="button"
                   key={tag}
-                  {...(selected ? { 'aria-pressed': true as const } : {})}
+                  aria-pressed={selected}
                   className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
                     selected
                       ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'

--- a/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
+++ b/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
@@ -19,8 +19,17 @@ type FoodDiaryEntryFormProps = {
   onSaved?: () => void;
 };
 
+type LastSavedSummary = {
+  mealTag: MealTag;
+  loggedAtIso: string;
+};
+
 /**
  * Food diary entry form used from home and episode-end flow.
+ *
+ * Standalone entries (`episodeId` null) collapse after save with a confirmation
+ * and an action to start a fresh entry. Episode-linked entries keep inline
+ * success feedback with the form visible.
  *
  * @param props - Form settings and completion callback.
  * @returns Accessible form for meal tag, note, and logged timestamp.
@@ -34,6 +43,8 @@ export function FoodDiaryEntryForm({
 }: FoodDiaryEntryFormProps) {
   const { announce } = useAnnounce();
   const supabase = useMemo(() => createBrowserClient(), []);
+  const isStandalone = episodeId == null;
+
   const [mealTag, setMealTag] = useState<MealTag | null>(null);
   const [foodNote, setFoodNote] = useState('');
   const [loggedAtLocal, setLoggedAtLocal] = useState(() =>
@@ -42,6 +53,21 @@ export function FoodDiaryEntryForm({
   const [saving, setSaving] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  /** Bumped when starting a new standalone entry so inputs remount like a fresh page load. */
+  const [formInstanceKey, setFormInstanceKey] = useState(0);
+  const [standaloneSaved, setStandaloneSaved] = useState(false);
+  const [lastSaved, setLastSaved] = useState<LastSavedSummary | null>(null);
+
+  const resetToFreshEntry = () => {
+    setMealTag(null);
+    setFoodNote('');
+    setLoggedAtLocal(toLocalDateTimeInputValue(new Date().toISOString()));
+    setErrorMessage(null);
+    setSuccessMessage(null);
+    setStandaloneSaved(false);
+    setLastSaved(null);
+    setFormInstanceKey((k) => k + 1);
+  };
 
   const onSubmit = async () => {
     if (saving) {
@@ -92,16 +118,64 @@ export function FoodDiaryEntryForm({
       return;
     }
 
-    setSuccessMessage(
-      episodeId
-        ? 'Food entry saved and linked to this episode.'
-        : 'Food entry saved.',
-    );
-    setFoodNote('');
-    setLoggedAtLocal(toLocalDateTimeInputValue(new Date().toISOString()));
+    if (isStandalone) {
+      setLastSaved({ mealTag, loggedAtIso });
+      setMealTag(null);
+      setFoodNote('');
+      setLoggedAtLocal(toLocalDateTimeInputValue(new Date().toISOString()));
+      setStandaloneSaved(true);
+    } else {
+      setSuccessMessage('Food entry saved and linked to this episode.');
+      setFoodNote('');
+      setLoggedAtLocal(toLocalDateTimeInputValue(new Date().toISOString()));
+    }
     announce('Food entry saved.', { politeness: 'polite' });
     onSaved?.();
   };
+
+  const savedLoggedAtDisplay =
+    lastSaved != null
+      ? new Date(lastSaved.loggedAtIso).toLocaleString(undefined, {
+          dateStyle: 'medium',
+          timeStyle: 'short',
+        })
+      : '';
+
+  if (isStandalone && standaloneSaved && lastSaved != null) {
+    return (
+      <section className="space-y-5 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8">
+        <div>
+          <h2 className="text-xl font-semibold tracking-tight text-app-ink">
+            {heading}
+          </h2>
+        </div>
+        <div
+          className="rounded-xl border border-green-200/80 bg-green-50 p-4 dark:border-green-800/60 dark:bg-green-950/35"
+          role="status"
+          aria-live="polite"
+        >
+          <p className="text-base font-medium text-green-900 dark:text-green-100">
+            Food entry saved.
+          </p>
+          <p className="mt-2 text-sm text-green-800/95 dark:text-green-200/90">
+            {lastSaved.mealTag} · {savedLoggedAtDisplay}
+          </p>
+        </div>
+        <button
+          type="button"
+          className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 dark:hover:bg-red-500"
+          onClick={() => {
+            resetToFreshEntry();
+            announce('Ready to add another food diary entry.', {
+              politeness: 'polite',
+            });
+          }}
+        >
+          Add a new entry
+        </button>
+      </section>
+    );
+  }
 
   return (
     <section className="space-y-5 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8">
@@ -112,68 +186,70 @@ export function FoodDiaryEntryForm({
         <p className="mt-1 text-sm text-app-muted">{description}</p>
       </div>
 
-      <fieldset className="space-y-2" disabled={saving}>
-        <legend className="text-sm font-medium text-app-ink">Meal tag</legend>
-        <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
-          {MEAL_TAGS.map((tag) => {
-            const selected = mealTag === tag;
-            return (
-              <button
-                type="button"
-                key={tag}
-                aria-pressed={selected}
-                className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
-                  selected
-                    ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
-                    : 'cursor-pointer border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
-                } ${saving ? 'cursor-not-allowed opacity-60' : ''}`}
-                disabled={saving}
-                onClick={() => {
-                  if (!saving) {
-                    setMealTag(selected ? null : tag);
-                  }
-                }}
-              >
-                {tag}
-              </button>
-            );
-          })}
-        </div>
-      </fieldset>
+      <div key={formInstanceKey} className="space-y-5">
+        <fieldset className="space-y-2" disabled={saving}>
+          <legend className="text-sm font-medium text-app-ink">Meal tag</legend>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            {MEAL_TAGS.map((tag) => {
+              const selected = mealTag === tag;
+              return (
+                <button
+                  type="button"
+                  key={tag}
+                  {...(selected ? { 'aria-pressed': true as const } : {})}
+                  className={`flex min-h-[44px] items-center justify-center rounded-lg border px-3 py-2 text-sm font-medium shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
+                    selected
+                      ? 'border-red-700 bg-red-50 text-red-900 dark:border-red-500 dark:bg-red-950/40 dark:text-red-100'
+                      : 'cursor-pointer border-app-border bg-app-surface text-app-ink hover:bg-app-surface/80'
+                  } ${saving ? 'cursor-not-allowed opacity-60' : ''}`}
+                  disabled={saving}
+                  onClick={() => {
+                    if (!saving) {
+                      setMealTag(selected ? null : tag);
+                    }
+                  }}
+                >
+                  {tag}
+                </button>
+              );
+            })}
+          </div>
+        </fieldset>
 
-      <label className="block space-y-1 text-sm font-medium text-app-ink">
-        <span>Logged at</span>
-        <input
-          type="datetime-local"
-          value={loggedAtLocal}
-          disabled={saving}
-          onChange={(e) => {
-            setLoggedAtLocal(e.target.value);
-          }}
-          className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
-        />
-      </label>
+        <label className="block space-y-1 text-sm font-medium text-app-ink">
+          <span>Logged at</span>
+          <input
+            type="datetime-local"
+            value={loggedAtLocal}
+            disabled={saving}
+            onChange={(e) => {
+              setLoggedAtLocal(e.target.value);
+            }}
+            className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+          />
+        </label>
 
-      <label className="block space-y-1 text-sm font-medium text-app-ink">
-        <span>Food note</span>
-        <textarea
-          rows={4}
-          value={foodNote}
-          disabled={saving}
-          onChange={(e) => {
-            setFoodNote(e.target.value);
-          }}
-          placeholder="What did you eat or drink?"
-          className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
-        />
-      </label>
+        <label className="block space-y-1 text-sm font-medium text-app-ink">
+          <span>Food note</span>
+          <textarea
+            rows={4}
+            value={foodNote}
+            disabled={saving}
+            onChange={(e) => {
+              setFoodNote(e.target.value);
+            }}
+            placeholder="What did you eat or drink?"
+            className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-app-ink outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
+          />
+        </label>
+      </div>
 
       {errorMessage ? (
         <p className="text-sm text-red-700 dark:text-red-300" role="alert">
           {errorMessage}
         </p>
       ) : null}
-      {successMessage ? (
+      {!isStandalone && successMessage ? (
         <p className="text-sm text-green-700 dark:text-green-300" role="status">
           {successMessage}
         </p>
@@ -181,7 +257,7 @@ export function FoodDiaryEntryForm({
 
       <button
         type="button"
-        className="inline-flex min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
+        className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
         disabled={saving}
         onClick={() => {
           void onSubmit();

--- a/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
+++ b/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import {
   createStandaloneHealthMarkerForLine,
   listHealthMarkerPresets,
@@ -76,12 +76,27 @@ export function StandaloneHealthMarkerFlow() {
   }, [activeIndex]);
 
   const currentLine = lines[activeIndex] ?? null;
+  const currentLineId = currentLine?.id;
   const currentDraft = currentLine
     ? (drafts[currentLine.id] ?? createDraftFromMarker(null))
     : createDraftFromMarker(null);
   const canSkip = currentLine
     ? !parseMeasurementDraftForSave(currentLine, currentDraft).ok
     : false;
+
+  const patchCurrentLineDraft = useCallback(
+    (patch: Partial<MarkerDraft>) => {
+      if (!currentLineId) {
+        return;
+      }
+      const id = currentLineId;
+      setDrafts((prev) => {
+        const base = prev[id] ?? createDraftFromMarker(null);
+        return { ...prev, [id]: { ...base, ...patch } };
+      });
+    },
+    [currentLineId],
+  );
 
   const startPresetFlow = async () => {
     if (!selectedPresetId || saving) {
@@ -358,7 +373,7 @@ export function StandaloneHealthMarkerFlow() {
       </div>
 
       {feedback ? (
-        <p className="text-sm text-amber-800 dark:text-amber-200" role="status">
+        <p className="text-sm text-red-700 dark:text-red-300" role="alert">
           {feedback}
         </p>
       ) : null}
@@ -379,13 +394,7 @@ export function StandaloneHealthMarkerFlow() {
                   value={currentDraft.systolic}
                   disabled={saving}
                   onChange={(e) => {
-                    setDrafts((prev) => ({
-                      ...prev,
-                      [currentLine.id]: {
-                        ...currentDraft,
-                        systolic: e.target.value,
-                      },
-                    }));
+                    patchCurrentLineDraft({ systolic: e.target.value });
                   }}
                   className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink"
                 />
@@ -399,13 +408,7 @@ export function StandaloneHealthMarkerFlow() {
                   value={currentDraft.diastolic}
                   disabled={saving}
                   onChange={(e) => {
-                    setDrafts((prev) => ({
-                      ...prev,
-                      [currentLine.id]: {
-                        ...currentDraft,
-                        diastolic: e.target.value,
-                      },
-                    }));
+                    patchCurrentLineDraft({ diastolic: e.target.value });
                   }}
                   className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink"
                 />
@@ -421,13 +424,7 @@ export function StandaloneHealthMarkerFlow() {
                 value={currentDraft.value}
                 disabled={saving}
                 onChange={(e) => {
-                  setDrafts((prev) => ({
-                    ...prev,
-                    [currentLine.id]: {
-                      ...currentDraft,
-                      value: e.target.value,
-                    },
-                  }));
+                  patchCurrentLineDraft({ value: e.target.value });
                 }}
                 className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink"
               />
@@ -441,10 +438,7 @@ export function StandaloneHealthMarkerFlow() {
               value={currentDraft.notes}
               disabled={saving}
               onChange={(e) => {
-                setDrafts((prev) => ({
-                  ...prev,
-                  [currentLine.id]: { ...currentDraft, notes: e.target.value },
-                }));
+                patchCurrentLineDraft({ notes: e.target.value });
               }}
               className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-app-ink"
             />

--- a/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
+++ b/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
@@ -28,6 +28,9 @@ import {
 /**
  * Standalone, non-episode health-marker prompt flow.
  *
+ * Presets with no marker lines stay on preset selection with guidance, or show
+ * recovery actions if prompting ever has an empty line list.
+ *
  * @returns Preset selection followed by one-line-at-a-time marker entry.
  */
 export function StandaloneHealthMarkerFlow() {
@@ -68,6 +71,10 @@ export function StandaloneHealthMarkerFlow() {
     }
   }, [authLoading, loadingPresets, session?.user?.id]);
 
+  useEffect(() => {
+    setFeedback(null);
+  }, [activeIndex]);
+
   const currentLine = lines[activeIndex] ?? null;
   const currentDraft = currentLine
     ? (drafts[currentLine.id] ?? createDraftFromMarker(null))
@@ -90,6 +97,13 @@ export function StandaloneHealthMarkerFlow() {
     if (!result.ok) {
       setFeedback(result.error.message);
       announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    if (result.data.length === 0) {
+      const message =
+        'This preset has no marker lines to log yet. Add markers under Health marker presets, or choose a different preset.';
+      setFeedback(message);
+      announce(message, { politeness: 'polite' });
       return;
     }
     const nextDrafts: Record<string, MarkerDraft> = {};
@@ -151,6 +165,7 @@ export function StandaloneHealthMarkerFlow() {
       return;
     }
     if (activeIndex >= lines.length - 1) {
+      setFeedback(null);
       setPhase('complete');
       announce('Standalone health markers saved.', { politeness: 'polite' });
       return;
@@ -278,6 +293,59 @@ export function StandaloneHealthMarkerFlow() {
     );
   }
 
+  if (lines.length === 0) {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+            Standalone health markers
+          </h1>
+          <p className="mt-2 text-sm text-app-muted" role="status">
+            This preset has no marker lines to log. Nothing was saved.
+          </p>
+        </div>
+        <div className="flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+          <button
+            type="button"
+            className="inline-flex min-h-[56px] items-center justify-center rounded-xl border border-app-border bg-app-surface px-5 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            onClick={() => {
+              setPhase('pickPreset');
+              setLines([]);
+              setDrafts({});
+              setActiveIndex(0);
+              setFeedback(null);
+              setSelectedPresetId(null);
+              announce('Choose a health marker preset.', {
+                politeness: 'polite',
+              });
+            }}
+          >
+            Choose another preset
+          </button>
+          <button
+            type="button"
+            className="inline-flex min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 dark:hover:bg-red-500"
+            onClick={() => {
+              router.push('/dashboard');
+            }}
+          >
+            Back to dashboard
+          </button>
+        </div>
+        <p className="text-sm text-app-muted">
+          Add lines to this preset under{' '}
+          <Link
+            href="/presets/health-markers"
+            className="font-medium text-app-primary underline decoration-app-primary/40 underline-offset-2 outline-none hover:text-app-ink focus-visible:ring-2 focus-visible:ring-app-ring"
+          >
+            Health marker presets
+          </Link>
+          .
+        </p>
+      </div>
+    );
+  }
+
   return (
     <div className="space-y-6">
       <div>
@@ -285,9 +353,7 @@ export function StandaloneHealthMarkerFlow() {
           Standalone health markers
         </h1>
         <p className="mt-2 text-sm text-app-muted">
-          {lines.length === 0
-            ? 'This preset has no marker lines.'
-            : `Step ${activeIndex + 1} of ${lines.length}`}
+          {`Step ${activeIndex + 1} of ${lines.length}`}
         </p>
       </div>
 
@@ -384,11 +450,7 @@ export function StandaloneHealthMarkerFlow() {
             />
           </label>
         </div>
-      ) : (
-        <p className="text-sm text-app-muted" role="status">
-          No markers to log for this preset.
-        </p>
-      )}
+      ) : null}
 
       <div className="flex flex-col gap-3 sm:flex-row">
         {currentLine ? (
@@ -397,6 +459,7 @@ export function StandaloneHealthMarkerFlow() {
             disabled={!canSkip || saving}
             onClick={() => {
               if (activeIndex >= lines.length - 1) {
+                setFeedback(null);
                 setPhase('complete');
                 return;
               }

--- a/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
+++ b/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
@@ -188,7 +188,7 @@ export function StandaloneHealthMarkerFlow() {
     setActiveIndex((prev) => prev + 1);
   };
 
-  if (authLoading || loadingPresets) {
+  if (authLoading) {
     return <PageLoading title="Log health markers" />;
   }
 
@@ -207,6 +207,10 @@ export function StandaloneHealthMarkerFlow() {
         </Link>
       </div>
     );
+  }
+
+  if (loadingPresets) {
+    return <PageLoading title="Log health markers" />;
   }
 
   if (phase === 'complete') {

--- a/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
+++ b/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
@@ -1,0 +1,427 @@
+'use client';
+
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect, useMemo, useState } from 'react';
+import {
+  createStandaloneHealthMarkerForLine,
+  listHealthMarkerPresets,
+  listPresetHealthMarkersForPreset,
+} from '@abstrack/supabase';
+import type {
+  HealthMarkerPresetRow,
+  PresetHealthMarkerRow,
+} from '@abstrack/types';
+import { validatePresetHealthMarkerCustomFields } from '@abstrack/types';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { useAuth } from '@/lib/auth-provider';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { PageLoading } from '@/components/page-states/PageLoading';
+import {
+  createDraftFromMarker,
+  markerLineTitle,
+  minForPresetMarkerValueInput,
+  parseMeasurementDraftForSave,
+  type MarkerDraft,
+} from './marker-draft';
+
+/**
+ * Standalone, non-episode health-marker prompt flow.
+ *
+ * @returns Preset selection followed by one-line-at-a-time marker entry.
+ */
+export function StandaloneHealthMarkerFlow() {
+  const router = useRouter();
+  const { announce } = useAnnounce();
+  const { session, loading: authLoading } = useAuth();
+  const supabase = useMemo(() => createBrowserClient(), []);
+
+  const [phase, setPhase] = useState<'pickPreset' | 'prompting' | 'complete'>(
+    'pickPreset',
+  );
+  const [loadingPresets, setLoadingPresets] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [presets, setPresets] = useState<HealthMarkerPresetRow[]>([]);
+  const [selectedPresetId, setSelectedPresetId] = useState<string | null>(null);
+  const [lines, setLines] = useState<PresetHealthMarkerRow[]>([]);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [drafts, setDrafts] = useState<Record<string, MarkerDraft>>({});
+  const [saving, setSaving] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+
+  const loadPresets = async () => {
+    setLoadingPresets(true);
+    setLoadError(null);
+    const result = await listHealthMarkerPresets(supabase);
+    if (!result.ok) {
+      setLoadError(result.error.message);
+      setLoadingPresets(false);
+      return;
+    }
+    setPresets(result.data);
+    setLoadingPresets(false);
+  };
+
+  useEffect(() => {
+    if (!authLoading && session?.user?.id && loadingPresets) {
+      void loadPresets();
+    }
+  }, [authLoading, loadingPresets, session?.user?.id]);
+
+  const currentLine = lines[activeIndex] ?? null;
+  const currentDraft = currentLine
+    ? (drafts[currentLine.id] ?? createDraftFromMarker(null))
+    : createDraftFromMarker(null);
+  const canSkip = currentLine
+    ? !parseMeasurementDraftForSave(currentLine, currentDraft).ok
+    : false;
+
+  const startPresetFlow = async () => {
+    if (!selectedPresetId || saving) {
+      return;
+    }
+    setSaving(true);
+    setFeedback(null);
+    const result = await listPresetHealthMarkersForPreset(
+      supabase,
+      selectedPresetId,
+    );
+    setSaving(false);
+    if (!result.ok) {
+      setFeedback(result.error.message);
+      announce(result.error.message, { politeness: 'assertive' });
+      return;
+    }
+    const nextDrafts: Record<string, MarkerDraft> = {};
+    for (const line of result.data) {
+      nextDrafts[line.id] = createDraftFromMarker(null);
+    }
+    setDrafts(nextDrafts);
+    setLines(result.data);
+    setActiveIndex(0);
+    setPhase('prompting');
+    announce('Health marker logging started.', { politeness: 'polite' });
+  };
+
+  const saveCurrentLine = async (): Promise<boolean> => {
+    if (!currentLine || !session?.user?.id) {
+      return false;
+    }
+    const customValidation = validatePresetHealthMarkerCustomFields(
+      currentLine.marker_kind,
+      currentLine.custom_name ?? '',
+      currentLine.custom_unit ?? '',
+    );
+    if (customValidation) {
+      setFeedback(customValidation);
+      announce(customValidation, { politeness: 'assertive' });
+      return false;
+    }
+    const parsed = parseMeasurementDraftForSave(currentLine, currentDraft);
+    if (!parsed.ok) {
+      setFeedback(parsed.message);
+      announce(parsed.message, { politeness: 'assertive' });
+      return false;
+    }
+    setSaving(true);
+    setFeedback(null);
+    const result = await createStandaloneHealthMarkerForLine(supabase, {
+      userId: session.user.id,
+      line: currentLine,
+      valueNumeric: parsed.valueNumeric,
+      systolicNumeric: parsed.systolicNumeric,
+      diastolicNumeric: parsed.diastolicNumeric,
+      notes: currentDraft.notes.trim() ? currentDraft.notes.trim() : null,
+    });
+    setSaving(false);
+    if (!result.ok) {
+      setFeedback(result.error.message);
+      announce(result.error.message, { politeness: 'assertive' });
+      return false;
+    }
+    return true;
+  };
+
+  const onNext = async () => {
+    if (saving || !currentLine) {
+      return;
+    }
+    const saved = await saveCurrentLine();
+    if (!saved) {
+      return;
+    }
+    if (activeIndex >= lines.length - 1) {
+      setPhase('complete');
+      announce('Standalone health markers saved.', { politeness: 'polite' });
+      return;
+    }
+    setActiveIndex((prev) => prev + 1);
+  };
+
+  if (authLoading || loadingPresets) {
+    return <PageLoading title="Log health markers" />;
+  }
+
+  if (!session) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Log health markers
+        </h1>
+        <p className="text-sm text-app-muted">You need to be signed in.</p>
+        <Link
+          href="/login"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-full bg-app-primary px-5 text-sm font-semibold text-white"
+        >
+          Sign in
+        </Link>
+      </div>
+    );
+  }
+
+  if (phase === 'complete') {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Health markers saved
+        </h1>
+        <p className="text-sm text-app-muted" role="status">
+          Your marker entries were saved.
+        </p>
+        <button
+          type="button"
+          onClick={() => {
+            router.push('/dashboard');
+          }}
+          className="inline-flex min-h-[44px] items-center justify-center rounded-xl bg-red-700 px-5 text-sm font-semibold text-white"
+        >
+          Back to dashboard
+        </button>
+      </div>
+    );
+  }
+
+  if (phase === 'pickPreset') {
+    return (
+      <div className="space-y-6">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+            Log health markers
+          </h1>
+          <p className="mt-2 text-sm text-app-muted">
+            Choose a health marker preset to log vitals without starting an
+            episode.
+          </p>
+        </div>
+        {loadError ? (
+          <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+            {loadError}
+          </p>
+        ) : null}
+        {presets.length === 0 ? (
+          <div className="rounded-2xl border border-app-border/90 bg-app-surface p-6">
+            <p className="text-sm leading-relaxed text-app-ink">
+              You do not have any health marker presets yet. Create one under{' '}
+              <Link
+                href="/presets/health-markers"
+                className="font-medium text-app-primary underline"
+              >
+                Health marker presets
+              </Link>
+              .
+            </p>
+          </div>
+        ) : (
+          <fieldset className="space-y-3">
+            <legend className="text-base font-semibold text-app-ink">
+              Choose one preset
+            </legend>
+            {presets.map((preset) => (
+              <label
+                key={preset.id}
+                className="flex min-h-[56px] cursor-pointer items-center gap-3 rounded-xl border border-app-border bg-app-surface px-4 py-3"
+              >
+                <input
+                  type="radio"
+                  name="marker-preset"
+                  checked={selectedPresetId === preset.id}
+                  onChange={() => {
+                    setSelectedPresetId(preset.id);
+                    setFeedback(null);
+                  }}
+                />
+                <span className="text-base font-medium text-app-ink">
+                  {preset.name}
+                </span>
+              </label>
+            ))}
+          </fieldset>
+        )}
+        {feedback ? (
+          <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+            {feedback}
+          </p>
+        ) : null}
+        {presets.length > 0 ? (
+          <button
+            type="button"
+            disabled={!selectedPresetId || saving}
+            onClick={() => {
+              void startPresetFlow();
+            }}
+            className="inline-flex min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white disabled:opacity-50"
+          >
+            {saving ? 'Loading…' : 'Start logging'}
+          </button>
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Standalone health markers
+        </h1>
+        <p className="mt-2 text-sm text-app-muted">
+          {lines.length === 0
+            ? 'This preset has no marker lines.'
+            : `Step ${activeIndex + 1} of ${lines.length}`}
+        </p>
+      </div>
+
+      {feedback ? (
+        <p className="text-sm text-amber-800 dark:text-amber-200" role="status">
+          {feedback}
+        </p>
+      ) : null}
+
+      {currentLine ? (
+        <div className="space-y-4">
+          <h2 className="text-xl font-semibold text-app-ink">
+            {markerLineTitle(currentLine)}
+          </h2>
+          {currentLine.marker_kind === 'blood_pressure' ? (
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="space-y-1 text-sm font-medium text-app-ink">
+                <span>Systolic</span>
+                <input
+                  type="number"
+                  step="any"
+                  min={0}
+                  value={currentDraft.systolic}
+                  disabled={saving}
+                  onChange={(e) => {
+                    setDrafts((prev) => ({
+                      ...prev,
+                      [currentLine.id]: {
+                        ...currentDraft,
+                        systolic: e.target.value,
+                      },
+                    }));
+                  }}
+                  className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink"
+                />
+              </label>
+              <label className="space-y-1 text-sm font-medium text-app-ink">
+                <span>Diastolic</span>
+                <input
+                  type="number"
+                  step="any"
+                  min={0}
+                  value={currentDraft.diastolic}
+                  disabled={saving}
+                  onChange={(e) => {
+                    setDrafts((prev) => ({
+                      ...prev,
+                      [currentLine.id]: {
+                        ...currentDraft,
+                        diastolic: e.target.value,
+                      },
+                    }));
+                  }}
+                  className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink"
+                />
+              </label>
+            </div>
+          ) : (
+            <label className="space-y-1 text-sm font-medium text-app-ink">
+              <span>Value</span>
+              <input
+                type="number"
+                step="any"
+                min={minForPresetMarkerValueInput(currentLine.marker_kind)}
+                value={currentDraft.value}
+                disabled={saving}
+                onChange={(e) => {
+                  setDrafts((prev) => ({
+                    ...prev,
+                    [currentLine.id]: {
+                      ...currentDraft,
+                      value: e.target.value,
+                    },
+                  }));
+                }}
+                className="min-h-[44px] w-full rounded-lg border border-app-border bg-app-surface px-3 text-app-ink"
+              />
+            </label>
+          )}
+
+          <label className="space-y-1 text-sm font-medium text-app-ink">
+            <span>Notes (optional)</span>
+            <textarea
+              rows={3}
+              value={currentDraft.notes}
+              disabled={saving}
+              onChange={(e) => {
+                setDrafts((prev) => ({
+                  ...prev,
+                  [currentLine.id]: { ...currentDraft, notes: e.target.value },
+                }));
+              }}
+              className="w-full rounded-lg border border-app-border bg-app-surface px-3 py-2 text-app-ink"
+            />
+          </label>
+        </div>
+      ) : (
+        <p className="text-sm text-app-muted" role="status">
+          No markers to log for this preset.
+        </p>
+      )}
+
+      <div className="flex flex-col gap-3 sm:flex-row">
+        {currentLine ? (
+          <button
+            type="button"
+            disabled={!canSkip || saving}
+            onClick={() => {
+              if (activeIndex >= lines.length - 1) {
+                setPhase('complete');
+                return;
+              }
+              setActiveIndex((prev) => prev + 1);
+            }}
+            className="inline-flex min-h-[56px] items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink disabled:opacity-50"
+          >
+            Skip marker
+          </button>
+        ) : null}
+        <button
+          type="button"
+          disabled={saving || !currentLine}
+          onClick={() => {
+            void onNext();
+          }}
+          className="inline-flex min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-4 text-base font-semibold text-white disabled:opacity-50"
+        >
+          {saving
+            ? 'Saving…'
+            : activeIndex >= lines.length - 1
+              ? 'Finish'
+              : 'Next'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
+++ b/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
@@ -52,24 +52,34 @@ export function StandaloneHealthMarkerFlow() {
   const [saving, setSaving] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
 
-  const loadPresets = async () => {
-    setLoadingPresets(true);
-    setLoadError(null);
-    const result = await listHealthMarkerPresets(supabase);
-    if (!result.ok) {
-      setLoadError(result.error.message);
-      setLoadingPresets(false);
+  useEffect(() => {
+    if (authLoading || !session?.user?.id || !loadingPresets) {
       return;
     }
-    setPresets(result.data);
-    setLoadingPresets(false);
-  };
 
-  useEffect(() => {
-    if (!authLoading && session?.user?.id && loadingPresets) {
-      void loadPresets();
-    }
-  }, [authLoading, loadingPresets, session?.user?.id]);
+    let cancelled = false;
+    const run = async () => {
+      setLoadingPresets(true);
+      setLoadError(null);
+      const result = await listHealthMarkerPresets(supabase);
+      if (cancelled) {
+        return;
+      }
+      if (!result.ok) {
+        setLoadError(result.error.message);
+        setLoadingPresets(false);
+        return;
+      }
+      setPresets(result.data);
+      setLoadingPresets(false);
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authLoading, loadingPresets, session?.user?.id, supabase]);
 
   useEffect(() => {
     setFeedback(null);
@@ -80,8 +90,18 @@ export function StandaloneHealthMarkerFlow() {
   const currentDraft = currentLine
     ? (drafts[currentLine.id] ?? createDraftFromMarker(null))
     : createDraftFromMarker(null);
-  const canSkip = currentLine
+  const measurementUnsavable = currentLine
     ? !parseMeasurementDraftForSave(currentLine, currentDraft).ok
+    : true;
+  const lineConfigBlocksSave = currentLine
+    ? validatePresetHealthMarkerCustomFields(
+        currentLine.marker_kind,
+        currentLine.custom_name ?? '',
+        currentLine.custom_unit ?? '',
+      ) != null
+    : false;
+  const canSkip = currentLine
+    ? measurementUnsavable || lineConfigBlocksSave
     : false;
 
   const patchCurrentLineDraft = useCallback(

--- a/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
+++ b/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
@@ -326,7 +326,7 @@ export function StandaloneHealthMarkerFlow() {
               .
             </p>
           </div>
-        ) : presets.length > 0 ? (
+        ) : !loadError && presets.length > 0 ? (
           <fieldset className="space-y-3">
             <legend className="text-base font-semibold text-app-ink">
               Choose one preset
@@ -357,7 +357,7 @@ export function StandaloneHealthMarkerFlow() {
             {feedback}
           </p>
         ) : null}
-        {presets.length > 0 ? (
+        {!loadError && presets.length > 0 ? (
           <button
             type="button"
             disabled={!selectedPresetId || saving}

--- a/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
+++ b/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   createStandaloneHealthMarkerForLine,
   listHealthMarkerPresets,
@@ -51,16 +51,48 @@ export function StandaloneHealthMarkerFlow() {
   const [drafts, setDrafts] = useState<Record<string, MarkerDraft>>({});
   const [saving, setSaving] = useState(false);
   const [feedback, setFeedback] = useState<string | null>(null);
+  const [presetRefetchTick, setPresetRefetchTick] = useState(0);
+  const lastPresetUserIdRef = useRef<string | null>(null);
 
   useEffect(() => {
-    if (authLoading || !session?.user?.id || !loadingPresets) {
+    if (authLoading) {
       return;
     }
 
-    let cancelled = false;
-    const run = async () => {
-      setLoadingPresets(true);
+    const userId = session?.user?.id ?? null;
+    if (!userId) {
+      lastPresetUserIdRef.current = null;
+      setPresets([]);
       setLoadError(null);
+      setLoadingPresets(false);
+      setPhase('pickPreset');
+      setLines([]);
+      setDrafts({});
+      setActiveIndex(0);
+      setSelectedPresetId(null);
+      setFeedback(null);
+      return;
+    }
+
+    const switchedAccount =
+      lastPresetUserIdRef.current !== null &&
+      lastPresetUserIdRef.current !== userId;
+    lastPresetUserIdRef.current = userId;
+
+    if (switchedAccount) {
+      setPhase('pickPreset');
+      setLines([]);
+      setDrafts({});
+      setActiveIndex(0);
+      setSelectedPresetId(null);
+      setFeedback(null);
+    }
+
+    let cancelled = false;
+    setLoadingPresets(true);
+    setLoadError(null);
+
+    void (async () => {
       const result = await listHealthMarkerPresets(supabase);
       if (cancelled) {
         return;
@@ -72,14 +104,12 @@ export function StandaloneHealthMarkerFlow() {
       }
       setPresets(result.data);
       setLoadingPresets(false);
-    };
-
-    void run();
+    })();
 
     return () => {
       cancelled = true;
     };
-  }, [authLoading, loadingPresets, session?.user?.id, supabase]);
+  }, [authLoading, session?.user?.id, supabase, presetRefetchTick]);
 
   useEffect(() => {
     setFeedback(null);
@@ -268,11 +298,22 @@ export function StandaloneHealthMarkerFlow() {
           </p>
         </div>
         {loadError ? (
-          <p className="text-sm text-red-700 dark:text-red-300" role="alert">
-            {loadError}
-          </p>
+          <div className="space-y-3">
+            <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+              {loadError}
+            </p>
+            <button
+              type="button"
+              className="inline-flex min-h-[44px] items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+              onClick={() => {
+                setPresetRefetchTick((n) => n + 1);
+              }}
+            >
+              Try again
+            </button>
+          </div>
         ) : null}
-        {presets.length === 0 ? (
+        {!loadError && presets.length === 0 ? (
           <div className="rounded-2xl border border-app-border/90 bg-app-surface p-6">
             <p className="text-sm leading-relaxed text-app-ink">
               You do not have any health marker presets yet. Create one under{' '}
@@ -285,7 +326,7 @@ export function StandaloneHealthMarkerFlow() {
               .
             </p>
           </div>
-        ) : (
+        ) : presets.length > 0 ? (
           <fieldset className="space-y-3">
             <legend className="text-base font-semibold text-app-ink">
               Choose one preset
@@ -310,7 +351,7 @@ export function StandaloneHealthMarkerFlow() {
               </label>
             ))}
           </fieldset>
-        )}
+        ) : null}
         {feedback ? (
           <p className="text-sm text-red-700 dark:text-red-300" role="alert">
             {feedback}

--- a/apps/web/src/components/health-markers/marker-draft.ts
+++ b/apps/web/src/components/health-markers/marker-draft.ts
@@ -1,0 +1,102 @@
+import type { HealthMarkerRow, PresetHealthMarkerRow } from '@abstrack/types';
+import { PRESET_HEALTH_MARKER_KIND_LABELS } from '@abstrack/types';
+
+export type MarkerDraft = {
+  value: string;
+  systolic: string;
+  diastolic: string;
+  notes: string;
+};
+
+type MeasurementDraftResult =
+  | {
+      ok: true;
+      valueNumeric: number | null;
+      systolicNumeric: number | null;
+      diastolicNumeric: number | null;
+    }
+  | { ok: false; message: string };
+
+function normalizeNullable(value: string | null | undefined): string | null {
+  const next = value?.trim() ?? '';
+  return next.length > 0 ? next : null;
+}
+
+export function markerLineTitle(line: PresetHealthMarkerRow): string {
+  if (line.marker_kind !== 'custom') {
+    return PRESET_HEALTH_MARKER_KIND_LABELS[line.marker_kind];
+  }
+  const customName = normalizeNullable(line.custom_name);
+  return customName ?? PRESET_HEALTH_MARKER_KIND_LABELS.custom;
+}
+
+export function createDraftFromMarker(
+  row: HealthMarkerRow | null,
+): MarkerDraft {
+  return {
+    value: row?.value_numeric != null ? String(row.value_numeric) : '',
+    systolic: row?.systolic_numeric != null ? String(row.systolic_numeric) : '',
+    diastolic:
+      row?.diastolic_numeric != null ? String(row.diastolic_numeric) : '',
+    notes: row?.notes ?? '',
+  };
+}
+
+export function parseMeasurementDraftForSave(
+  line: PresetHealthMarkerRow,
+  draft: MarkerDraft,
+): MeasurementDraftResult {
+  const value = parseOptionalNumber(draft.value);
+  const systolic = parseOptionalNumber(draft.systolic);
+  const diastolic = parseOptionalNumber(draft.diastolic);
+
+  if (line.marker_kind === 'blood_pressure') {
+    if (systolic == null || diastolic == null) {
+      return {
+        ok: false,
+        message:
+          'Enter both systolic and diastolic blood pressure values to continue.',
+      };
+    }
+    if (Number.isNaN(systolic) || Number.isNaN(diastolic)) {
+      return {
+        ok: false,
+        message:
+          'Blood pressure values must be valid numbers (for example 120 and 80).',
+      };
+    }
+    return {
+      ok: true,
+      valueNumeric: null,
+      systolicNumeric: systolic,
+      diastolicNumeric: diastolic,
+    };
+  }
+  if (value == null) {
+    return { ok: false, message: 'Enter a numeric value to continue.' };
+  }
+  if (Number.isNaN(value)) {
+    return { ok: false, message: 'Value must be a valid number.' };
+  }
+  return {
+    ok: true,
+    valueNumeric: value,
+    systolicNumeric: null,
+    diastolicNumeric: null,
+  };
+}
+
+export function minForPresetMarkerValueInput(
+  kind: PresetHealthMarkerRow['marker_kind'],
+): number | undefined {
+  return kind === 'custom' ? undefined : 0;
+}
+
+function parseOptionalNumber(raw: string | undefined): number | null {
+  const trimmed = (raw ?? '').trim();
+  if (!trimmed) {
+    return null;
+  }
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : Number.NaN;
+}

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -96,6 +96,7 @@ export {
   upsertEpisodeSymptomAnswer,
 } from './lib/episode-symptom-data.js';
 export {
+  createStandaloneHealthMarkerForLine,
   listEpisodeHealthMarkersForEpisode,
   upsertEpisodeHealthMarkerForLine,
 } from './lib/episode-health-marker-data.js';

--- a/packages/supabase/src/lib/episode-health-marker-data.spec.ts
+++ b/packages/supabase/src/lib/episode-health-marker-data.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { PresetHealthMarkerRow } from '@abstrack/types';
 import {
+  createStandaloneHealthMarkerForLine,
   listEpisodeHealthMarkersForEpisode,
   upsertEpisodeHealthMarkerForLine,
 } from './episode-health-marker-data.js';
@@ -451,5 +452,61 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
     expect(upsertMock).toHaveBeenCalledWith(expect.any(Object), {
       onConflict: 'episode_id,preset_health_marker_id',
     });
+  });
+});
+
+describe('createStandaloneHealthMarkerForLine', () => {
+  it('inserts a standalone marker with episode_id null', async () => {
+    const inserted = {
+      id: 'hm-standalone-1',
+      user_id: 'u1',
+      episode_id: null,
+      preset_health_marker_id: 'phm-1',
+      marker_kind: 'blood_glucose',
+      custom_name: null,
+      custom_unit: null,
+      custom_name_key: '',
+      custom_unit_key: '',
+      value_numeric: 101,
+      systolic_numeric: null,
+      diastolic_numeric: null,
+      notes: 'daily check',
+      recorded_at: '2026-04-18T12:00:00.000Z',
+      created_at: '2026-04-18T12:00:00.000Z',
+      updated_at: '2026-04-18T12:00:00.000Z',
+    };
+    const insertMock = vi.fn((payload: Record<string, unknown>) => {
+      expect(payload).toEqual(
+        expect.objectContaining({
+          user_id: 'u1',
+          episode_id: null,
+          preset_health_marker_id: 'phm-1',
+          marker_kind: 'blood_glucose',
+          value_numeric: 101,
+          notes: 'daily check',
+        }),
+      );
+      return {
+        select: vi.fn(() => ({
+          single: vi.fn(async () => ({ data: inserted, error: null })),
+        })),
+      };
+    });
+    const client = {
+      from: vi.fn(() => ({
+        insert: insertMock,
+      })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await createStandaloneHealthMarkerForLine(client, {
+      userId: 'u1',
+      line,
+      valueNumeric: 101,
+      notes: 'daily check',
+      recordedAt: '2026-04-18T12:00:00.000Z',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(insertMock).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/supabase/src/lib/episode-health-marker-data.spec.ts
+++ b/packages/supabase/src/lib/episode-health-marker-data.spec.ts
@@ -475,6 +475,8 @@ describe('createStandaloneHealthMarkerForLine', () => {
       created_at: '2026-04-18T12:00:00.000Z',
       updated_at: '2026-04-18T12:00:00.000Z',
     };
+    const singleMock = vi.fn(async () => ({ data: inserted, error: null }));
+    const selectMock = vi.fn(() => ({ single: singleMock }));
     const insertMock = vi.fn((payload: Record<string, unknown>) => {
       expect(payload).toEqual(
         expect.objectContaining({
@@ -484,12 +486,11 @@ describe('createStandaloneHealthMarkerForLine', () => {
           marker_kind: 'blood_glucose',
           value_numeric: 101,
           notes: 'daily check',
+          recorded_at: '2026-04-18T12:00:00.000Z',
         }),
       );
       return {
-        select: vi.fn(() => ({
-          single: vi.fn(async () => ({ data: inserted, error: null })),
-        })),
+        select: selectMock,
       };
     });
     const client = {
@@ -498,15 +499,22 @@ describe('createStandaloneHealthMarkerForLine', () => {
       })),
     } as unknown as AbstrackSupabaseClient;
 
+    const recordedAt = '2026-04-18T12:00:00.000Z';
     const result = await createStandaloneHealthMarkerForLine(client, {
       userId: 'u1',
       line,
       valueNumeric: 101,
       notes: 'daily check',
-      recordedAt: '2026-04-18T12:00:00.000Z',
+      recordedAt,
     });
 
     expect(result.ok).toBe(true);
     expect(insertMock).toHaveBeenCalledTimes(1);
+    expect(selectMock).toHaveBeenCalledTimes(1);
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(singleMock).toHaveBeenCalledTimes(1);
+    if (result.ok) {
+      expect(result.data).toEqual(inserted);
+    }
   });
 });

--- a/packages/supabase/src/lib/episode-health-marker-data.ts
+++ b/packages/supabase/src/lib/episode-health-marker-data.ts
@@ -166,28 +166,149 @@ export async function upsertEpisodeHealthMarkerForLine(
   }
 
   return wrap(async () => {
-    const row: HealthMarkersInsert = {
-      user_id: userId,
-      episode_id: episodeId,
-      preset_health_marker_id: line.id,
-      marker_kind: line.marker_kind,
-      custom_name: customName,
-      custom_unit: customUnit,
-      value_numeric:
-        line.marker_kind === 'blood_pressure' ? null : valueNumeric,
-      systolic_numeric:
-        line.marker_kind === 'blood_pressure' ? systolicNumeric : null,
-      diastolic_numeric:
-        line.marker_kind === 'blood_pressure' ? diastolicNumeric : null,
+    const row: HealthMarkersInsert = createHealthMarkerInsertRow({
+      userId,
+      episodeId,
+      line,
+      customName,
+      customUnit,
+      valueNumeric,
+      systolicNumeric,
+      diastolicNumeric,
       notes,
-      recorded_at: recordedAt,
-    };
+      recordedAt,
+    });
 
     const r = await client
       .from('health_markers')
       .upsert(row, {
         onConflict: 'episode_id,preset_health_marker_id',
       })
+      .select('*')
+      .single();
+    return {
+      data: r.data as HealthMarkerRow | null,
+      error: r.error,
+    };
+  });
+}
+
+function createHealthMarkerInsertRow(args: {
+  userId: Uuid;
+  episodeId: Uuid | null;
+  line: PresetHealthMarkerRow;
+  customName: string | null;
+  customUnit: string | null;
+  valueNumeric: number | null;
+  systolicNumeric: number | null;
+  diastolicNumeric: number | null;
+  notes: string | null;
+  recordedAt: string;
+}): HealthMarkersInsert {
+  const {
+    userId,
+    episodeId,
+    line,
+    customName,
+    customUnit,
+    valueNumeric,
+    systolicNumeric,
+    diastolicNumeric,
+    notes,
+    recordedAt,
+  } = args;
+  return {
+    user_id: userId,
+    episode_id: episodeId,
+    preset_health_marker_id: line.id,
+    marker_kind: line.marker_kind,
+    custom_name: customName,
+    custom_unit: customUnit,
+    value_numeric: line.marker_kind === 'blood_pressure' ? null : valueNumeric,
+    systolic_numeric:
+      line.marker_kind === 'blood_pressure' ? systolicNumeric : null,
+    diastolic_numeric:
+      line.marker_kind === 'blood_pressure' ? diastolicNumeric : null,
+    notes,
+    recorded_at: recordedAt,
+  };
+}
+
+/**
+ * Inserts one standalone `health_markers` row (`episode_id = null`) from a preset line.
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param args.userId - Authenticated patient (or caretaker target under RLS).
+ * @param args.line - Active preset health marker line.
+ * @param args.valueNumeric - Required finite number for non-blood-pressure kinds.
+ * @param args.systolicNumeric - Systolic value for blood pressure.
+ * @param args.diastolicNumeric - Diastolic value for blood pressure.
+ * @param args.notes - Optional free-text note.
+ * @param args.recordedAt - Timestamp override (defaults to now).
+ * @returns Inserted marker row with `episode_id = null`.
+ */
+export async function createStandaloneHealthMarkerForLine(
+  client: AbstrackSupabaseClient,
+  args: {
+    userId: Uuid;
+    line: PresetHealthMarkerRow;
+    valueNumeric?: number | null;
+    systolicNumeric?: number | null;
+    diastolicNumeric?: number | null;
+    notes?: string | null;
+    recordedAt?: string;
+  },
+): Promise<PresetDataResult<HealthMarkerRow>> {
+  const {
+    userId,
+    line,
+    valueNumeric = null,
+    systolicNumeric = null,
+    diastolicNumeric = null,
+    notes = null,
+    recordedAt = new Date().toISOString(),
+  } = args;
+  const customName = normalizeCustomField(line.custom_name);
+  const customUnit = normalizeCustomField(line.custom_unit);
+  const customValidation = validatePresetHealthMarkerCustomFields(
+    line.marker_kind,
+    customName ?? '',
+    customUnit ?? '',
+  );
+  if (customValidation) {
+    return {
+      ok: false,
+      error: new PresetDataError('validation_error', customValidation),
+    };
+  }
+  const numericValidation = validateHealthMarkerNumericPayload(
+    line.marker_kind,
+    valueNumeric,
+    systolicNumeric,
+    diastolicNumeric,
+  );
+  if (numericValidation) {
+    return {
+      ok: false,
+      error: new PresetDataError('validation_error', numericValidation),
+    };
+  }
+  return wrap(async () => {
+    const row = createHealthMarkerInsertRow({
+      userId,
+      episodeId: null,
+      line,
+      customName,
+      customUnit,
+      valueNumeric,
+      systolicNumeric,
+      diastolicNumeric,
+      notes,
+      recordedAt,
+    });
+    const r = await client
+      .from('health_markers')
+      .insert(row)
       .select('*')
       .single();
     return {


### PR DESCRIPTION
Closes #98

## Summary

Adds **standalone health marker logging** on web (no episode) and improves **food diary post-save UX** on both web and mobile so saved entries feel finished instead of leaving an open form with stale selection.

## Changes

### Standalone health markers (web)

- New route **`/health-markers/new`** with preset picker → linear marker prompts → completion.
- Dashboard link **“Log health markers”** (distinct from episode start).
- **`createStandaloneHealthMarkerForLine`** in `@abstrack/supabase`: inserts `health_markers` with `episode_id = null`, reusing the same validation path as episode-bound saves; exported from package index; covered by unit tests.
- Shared **`marker-draft`** helpers used by **`HealthMarkerPromptFlow`** and the standalone flow to avoid duplicating parse/validation/title logic.

### Food diary post-save UX

- **Web** (`FoodDiaryEntryForm`): when `episodeId` is null, after save the form **collapses** into a saved summary (meal tag + time) and **“Add a new entry”** resets fields and remounts the form block for a fresh entry. Episode-linked behavior unchanged.
- **Mobile** (`FoodDiaryEntryScreen`): same pattern for standalone (`episodeId` absent); episode-linked flow unchanged.
- **Tests**: new mobile spec for standalone save / add another; existing episode-linked mobile spec preserved.

## How to verify

- Web: Dashboard → **Log health markers** → pick preset → save lines → confirm rows in Supabase with `episode_id` null for the signed-in user (RLS as before).
- Web: `/food-diary/new` → save → confirm collapsed summary → **Add a new entry** → empty form.
- Mobile: Food diary from home → same save / add-new flow; in-episode food path still shows inline success with form.

## Notes

- No migration or `database.types.ts` edits in this work; RLS for `health_markers` already allows patient-scoped inserts with `episode_id` null.