### PR TITLE
feat(episodes): multi-pass observations (append rows, RLS/triggers), timeline, and post-pass episode hub with resume

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Details: **[docs/SUPABASE_CLOUD_DEVELOPER.md](docs/SUPABASE_CLOUD_DEVELOPER.md)*
 ### Correct flow for migrations and database.types.ts (agents: follow this)
 
 1. **Change `supabase/migrations/*.sql` only.** Do **not** edit **`packages/supabase/src/lib/database.types.ts`** to “match” new tables/columns or to fix TypeScript before generation—that file is **only** the output of **`supabase gen types`** (see step 4).
-2. **Push and finish reviews** (Copilot, humans). Revise migration SQL as needed. Still **do not** hand-edit `database.types.ts`.
+2. **Push and finish reviews** (Copilot, humans). Revise the **same migration file(s)** as needed. **Do not create a new migration file during review iterations** unless Sarah explicitly asks. Assume migrations are **not pushed to cloud yet** until Sarah says she is done reviewing and ready. Still **do not** hand-edit `database.types.ts`.
 3. **After reviews are done**, Sarah runs **`db push`** and **`gen types typescript --linked`** in **her** terminal (see commands below). **`--linked` reads Supabase Cloud**; it does **not** read migration files from git, so types cannot honestly reflect new SQL until it is applied to the linked project.
 4. **Regenerated `database.types.ts`** is committed **with** the migration(s), then the PR merges.
 

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -65,6 +65,7 @@ function navigateFromHomeTabToEpisodeResume(
     stackNavigation.navigate('HealthMarkerPrompt', {
       episodeId: episode.episodeId,
       resume: true,
+      hub: true,
     });
     return;
   }

--- a/apps/mobile/src/app/navigation/types.ts
+++ b/apps/mobile/src/app/navigation/types.ts
@@ -55,6 +55,11 @@ export type MainStackParamList = {
     episodeId: string;
     /** When true, initial step is derived from saved marker rows. */
     resume?: boolean;
+    /**
+     * When true with `resume`, opens the episode hub after a saved pass instead of the marker
+     * stepper (home / Manage “Continue this episode”).
+     */
+    hub?: boolean;
   };
   FoodDiaryEntry: {
     /** Optional episode link for entries logged from inside an episode flow. */

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -255,6 +255,7 @@ export function EpisodeStartScreen() {
       navigation.replace('HealthMarkerPrompt', {
         episodeId: row.id,
         resume: true,
+        hub: true,
       });
       return;
     }

--- a/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
+++ b/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
@@ -218,6 +218,7 @@ export function EpisodesManagementPanel({
       navigation.navigate('HealthMarkerPrompt', {
         episodeId: episode.id,
         resume: true,
+        hub: true,
       });
       return;
     }

--- a/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
@@ -211,6 +211,7 @@ describe('EpisodesScreen', () => {
     expect(mockNavigate).toHaveBeenCalledWith('HealthMarkerPrompt', {
       episodeId: 'ep-end-step',
       resume: true,
+      hub: true,
     });
   });
 

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
@@ -10,6 +10,7 @@ import {
   getEpisodeById,
   listFoodDiaryEntriesForEpisode,
   listEpisodeHealthMarkersForEpisode,
+  listEpisodeObservationTimeline,
   listPresetHealthMarkersForPreset,
   PresetDataError,
   updateFoodDiaryEntry,
@@ -324,6 +325,7 @@ describe('HealthMarkerPromptScreen', () => {
     await waitFor(() => {
       expect(screen.getByText('Step 2 of 2')).toBeTruthy();
     });
+    expect(listEpisodeObservationTimeline).toHaveBeenCalledTimes(1);
   });
 
   test('blood pressure validation blocks when either value missing', async () => {

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
@@ -248,6 +248,21 @@ describe('HealthMarkerPromptScreen', () => {
     expect(getMobileSupabaseClient).toHaveBeenCalled();
   });
 
+  test('hub resume does not bypass flow when post-marker boundary is missing', async () => {
+    jest.mocked(useRoute).mockReturnValue({
+      key: 'HealthMarkerPrompt',
+      name: 'HealthMarkerPrompt',
+      params: { episodeId, resume: true, hub: true },
+    } as never);
+
+    const screen = render(<HealthMarkerPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 2')).toBeTruthy();
+    });
+    expect(screen.queryByLabelText('Log another check-in')).toBeNull();
+  });
+
   test('validation blocks Next and does not upsert when numeric value missing', async () => {
     const screen = render(<HealthMarkerPromptScreen />);
 

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
@@ -416,8 +416,7 @@ describe('HealthMarkerPromptScreen', () => {
         episode_label: 'Evening flare',
         additional_notes: 'Extra symptom text',
         note: 'Felt off',
-        post_marker_step_completed_at:
-          expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+        post_marker_step_completed_at: null,
       }),
     );
 

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
@@ -13,7 +13,7 @@ import {
   listPresetHealthMarkersForPreset,
   PresetDataError,
   updateFoodDiaryEntry,
-  upsertEpisodeHealthMarkerForLine,
+  insertEpisodeHealthMarkerForLine,
 } from '@abstrack/supabase';
 import type { PresetHealthMarkerRow } from '@abstrack/types';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
@@ -42,8 +42,12 @@ jest.mock('@abstrack/supabase', () => {
     listFoodDiaryEntriesForEpisode: jest.fn(),
     listEpisodeHealthMarkersForEpisode: jest.fn(),
     listPresetHealthMarkersForPreset: jest.fn(),
+    listEpisodeObservationTimeline: jest.fn(async () => ({
+      ok: true,
+      data: [],
+    })),
     updateFoodDiaryEntry: jest.fn(),
-    upsertEpisodeHealthMarkerForLine: jest.fn(),
+    insertEpisodeHealthMarkerForLine: jest.fn(),
   };
 });
 
@@ -150,7 +154,7 @@ describe('HealthMarkerPromptScreen', () => {
       ok: true,
       data: [],
     });
-    jest.mocked(upsertEpisodeHealthMarkerForLine).mockResolvedValue({
+    jest.mocked(insertEpisodeHealthMarkerForLine).mockResolvedValue({
       ok: true,
       data: {
         id: 'hm-row-1',
@@ -258,7 +262,7 @@ describe('HealthMarkerPromptScreen', () => {
         screen.getByText('Enter a numeric value to continue.'),
       ).toBeTruthy();
     });
-    expect(upsertEpisodeHealthMarkerForLine).not.toHaveBeenCalled();
+    expect(insertEpisodeHealthMarkerForLine).not.toHaveBeenCalled();
   });
 
   test('Skip advances to next marker when current line is unanswered', async () => {
@@ -288,9 +292,9 @@ describe('HealthMarkerPromptScreen', () => {
     fireEvent.press(screen.getByLabelText('Next health marker'));
 
     await waitFor(() => {
-      expect(upsertEpisodeHealthMarkerForLine).toHaveBeenCalledTimes(1);
+      expect(insertEpisodeHealthMarkerForLine).toHaveBeenCalledTimes(1);
     });
-    expect(upsertEpisodeHealthMarkerForLine).toHaveBeenCalledWith(
+    expect(insertEpisodeHealthMarkerForLine).toHaveBeenCalledWith(
       expect.objectContaining({ mockClient: true }),
       expect.objectContaining({
         userId: 'test-user-1',
@@ -333,10 +337,10 @@ describe('HealthMarkerPromptScreen', () => {
         ),
       ).toBeTruthy();
     });
-    expect(upsertEpisodeHealthMarkerForLine).not.toHaveBeenCalled();
+    expect(insertEpisodeHealthMarkerForLine).not.toHaveBeenCalled();
   });
 
-  test('food diary comes before episode details, then save shows completion UI', async () => {
+  test('food diary comes before episode details, then save opens episode hub with log another check-in', async () => {
     jest.mocked(listPresetHealthMarkersForPreset).mockResolvedValue({
       ok: true,
       data: [lineA],
@@ -401,13 +405,12 @@ describe('HealthMarkerPromptScreen', () => {
     );
 
     await waitFor(() => {
-      expect(
-        screen.getByText(
-          /Preset prompts and episode details are saved\. End this episode to prevent stale resume state\./,
-        ),
-      ).toBeTruthy();
+      expect(screen.getByLabelText('Log another check-in')).toBeTruthy();
     });
-    expect(screen.getByLabelText('End episode')).toBeTruthy();
+    expect(mockReplace).not.toHaveBeenCalledWith(
+      'SymptomPrompt',
+      expect.anything(),
+    );
   });
 
   test('post-marker save failure shows postFeedback', async () => {

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -28,6 +28,8 @@ import type {
 } from '@abstrack/types';
 import {
   bacReadingSuggestsAbsEpisode,
+  filterHealthMarkerRowsForOpenPass,
+  findLatestHealthMarkerForLineInPass,
   formatEpisodeDurationSimple,
   PRESET_HEALTH_MARKER_KIND_LABELS,
   validatePresetHealthMarkerCustomFields,
@@ -37,9 +39,11 @@ import {
   completeEpisodePostMarkerStep,
   endEpisodeIfStillActive,
   getEpisodeById,
+  insertEpisodeHealthMarkerForLine,
   listEpisodeHealthMarkersForEpisode,
+  listEpisodeObservationTimeline,
   listPresetHealthMarkersForPreset,
-  upsertEpisodeHealthMarkerForLine,
+  type EpisodeTimelineItem,
 } from '@abstrack/supabase';
 import { announce, COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
@@ -100,11 +104,16 @@ function createDraftFromMarker(row: HealthMarkerRow | null): MarkerDraft {
   };
 }
 
-function findExistingMarkerForLine(
-  rows: HealthMarkerRow[],
+function findCurrentPassMarkerForLine(
+  allRows: HealthMarkerRow[],
   line: PresetHealthMarkerRow,
+  lastPostMarkerStepCompletedAt: string | null,
 ): HealthMarkerRow | null {
-  return rows.find((row) => row.preset_health_marker_id === line.id) ?? null;
+  const pass = filterHealthMarkerRowsForOpenPass(
+    allRows,
+    lastPostMarkerStepCompletedAt,
+  );
+  return findLatestHealthMarkerForLineInPass(pass, line);
 }
 
 type MeasurementDraftResult =
@@ -181,7 +190,7 @@ function parseOptionalNumber(raw: string | undefined): number | null {
 export function HealthMarkerPromptScreen() {
   const navigation = useNavigation<HealthMarkerPromptNav>();
   const route = useRoute<HealthMarkerPromptRoute>();
-  const { episodeId, resume = false } = route.params;
+  const { episodeId, resume = false, hub = false } = route.params;
   const { colors } = useAppTheme();
 
   const [status, setStatus] = useState<'loading' | 'error' | 'ready'>(
@@ -206,9 +215,6 @@ export function HealthMarkerPromptScreen() {
   const [postNote, setPostNote] = useState('');
   const [savingPost, setSavingPost] = useState(false);
   const [postFeedback, setPostFeedback] = useState<string | null>(null);
-  const [foodDiaryDecision, setFoodDiaryDecision] = useState<
-    'pending' | 'saved' | 'skipped'
-  >('pending');
   const [endingEpisode, setEndingEpisode] = useState(false);
   const [endFeedback, setEndFeedback] = useState<string | null>(null);
   const [endedSummary, setEndedSummary] = useState<{
@@ -217,14 +223,16 @@ export function HealthMarkerPromptScreen() {
   } | null>(null);
   const postFormInitRef = useRef(false);
   const [cancelingEpisode, setCancelingEpisode] = useState(false);
+  const [observationTimeline, setObservationTimeline] = useState<
+    EpisodeTimelineItem[]
+  >([]);
 
   const supabase = useMemo(() => getMobileSupabaseClient(), []);
   /** Bumps when the screen unmounts or `load` deps change so stale async work does not setState. */
   const loadGenerationRef = useRef(0);
 
   const onLeaveFoodDiary = useCallback(
-    async (decision: 'saved' | 'skipped') => {
-      setFoodDiaryDecision(decision);
+    async (_decision: 'saved' | 'skipped') => {
       setPhase('postMarkers');
     },
     [],
@@ -274,7 +282,6 @@ export function HealthMarkerPromptScreen() {
     postFormInitRef.current = false;
     setPostFeedback(null);
     resetFoodDiaryState();
-    setFoodDiaryDecision('pending');
     setEndFeedback(null);
     setEndedSummary(null);
 
@@ -341,9 +348,15 @@ export function HealthMarkerPromptScreen() {
 
     setLines(presetLines.data);
 
+    const lastPost: string | null =
+      episode.data?.post_marker_step_completed_at ?? null;
     const nextDrafts: Record<string, MarkerDraft> = {};
     for (const line of presetLines.data) {
-      const marker = findExistingMarkerForLine(markerRows.data, line);
+      const marker = findCurrentPassMarkerForLine(
+        markerRows.data,
+        line,
+        lastPost,
+      );
       nextDrafts[line.id] = createDraftFromMarker(marker);
     }
     setDrafts(nextDrafts);
@@ -353,22 +366,28 @@ export function HealthMarkerPromptScreen() {
     setBacSuggestAbs(bacReadingSuggestsAbsEpisode(markerRows.data));
 
     const firstUnanswered = presetLines.data.findIndex((line) => {
-      const row = findExistingMarkerForLine(markerRows.data, line);
+      const row = findCurrentPassMarkerForLine(markerRows.data, line, lastPost);
       return row === null;
     });
-    if (resume && firstUnanswered === -1) {
-      if (episode.data?.post_marker_step_completed_at) {
-        setPhase('complete');
-      } else {
-        setPhase('foodDiary');
-      }
+    if (resume && hub) {
+      setPhase('complete');
+    } else if (resume && firstUnanswered === -1) {
+      setPhase('foodDiary');
     } else if (resume && firstUnanswered >= 0) {
       setActiveIndex(firstUnanswered);
     } else {
       setActiveIndex(0);
     }
     setStatus('ready');
-  }, [episodeId, resetFoodDiaryState, resume, supabase]);
+
+    const tl = await listEpisodeObservationTimeline(supabase, episodeId);
+    if (stale()) {
+      return;
+    }
+    if (tl.ok) {
+      setObservationTimeline(tl.data);
+    }
+  }, [episodeId, hub, resetFoodDiaryState, resume, supabase]);
 
   useEffect(() => {
     void load();
@@ -438,7 +457,7 @@ export function HealthMarkerPromptScreen() {
 
     setSaving(true);
     setPersistFeedback(null);
-    const result = await upsertEpisodeHealthMarkerForLine(supabase, {
+    const result = await insertEpisodeHealthMarkerForLine(supabase, {
       userId,
       episodeId,
       line: currentLine,
@@ -457,6 +476,10 @@ export function HealthMarkerPromptScreen() {
         },
       );
       return false;
+    }
+    const tlo = await listEpisodeObservationTimeline(supabase, episodeId);
+    if (tlo.ok) {
+      setObservationTimeline(tlo.data);
     }
     return true;
   };
@@ -538,8 +561,33 @@ export function HealthMarkerPromptScreen() {
     setEndFeedback(null);
     setEndedSummary(null);
     setPhase('complete');
-    await announce('Episode details saved.', { politeness: 'polite' });
+    await announce(
+      result.data.symptom_preset_id
+        ? 'This check-in is saved. You can log another when you are ready, or return home.'
+        : 'Episode details saved.',
+      { politeness: 'polite' },
+    );
   };
+
+  const onLogAnotherCheckIn = useCallback(() => {
+    const presetId = episodeRow?.symptom_preset_id;
+    if (!presetId) {
+      void announce(
+        'This episode has no symptom preset linked, so another check-in cannot start here.',
+        { politeness: 'assertive' },
+      );
+      return;
+    }
+    clearSymptomPromptSession(episodeId);
+    void announce('Opening symptoms for another check-in.', {
+      politeness: 'polite',
+    });
+    navigation.replace('SymptomPrompt', {
+      episodeId,
+      symptomPresetId: presetId,
+      resume: true,
+    });
+  }, [announce, episodeId, episodeRow?.symptom_preset_id, navigation]);
 
   const onBackToSymptomsFromHealthMarkers = useCallback(async () => {
     const symptomPresetId = episodeRow?.symptom_preset_id;
@@ -730,7 +778,9 @@ export function HealthMarkerPromptScreen() {
             ? 'Episode details'
             : phase === 'foodDiary'
               ? 'Food diary'
-              : 'Episode health markers'}
+              : phase === 'complete' && !endedSummary
+                ? 'This check-in is saved'
+                : 'Episode health markers'}
         </Text>
         {phase === 'prompting' && persistFeedback ? (
           <Text
@@ -745,77 +795,154 @@ export function HealthMarkerPromptScreen() {
         ) : null}
 
         {phase === 'complete' ? (
-          <View className="gap-4" accessibilityLiveRegion="polite">
-            {endedSummary ? (
-              <>
+          <ScrollView
+            className="flex-1"
+            keyboardShouldPersistTaps="handled"
+            contentContainerStyle={{ paddingBottom: 24 }}
+          >
+            <View className="gap-4" accessibilityLiveRegion="polite">
+              {observationTimeline.length > 0 && !endedSummary ? (
+                <View
+                  className={`rounded-2xl border border-app-border bg-app-surface p-4 dark:border-app-border-dark dark:bg-app-bg-dark`}
+                  accessibilityLabel="Log so far in this episode"
+                >
+                  <Text
+                    className={`text-sm font-semibold ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Log so far in this episode
+                  </Text>
+                  <Text
+                    className={`mt-1 text-xs ${nw.textMuted}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Oldest first. New entries are added as you go.
+                  </Text>
+                  {observationTimeline.map((row) => (
+                    <Text
+                      key={`${row.kind}-${row.id}`}
+                      className={`mt-2 text-sm ${nw.textInk}`}
+                      maxFontSizeMultiplier={2}
+                    >
+                      {row.sortAt
+                        .replace('T', ' ')
+                        .replace(/\.\d{3}Z$/, ' UTC')
+                        .slice(0, 19)}
+                      {' — '}
+                      {row.label}: {row.detail}
+                    </Text>
+                  ))}
+                </View>
+              ) : null}
+              {endedSummary ? (
+                <>
+                  <Text
+                    className={`text-base leading-relaxed ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    This episode is ended and saved.
+                  </Text>
+                  <Text
+                    className={`text-sm ${nw.textMuted}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Ended {new Date(endedSummary.endedAt).toLocaleString()}
+                  </Text>
+                  <Text
+                    className={`text-sm ${nw.textMuted}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Duration {endedSummary.durationText ?? '—'}
+                  </Text>
+                </>
+              ) : (
+                <View className="gap-3">
+                  <Text
+                    className={`text-base leading-relaxed ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    This round is saved: symptoms, health markers, any food
+                    diary entries you added, and episode details.
+                  </Text>
+                  <Text
+                    className={`text-sm leading-relaxed ${nw.textMuted}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Return home, log another full check-in when you are ready,
+                    or end this episode when you are completely done.
+                  </Text>
+                </View>
+              )}
+              {endFeedback ? (
                 <Text
-                  className={`text-base leading-relaxed ${nw.textInk}`}
+                  className={`text-sm ${nw.textError}`}
+                  accessibilityLiveRegion="assertive"
                   maxFontSizeMultiplier={2}
                 >
-                  This episode is ended and saved.
+                  {endFeedback}
                 </Text>
-                <Text
-                  className={`text-sm ${nw.textMuted}`}
-                  maxFontSizeMultiplier={2}
+              ) : null}
+              {endedSummary ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Return to home"
+                  onPress={onFinishToHome}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
                 >
-                  Ended {new Date(endedSummary.endedAt).toLocaleString()}
-                </Text>
-                <Text
-                  className={`text-sm ${nw.textMuted}`}
-                  maxFontSizeMultiplier={2}
-                >
-                  Duration {endedSummary.durationText ?? '—'}
-                </Text>
-              </>
-            ) : (
-              <Text
-                className={`text-base leading-relaxed ${nw.textInk}`}
-                maxFontSizeMultiplier={2}
-              >
-                {foodDiaryDecision === 'saved'
-                  ? 'Preset prompts, episode details, and food diary are saved. End this episode to prevent stale resume state.'
-                  : 'Preset prompts and episode details are saved. End this episode to prevent stale resume state.'}
-              </Text>
-            )}
-            {endFeedback ? (
-              <Text
-                className={`text-sm ${nw.textError}`}
-                accessibilityLiveRegion="assertive"
-                maxFontSizeMultiplier={2}
-              >
-                {endFeedback}
-              </Text>
-            ) : null}
-            {endedSummary ? (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Return to home"
-                onPress={onFinishToHome}
-                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                className="items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
-              >
-                <Text className="text-center text-[17px] font-semibold text-white">
-                  Return home
-                </Text>
-              </Pressable>
-            ) : (
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel={
-                  endingEpisode ? 'Ending episode' : 'End episode'
-                }
-                accessibilityState={{ disabled: endingEpisode }}
-                disabled={endingEpisode}
-                onPress={onRequestEndEpisode}
-                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                className="items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 disabled:opacity-60 dark:bg-red-600"
-              >
-                <Text className="text-center text-[17px] font-semibold text-white">
-                  {endingEpisode ? 'Ending episode…' : 'End episode'}
-                </Text>
-              </Pressable>
-            )}
-          </View>
+                  <Text className="text-center text-[17px] font-semibold text-white">
+                    Return home
+                  </Text>
+                </Pressable>
+              ) : (
+                <View className="gap-3">
+                  {episodeRow?.symptom_preset_id ? (
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel="Log another check-in"
+                      onPress={onLogAnotherCheckIn}
+                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                      className="items-center justify-center rounded-xl bg-red-700 px-4 py-4 active:opacity-90 dark:bg-red-600"
+                    >
+                      <Text className="text-center text-[17px] font-semibold text-white">
+                        Log another check-in
+                      </Text>
+                    </Pressable>
+                  ) : null}
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Return to home"
+                    onPress={onFinishToHome}
+                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                    className="items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-4 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
+                  >
+                    <Text
+                      className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                    >
+                      Return home
+                    </Text>
+                  </Pressable>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel={
+                      endingEpisode ? 'Ending episode' : 'End episode'
+                    }
+                    accessibilityState={{ disabled: endingEpisode }}
+                    disabled={endingEpisode}
+                    onPress={onRequestEndEpisode}
+                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                    className="items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-4 py-4 active:opacity-90 disabled:opacity-60 dark:border-app-border-dark dark:bg-app-bg-dark"
+                  >
+                    <Text
+                      className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                    >
+                      {endingEpisode ? 'Ending episode…' : 'End episode'}
+                    </Text>
+                  </Pressable>
+                </View>
+              )}
+            </View>
+          </ScrollView>
         ) : phase === 'foodDiary' ? (
           <HealthMarkerFoodDiaryStep
             fd={foodDiary}
@@ -1199,6 +1326,35 @@ export function HealthMarkerPromptScreen() {
                     </Text>
                   </Pressable>
                 </View>
+                {observationTimeline.length > 0 ? (
+                  <View
+                    accessibilityLabel="Log so far in this episode, oldest first"
+                    className="mt-6 rounded-xl border border-app-border bg-app-surface/60 p-4"
+                  >
+                    <Text
+                      className={`text-sm font-semibold ${nw.textInk}`}
+                      maxFontSizeMultiplier={2}
+                    >
+                      Log so far in this episode
+                    </Text>
+                    <Text
+                      className={`mb-2 text-xs ${nw.textMuted}`}
+                      maxFontSizeMultiplier={2}
+                    >
+                      Oldest first
+                    </Text>
+                    {observationTimeline.map((row) => (
+                      <Text
+                        key={`${row.kind}-${row.id}`}
+                        className={`mb-2 text-sm ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      >
+                        {row.sortAt.replace('T', ' ').slice(0, 19)} —{' '}
+                        {row.label}: {row.detail}
+                      </Text>
+                    ))}
+                  </View>
+                ) : null}
               </ScrollView>
             </AsyncScreenContainer>
             <Pressable

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -344,6 +344,7 @@ export function HealthMarkerPromptScreen() {
     resetFoodDiaryState();
     setEndFeedback(null);
     setEndedSummary(null);
+    setObservationTimeline([]);
 
     const {
       data: { user },
@@ -446,6 +447,8 @@ export function HealthMarkerPromptScreen() {
     }
     if (tl.ok) {
       setObservationTimeline(tl.data);
+    } else {
+      setObservationTimeline([]);
     }
   }, [episodeId, hub, resetFoodDiaryState, resume, supabase]);
 
@@ -607,13 +610,13 @@ export function HealthMarkerPromptScreen() {
     }
     setSavingPost(true);
     setPostFeedback(null);
-    const completedAt = new Date().toISOString();
     const result = await completeEpisodePostMarkerStep(supabase, episodeId, {
       episode_type: postEpisodeKind,
       episode_label: trimToNull(postLabel),
       additional_notes: trimToNull(postAdditional),
       note: trimToNull(postNote),
-      post_marker_step_completed_at: completedAt,
+      // Ignored by completeEpisodePostMarkerStep: boundary is server-derived to avoid clock skew.
+      post_marker_step_completed_at: null,
     });
     setSavingPost(false);
     if (!result.ok) {

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -94,6 +94,58 @@ function formatTimelineInstant(isoLike: string): string {
   return new Date(ms).toLocaleString();
 }
 
+function compareTimelineItems(
+  a: EpisodeTimelineItem,
+  b: EpisodeTimelineItem,
+): number {
+  const aMs = Date.parse(a.sortAt);
+  const bMs = Date.parse(b.sortAt);
+  const aValid = Number.isFinite(aMs);
+  const bValid = Number.isFinite(bMs);
+  if (aValid && bValid) {
+    const c = aMs - bMs;
+    if (c !== 0) {
+      return c;
+    }
+  } else {
+    const c = a.sortAt.localeCompare(b.sortAt);
+    if (c !== 0) {
+      return c;
+    }
+  }
+  return a.id.localeCompare(b.id);
+}
+
+function upsertTimelineItem(
+  prev: EpisodeTimelineItem[],
+  next: EpisodeTimelineItem,
+): EpisodeTimelineItem[] {
+  const rows = prev.filter((r) => !(r.kind === next.kind && r.id === next.id));
+  rows.push(next);
+  rows.sort(compareTimelineItems);
+  return rows;
+}
+
+function healthMarkerDetailForTimeline(row: HealthMarkerRow): string {
+  if (row.marker_kind === 'blood_pressure') {
+    if (row.systolic_numeric != null && row.diastolic_numeric != null) {
+      return `${row.systolic_numeric}/${row.diastolic_numeric}`;
+    }
+    return '—';
+  }
+  if (row.value_numeric != null) {
+    let detail = String(row.value_numeric);
+    if (row.custom_unit) {
+      detail = `${detail} ${row.custom_unit}`;
+    } else if (row.marker_kind === 'bac') {
+      detail = `${detail} g/dL`;
+    }
+    return detail;
+  }
+  const n = row.notes?.trim();
+  return n ? (n.length > 80 ? `${n.slice(0, 77)}…` : n) : '—';
+}
+
 function markerLineTitle(line: PresetHealthMarkerRow): string {
   if (line.marker_kind !== 'custom') {
     return PRESET_HEALTH_MARKER_KIND_LABELS[line.marker_kind];
@@ -485,10 +537,14 @@ export function HealthMarkerPromptScreen() {
       );
       return false;
     }
-    const tlo = await listEpisodeObservationTimeline(supabase, episodeId);
-    if (tlo.ok) {
-      setObservationTimeline(tlo.data);
-    }
+    const timelineItem: EpisodeTimelineItem = {
+      kind: 'health_marker',
+      sortAt: result.data.recorded_at,
+      id: result.data.id,
+      label: markerLineTitle(currentLine),
+      detail: healthMarkerDetailForTimeline(result.data),
+    };
+    setObservationTimeline((prev) => upsertTimelineItem(prev, timelineItem));
     return true;
   };
 

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -586,7 +586,7 @@ export function HealthMarkerPromptScreen() {
       episode_label: trimToNull(postLabel),
       additional_notes: trimToNull(postAdditional),
       note: trimToNull(postNote),
-      // Ignored by completeEpisodePostMarkerStep: boundary is server-derived to avoid clock skew.
+      // Completion signal only: DB overwrites stored boundary with authoritative server time.
       post_marker_step_completed_at: null,
     });
     setSavingPost(false);

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -29,7 +29,6 @@ import type {
 import {
   bacReadingSuggestsAbsEpisode,
   filterHealthMarkerRowsForOpenPass,
-  findLatestHealthMarkerForLineInPass,
   formatEpisodeDurationSimple,
   PRESET_HEALTH_MARKER_KIND_LABELS,
   validatePresetHealthMarkerCustomFields,
@@ -164,16 +163,50 @@ function createDraftFromMarker(row: HealthMarkerRow | null): MarkerDraft {
   };
 }
 
-function findCurrentPassMarkerForLine(
-  allRows: HealthMarkerRow[],
-  line: PresetHealthMarkerRow,
-  lastPostMarkerStepCompletedAt: string | null,
-): HealthMarkerRow | null {
-  const pass = filterHealthMarkerRowsForOpenPass(
-    allRows,
-    lastPostMarkerStepCompletedAt,
-  );
-  return findLatestHealthMarkerForLineInPass(pass, line);
+function isHealthMarkerRowLater(
+  a: HealthMarkerRow,
+  b: HealthMarkerRow,
+): boolean {
+  const recA = Date.parse(a.recorded_at);
+  const recB = Date.parse(b.recorded_at);
+  const recAValid = Number.isFinite(recA);
+  const recBValid = Number.isFinite(recB);
+  if (recAValid && recBValid && recA !== recB) {
+    return recA > recB;
+  }
+  if (recAValid !== recBValid) {
+    return recAValid;
+  }
+
+  const createdA = Date.parse(a.created_at);
+  const createdB = Date.parse(b.created_at);
+  const createdAValid = Number.isFinite(createdA);
+  const createdBValid = Number.isFinite(createdB);
+  if (createdAValid && createdBValid && createdA !== createdB) {
+    return createdA > createdB;
+  }
+  if (createdAValid !== createdBValid) {
+    return createdAValid;
+  }
+
+  return a.id.localeCompare(b.id) > 0;
+}
+
+function buildLatestMarkerByLineMap(
+  passRows: HealthMarkerRow[],
+): Map<string, HealthMarkerRow> {
+  const latestByLine = new Map<string, HealthMarkerRow>();
+  for (const row of passRows) {
+    const lineId = row.preset_health_marker_id;
+    if (!lineId) {
+      continue;
+    }
+    const prev = latestByLine.get(lineId);
+    if (!prev || isHealthMarkerRowLater(row, prev)) {
+      latestByLine.set(lineId, row);
+    }
+  }
+  return latestByLine;
 }
 
 type MeasurementDraftResult =
@@ -421,13 +454,14 @@ export function HealthMarkerPromptScreen() {
 
     const lastPost: string | null =
       episode.data?.post_marker_step_completed_at ?? null;
+    const passRows = filterHealthMarkerRowsForOpenPass(
+      markerRows.data,
+      lastPost,
+    );
+    const latestMarkerByLine = buildLatestMarkerByLineMap(passRows);
     const nextDrafts: Record<string, MarkerDraft> = {};
     for (const line of presetLines.data) {
-      const marker = findCurrentPassMarkerForLine(
-        markerRows.data,
-        line,
-        lastPost,
-      );
+      const marker = latestMarkerByLine.get(line.id) ?? null;
       nextDrafts[line.id] = createDraftFromMarker(marker);
     }
     setDrafts(nextDrafts);
@@ -436,10 +470,9 @@ export function HealthMarkerPromptScreen() {
     // enterFoodDiaryPhaseAfterMarkers before the post-marker step.
     setBacSuggestAbs(bacReadingSuggestsAbsEpisode(markerRows.data));
 
-    const firstUnanswered = presetLines.data.findIndex((line) => {
-      const row = findCurrentPassMarkerForLine(markerRows.data, line, lastPost);
-      return row === null;
-    });
+    const firstUnanswered = presetLines.data.findIndex(
+      (line) => !latestMarkerByLine.has(line.id),
+    );
     if (resume && hub && lastPost != null) {
       setPhase('complete');
     } else if (resume && firstUnanswered === -1) {
@@ -451,7 +484,9 @@ export function HealthMarkerPromptScreen() {
     }
     setStatus('ready');
 
-    const tl = await listEpisodeObservationTimeline(supabase, episodeId);
+    const tl = await listEpisodeObservationTimeline(supabase, episodeId, {
+      prefetchedHealthMarkers: markerRows.data,
+    });
     if (stale()) {
       return;
     }

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -29,6 +29,7 @@ import type {
 import {
   bacReadingSuggestsAbsEpisode,
   filterHealthMarkerRowsForOpenPass,
+  findLatestHealthMarkerForLineInPass,
   formatEpisodeDurationSimple,
   PRESET_HEALTH_MARKER_KIND_LABELS,
   validatePresetHealthMarkerCustomFields,
@@ -161,52 +162,6 @@ function createDraftFromMarker(row: HealthMarkerRow | null): MarkerDraft {
       row?.diastolic_numeric != null ? String(row.diastolic_numeric) : '',
     notes: row?.notes ?? '',
   };
-}
-
-function isHealthMarkerRowLater(
-  a: HealthMarkerRow,
-  b: HealthMarkerRow,
-): boolean {
-  const recA = Date.parse(a.recorded_at);
-  const recB = Date.parse(b.recorded_at);
-  const recAValid = Number.isFinite(recA);
-  const recBValid = Number.isFinite(recB);
-  if (recAValid && recBValid && recA !== recB) {
-    return recA > recB;
-  }
-  if (recAValid !== recBValid) {
-    return recAValid;
-  }
-
-  const createdA = Date.parse(a.created_at);
-  const createdB = Date.parse(b.created_at);
-  const createdAValid = Number.isFinite(createdA);
-  const createdBValid = Number.isFinite(createdB);
-  if (createdAValid && createdBValid && createdA !== createdB) {
-    return createdA > createdB;
-  }
-  if (createdAValid !== createdBValid) {
-    return createdAValid;
-  }
-
-  return a.id.localeCompare(b.id) > 0;
-}
-
-function buildLatestMarkerByLineMap(
-  passRows: HealthMarkerRow[],
-): Map<string, HealthMarkerRow> {
-  const latestByLine = new Map<string, HealthMarkerRow>();
-  for (const row of passRows) {
-    const lineId = row.preset_health_marker_id;
-    if (!lineId) {
-      continue;
-    }
-    const prev = latestByLine.get(lineId);
-    if (!prev || isHealthMarkerRowLater(row, prev)) {
-      latestByLine.set(lineId, row);
-    }
-  }
-  return latestByLine;
 }
 
 type MeasurementDraftResult =
@@ -458,11 +413,14 @@ export function HealthMarkerPromptScreen() {
       markerRows.data,
       lastPost,
     );
-    const latestMarkerByLine = buildLatestMarkerByLineMap(passRows);
     const nextDrafts: Record<string, MarkerDraft> = {};
-    for (const line of presetLines.data) {
-      const marker = latestMarkerByLine.get(line.id) ?? null;
+    let firstUnanswered = -1;
+    for (const [idx, line] of presetLines.data.entries()) {
+      const marker = findLatestHealthMarkerForLineInPass(passRows, line);
       nextDrafts[line.id] = createDraftFromMarker(marker);
+      if (firstUnanswered === -1 && marker == null) {
+        firstUnanswered = idx;
+      }
     }
     setDrafts(nextDrafts);
 
@@ -470,9 +428,6 @@ export function HealthMarkerPromptScreen() {
     // enterFoodDiaryPhaseAfterMarkers before the post-marker step.
     setBacSuggestAbs(bacReadingSuggestsAbsEpisode(markerRows.data));
 
-    const firstUnanswered = presetLines.data.findIndex(
-      (line) => !latestMarkerByLine.has(line.id),
-    );
     if (resume && hub && lastPost != null) {
       setPhase('complete');
     } else if (resume && firstUnanswered === -1) {

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -86,6 +86,14 @@ function trimToNull(value: string): string | null {
   return t.length > 0 ? t : null;
 }
 
+function formatTimelineInstant(isoLike: string): string {
+  const ms = Date.parse(isoLike);
+  if (!Number.isFinite(ms)) {
+    return isoLike;
+  }
+  return new Date(ms).toLocaleString();
+}
+
 function markerLineTitle(line: PresetHealthMarkerRow): string {
   if (line.marker_kind !== 'custom') {
     return PRESET_HEALTH_MARKER_KIND_LABELS[line.marker_kind];
@@ -369,7 +377,7 @@ export function HealthMarkerPromptScreen() {
       const row = findCurrentPassMarkerForLine(markerRows.data, line, lastPost);
       return row === null;
     });
-    if (resume && hub) {
+    if (resume && hub && lastPost != null) {
       setPhase('complete');
     } else if (resume && firstUnanswered === -1) {
       setPhase('foodDiary');
@@ -824,10 +832,7 @@ export function HealthMarkerPromptScreen() {
                       className={`mt-2 text-sm ${nw.textInk}`}
                       maxFontSizeMultiplier={2}
                     >
-                      {row.sortAt
-                        .replace('T', ' ')
-                        .replace(/\.\d{3}Z$/, ' UTC')
-                        .slice(0, 19)}
+                      {formatTimelineInstant(row.sortAt)}
                       {' — '}
                       {row.label}: {row.detail}
                     </Text>
@@ -1349,8 +1354,8 @@ export function HealthMarkerPromptScreen() {
                         className={`mb-2 text-sm ${nw.textInk}`}
                         maxFontSizeMultiplier={2}
                       >
-                        {row.sortAt.replace('T', ' ').slice(0, 19)} —{' '}
-                        {row.label}: {row.detail}
+                        {formatTimelineInstant(row.sortAt)} — {row.label}:{' '}
+                        {row.detail}
                       </Text>
                     ))}
                   </View>

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -291,11 +291,21 @@ export function HealthMarkerPromptScreen() {
   /** Bumps when the screen unmounts or `load` deps change so stale async work does not setState. */
   const loadGenerationRef = useRef(0);
 
+  const refreshObservationTimeline = useCallback(async () => {
+    const tl = await listEpisodeObservationTimeline(supabase, episodeId);
+    if (tl.ok) {
+      setObservationTimeline(tl.data);
+      return;
+    }
+    setObservationTimeline([]);
+  }, [episodeId, supabase]);
+
   const onLeaveFoodDiary = useCallback(
     async (_decision: 'saved' | 'skipped') => {
+      await refreshObservationTimeline();
       setPhase('postMarkers');
     },
-    [],
+    [refreshObservationTimeline],
   );
 
   const onBackToHealthMarkersFromFoodDiaryBody = useCallback(async () => {
@@ -627,6 +637,7 @@ export function HealthMarkerPromptScreen() {
     setEpisodeRow(result.data);
     setEndFeedback(null);
     setEndedSummary(null);
+    await refreshObservationTimeline();
     setPhase('complete');
     await announce(
       result.data.symptom_preset_id

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -44,6 +44,7 @@ import {
   listEpisodeObservationTimeline,
   listPresetHealthMarkersForPreset,
   type EpisodeTimelineItem,
+  upsertEpisodeTimelineItem,
 } from '@abstrack/supabase';
 import { announce, COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
@@ -92,38 +93,6 @@ function formatTimelineInstant(isoLike: string): string {
     return isoLike;
   }
   return new Date(ms).toLocaleString();
-}
-
-function compareTimelineItems(
-  a: EpisodeTimelineItem,
-  b: EpisodeTimelineItem,
-): number {
-  const aMs = Date.parse(a.sortAt);
-  const bMs = Date.parse(b.sortAt);
-  const aValid = Number.isFinite(aMs);
-  const bValid = Number.isFinite(bMs);
-  if (aValid && bValid) {
-    const c = aMs - bMs;
-    if (c !== 0) {
-      return c;
-    }
-  } else {
-    const c = a.sortAt.localeCompare(b.sortAt);
-    if (c !== 0) {
-      return c;
-    }
-  }
-  return a.id.localeCompare(b.id);
-}
-
-function upsertTimelineItem(
-  prev: EpisodeTimelineItem[],
-  next: EpisodeTimelineItem,
-): EpisodeTimelineItem[] {
-  const rows = prev.filter((r) => !(r.kind === next.kind && r.id === next.id));
-  rows.push(next);
-  rows.sort(compareTimelineItems);
-  return rows;
 }
 
 function healthMarkerDetailForTimeline(row: HealthMarkerRow): string {
@@ -547,7 +516,9 @@ export function HealthMarkerPromptScreen() {
       label: markerLineTitle(currentLine),
       detail: healthMarkerDetailForTimeline(result.data),
     };
-    setObservationTimeline((prev) => upsertTimelineItem(prev, timelineItem));
+    setObservationTimeline((prev) =>
+      upsertEpisodeTimelineItem(prev, timelineItem),
+    );
     return true;
   };
 

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -843,19 +843,19 @@ export function HealthMarkerPromptScreen() {
               {observationTimeline.length > 0 && !endedSummary ? (
                 <View
                   className={`rounded-2xl border border-app-border bg-app-surface p-4 dark:border-app-border-dark dark:bg-app-bg-dark`}
-                  accessibilityLabel="Log so far in this episode"
+                  accessibilityLabel="Recent log entries in this episode"
                 >
                   <Text
                     className={`text-sm font-semibold ${nw.textInk}`}
                     maxFontSizeMultiplier={2}
                   >
-                    Log so far in this episode
+                    Recent log entries in this episode
                   </Text>
                   <Text
                     className={`mt-1 text-xs ${nw.textMuted}`}
                     maxFontSizeMultiplier={2}
                   >
-                    Oldest first. New entries are added as you go.
+                    Showing recent entries only. Oldest first within this slice.
                   </Text>
                   {observationTimeline.map((row) => (
                     <Text
@@ -1364,20 +1364,21 @@ export function HealthMarkerPromptScreen() {
                 </View>
                 {observationTimeline.length > 0 ? (
                   <View
-                    accessibilityLabel="Log so far in this episode, oldest first"
+                    accessibilityLabel="Recent log entries in this episode, oldest first within this slice"
                     className="mt-6 rounded-xl border border-app-border bg-app-surface/60 p-4"
                   >
                     <Text
                       className={`text-sm font-semibold ${nw.textInk}`}
                       maxFontSizeMultiplier={2}
                     >
-                      Log so far in this episode
+                      Recent log entries in this episode
                     </Text>
                     <Text
                       className={`mb-2 text-xs ${nw.textMuted}`}
                       maxFontSizeMultiplier={2}
                     >
-                      Oldest first
+                      Showing recent entries only. Oldest first within this
+                      slice.
                     </Text>
                     {observationTimeline.map((row) => (
                       <Text

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -5,10 +5,11 @@ import { CommonActions, DefaultTheme } from '@react-navigation/native';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import {
   cancelActiveEpisodeById,
-  deleteEpisodeSymptomAnswer,
+  deleteCurrentPassEpisodeSymptomAnswer,
+  getEpisodeById,
   listEpisodeSymptomsForEpisode,
   listPresetSymptomsForPreset,
-  upsertEpisodeSymptomAnswer,
+  insertEpisodeSymptomAnswer,
 } from '@abstrack/supabase';
 import { createInitialSymptomPromptSession } from '@abstrack/types';
 import type { PresetSymptomRow } from '@abstrack/types';
@@ -31,10 +32,11 @@ jest.mock('@react-navigation/native', () => ({
 
 jest.mock('@abstrack/supabase', () => ({
   cancelActiveEpisodeById: jest.fn(),
-  deleteEpisodeSymptomAnswer: jest.fn(),
+  getEpisodeById: jest.fn(),
+  deleteCurrentPassEpisodeSymptomAnswer: jest.fn(),
   listPresetSymptomsForPreset: jest.fn(),
   listEpisodeSymptomsForEpisode: jest.fn(),
-  upsertEpisodeSymptomAnswer: jest.fn(),
+  insertEpisodeSymptomAnswer: jest.fn(),
 }));
 
 jest.mock('../../lib/supabase-wiring', () => ({
@@ -131,6 +133,25 @@ describe('SymptomPromptScreen', () => {
       .mocked(getSymptomPromptSession)
       .mockReturnValue(createInitialSymptomPromptSession());
 
+    jest.mocked(getEpisodeById).mockResolvedValue({
+      ok: true,
+      data: {
+        id: episodeId,
+        user_id: 'test-user-1',
+        symptom_preset_id: symptomPresetId,
+        health_marker_preset_id: 'hm-preset-1',
+        episode_type: 'Other',
+        episode_label: null,
+        additional_notes: null,
+        note: null,
+        started_at: '2020-01-01T00:00:00Z',
+        ended_at: null,
+        post_marker_step_completed_at: null,
+        created_at: '2020-01-01T00:00:00Z',
+        updated_at: '2020-01-01T00:00:00Z',
+      },
+    });
+
     jest.mocked(listPresetSymptomsForPreset).mockResolvedValue({
       ok: true,
       data: [lineA, lineB],
@@ -139,7 +160,7 @@ describe('SymptomPromptScreen', () => {
       ok: true,
       data: [],
     });
-    jest.mocked(upsertEpisodeSymptomAnswer).mockResolvedValue({
+    jest.mocked(insertEpisodeSymptomAnswer).mockResolvedValue({
       ok: true,
       data: {
         id: 'es-1',
@@ -156,7 +177,7 @@ describe('SymptomPromptScreen', () => {
         updated_at: '2020-01-01T00:00:00Z',
       },
     });
-    jest.mocked(deleteEpisodeSymptomAnswer).mockResolvedValue({
+    jest.mocked(deleteCurrentPassEpisodeSymptomAnswer).mockResolvedValue({
       ok: true,
       data: true,
     });
@@ -166,22 +187,22 @@ describe('SymptomPromptScreen', () => {
     });
   });
 
-  test('non-free-text answer triggers upsertEpisodeSymptomAnswer', async () => {
+  test('non-free-text answer triggers insertEpisodeSymptomAnswer', async () => {
     const screen = render(<SymptomPromptScreen />);
 
     await waitFor(() => {
       expect(screen.getByText('Step 1 of 2')).toBeTruthy();
     });
 
-    jest.mocked(upsertEpisodeSymptomAnswer).mockClear();
+    jest.mocked(insertEpisodeSymptomAnswer).mockClear();
 
     fireEvent.press(screen.getByText('yes'));
 
     await waitFor(() => {
-      expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledTimes(1);
+      expect(insertEpisodeSymptomAnswer).toHaveBeenCalledTimes(1);
     });
 
-    expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledWith(
+    expect(insertEpisodeSymptomAnswer).toHaveBeenCalledWith(
       expect.objectContaining({ mockClient: true }),
       expect.objectContaining({
         userId: 'test-user-1',
@@ -205,7 +226,7 @@ describe('SymptomPromptScreen', () => {
 
     fireEvent.press(screen.getByLabelText('Severity 3'));
     await waitFor(() => {
-      expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledWith(
+      expect(insertEpisodeSymptomAnswer).toHaveBeenCalledWith(
         expect.objectContaining({ mockClient: true }),
         expect.objectContaining({
           line: lineSeverityOnly,
@@ -214,20 +235,21 @@ describe('SymptomPromptScreen', () => {
       );
     });
 
-    jest.mocked(upsertEpisodeSymptomAnswer).mockClear();
-    jest.mocked(deleteEpisodeSymptomAnswer).mockClear();
+    jest.mocked(insertEpisodeSymptomAnswer).mockClear();
+    jest.mocked(deleteCurrentPassEpisodeSymptomAnswer).mockClear();
     fireEvent.press(screen.getByLabelText('Severity 3'));
 
     await waitFor(() => {
-      expect(deleteEpisodeSymptomAnswer).toHaveBeenCalledWith(
+      expect(deleteCurrentPassEpisodeSymptomAnswer).toHaveBeenCalledWith(
         expect.objectContaining({ mockClient: true }),
         expect.objectContaining({
           episodeId,
           presetSymptomId: lineSeverityOnly.id,
+          lastPostMarkerStepCompletedAt: null,
         }),
       );
     });
-    expect(upsertEpisodeSymptomAnswer).not.toHaveBeenCalled();
+    expect(insertEpisodeSymptomAnswer).not.toHaveBeenCalled();
   });
 
   test('free_text changes debounce to a single upsert', async () => {
@@ -242,14 +264,14 @@ describe('SymptomPromptScreen', () => {
       expect(screen.getByText('Step 1 of 1')).toBeTruthy();
     });
 
-    jest.mocked(upsertEpisodeSymptomAnswer).mockClear();
+    jest.mocked(insertEpisodeSymptomAnswer).mockClear();
 
     jest.useFakeTimers();
     try {
       const input = screen.getByLabelText('Notes notes');
       fireEvent.changeText(input, 'a');
       fireEvent.changeText(input, 'ab');
-      expect(upsertEpisodeSymptomAnswer).not.toHaveBeenCalled();
+      expect(insertEpisodeSymptomAnswer).not.toHaveBeenCalled();
 
       await act(async () => {
         jest.advanceTimersByTime(300);
@@ -259,10 +281,10 @@ describe('SymptomPromptScreen', () => {
       });
 
       await waitFor(() => {
-        expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledTimes(1);
+        expect(insertEpisodeSymptomAnswer).toHaveBeenCalledTimes(1);
       });
 
-      expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledWith(
+      expect(insertEpisodeSymptomAnswer).toHaveBeenCalledWith(
         expect.objectContaining({ mockClient: true }),
         expect.objectContaining({
           userId: 'test-user-1',
@@ -289,12 +311,12 @@ describe('SymptomPromptScreen', () => {
       expect(screen.getByText('Step 1 of 2')).toBeTruthy();
     });
 
-    jest.mocked(upsertEpisodeSymptomAnswer).mockClear();
+    jest.mocked(insertEpisodeSymptomAnswer).mockClear();
 
     jest.useFakeTimers();
     try {
       fireEvent.changeText(screen.getByLabelText('Notes notes'), 'draft');
-      expect(upsertEpisodeSymptomAnswer).not.toHaveBeenCalled();
+      expect(insertEpisodeSymptomAnswer).not.toHaveBeenCalled();
 
       fireEvent.press(screen.getByLabelText('Next symptom'));
 
@@ -303,10 +325,10 @@ describe('SymptomPromptScreen', () => {
       });
 
       await waitFor(() => {
-        expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledTimes(1);
+        expect(insertEpisodeSymptomAnswer).toHaveBeenCalledTimes(1);
       });
 
-      expect(upsertEpisodeSymptomAnswer).toHaveBeenCalledWith(
+      expect(insertEpisodeSymptomAnswer).toHaveBeenCalledWith(
         expect.objectContaining({ mockClient: true }),
         expect.objectContaining({
           answer: { type: 'free_text', value: 'draft' },
@@ -398,18 +420,19 @@ describe('SymptomPromptScreen', () => {
       expect(screen.getByText('Step 1 of 2')).toBeTruthy();
     });
 
-    jest.mocked(deleteEpisodeSymptomAnswer).mockClear();
+    jest.mocked(deleteCurrentPassEpisodeSymptomAnswer).mockClear();
     fireEvent.press(screen.getByLabelText('Skip this symptom'));
 
     await waitFor(() => {
       expect(screen.getByText('Step 2 of 2')).toBeTruthy();
     });
 
-    expect(deleteEpisodeSymptomAnswer).toHaveBeenCalledWith(
+    expect(deleteCurrentPassEpisodeSymptomAnswer).toHaveBeenCalledWith(
       expect.objectContaining({ mockClient: true }),
       expect.objectContaining({
         episodeId,
         presetSymptomId: lineA.id,
+        lastPostMarkerStepCompletedAt: null,
       }),
     );
     expect(setSymptomPromptSession).toHaveBeenCalledWith(episodeId, {
@@ -586,7 +609,7 @@ describe('SymptomPromptScreen', () => {
     });
 
     fireEvent.changeText(screen.getByLabelText('Notes notes'), 'draft text');
-    jest.mocked(deleteEpisodeSymptomAnswer).mockClear();
+    jest.mocked(deleteCurrentPassEpisodeSymptomAnswer).mockClear();
 
     const skipButton = screen.getByLabelText('Skip this symptom');
     expect(skipButton.props.accessibilityState).toEqual({ disabled: true });
@@ -598,11 +621,12 @@ describe('SymptomPromptScreen', () => {
       expect(screen.getByText('Step 2 of 2')).toBeTruthy();
     });
 
-    expect(deleteEpisodeSymptomAnswer).toHaveBeenCalledWith(
+    expect(deleteCurrentPassEpisodeSymptomAnswer).toHaveBeenCalledWith(
       expect.objectContaining({ mockClient: true }),
       expect.objectContaining({
         episodeId,
         presetSymptomId: lineFreeOnly.id,
+        lastPostMarkerStepCompletedAt: null,
       }),
     );
   });

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -252,7 +252,7 @@ describe('SymptomPromptScreen', () => {
     expect(insertEpisodeSymptomAnswer).not.toHaveBeenCalled();
   });
 
-  test('free_text changes debounce to a single upsert', async () => {
+  test('free_text typing stages changes without server insert until explicit commit', async () => {
     jest.mocked(listPresetSymptomsForPreset).mockResolvedValue({
       ok: true,
       data: [lineFreeOnly],
@@ -266,36 +266,10 @@ describe('SymptomPromptScreen', () => {
 
     jest.mocked(insertEpisodeSymptomAnswer).mockClear();
 
-    jest.useFakeTimers();
-    try {
-      const input = screen.getByLabelText('Notes notes');
-      fireEvent.changeText(input, 'a');
-      fireEvent.changeText(input, 'ab');
-      expect(insertEpisodeSymptomAnswer).not.toHaveBeenCalled();
-
-      await act(async () => {
-        jest.advanceTimersByTime(300);
-      });
-      await act(async () => {
-        await Promise.resolve();
-      });
-
-      await waitFor(() => {
-        expect(insertEpisodeSymptomAnswer).toHaveBeenCalledTimes(1);
-      });
-
-      expect(insertEpisodeSymptomAnswer).toHaveBeenCalledWith(
-        expect.objectContaining({ mockClient: true }),
-        expect.objectContaining({
-          userId: 'test-user-1',
-          episodeId,
-          line: lineFreeOnly,
-          answer: { type: 'free_text', value: 'ab' },
-        }),
-      );
-    } finally {
-      jest.useRealTimers();
-    }
+    const input = screen.getByLabelText('Notes notes');
+    fireEvent.changeText(input, 'a');
+    fireEvent.changeText(input, 'ab');
+    expect(insertEpisodeSymptomAnswer).not.toHaveBeenCalled();
   });
 
   test('free_text flush on Next runs upsert without waiting for debounce', async () => {

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -104,9 +104,6 @@ export function SymptomPromptScreen() {
   const answersRef = useRef(answers);
   const activeIndexRef = useRef(activeIndex);
   const episodeIdRef = useRef(episodeId);
-  const serverPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
   /** Latest staged free-text payload for Supabase; flushed on explicit commit actions. */
   const pendingServerFreeTextPersistRef = useRef<{
     line: PresetSymptomRow;
@@ -311,10 +308,6 @@ export function SymptomPromptScreen() {
    * explicit transition.
    */
   const flushPendingServerPersist = useCallback(() => {
-    if (serverPersistTimerRef.current !== null) {
-      clearTimeout(serverPersistTimerRef.current);
-      serverPersistTimerRef.current = null;
-    }
     const pending = pendingServerFreeTextPersistRef.current;
     pendingServerFreeTextPersistRef.current = null;
     if (!pending) {
@@ -324,14 +317,10 @@ export function SymptomPromptScreen() {
   }, [executeServerPersist]);
 
   /**
-   * Cancels pending debounced free-text upserts and invalidates older in-flight persists.
-   * Used on skip/delete so delayed upserts cannot recreate deleted symptom rows.
+   * Cancels pending staged free-text inserts and invalidates older in-flight persists.
+   * Used on skip/delete so delayed inserts cannot recreate deleted symptom rows.
    */
   const cancelPendingServerPersist = useCallback(() => {
-    if (serverPersistTimerRef.current !== null) {
-      clearTimeout(serverPersistTimerRef.current);
-      serverPersistTimerRef.current = null;
-    }
     pendingServerFreeTextPersistRef.current = null;
     serverPersistEpochRef.current += 1;
   }, []);
@@ -349,18 +338,10 @@ export function SymptomPromptScreen() {
       }
       if (answer.type === 'free_text') {
         pendingServerFreeTextPersistRef.current = { line, answer };
-        if (serverPersistTimerRef.current !== null) {
-          clearTimeout(serverPersistTimerRef.current);
-          serverPersistTimerRef.current = null;
-        }
         // Intentional: free-text answers are insert-only now, so we stage while typing and only
         // write on explicit commit actions (Next/Back/unmount) via flushPendingServerPersist.
       } else {
         pendingServerFreeTextPersistRef.current = null;
-        if (serverPersistTimerRef.current !== null) {
-          clearTimeout(serverPersistTimerRef.current);
-          serverPersistTimerRef.current = null;
-        }
         executeServerPersist(line, answer);
       }
     },

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -14,6 +14,7 @@ import {
 } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type {
+  EpisodeRow,
   PresetSymptomRow,
   SymptomPromptAnswer,
   SymptomPromptAnswers,
@@ -21,15 +22,18 @@ import type {
 import {
   computeSymptomResumePlacement,
   createDefaultSymptomPromptAnswer,
-  episodeSymptomRowsToAnswersMap,
+  episodeSymptomRowsToAnswersMapForOpenPass,
+  formatEpisodeDurationSimple,
   symptomPromptAnswerHasValue,
 } from '@abstrack/types';
 import {
   cancelActiveEpisodeById,
-  deleteEpisodeSymptomAnswer,
+  deleteCurrentPassEpisodeSymptomAnswer,
+  endEpisodeIfStillActive,
+  getEpisodeById,
+  insertEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
   listPresetSymptomsForPreset,
-  upsertEpisodeSymptomAnswer,
 } from '@abstrack/supabase';
 import { announce } from '@abstrack/ui/native';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
@@ -132,6 +136,11 @@ export function SymptomPromptScreen() {
   /** Suppresses {@link setPersistError} after unmount. */
   const isMountedRef = useRef(true);
   const allowRemovalRef = useRef(false);
+  const lastPostMarkerStepCompletedAtRef = useRef<string | null>(null);
+  const [episodeForEndCta, setEpisodeForEndCta] = useState<EpisodeRow | null>(
+    null,
+  );
+  const [endingEpisode, setEndingEpisode] = useState(false);
 
   /**
    * Caches the auth user id on {@link userIdRef}. Called from {@link load} before `ready`, and
@@ -200,7 +209,7 @@ export function SymptomPromptScreen() {
             }
             return;
           }
-          const r = await upsertEpisodeSymptomAnswer(supabase, {
+          const r = await insertEpisodeSymptomAnswer(supabase, {
             userId: uid,
             episodeId: targetEpisodeId,
             line,
@@ -265,9 +274,11 @@ export function SymptomPromptScreen() {
             }
             return;
           }
-          const r = await deleteEpisodeSymptomAnswer(supabase, {
+          const r = await deleteCurrentPassEpisodeSymptomAnswer(supabase, {
             episodeId: targetEpisodeId,
             presetSymptomId: line.id,
+            lastPostMarkerStepCompletedAt:
+              lastPostMarkerStepCompletedAtRef.current,
           });
           if (enqueueEpoch !== serverPersistEpochRef.current) {
             return;
@@ -402,6 +413,24 @@ export function SymptomPromptScreen() {
         setStatus('error');
         return;
       }
+      const ep = await getEpisodeById(supabase, episodeId);
+      if (stale()) {
+        return;
+      }
+      if (!ep.ok) {
+        setErrorMessage(ep.error.message);
+        setStatus('error');
+        return;
+      }
+      if (!ep.data) {
+        setErrorMessage('Could not load this episode.');
+        setStatus('error');
+        return;
+      }
+      setEpisodeForEndCta(ep.data);
+      const passBoundary = ep.data.post_marker_step_completed_at ?? null;
+      lastPostMarkerStepCompletedAtRef.current = passBoundary;
+
       const result = await listPresetSymptomsForPreset(
         supabase,
         symptomPresetId,
@@ -423,7 +452,10 @@ export function SymptomPromptScreen() {
         return;
       }
       const serverAnswers = fromServer.ok
-        ? episodeSymptomRowsToAnswersMap(fromServer.data)
+        ? episodeSymptomRowsToAnswersMapForOpenPass(
+            fromServer.data,
+            passBoundary,
+          )
         : {};
       const session = getSymptomPromptSession(episodeId);
       // Session overlays server so local drafts survive hydrate (debounced/offline/failed sync).
@@ -638,6 +670,68 @@ export function SymptomPromptScreen() {
     );
   }, [cancelPendingServerPersist, navigation]);
 
+  const onEndEpisodePress = useCallback(() => {
+    if (endingEpisode || !episodeForEndCta) {
+      return;
+    }
+    Alert.alert('End this episode now?', 'You can still view it in history.', [
+      { text: 'Not yet', style: 'cancel' },
+      {
+        text: 'End episode',
+        style: 'destructive',
+        onPress: () => {
+          void (async () => {
+            if (!episodeForEndCta) {
+              return;
+            }
+            setEndingEpisode(true);
+            const nowIso = new Date().toISOString();
+            const startedAtMs = Date.parse(episodeForEndCta.started_at);
+            const nowMs = Date.parse(nowIso);
+            const endedAt =
+              Number.isFinite(startedAtMs) &&
+              Number.isFinite(nowMs) &&
+              nowMs < startedAtMs
+                ? episodeForEndCta.started_at
+                : nowIso;
+            const supabase = getMobileSupabaseClient();
+            const result = await endEpisodeIfStillActive(
+              supabase,
+              episodeId,
+              endedAt,
+              episodeForEndCta.started_at,
+            );
+            setEndingEpisode(false);
+            if (!result.ok) {
+              await announce(result.error.message, { politeness: 'assertive' });
+              return;
+            }
+            clearSymptomPromptSession(episodeId);
+            if (result.data.didEnd) {
+              const durationText = formatEpisodeDurationSimple(
+                episodeForEndCta.started_at,
+                endedAt,
+              );
+              await announce(
+                durationText
+                  ? `Episode ended. Duration ${durationText}.`
+                  : 'Episode ended.',
+                { politeness: 'polite' },
+              );
+            }
+            allowRemovalRef.current = true;
+            navigation.dispatch(
+              CommonActions.reset({
+                index: 0,
+                routes: [{ name: 'MainTabs' }],
+              }),
+            );
+          })();
+        },
+      },
+    ]);
+  }, [endingEpisode, episodeForEndCta, episodeId, navigation]);
+
   const advanceToNextStep = () => {
     if (lines.length === 0) {
       setSymptomPromptSession(episodeIdRef.current, {
@@ -845,6 +939,25 @@ export function SymptomPromptScreen() {
             Exit symptom flow
           </Text>
         </Pressable>
+        {episodeForEndCta?.post_marker_step_completed_at &&
+        !episodeForEndCta.ended_at ? (
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="End this episode"
+            accessibilityState={{ disabled: endingEpisode }}
+            disabled={endingEpisode}
+            onPress={onEndEpisodePress}
+            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+            className="w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
+          >
+            <Text
+              className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              {endingEpisode ? 'Ending…' : 'End this episode'}
+            </Text>
+          </Pressable>
+        ) : null}
         <Pressable
           accessibilityRole="button"
           accessibilityLabel="Cancel episode"

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -71,9 +71,6 @@ function lineWriteQueueKey(episodeId: string, presetSymptomId: string): string {
   return `${episodeId}:${presetSymptomId}`;
 }
 
-/** Debounce Supabase writes for free-text answers (matches web episode flow). */
-const SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS = 300;
-
 /**
  * Linear symptom stepper for the active episode’s selected preset (Week 5 skeleton).
  *
@@ -110,7 +107,7 @@ export function SymptomPromptScreen() {
   const serverPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  /** Latest debounced free-text payload for Supabase; read in {@link flushPendingServerPersist}. */
+  /** Latest staged free-text payload for Supabase; flushed on explicit commit actions. */
   const pendingServerFreeTextPersistRef = useRef<{
     line: PresetSymptomRow;
     answer: SymptomPromptAnswer;
@@ -309,9 +306,9 @@ export function SymptomPromptScreen() {
   );
 
   /**
-   * Cancels the debounced server timer, then **immediately** persists the latest free-text
-   * `{ line, answer }` from {@link pendingServerFreeTextPersistRef} (if any). Call from
-   * Next/Back, `useLayoutEffect` (episode change), and unmount so the last keystrokes are not lost.
+   * Flushes the latest staged free-text `{ line, answer }` (if any). Call from Next/Back,
+   * `useLayoutEffect` (episode change), and unmount so the last keystrokes are committed once per
+   * explicit transition.
    */
   const flushPendingServerPersist = useCallback(() => {
     if (serverPersistTimerRef.current !== null) {
@@ -354,15 +351,10 @@ export function SymptomPromptScreen() {
         pendingServerFreeTextPersistRef.current = { line, answer };
         if (serverPersistTimerRef.current !== null) {
           clearTimeout(serverPersistTimerRef.current);
-        }
-        serverPersistTimerRef.current = setTimeout(() => {
           serverPersistTimerRef.current = null;
-          const pending = pendingServerFreeTextPersistRef.current;
-          pendingServerFreeTextPersistRef.current = null;
-          if (pending) {
-            executeServerPersist(pending.line, pending.answer);
-          }
-        }, SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS);
+        }
+        // Intentional: free-text answers are insert-only now, so we stage while typing and only
+        // write on explicit commit actions (Next/Back/unmount) via flushPendingServerPersist.
       } else {
         pendingServerFreeTextPersistRef.current = null;
         if (serverPersistTimerRef.current !== null) {

--- a/apps/web/src/app/(app)/episode/[episodeId]/health-markers/page.tsx
+++ b/apps/web/src/app/(app)/episode/[episodeId]/health-markers/page.tsx
@@ -3,7 +3,7 @@ import { HealthMarkerPromptFlow } from '@/components/episode-flow/HealthMarkerPr
 type PageProps = {
   /** Next.js 16 passes dynamic route params as a Promise (await before use). */
   params: Promise<{ episodeId: string }>;
-  searchParams: Promise<{ resume?: string }>;
+  searchParams: Promise<{ resume?: string; hub?: string }>;
 };
 
 /**
@@ -17,14 +17,17 @@ export default async function EpisodeHealthMarkersPage({
   searchParams,
 }: PageProps) {
   const { episodeId } = await params;
-  const { resume } = await searchParams;
+  const { resume, hub } = await searchParams;
   const resumeFromEntry =
     resume === '1' || resume === 'true' || resume === 'yes';
+  const resumeToEpisodeHub =
+    resumeFromEntry && (hub === '1' || hub === 'true' || hub === 'yes');
 
   return (
     <HealthMarkerPromptFlow
       episodeId={episodeId}
       resumeFromEntry={resumeFromEntry}
+      resumeToEpisodeHub={resumeToEpisodeHub}
     />
   );
 }

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -296,7 +296,7 @@ export function EpisodeStartFlow() {
           {canResume ? (
             <Link
               href={buildResumeEpisodeHref(blockingActiveEpisode.id, presetId, {
-                toHealthMarkers: isAtEndStep,
+                toEpisodeHub: isAtEndStep,
               })}
               className={primaryLinkClass}
               aria-describedby={gateStatusId}

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -35,6 +35,7 @@ export function EpisodeStartHomeCta({
 
   const [ctaMode, setCtaMode] = useState<CtaMode>('loading');
   const [resumeHref, setResumeHref] = useState<string | null>(null);
+  const [resumeToHub, setResumeToHub] = useState(false);
 
   useEffect(() => {
     if (authLoading) {
@@ -44,12 +45,14 @@ export function EpisodeStartHomeCta({
     if (!userId) {
       setCtaMode('start');
       setResumeHref(null);
+      setResumeToHub(false);
       return;
     }
 
     let cancelled = false;
     setCtaMode('loading');
     setResumeHref(null);
+    setResumeToHub(false);
 
     const run = async (): Promise<void> => {
       const supabase = createBrowserClient();
@@ -60,21 +63,25 @@ export function EpisodeStartHomeCta({
       if (!result.ok) {
         setCtaMode('start');
         setResumeHref(null);
+        setResumeToHub(false);
         return;
       }
       const row = result.data;
       const presetId = row?.symptom_preset_id ?? null;
       if (row && (row.post_marker_step_completed_at != null || presetId)) {
+        const toHub = row.post_marker_step_completed_at != null;
         setResumeHref(
           buildResumeEpisodeHref(row.id, presetId, {
-            toHealthMarkers: row.post_marker_step_completed_at != null,
+            toHealthMarkers: toHub,
           }),
         );
+        setResumeToHub(toHub);
         setCtaMode('resume');
         return;
       }
       setCtaMode('start');
       setResumeHref(null);
+      setResumeToHub(false);
     };
 
     void run();
@@ -101,14 +108,18 @@ export function EpisodeStartHomeCta({
       <p id={descId} className="mt-1.5 text-sm leading-relaxed text-app-muted">
         {ctaMode === 'loading' && 'Checking for an episode in progress…'}
         {ctaMode === 'resume' &&
-          'You have an episode in progress. Continue opens your episode hub: return to the dashboard, log another full check-in, or end the episode when you are done.'}
+          (resumeToHub
+            ? 'You have an episode in progress. Continue opens your episode hub: return to the dashboard, log another full check-in, or end the episode when you are done.'
+            : 'You have an episode in progress. Continue resumes the guided symptom flow where you left off.')}
         {ctaMode === 'start' &&
           'Opens the guided flow to record what you are experiencing during this episode.'}
       </p>
       <p id={statusId} className="sr-only" role="status" aria-live="polite">
         {ctaMode === 'loading' && 'Checking for an in-progress episode.'}
         {ctaMode === 'resume' &&
-          'An episode is in progress. Primary action: Continue this episode to the episode hub.'}
+          (resumeToHub
+            ? 'An episode is in progress. Primary action: Continue this episode to the episode hub.'
+            : 'An episode is in progress. Primary action: Continue this episode in the guided symptom flow.')}
         {ctaMode === 'start' &&
           'No episode in progress. Primary action: start a new episode.'}
       </p>

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -101,14 +101,14 @@ export function EpisodeStartHomeCta({
       <p id={descId} className="mt-1.5 text-sm leading-relaxed text-app-muted">
         {ctaMode === 'loading' && 'Checking for an episode in progress…'}
         {ctaMode === 'resume' &&
-          'You have an episode in progress. Continue this episode to pick up where you left off in the guided symptom flow.'}
+          'You have an episode in progress. Continue opens your episode hub: return to the dashboard, log another full check-in, or end the episode when you are done.'}
         {ctaMode === 'start' &&
           'Opens the guided flow to record what you are experiencing during this episode.'}
       </p>
       <p id={statusId} className="sr-only" role="status" aria-live="polite">
         {ctaMode === 'loading' && 'Checking for an in-progress episode.'}
         {ctaMode === 'resume' &&
-          'An episode is in progress. Primary action: Continue this episode.'}
+          'An episode is in progress. Primary action: Continue this episode to the episode hub.'}
         {ctaMode === 'start' &&
           'No episode in progress. Primary action: start a new episode.'}
       </p>

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -77,7 +77,7 @@ export function EpisodeStartHomeCta({
         const toHub = row.post_marker_step_completed_at != null;
         setResumeHref(
           buildResumeEpisodeHref(row.id, presetId, {
-            toHealthMarkers: toHub,
+            toEpisodeHub: toHub,
           }),
         );
         setResumeToHub(toHub);

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -36,6 +36,8 @@ export function EpisodeStartHomeCta({
   const [ctaMode, setCtaMode] = useState<CtaMode>('loading');
   const [resumeHref, setResumeHref] = useState<string | null>(null);
   const [resumeToHub, setResumeToHub] = useState(false);
+  const [resumeSupportsAnotherCheckIn, setResumeSupportsAnotherCheckIn] =
+    useState(false);
 
   useEffect(() => {
     if (authLoading) {
@@ -46,6 +48,7 @@ export function EpisodeStartHomeCta({
       setCtaMode('start');
       setResumeHref(null);
       setResumeToHub(false);
+      setResumeSupportsAnotherCheckIn(false);
       return;
     }
 
@@ -53,6 +56,7 @@ export function EpisodeStartHomeCta({
     setCtaMode('loading');
     setResumeHref(null);
     setResumeToHub(false);
+    setResumeSupportsAnotherCheckIn(false);
 
     const run = async (): Promise<void> => {
       const supabase = createBrowserClient();
@@ -64,6 +68,7 @@ export function EpisodeStartHomeCta({
         setCtaMode('start');
         setResumeHref(null);
         setResumeToHub(false);
+        setResumeSupportsAnotherCheckIn(false);
         return;
       }
       const row = result.data;
@@ -76,12 +81,16 @@ export function EpisodeStartHomeCta({
           }),
         );
         setResumeToHub(toHub);
+        setResumeSupportsAnotherCheckIn(
+          typeof presetId === 'string' && presetId.length > 0,
+        );
         setCtaMode('resume');
         return;
       }
       setCtaMode('start');
       setResumeHref(null);
       setResumeToHub(false);
+      setResumeSupportsAnotherCheckIn(false);
     };
 
     void run();
@@ -109,7 +118,9 @@ export function EpisodeStartHomeCta({
         {ctaMode === 'loading' && 'Checking for an episode in progress…'}
         {ctaMode === 'resume' &&
           (resumeToHub
-            ? 'You have an episode in progress. Continue opens your episode hub: return to the dashboard, log another full check-in, or end the episode when you are done.'
+            ? resumeSupportsAnotherCheckIn
+              ? 'You have an episode in progress. Continue opens your episode hub: return to the dashboard, log another full check-in, or end the episode when you are done.'
+              : 'You have an episode in progress. Continue opens your episode hub: return to the dashboard or end the episode when you are done.'
             : 'You have an episode in progress. Continue resumes the guided symptom flow where you left off.')}
         {ctaMode === 'start' &&
           'Opens the guided flow to record what you are experiencing during this episode.'}
@@ -118,7 +129,9 @@ export function EpisodeStartHomeCta({
         {ctaMode === 'loading' && 'Checking for an in-progress episode.'}
         {ctaMode === 'resume' &&
           (resumeToHub
-            ? 'An episode is in progress. Primary action: Continue this episode to the episode hub.'
+            ? resumeSupportsAnotherCheckIn
+              ? 'An episode is in progress. Primary action: Continue this episode to the episode hub where you can return to dashboard, log another check-in, or end it.'
+              : 'An episode is in progress. Primary action: Continue this episode to the episode hub where you can return to dashboard or end it.'
             : 'An episode is in progress. Primary action: Continue this episode in the guided symptom flow.')}
         {ctaMode === 'start' &&
           'No episode in progress. Primary action: start a new episode.'}

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -47,6 +47,24 @@ function trimToNull(value: string): string | null {
   return t.length > 0 ? t : null;
 }
 
+const timelineInstantFormatter = new Intl.DateTimeFormat(undefined, {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  timeZoneName: 'short',
+});
+
+function formatTimelineInstant(isoLike: string): string {
+  const ms = Date.parse(isoLike);
+  if (!Number.isFinite(ms)) {
+    return isoLike;
+  }
+  return timelineInstantFormatter.format(new Date(ms));
+}
+
 function findCurrentPassMarkerForLine(
   allRows: HealthMarkerRow[],
   line: PresetHealthMarkerRow,
@@ -249,7 +267,7 @@ export function HealthMarkerPromptFlow({
       return row === null;
     });
     if (resumeFromEntry) {
-      if (resumeToEpisodeHub) {
+      if (resumeToEpisodeHub && lastPost != null) {
         setPhase('complete');
       } else if (firstUnanswered === -1) {
         setPhase('foodDiary');
@@ -824,10 +842,7 @@ export function HealthMarkerPromptFlow({
                 {observationTimeline.map((row) => (
                   <li key={`${row.kind}-${row.id}`} className="break-words">
                     <span className="text-app-muted">
-                      {row.sortAt
-                        .replace('T', ' ')
-                        .replace(/\.\d{3}Z$/, ' UTC')
-                        .slice(0, 19)}
+                      {formatTimelineInstant(row.sortAt)}
                       {' — '}
                     </span>
                     {row.label}: {row.detail}
@@ -1125,10 +1140,7 @@ export function HealthMarkerPromptFlow({
               {observationTimeline.map((row) => (
                 <li key={`${row.kind}-${row.id}`} className="break-words">
                   <span className="text-app-muted">
-                    {row.sortAt
-                      .replace('T', ' ')
-                      .replace(/\.\d{3}Z$/, ' UTC')
-                      .slice(0, 19)}
+                    {formatTimelineInstant(row.sortAt)}
                     {' — '}
                   </span>
                   {row.label}: {row.detail}

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -191,9 +191,22 @@ export function HealthMarkerPromptFlow({
   >([]);
   const loadGenRef = useRef(0);
 
-  const onLeaveFoodDiary = useCallback((_decision: 'saved' | 'skipped') => {
-    setPhase('postMarkers');
-  }, []);
+  const refreshObservationTimeline = useCallback(async () => {
+    const tl = await listEpisodeObservationTimeline(supabase, episodeId);
+    if (tl.ok) {
+      setObservationTimeline(tl.data);
+      return;
+    }
+    setObservationTimeline([]);
+  }, [episodeId, supabase]);
+
+  const onLeaveFoodDiary = useCallback(
+    (_decision: 'saved' | 'skipped') => {
+      void refreshObservationTimeline();
+      setPhase('postMarkers');
+    },
+    [refreshObservationTimeline],
+  );
 
   const foodDiary = useEpisodeFoodDiary({
     episodeId,
@@ -519,6 +532,7 @@ export function HealthMarkerPromptFlow({
     setEpisodeRow(result.data);
     setEndFeedback(null);
     setEndedSummary(null);
+    await refreshObservationTimeline();
     setPhase('complete');
     announce(
       result.data.symptom_preset_id

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -30,6 +30,7 @@ import {
   listEpisodeObservationTimeline,
   listPresetHealthMarkersForPreset,
   type EpisodeTimelineItem,
+  upsertEpisodeTimelineItem,
 } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
@@ -45,38 +46,6 @@ type PersistFeedback =
 function trimToNull(value: string): string | null {
   const t = value.trim();
   return t.length > 0 ? t : null;
-}
-
-function compareTimelineItems(
-  a: EpisodeTimelineItem,
-  b: EpisodeTimelineItem,
-): number {
-  const aMs = Date.parse(a.sortAt);
-  const bMs = Date.parse(b.sortAt);
-  const aValid = Number.isFinite(aMs);
-  const bValid = Number.isFinite(bMs);
-  if (aValid && bValid) {
-    const c = aMs - bMs;
-    if (c !== 0) {
-      return c;
-    }
-  } else {
-    const c = a.sortAt.localeCompare(b.sortAt);
-    if (c !== 0) {
-      return c;
-    }
-  }
-  return a.id.localeCompare(b.id);
-}
-
-function upsertTimelineItem(
-  prev: EpisodeTimelineItem[],
-  next: EpisodeTimelineItem,
-): EpisodeTimelineItem[] {
-  const rows = prev.filter((r) => !(r.kind === next.kind && r.id === next.id));
-  rows.push(next);
-  rows.sort(compareTimelineItems);
-  return rows;
 }
 
 function healthMarkerDetailForTimeline(row: HealthMarkerRow): string {
@@ -424,7 +393,9 @@ export function HealthMarkerPromptFlow({
       label: markerLineTitle(currentLine),
       detail: healthMarkerDetailForTimeline(result.data),
     };
-    setObservationTimeline((prev) => upsertTimelineItem(prev, timelineItem));
+    setObservationTimeline((prev) =>
+      upsertEpisodeTimelineItem(prev, timelineItem),
+    );
     return true;
   };
 

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -235,6 +235,7 @@ export function HealthMarkerPromptFlow({
     foodDiary.reset();
     setEndFeedback(null);
     setEndedSummary(null);
+    setObservationTimeline([]);
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -337,6 +338,8 @@ export function HealthMarkerPromptFlow({
     }
     if (tl.ok) {
       setObservationTimeline(tl.data);
+    } else {
+      setObservationTimeline([]);
     }
   }, [
     episodeId,

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -11,6 +11,8 @@ import type {
 import {
   bacReadingSuggestsAbsEpisode,
   createDraftFromMarker,
+  filterHealthMarkerRowsForOpenPass,
+  findLatestHealthMarkerForLineInPass,
   formatEpisodeDurationSimple,
   markerLineTitle,
   minForPresetMarkerValueInput,
@@ -23,9 +25,11 @@ import {
   completeEpisodePostMarkerStep,
   endEpisodeIfStillActive,
   getEpisodeById,
+  insertEpisodeHealthMarkerForLine,
   listEpisodeHealthMarkersForEpisode,
+  listEpisodeObservationTimeline,
   listPresetHealthMarkersForPreset,
-  upsertEpisodeHealthMarkerForLine,
+  type EpisodeTimelineItem,
 } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
@@ -43,27 +47,38 @@ function trimToNull(value: string): string | null {
   return t.length > 0 ? t : null;
 }
 
-function findExistingMarkerForLine(
-  rows: HealthMarkerRow[],
+function findCurrentPassMarkerForLine(
+  allRows: HealthMarkerRow[],
   line: PresetHealthMarkerRow,
+  lastPostMarkerStepCompletedAt: string | null,
 ): HealthMarkerRow | null {
-  return rows.find((row) => row.preset_health_marker_id === line.id) ?? null;
+  const pass = filterHealthMarkerRowsForOpenPass(
+    allRows,
+    lastPostMarkerStepCompletedAt,
+  );
+  return findLatestHealthMarkerForLineInPass(pass, line);
 }
 
 export type HealthMarkerPromptFlowProps = {
   episodeId: string;
   resumeFromEntry?: boolean;
+  /**
+   * When true with `resumeFromEntry`, opens the episode hub (after a saved pass) instead of the
+   * marker stepper or food diary.
+   */
+  resumeToEpisodeHub?: boolean;
 };
 
 /**
  * Linear in-episode health marker stepper that runs after symptom prompts.
  *
- * @param props - Episode id and optional resume intent.
+ * @param props - Episode id and optional resume / hub intent.
  * @returns Marker prompt UI with per-line manual entry and persistence.
  */
 export function HealthMarkerPromptFlow({
   episodeId,
   resumeFromEntry = false,
+  resumeToEpisodeHub = false,
 }: HealthMarkerPromptFlowProps) {
   const router = useRouter();
   const { announce } = useAnnounce();
@@ -90,9 +105,6 @@ export function HealthMarkerPromptFlow({
   const [postNote, setPostNote] = useState('');
   const [savingPost, setSavingPost] = useState(false);
   const [postFeedback, setPostFeedback] = useState<string | null>(null);
-  const [foodDiaryDecision, setFoodDiaryDecision] = useState<
-    'pending' | 'saved' | 'skipped'
-  >('pending');
   const [endingEpisode, setEndingEpisode] = useState(false);
   const [endDialogOpen, setEndDialogOpen] = useState(false);
   const [endFeedback, setEndFeedback] = useState<string | null>(null);
@@ -104,10 +116,12 @@ export function HealthMarkerPromptFlow({
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [cancelingEpisode, setCancelingEpisode] = useState(false);
   const [episodeRow, setEpisodeRow] = useState<EpisodeRow | null>(null);
+  const [observationTimeline, setObservationTimeline] = useState<
+    EpisodeTimelineItem[]
+  >([]);
   const loadGenRef = useRef(0);
 
-  const onLeaveFoodDiary = useCallback((decision: 'saved' | 'skipped') => {
-    setFoodDiaryDecision(decision);
+  const onLeaveFoodDiary = useCallback((_decision: 'saved' | 'skipped') => {
     setPhase('postMarkers');
   }, []);
 
@@ -148,7 +162,6 @@ export function HealthMarkerPromptFlow({
     setPhase('prompting');
     postFormInitRef.current = false;
     setPostFeedback(null);
-    setFoodDiaryDecision('pending');
     foodDiary.reset();
     setEndFeedback(null);
     setEndedSummary(null);
@@ -214,9 +227,15 @@ export function HealthMarkerPromptFlow({
     }
 
     setLines(presetLines.data);
+    const lastPost: string | null =
+      episode.data?.post_marker_step_completed_at ?? null;
     const nextDrafts: Record<string, MarkerDraft> = {};
     for (const line of presetLines.data) {
-      const marker = findExistingMarkerForLine(markerRows.data, line);
+      const marker = findCurrentPassMarkerForLine(
+        markerRows.data,
+        line,
+        lastPost,
+      );
       nextDrafts[line.id] = createDraftFromMarker(marker);
     }
     setDrafts(nextDrafts);
@@ -226,16 +245,14 @@ export function HealthMarkerPromptFlow({
     setBacSuggestAbs(bacReadingSuggestsAbsEpisode(markerRows.data));
 
     const firstUnanswered = presetLines.data.findIndex((line) => {
-      const row = findExistingMarkerForLine(markerRows.data, line);
+      const row = findCurrentPassMarkerForLine(markerRows.data, line, lastPost);
       return row === null;
     });
     if (resumeFromEntry) {
-      if (firstUnanswered === -1) {
-        if (episode.data?.post_marker_step_completed_at) {
-          setPhase('complete');
-        } else {
-          setPhase('foodDiary');
-        }
+      if (resumeToEpisodeHub) {
+        setPhase('complete');
+      } else if (firstUnanswered === -1) {
+        setPhase('foodDiary');
       } else {
         setActiveIndex(firstUnanswered);
       }
@@ -243,7 +260,21 @@ export function HealthMarkerPromptFlow({
       setActiveIndex(0);
     }
     setStatus('ready');
-  }, [episodeId, foodDiary.reset, resumeFromEntry, supabase]);
+
+    const tl = await listEpisodeObservationTimeline(supabase, episodeId);
+    if (isStale()) {
+      return;
+    }
+    if (tl.ok) {
+      setObservationTimeline(tl.data);
+    }
+  }, [
+    episodeId,
+    foodDiary.reset,
+    resumeFromEntry,
+    resumeToEpisodeHub,
+    supabase,
+  ]);
 
   useEffect(() => {
     void load();
@@ -311,7 +342,7 @@ export function HealthMarkerPromptFlow({
 
     setSaving(true);
     setPersistFeedback(null);
-    const result = await upsertEpisodeHealthMarkerForLine(supabase, {
+    const result = await insertEpisodeHealthMarkerForLine(supabase, {
       userId,
       episodeId,
       line: currentLine,
@@ -328,7 +359,10 @@ export function HealthMarkerPromptFlow({
       });
       return false;
     }
-
+    const tl = await listEpisodeObservationTimeline(supabase, episodeId);
+    if (tl.ok) {
+      setObservationTimeline(tl.data);
+    }
     return true;
   };
 
@@ -409,8 +443,31 @@ export function HealthMarkerPromptFlow({
     setEndFeedback(null);
     setEndedSummary(null);
     setPhase('complete');
-    announce('Episode details saved.', { politeness: 'polite' });
+    announce(
+      result.data.symptom_preset_id
+        ? 'This check-in is saved. You can log another when you are ready, or return to the dashboard.'
+        : 'Episode details saved.',
+      { politeness: 'polite' },
+    );
   };
+
+  const onLogAnotherCheckIn = useCallback(() => {
+    const presetId = episodeRow?.symptom_preset_id;
+    if (!presetId) {
+      const message =
+        'This episode has no symptom preset linked, so another check-in cannot start here.';
+      announce(message, { politeness: 'assertive' });
+      return;
+    }
+    clearSymptomPromptSession(episodeId);
+    const q = new URLSearchParams();
+    q.set('symptomPresetId', presetId);
+    q.set('resume', '1');
+    announce('Opening symptoms for another check-in.', {
+      politeness: 'polite',
+    });
+    router.push(`/episode/${episodeId}/symptoms?${q.toString()}`);
+  }, [announce, episodeId, episodeRow?.symptom_preset_id, router]);
 
   const onBackToHealthMarkersFromFoodDiary = () => {
     setPhase('prompting');
@@ -747,8 +804,38 @@ export function HealthMarkerPromptFlow({
       <>
         <div className="space-y-4">
           <h1 className="text-2xl font-bold tracking-tight text-app-ink">
-            Episode health markers
+            {endedSummary ? 'Episode health markers' : 'This check-in is saved'}
           </h1>
+          {observationTimeline.length > 0 ? (
+            <section
+              className="rounded-2xl border border-app-border/90 bg-app-surface/60 p-4"
+              aria-label="Log so far in this episode"
+            >
+              <h2 className="text-sm font-semibold text-app-ink">
+                Log so far in this episode
+              </h2>
+              <p className="mt-1 text-xs text-app-muted" id="ep-hub-tl-hint">
+                Oldest first. New entries are added as you go.
+              </p>
+              <ol
+                className="mt-3 list-decimal space-y-2 pl-5 text-sm text-app-ink"
+                aria-describedby="ep-hub-tl-hint"
+              >
+                {observationTimeline.map((row) => (
+                  <li key={`${row.kind}-${row.id}`} className="break-words">
+                    <span className="text-app-muted">
+                      {row.sortAt
+                        .replace('T', ' ')
+                        .replace(/\.\d{3}Z$/, ' UTC')
+                        .slice(0, 19)}
+                      {' — '}
+                    </span>
+                    {row.label}: {row.detail}
+                  </li>
+                ))}
+              </ol>
+            </section>
+          ) : null}
           <div
             className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
             role="status"
@@ -767,11 +854,16 @@ export function HealthMarkerPromptFlow({
                 </p>
               </div>
             ) : (
-              <p className="text-sm leading-relaxed text-app-ink">
-                {foodDiaryDecision === 'saved'
-                  ? 'Preset prompts, episode details, and food diary are saved. End this episode to prevent stale resume state.'
-                  : 'Preset prompts and episode details are saved. End this episode to prevent stale resume state.'}
-              </p>
+              <div className="space-y-3 text-sm leading-relaxed text-app-ink">
+                <p>
+                  This round is saved: symptoms, health markers, any food diary
+                  entries you added, and episode details.
+                </p>
+                <p className="text-app-muted">
+                  Return to the dashboard, log another full check-in when you
+                  are ready, or end this episode when you are completely done.
+                </p>
+              </div>
             )}
           </div>
           {endFeedback ? (
@@ -788,16 +880,34 @@ export function HealthMarkerPromptFlow({
               Back to dashboard
             </button>
           ) : (
-            <button
-              type="button"
-              className="inline-flex min-h-[56px] items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:bg-red-600 dark:hover:bg-red-500"
-              onClick={() => {
-                setEndDialogOpen(true);
-              }}
-              disabled={endingEpisode}
-            >
-              {endingEpisode ? 'Ending episode…' : 'End episode'}
-            </button>
+            <div className="flex flex-col gap-3 sm:max-w-md">
+              {episodeRow?.symptom_preset_id ? (
+                <button
+                  type="button"
+                  className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 text-base font-semibold text-white shadow-md transition hover:bg-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-600 dark:hover:bg-red-500"
+                  onClick={onLogAnotherCheckIn}
+                >
+                  Log another check-in
+                </button>
+              ) : null}
+              <button
+                type="button"
+                className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-surface px-5 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-neutral-600 dark:bg-neutral-900/60"
+                onClick={onFinishToDashboard}
+              >
+                Back to dashboard
+              </button>
+              <button
+                type="button"
+                className="inline-flex min-h-[56px] w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-surface px-5 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:opacity-60 dark:border-neutral-600 dark:bg-neutral-900/60"
+                onClick={() => {
+                  setEndDialogOpen(true);
+                }}
+                disabled={endingEpisode}
+              >
+                {endingEpisode ? 'Ending episode…' : 'End episode'}
+              </button>
+            </div>
           )}
         </div>
         <ConfirmDialog
@@ -997,6 +1107,36 @@ export function HealthMarkerPromptFlow({
                 : 'Next'}
           </button>
         </div>
+        {observationTimeline.length > 0 ? (
+          <section
+            className="rounded-2xl border border-app-border/90 bg-app-surface/60 p-4"
+            aria-label="Log so far in this episode"
+          >
+            <h2 className="text-sm font-semibold text-app-ink">
+              Log so far in this episode
+            </h2>
+            <p className="mt-1 text-xs text-app-muted" id="ep-tl-hint">
+              Oldest first. New entries are added as you go.
+            </p>
+            <ol
+              className="mt-3 list-decimal space-y-2 pl-5 text-sm text-app-ink"
+              aria-describedby="ep-tl-hint"
+            >
+              {observationTimeline.map((row) => (
+                <li key={`${row.kind}-${row.id}`} className="break-words">
+                  <span className="text-app-muted">
+                    {row.sortAt
+                      .replace('T', ' ')
+                      .replace(/\.\d{3}Z$/, ' UTC')
+                      .slice(0, 19)}
+                    {' — '}
+                  </span>
+                  {row.label}: {row.detail}
+                </li>
+              ))}
+            </ol>
+          </section>
+        ) : null}
         <button
           type="button"
           className="inline-flex min-h-[44px] items-center justify-center rounded-lg px-3 py-2 text-sm font-medium text-red-700 transition hover:text-red-800 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:text-red-300 dark:hover:text-red-200"

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -12,6 +12,7 @@ import {
   bacReadingSuggestsAbsEpisode,
   createDraftFromMarker,
   filterHealthMarkerRowsForOpenPass,
+  findLatestHealthMarkerForLineInPass,
   formatEpisodeDurationSimple,
   markerLineTitle,
   minForPresetMarkerValueInput,
@@ -96,52 +97,6 @@ function healthMarkerDetailForTimeline(row: HealthMarkerRow): string {
   }
   const n = row.notes?.trim();
   return n ? (n.length > 80 ? `${n.slice(0, 77)}…` : n) : '—';
-}
-
-function isHealthMarkerRowLater(
-  a: HealthMarkerRow,
-  b: HealthMarkerRow,
-): boolean {
-  const recA = Date.parse(a.recorded_at);
-  const recB = Date.parse(b.recorded_at);
-  const recAValid = Number.isFinite(recA);
-  const recBValid = Number.isFinite(recB);
-  if (recAValid && recBValid && recA !== recB) {
-    return recA > recB;
-  }
-  if (recAValid !== recBValid) {
-    return recAValid;
-  }
-
-  const createdA = Date.parse(a.created_at);
-  const createdB = Date.parse(b.created_at);
-  const createdAValid = Number.isFinite(createdA);
-  const createdBValid = Number.isFinite(createdB);
-  if (createdAValid && createdBValid && createdA !== createdB) {
-    return createdA > createdB;
-  }
-  if (createdAValid !== createdBValid) {
-    return createdAValid;
-  }
-
-  return a.id.localeCompare(b.id) > 0;
-}
-
-function buildLatestMarkerByLineMap(
-  passRows: HealthMarkerRow[],
-): Map<string, HealthMarkerRow> {
-  const latestByLine = new Map<string, HealthMarkerRow>();
-  for (const row of passRows) {
-    const lineId = row.preset_health_marker_id;
-    if (!lineId) {
-      continue;
-    }
-    const prev = latestByLine.get(lineId);
-    if (!prev || isHealthMarkerRowLater(row, prev)) {
-      latestByLine.set(lineId, row);
-    }
-  }
-  return latestByLine;
 }
 
 export type HealthMarkerPromptFlowProps = {
@@ -332,11 +287,14 @@ export function HealthMarkerPromptFlow({
       markerRows.data,
       lastPost,
     );
-    const latestMarkerByLine = buildLatestMarkerByLineMap(passRows);
     const nextDrafts: Record<string, MarkerDraft> = {};
-    for (const line of presetLines.data) {
-      const marker = latestMarkerByLine.get(line.id) ?? null;
+    let firstUnanswered = -1;
+    for (const [idx, line] of presetLines.data.entries()) {
+      const marker = findLatestHealthMarkerForLineInPass(passRows, line);
       nextDrafts[line.id] = createDraftFromMarker(marker);
+      if (firstUnanswered === -1 && marker == null) {
+        firstUnanswered = idx;
+      }
     }
     setDrafts(nextDrafts);
 
@@ -344,9 +302,6 @@ export function HealthMarkerPromptFlow({
     // enterFoodDiaryPhaseAfterMarkers before the food diary step.
     setBacSuggestAbs(bacReadingSuggestsAbsEpisode(markerRows.data));
 
-    const firstUnanswered = presetLines.data.findIndex(
-      (line) => !latestMarkerByLine.has(line.id),
-    );
     if (resumeFromEntry) {
       if (resumeToEpisodeHub && lastPost != null) {
         setPhase('complete');

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -65,6 +65,58 @@ function formatTimelineInstant(isoLike: string): string {
   return timelineInstantFormatter.format(new Date(ms));
 }
 
+function compareTimelineItems(
+  a: EpisodeTimelineItem,
+  b: EpisodeTimelineItem,
+): number {
+  const aMs = Date.parse(a.sortAt);
+  const bMs = Date.parse(b.sortAt);
+  const aValid = Number.isFinite(aMs);
+  const bValid = Number.isFinite(bMs);
+  if (aValid && bValid) {
+    const c = aMs - bMs;
+    if (c !== 0) {
+      return c;
+    }
+  } else {
+    const c = a.sortAt.localeCompare(b.sortAt);
+    if (c !== 0) {
+      return c;
+    }
+  }
+  return a.id.localeCompare(b.id);
+}
+
+function upsertTimelineItem(
+  prev: EpisodeTimelineItem[],
+  next: EpisodeTimelineItem,
+): EpisodeTimelineItem[] {
+  const rows = prev.filter((r) => !(r.kind === next.kind && r.id === next.id));
+  rows.push(next);
+  rows.sort(compareTimelineItems);
+  return rows;
+}
+
+function healthMarkerDetailForTimeline(row: HealthMarkerRow): string {
+  if (row.marker_kind === 'blood_pressure') {
+    if (row.systolic_numeric != null && row.diastolic_numeric != null) {
+      return `${row.systolic_numeric}/${row.diastolic_numeric}`;
+    }
+    return '—';
+  }
+  if (row.value_numeric != null) {
+    let detail = String(row.value_numeric);
+    if (row.custom_unit) {
+      detail = `${detail} ${row.custom_unit}`;
+    } else if (row.marker_kind === 'bac') {
+      detail = `${detail} g/dL`;
+    }
+    return detail;
+  }
+  const n = row.notes?.trim();
+  return n ? (n.length > 80 ? `${n.slice(0, 77)}…` : n) : '—';
+}
+
 function findCurrentPassMarkerForLine(
   allRows: HealthMarkerRow[],
   line: PresetHealthMarkerRow,
@@ -377,10 +429,14 @@ export function HealthMarkerPromptFlow({
       });
       return false;
     }
-    const tl = await listEpisodeObservationTimeline(supabase, episodeId);
-    if (tl.ok) {
-      setObservationTimeline(tl.data);
-    }
+    const timelineItem: EpisodeTimelineItem = {
+      kind: 'health_marker',
+      sortAt: result.data.recorded_at,
+      id: result.data.id,
+      label: markerLineTitle(currentLine),
+      detail: healthMarkerDetailForTimeline(result.data),
+    };
+    setObservationTimeline((prev) => upsertTimelineItem(prev, timelineItem));
     return true;
   };
 

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -12,7 +12,6 @@ import {
   bacReadingSuggestsAbsEpisode,
   createDraftFromMarker,
   filterHealthMarkerRowsForOpenPass,
-  findLatestHealthMarkerForLineInPass,
   formatEpisodeDurationSimple,
   markerLineTitle,
   minForPresetMarkerValueInput,
@@ -117,16 +116,50 @@ function healthMarkerDetailForTimeline(row: HealthMarkerRow): string {
   return n ? (n.length > 80 ? `${n.slice(0, 77)}…` : n) : '—';
 }
 
-function findCurrentPassMarkerForLine(
-  allRows: HealthMarkerRow[],
-  line: PresetHealthMarkerRow,
-  lastPostMarkerStepCompletedAt: string | null,
-): HealthMarkerRow | null {
-  const pass = filterHealthMarkerRowsForOpenPass(
-    allRows,
-    lastPostMarkerStepCompletedAt,
-  );
-  return findLatestHealthMarkerForLineInPass(pass, line);
+function isHealthMarkerRowLater(
+  a: HealthMarkerRow,
+  b: HealthMarkerRow,
+): boolean {
+  const recA = Date.parse(a.recorded_at);
+  const recB = Date.parse(b.recorded_at);
+  const recAValid = Number.isFinite(recA);
+  const recBValid = Number.isFinite(recB);
+  if (recAValid && recBValid && recA !== recB) {
+    return recA > recB;
+  }
+  if (recAValid !== recBValid) {
+    return recAValid;
+  }
+
+  const createdA = Date.parse(a.created_at);
+  const createdB = Date.parse(b.created_at);
+  const createdAValid = Number.isFinite(createdA);
+  const createdBValid = Number.isFinite(createdB);
+  if (createdAValid && createdBValid && createdA !== createdB) {
+    return createdA > createdB;
+  }
+  if (createdAValid !== createdBValid) {
+    return createdAValid;
+  }
+
+  return a.id.localeCompare(b.id) > 0;
+}
+
+function buildLatestMarkerByLineMap(
+  passRows: HealthMarkerRow[],
+): Map<string, HealthMarkerRow> {
+  const latestByLine = new Map<string, HealthMarkerRow>();
+  for (const row of passRows) {
+    const lineId = row.preset_health_marker_id;
+    if (!lineId) {
+      continue;
+    }
+    const prev = latestByLine.get(lineId);
+    if (!prev || isHealthMarkerRowLater(row, prev)) {
+      latestByLine.set(lineId, row);
+    }
+  }
+  return latestByLine;
 }
 
 export type HealthMarkerPromptFlowProps = {
@@ -313,13 +346,14 @@ export function HealthMarkerPromptFlow({
     setLines(presetLines.data);
     const lastPost: string | null =
       episode.data?.post_marker_step_completed_at ?? null;
+    const passRows = filterHealthMarkerRowsForOpenPass(
+      markerRows.data,
+      lastPost,
+    );
+    const latestMarkerByLine = buildLatestMarkerByLineMap(passRows);
     const nextDrafts: Record<string, MarkerDraft> = {};
     for (const line of presetLines.data) {
-      const marker = findCurrentPassMarkerForLine(
-        markerRows.data,
-        line,
-        lastPost,
-      );
+      const marker = latestMarkerByLine.get(line.id) ?? null;
       nextDrafts[line.id] = createDraftFromMarker(marker);
     }
     setDrafts(nextDrafts);
@@ -328,10 +362,9 @@ export function HealthMarkerPromptFlow({
     // enterFoodDiaryPhaseAfterMarkers before the food diary step.
     setBacSuggestAbs(bacReadingSuggestsAbsEpisode(markerRows.data));
 
-    const firstUnanswered = presetLines.data.findIndex((line) => {
-      const row = findCurrentPassMarkerForLine(markerRows.data, line, lastPost);
-      return row === null;
-    });
+    const firstUnanswered = presetLines.data.findIndex(
+      (line) => !latestMarkerByLine.has(line.id),
+    );
     if (resumeFromEntry) {
       if (resumeToEpisodeHub && lastPost != null) {
         setPhase('complete');
@@ -345,7 +378,9 @@ export function HealthMarkerPromptFlow({
     }
     setStatus('ready');
 
-    const tl = await listEpisodeObservationTimeline(supabase, episodeId);
+    const tl = await listEpisodeObservationTimeline(supabase, episodeId, {
+      prefetchedHealthMarkers: markerRows.data,
+    });
     if (isStale()) {
       return;
     }

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -46,24 +46,6 @@ function trimToNull(value: string): string | null {
   return t.length > 0 ? t : null;
 }
 
-const timelineInstantFormatter = new Intl.DateTimeFormat(undefined, {
-  year: 'numeric',
-  month: '2-digit',
-  day: '2-digit',
-  hour: '2-digit',
-  minute: '2-digit',
-  second: '2-digit',
-  timeZoneName: 'short',
-});
-
-function formatTimelineInstant(isoLike: string): string {
-  const ms = Date.parse(isoLike);
-  if (!Number.isFinite(ms)) {
-    return isoLike;
-  }
-  return timelineInstantFormatter.format(new Date(ms));
-}
-
 function compareTimelineItems(
   a: EpisodeTimelineItem,
   b: EpisodeTimelineItem,
@@ -950,7 +932,7 @@ export function HealthMarkerPromptFlow({
                 {observationTimeline.map((row) => (
                   <li key={`${row.kind}-${row.id}`} className="break-words">
                     <span className="text-app-muted">
-                      {formatTimelineInstant(row.sortAt)}
+                      <EpisodeLocaleInstant iso={row.sortAt} />
                       {' — '}
                     </span>
                     {row.label}: {row.detail}
@@ -1248,7 +1230,7 @@ export function HealthMarkerPromptFlow({
               {observationTimeline.map((row) => (
                 <li key={`${row.kind}-${row.id}`} className="break-words">
                   <span className="text-app-muted">
-                    {formatTimelineInstant(row.sortAt)}
+                    <EpisodeLocaleInstant iso={row.sortAt} />
                     {' — '}
                   </span>
                   {row.label}: {row.detail}

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -843,13 +843,13 @@ export function HealthMarkerPromptFlow({
           {observationTimeline.length > 0 ? (
             <section
               className="rounded-2xl border border-app-border/90 bg-app-surface/60 p-4"
-              aria-label="Log so far in this episode"
+              aria-label="Recent log entries in this episode"
             >
               <h2 className="text-sm font-semibold text-app-ink">
-                Log so far in this episode
+                Recent log entries in this episode
               </h2>
               <p className="mt-1 text-xs text-app-muted" id="ep-hub-tl-hint">
-                Oldest first. New entries are added as you go.
+                Showing recent entries only. Oldest first within this slice.
               </p>
               <ol
                 className="mt-3 list-decimal space-y-2 pl-5 text-sm text-app-ink"
@@ -1141,13 +1141,13 @@ export function HealthMarkerPromptFlow({
         {observationTimeline.length > 0 ? (
           <section
             className="rounded-2xl border border-app-border/90 bg-app-surface/60 p-4"
-            aria-label="Log so far in this episode"
+            aria-label="Recent log entries in this episode"
           >
             <h2 className="text-sm font-semibold text-app-ink">
-              Log so far in this episode
+              Recent log entries in this episode
             </h2>
             <p className="mt-1 text-xs text-app-muted" id="ep-tl-hint">
-              Oldest first. New entries are added as you go.
+              Showing recent entries only. Oldest first within this slice.
             </p>
             <ol
               className="mt-3 list-decimal space-y-2 pl-5 text-sm text-app-ink"

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -61,9 +61,6 @@ export type SymptomPromptFlowProps = {
 /** Delay before writing free-text drafts to `sessionStorage` (keystrokes stay snappy in React state). */
 const FREE_TEXT_PERSIST_DEBOUNCE_MS = 300;
 
-/** Same debounce for Supabase `episode_symptoms` writes (plaintext columns under RLS). */
-const SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS = 300;
-
 function clampIndex(index: number, length: number): number {
   if (length <= 0) {
     return 0;
@@ -123,7 +120,7 @@ export function SymptomPromptFlow({
   const serverPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  /** Latest debounced free-text payload; cleared when the write runs or is flushed. */
+  /** Latest staged free-text payload; flushed on explicit commit actions. */
   const pendingServerFreeTextPersistRef = useRef<{
     line: PresetSymptomRow;
     answer: SymptomPromptAnswer;
@@ -340,8 +337,8 @@ export function SymptomPromptFlow({
   );
 
   /**
-   * Clears the debounced server timer and immediately persists the latest free-text
-   * payload (if any). Call before navigation / unmount so the last keystrokes are not lost.
+   * Flushes the latest staged free-text payload (if any). Call before navigation / unmount so the
+   * last keystrokes are committed once per explicit transition.
    */
   const flushPendingServerPersist = useCallback(() => {
     if (serverPersistTimerRef.current !== null) {
@@ -380,15 +377,10 @@ export function SymptomPromptFlow({
         pendingServerFreeTextPersistRef.current = { line, answer };
         if (serverPersistTimerRef.current !== null) {
           clearTimeout(serverPersistTimerRef.current);
-        }
-        serverPersistTimerRef.current = setTimeout(() => {
           serverPersistTimerRef.current = null;
-          const pending = pendingServerFreeTextPersistRef.current;
-          pendingServerFreeTextPersistRef.current = null;
-          if (pending) {
-            executeServerPersist(pending.line, pending.answer);
-          }
-        }, SERVER_SYMPTOM_PERSIST_DEBOUNCE_MS);
+        }
+        // Intentional: append-only insert semantics for free-text require explicit commit writes
+        // (Next/Back/route change) to avoid generating duplicate rows from typing pauses.
       } else {
         pendingServerFreeTextPersistRef.current = null;
         if (serverPersistTimerRef.current !== null) {

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -117,9 +117,6 @@ export function SymptomPromptFlow({
   const textPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
     null,
   );
-  const serverPersistTimerRef = useRef<ReturnType<typeof setTimeout> | null>(
-    null,
-  );
   /** Latest staged free-text payload; flushed on explicit commit actions. */
   const pendingServerFreeTextPersistRef = useRef<{
     line: PresetSymptomRow;
@@ -136,7 +133,7 @@ export function SymptomPromptFlow({
   /**
    * Bumped only by {@link cancelPendingServerPersist}. Used with mount + episode id to gate
    * {@link setPersistError} only — insert/delete for the captured `enqueueEpisodeId` always runs
-   * so Supabase stays aligned when the user navigates or cancels debounced work.
+   * so Supabase stays aligned when the user navigates or cancels staged work.
    */
   const serverPersistEpochRef = useRef(0);
   /**
@@ -341,10 +338,6 @@ export function SymptomPromptFlow({
    * last keystrokes are committed once per explicit transition.
    */
   const flushPendingServerPersist = useCallback(() => {
-    if (serverPersistTimerRef.current !== null) {
-      clearTimeout(serverPersistTimerRef.current);
-      serverPersistTimerRef.current = null;
-    }
     const pending = pendingServerFreeTextPersistRef.current;
     pendingServerFreeTextPersistRef.current = null;
     if (!pending) {
@@ -358,10 +351,6 @@ export function SymptomPromptFlow({
    * Used before skip/delete so a delayed insert cannot recreate a row after delete.
    */
   const cancelPendingServerPersist = useCallback(() => {
-    if (serverPersistTimerRef.current !== null) {
-      clearTimeout(serverPersistTimerRef.current);
-      serverPersistTimerRef.current = null;
-    }
     pendingServerFreeTextPersistRef.current = null;
     serverPersistEpochRef.current += 1;
   }, []);
@@ -375,18 +364,10 @@ export function SymptomPromptFlow({
       }
       if (answer.type === 'free_text') {
         pendingServerFreeTextPersistRef.current = { line, answer };
-        if (serverPersistTimerRef.current !== null) {
-          clearTimeout(serverPersistTimerRef.current);
-          serverPersistTimerRef.current = null;
-        }
         // Intentional: append-only insert semantics for free-text require explicit commit writes
         // (Next/Back/route change) to avoid generating duplicate rows from typing pauses.
       } else {
         pendingServerFreeTextPersistRef.current = null;
-        if (serverPersistTimerRef.current !== null) {
-          clearTimeout(serverPersistTimerRef.current);
-          serverPersistTimerRef.current = null;
-        }
         executeServerPersist(line, answer);
       }
     },

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -14,19 +14,23 @@ import type {
   SymptomPromptAnswer,
   SymptomPromptAnswers,
 } from '@abstrack/types';
+import type { EpisodeRow } from '@abstrack/types';
 import {
   computeSymptomResumePlacement,
   createDefaultSymptomPromptAnswer,
   createInitialSymptomPromptSession,
-  episodeSymptomRowsToAnswersMap,
+  episodeSymptomRowsToAnswersMapForOpenPass,
+  formatEpisodeDurationSimple,
   symptomPromptAnswerHasValue,
 } from '@abstrack/types';
 import {
   cancelActiveEpisodeById,
-  deleteEpisodeSymptomAnswer,
+  deleteCurrentPassEpisodeSymptomAnswer,
+  endEpisodeIfStillActive,
+  getEpisodeById,
+  insertEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
   listPresetSymptomsForPreset,
-  upsertEpisodeSymptomAnswer,
 } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
@@ -156,6 +160,13 @@ export function SymptomPromptFlow({
   const [discardDialogOpen, setDiscardDialogOpen] = useState(false);
   const [cancelDialogOpen, setCancelDialogOpen] = useState(false);
   const [cancelingEpisode, setCancelingEpisode] = useState(false);
+  const [endEpisodeDialogOpen, setEndEpisodeDialogOpen] = useState(false);
+  const [endingEpisode, setEndingEpisode] = useState(false);
+  const [endEpisodeError, setEndEpisodeError] = useState<string | null>(null);
+  const [episodeForEndCta, setEpisodeForEndCta] = useState<EpisodeRow | null>(
+    null,
+  );
+  const lastPostMarkerStepCompletedAtRef = useRef<string | null>(null);
   const pendingLeaveRef = useRef<PendingLeaveAction | null>(null);
   /**
    * When `episodeId` / `symptomPresetId` change, the layout reset syncs this to `resumeFromEntry` so a
@@ -238,7 +249,7 @@ export function SymptomPromptFlow({
             }
             return;
           }
-          const r = await upsertEpisodeSymptomAnswer(supabase, {
+          const r = await insertEpisodeSymptomAnswer(supabase, {
             userId: uid,
             episodeId: targetEpisodeId,
             line,
@@ -298,9 +309,11 @@ export function SymptomPromptFlow({
             }
             return;
           }
-          const r = await deleteEpisodeSymptomAnswer(supabase, {
+          const r = await deleteCurrentPassEpisodeSymptomAnswer(supabase, {
             episodeId: targetEpisodeId,
             presetSymptomId: line.id,
+            lastPostMarkerStepCompletedAt:
+              lastPostMarkerStepCompletedAtRef.current,
           });
           // Epoch/mount/episode/attempt gate UI only — the delete above always ran for `targetEpisodeId`.
           if (
@@ -516,6 +529,24 @@ export function SymptomPromptFlow({
       setStatus('error');
       return;
     }
+    const ep = await getEpisodeById(supabase, episodeId);
+    if (stale()) {
+      return;
+    }
+    if (!ep.ok) {
+      setErrorMessage(ep.error.message);
+      setStatus('error');
+      return;
+    }
+    if (!ep.data) {
+      setErrorMessage('Could not load this episode.');
+      setStatus('error');
+      return;
+    }
+    setEpisodeForEndCta(ep.data);
+    const passBoundary = ep.data.post_marker_step_completed_at ?? null;
+    lastPostMarkerStepCompletedAtRef.current = passBoundary;
+
     const result = await listPresetSymptomsForPreset(supabase, symptomPresetId);
     if (stale()) {
       return;
@@ -531,7 +562,7 @@ export function SymptomPromptFlow({
       return;
     }
     const serverAnswers = fromServer.ok
-      ? episodeSymptomRowsToAnswersMap(fromServer.data)
+      ? episodeSymptomRowsToAnswersMapForOpenPass(fromServer.data, passBoundary)
       : {};
     const session = getSymptomPromptSession(episodeId);
     // Session overlays server so local drafts survive hydrate (debounced/offline/failed sync).
@@ -758,6 +789,59 @@ export function SymptomPromptFlow({
     supabase,
   ]);
 
+  const handleEndEpisodeConfirm = useCallback(async (): Promise<
+    void | false
+  > => {
+    if (endingEpisode || !episodeForEndCta) {
+      return false;
+    }
+    setEndingEpisode(true);
+    setEndEpisodeError(null);
+    try {
+      const nowIso = new Date().toISOString();
+      const startedAtMs = Date.parse(episodeForEndCta.started_at);
+      const nowMs = Date.parse(nowIso);
+      const endedAt =
+        Number.isFinite(startedAtMs) &&
+        Number.isFinite(nowMs) &&
+        nowMs < startedAtMs
+          ? episodeForEndCta.started_at
+          : nowIso;
+      const result = await endEpisodeIfStillActive(
+        supabase,
+        episodeId,
+        endedAt,
+        episodeForEndCta.started_at,
+      );
+      if (!result.ok) {
+        setEndEpisodeError(result.error.message);
+        announce(result.error.message, { politeness: 'assertive' });
+        return false;
+      }
+      clearSymptomPromptSession(episodeId);
+      omitSymptomPromptSnapshotOnUnmountRef.current = true;
+      if (result.data.didEnd) {
+        const durationText = formatEpisodeDurationSimple(
+          episodeForEndCta.started_at,
+          endedAt,
+        );
+        announce(
+          durationText
+            ? `Episode ended. Duration ${durationText}.`
+            : 'Episode ended.',
+          { politeness: 'polite' },
+        );
+        setEndEpisodeDialogOpen(false);
+        router.push('/dashboard');
+        return;
+      }
+      setEndEpisodeError('This episode is no longer active.');
+      return false;
+    } finally {
+      setEndingEpisode(false);
+    }
+  }, [announce, endingEpisode, episodeForEndCta, episodeId, router, supabase]);
+
   const goNext = () => {
     flushPendingTextPersist();
     flushPendingServerPersist();
@@ -931,6 +1015,28 @@ export function SymptomPromptFlow({
         >
           Cancel episode
         </button>
+        {episodeForEndCta?.post_marker_step_completed_at &&
+        !episodeForEndCta.ended_at ? (
+          <>
+            <button
+              type="button"
+              className="inline-flex min-h-[48px] w-full max-w-md items-center justify-center rounded-xl border-2 border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+              onClick={() => {
+                setEndEpisodeDialogOpen(true);
+              }}
+            >
+              End this episode
+            </button>
+            {endEpisodeError ? (
+              <p
+                className="text-sm text-red-700 dark:text-red-300"
+                role="alert"
+              >
+                {endEpisodeError}
+              </p>
+            ) : null}
+          </>
+        ) : null}
       </div>
 
       <ConfirmDialog
@@ -957,6 +1063,18 @@ export function SymptomPromptFlow({
         onConfirm={handleCancelEpisodeConfirm}
         onClose={() => {
           setCancelDialogOpen(false);
+        }}
+      />
+      <ConfirmDialog
+        open={endEpisodeDialogOpen}
+        title="End this episode now?"
+        description="Ending sets this episode as complete. You can still view it in your episode history when you are ready."
+        confirmLabel="End episode"
+        confirmBusyLabel="Ending episode…"
+        cancelLabel="Not yet"
+        onConfirm={handleEndEpisodeConfirm}
+        onClose={() => {
+          setEndEpisodeDialogOpen(false);
         }}
       />
     </>

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -126,7 +126,7 @@ export function SymptomPromptFlow({
     answer: SymptomPromptAnswer;
   } | null>(null);
   /**
-   * Per (episode, preset symptom) write queue so upsert/delete requests execute in user action
+   * Per (episode, preset symptom) write queue so insert/delete requests execute in user action
    * order within an episode only — not across `episodeId` changes while mounted.
    */
   const lineWriteQueueRef = useRef<Map<string, Promise<void>>>(new Map());
@@ -135,7 +135,7 @@ export function SymptomPromptFlow({
   const loadGenRef = useRef(0);
   /**
    * Bumped only by {@link cancelPendingServerPersist}. Used with mount + episode id to gate
-   * {@link setPersistError} only — upsert/delete for the captured `enqueueEpisodeId` always runs
+   * {@link setPersistError} only — insert/delete for the captured `enqueueEpisodeId` always runs
    * so Supabase stays aligned when the user navigates or cancels debounced work.
    */
   const serverPersistEpochRef = useRef(0);
@@ -252,7 +252,7 @@ export function SymptomPromptFlow({
             line,
             answer,
           });
-          // Epoch/mount/episode/attempt gate UI only — the upsert above always ran for `targetEpisodeId`.
+          // Epoch/mount/episode/attempt gate UI only — the insert above always ran for `targetEpisodeId`.
           if (
             isMountedRef.current &&
             episodeIdRef.current === enqueueEpisodeId &&
@@ -354,8 +354,8 @@ export function SymptomPromptFlow({
   }, [executeServerPersist]);
 
   /**
-   * Cancels any pending debounced free-text upsert and invalidates older in-flight persists.
-   * Used before skip/delete so a delayed upsert cannot recreate a row after delete.
+   * Cancels any pending staged free-text insert and invalidates older in-flight persists.
+   * Used before skip/delete so a delayed insert cannot recreate a row after delete.
    */
   const cancelPendingServerPersist = useCallback(() => {
     if (serverPersistTimerRef.current !== null) {

--- a/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
+++ b/apps/web/src/components/episodes/ActiveEpisodeCard.tsx
@@ -98,8 +98,7 @@ export function ActiveEpisodeCard({
                 episode.id,
                 episode.symptom_preset_id,
                 {
-                  toHealthMarkers:
-                    episode.post_marker_step_completed_at != null,
+                  toEpisodeHub: episode.post_marker_step_completed_at != null,
                 },
               )}
               className={resumeLinkClass}

--- a/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
@@ -9,11 +9,14 @@ describe('buildResumeEpisodeHref', () => {
     expect(url.searchParams.get('resume')).toBe('1');
   });
 
-  it('builds direct health-marker resume link when requested', () => {
+  it('builds episode-hub health-marker resume link when requested', () => {
     const href = buildResumeEpisodeHref('ep-uuid', null, {
       toHealthMarkers: true,
     });
-    expect(href).toBe('/episode/ep-uuid/health-markers?resume=1');
+    const url = new URL(`https://example.test${href}`);
+    expect(url.pathname).toBe('/episode/ep-uuid/health-markers');
+    expect(url.searchParams.get('resume')).toBe('1');
+    expect(url.searchParams.get('hub')).toBe('1');
   });
 
   it('throws when symptom resume has no symptomPresetId', () => {

--- a/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
@@ -11,7 +11,7 @@ describe('buildResumeEpisodeHref', () => {
 
   it('builds episode-hub health-marker resume link when requested', () => {
     const href = buildResumeEpisodeHref('ep-uuid', null, {
-      toHealthMarkers: true,
+      toEpisodeHub: true,
     });
     const url = new URL(`https://example.test${href}`);
     expect(url.pathname).toBe('/episode/ep-uuid/health-markers');

--- a/apps/web/src/lib/episode-flow/resume-episode-href.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.ts
@@ -1,7 +1,7 @@
 export type BuildResumeEpisodeHrefOptions = {
   /**
-   * When true, resume enters `/health-markers` directly. Use this for episodes that already
-   * completed post-marker details and only need explicit ending.
+   * When true, resume enters `/health-markers` with `hub=1`: the episode hub (dashboard / another
+   * check-in / end), not the marker stepper. Use when `post_marker_step_completed_at` is set.
    */
   toHealthMarkers?: boolean;
 };
@@ -15,7 +15,8 @@ export type BuildResumeEpisodeHrefOptions = {
  * @param episodeId - `episodes.id`.
  * @param symptomPresetId - `symptom_presets.id` on the episode row (ignored for health-marker resumes).
  * @param options - Optional destination override.
- * @returns Path under `/episode/[id]/symptoms` or `/episode/[id]/health-markers`.
+ * @returns Path under `/episode/[id]/symptoms` or `/episode/[id]/health-markers` (with `hub=1`
+ * when resuming to the episode hub after a completed pass).
  */
 export function buildResumeEpisodeHref(
   episodeId: string,
@@ -25,6 +26,7 @@ export function buildResumeEpisodeHref(
   const q = new URLSearchParams();
   q.set('resume', '1');
   if (options.toHealthMarkers) {
+    q.set('hub', '1');
     return `/episode/${episodeId}/health-markers?${q.toString()}`;
   }
   if (!symptomPresetId) {

--- a/apps/web/src/lib/episode-flow/resume-episode-href.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.ts
@@ -3,7 +3,7 @@ export type BuildResumeEpisodeHrefOptions = {
    * When true, resume enters `/health-markers` with `hub=1`: the episode hub (dashboard / another
    * check-in / end), not the marker stepper. Use when `post_marker_step_completed_at` is set.
    */
-  toHealthMarkers?: boolean;
+  toEpisodeHub?: boolean;
 };
 
 /**
@@ -25,7 +25,7 @@ export function buildResumeEpisodeHref(
 ): string {
   const q = new URLSearchParams();
   q.set('resume', '1');
-  if (options.toHealthMarkers) {
+  if (options.toEpisodeHub) {
     q.set('hub', '1');
     return `/episode/${episodeId}/health-markers?${q.toString()}`;
   }

--- a/docs/SUPABASE_CLOUD_DEVELOPER.md
+++ b/docs/SUPABASE_CLOUD_DEVELOPER.md
@@ -177,6 +177,8 @@ pnpm exec nx test @abstrack/supabase
 
 2. **Recommended migration flow for Sarah:** when changing **`supabase/migrations/`**, tell her—in the **same message**—to **`db push`** to cloud **only when the migration SQL is stable** (e.g. after Copilot/PR review), **then** **`gen types --linked`** + Prettier **then** commit **both** migration and `packages/supabase/src/lib/database.types.ts` **before** or as part of merge (see **Recommended workflow** and **Revising a migration already pushed** above). **GitHub Actions** still runs `db push` on `main` as a backstop. **Do not** imply she must `db push` immediately on first draft if reviews may rewrite the same file.
 
+   **Critical review-phase rule:** while Sarah is still iterating on Copilot/PR review feedback, assume migrations have **not** been pushed yet and **modify existing migration file(s) only**. **Do not create new migration files during review iterations** unless Sarah explicitly asks.
+
 3. **Never imply `supabase db reset` affects cloud.** Local Docker only (or CI-only).
 
 4. **Say explicitly** when she must use **her terminal** (CLI login, link, `db push`, `gen types`) vs what CI does after merge.

--- a/packages/supabase/src/episode-foundation.integration.spec.ts
+++ b/packages/supabase/src/episode-foundation.integration.spec.ts
@@ -244,17 +244,17 @@ describe.skipIf(!episodeFoundationReady)(
       });
 
       it('writes episode_symptoms and reads plaintext under the same session', async () => {
-        const upsert = await insertEpisodeSymptomAnswer(clientA, {
+        const insert = await insertEpisodeSymptomAnswer(clientA, {
           userId: userAId,
           episodeId,
           line: presetLineRow,
           answer: { type: 'free_text', value: 'mild cramping' },
         });
-        expect(upsert.ok).toBe(true);
-        if (!upsert.ok) {
+        expect(insert.ok).toBe(true);
+        if (!insert.ok) {
           return;
         }
-        expect(upsert.data.response_text).toBe('mild cramping');
+        expect(insert.data.response_text).toBe('mild cramping');
 
         const list = await listEpisodeSymptomsForEpisode(clientA, episodeId);
         expect(list.ok).toBe(true);
@@ -460,13 +460,13 @@ describe.skipIf(!episodeFoundationReady)(
         }
         victimEpisodeId = ep.data.id;
 
-        const up = await insertEpisodeSymptomAnswer(clientA, {
+        const insert = await insertEpisodeSymptomAnswer(clientA, {
           userId: userAId,
           episodeId: victimEpisodeId,
           line: victimPresetLine,
           answer: { type: 'yes_no', value: true },
         });
-        expect(up.ok).toBe(true);
+        expect(insert.ok).toBe(true);
       });
 
       afterAll(async () => {

--- a/packages/supabase/src/episode-foundation.integration.spec.ts
+++ b/packages/supabase/src/episode-foundation.integration.spec.ts
@@ -19,7 +19,7 @@ import {
 } from './lib/episode-data.js';
 import {
   listEpisodeSymptomsForEpisode,
-  upsertEpisodeSymptomAnswer,
+  insertEpisodeSymptomAnswer,
 } from './lib/episode-symptom-data.js';
 import {
   createHealthMarkerPreset,
@@ -244,7 +244,7 @@ describe.skipIf(!episodeFoundationReady)(
       });
 
       it('writes episode_symptoms and reads plaintext under the same session', async () => {
-        const upsert = await upsertEpisodeSymptomAnswer(clientA, {
+        const upsert = await insertEpisodeSymptomAnswer(clientA, {
           userId: userAId,
           episodeId,
           line: presetLineRow,
@@ -460,7 +460,7 @@ describe.skipIf(!episodeFoundationReady)(
         }
         victimEpisodeId = ep.data.id;
 
-        const up = await upsertEpisodeSymptomAnswer(clientA, {
+        const up = await insertEpisodeSymptomAnswer(clientA, {
           userId: userAId,
           episodeId: victimEpisodeId,
           line: victimPresetLine,

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -103,8 +103,10 @@ export {
   listStandaloneHealthMarkersForUser,
 } from './lib/episode-health-marker-data.js';
 export {
+  compareEpisodeTimelineItems,
   listEpisodeObservationTimeline,
   type EpisodeTimelineItem,
+  upsertEpisodeTimelineItem,
 } from './lib/episode-observation-timeline.js';
 export {
   createFoodDiaryEntry,

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -91,17 +91,21 @@ export {
   listCompletedEpisodesForUser,
 } from './lib/episode-data.js';
 export {
-  deleteEpisodeSymptomAnswer,
+  deleteCurrentPassEpisodeSymptomAnswer,
+  insertEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
-  upsertEpisodeSymptomAnswer,
 } from './lib/episode-symptom-data.js';
 export {
   createStandaloneHealthMarkerForLine,
   deleteHealthMarkerById,
+  insertEpisodeHealthMarkerForLine,
   listEpisodeHealthMarkersForEpisode,
   listStandaloneHealthMarkersForUser,
-  upsertEpisodeHealthMarkerForLine,
 } from './lib/episode-health-marker-data.js';
+export {
+  listEpisodeObservationTimeline,
+  type EpisodeTimelineItem,
+} from './lib/episode-observation-timeline.js';
 export {
   createFoodDiaryEntry,
   deleteFoodDiaryEntry,

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -216,13 +216,13 @@ export async function endEpisodeIfStillActive(
 /**
  * Persists episode type, labels, notes, and completion of the post–health-marker step.
  * Updates only rows that are still active (`ended_at IS NULL`).
- * `post_marker_step_completed_at` is stamped from a server-generated timestamp (`updated_at`) to
- * avoid client clock skew affecting pass-boundary semantics.
+ * `post_marker_step_completed_at` is stamped atomically from a server-generated timestamp
+ * (`updated_at`) by DB trigger logic to avoid client clock skew and partial-write semantics.
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - Target episode id.
- * @param fields - Episode fields to write; provided `post_marker_step_completed_at` is ignored and
- *   replaced with a server-derived timestamp.
+ * @param fields - Episode fields to write; `post_marker_step_completed_at` acts as a completion
+ *   signal and is replaced by a server-derived timestamp.
  * @returns Updated row, or an error when the update matches no visible row.
  */
 export async function completeEpisodePostMarkerStep(
@@ -231,47 +231,23 @@ export async function completeEpisodePostMarkerStep(
   fields: EpisodePostMarkerStepWrite,
 ): Promise<PresetDataResult<EpisodeRow>> {
   try {
-    const {
-      // Intentionally ignored; server timestamp is used instead.
-      post_marker_step_completed_at: _ignoredBoundary,
-      ...rest
-    } = fields;
-
-    const firstPayload: EpisodesTableUpdate = rest;
-    const { data: first, error: firstError } = await client
-      .from('episodes')
-      .update(firstPayload)
-      .eq('id', episodeId)
-      .is('ended_at', null)
-      .select('*')
-      .maybeSingle();
-    if (firstError) {
-      return { ok: false, error: toPresetDataError(firstError) };
-    }
-    if (!first) {
-      return {
-        ok: false,
-        error: new PresetDataError(
-          'not_found',
-          'Could not save episode details. This episode may be missing, already ended, or no longer available.',
-        ),
-      };
-    }
-
-    const secondPayload: EpisodesTableUpdate = {
-      post_marker_step_completed_at: first.updated_at,
+    const payload: EpisodesTableUpdate = {
+      ...fields,
+      // Value is only a non-null signal; DB trigger stamps authoritative server timestamp.
+      post_marker_step_completed_at:
+        fields.post_marker_step_completed_at ?? new Date().toISOString(),
     };
-    const { data: second, error: secondError } = await client
+    const { data, error } = await client
       .from('episodes')
-      .update(secondPayload)
+      .update(payload)
       .eq('id', episodeId)
       .is('ended_at', null)
       .select('*')
       .maybeSingle();
-    if (secondError) {
-      return { ok: false, error: toPresetDataError(secondError) };
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
     }
-    if (!second) {
+    if (!data) {
       return {
         ok: false,
         error: new PresetDataError(
@@ -280,8 +256,7 @@ export async function completeEpisodePostMarkerStep(
         ),
       };
     }
-
-    return { ok: true, data: second as EpisodeRow };
+    return { ok: true, data: data as EpisodeRow };
   } catch (caught) {
     return { ok: false, error: toPresetDataError(caught) };
   }

--- a/packages/supabase/src/lib/episode-data.ts
+++ b/packages/supabase/src/lib/episode-data.ts
@@ -216,10 +216,13 @@ export async function endEpisodeIfStillActive(
 /**
  * Persists episode type, labels, notes, and completion of the post–health-marker step.
  * Updates only rows that are still active (`ended_at IS NULL`).
+ * `post_marker_step_completed_at` is stamped from a server-generated timestamp (`updated_at`) to
+ * avoid client clock skew affecting pass-boundary semantics.
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - Target episode id.
- * @param fields - Episode fields to write; `post_marker_step_completed_at` should be set when the user finishes this step.
+ * @param fields - Episode fields to write; provided `post_marker_step_completed_at` is ignored and
+ *   replaced with a server-derived timestamp.
  * @returns Updated row, or an error when the update matches no visible row.
  */
 export async function completeEpisodePostMarkerStep(
@@ -228,18 +231,24 @@ export async function completeEpisodePostMarkerStep(
   fields: EpisodePostMarkerStepWrite,
 ): Promise<PresetDataResult<EpisodeRow>> {
   try {
-    const payload: EpisodesTableUpdate = fields;
-    const { data, error } = await client
+    const {
+      // Intentionally ignored; server timestamp is used instead.
+      post_marker_step_completed_at: _ignoredBoundary,
+      ...rest
+    } = fields;
+
+    const firstPayload: EpisodesTableUpdate = rest;
+    const { data: first, error: firstError } = await client
       .from('episodes')
-      .update(payload)
+      .update(firstPayload)
       .eq('id', episodeId)
       .is('ended_at', null)
       .select('*')
       .maybeSingle();
-    if (error) {
-      return { ok: false, error: toPresetDataError(error) };
+    if (firstError) {
+      return { ok: false, error: toPresetDataError(firstError) };
     }
-    if (!data) {
+    if (!first) {
       return {
         ok: false,
         error: new PresetDataError(
@@ -248,7 +257,31 @@ export async function completeEpisodePostMarkerStep(
         ),
       };
     }
-    return { ok: true, data: data as EpisodeRow };
+
+    const secondPayload: EpisodesTableUpdate = {
+      post_marker_step_completed_at: first.updated_at,
+    };
+    const { data: second, error: secondError } = await client
+      .from('episodes')
+      .update(secondPayload)
+      .eq('id', episodeId)
+      .is('ended_at', null)
+      .select('*')
+      .maybeSingle();
+    if (secondError) {
+      return { ok: false, error: toPresetDataError(secondError) };
+    }
+    if (!second) {
+      return {
+        ok: false,
+        error: new PresetDataError(
+          'not_found',
+          'Could not save episode details. This episode may be missing, already ended, or no longer available.',
+        ),
+      };
+    }
+
+    return { ok: true, data: second as EpisodeRow };
   } catch (caught) {
     return { ok: false, error: toPresetDataError(caught) };
   }

--- a/packages/supabase/src/lib/episode-health-marker-data.spec.ts
+++ b/packages/supabase/src/lib/episode-health-marker-data.spec.ts
@@ -5,7 +5,7 @@ import {
   deleteHealthMarkerById,
   listEpisodeHealthMarkersForEpisode,
   listStandaloneHealthMarkersForUser,
-  upsertEpisodeHealthMarkerForLine,
+  insertEpisodeHealthMarkerForLine,
 } from './episode-health-marker-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
@@ -54,7 +54,7 @@ describe('listEpisodeHealthMarkersForEpisode', () => {
   });
 });
 
-describe('upsertEpisodeHealthMarkerForLine', () => {
+describe('insertEpisodeHealthMarkerForLine', () => {
   it('returns validation_error when non-blood_pressure line omits valueNumeric', async () => {
     const client = {
       from: vi.fn(() => {
@@ -62,7 +62,7 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       }),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await upsertEpisodeHealthMarkerForLine(client, {
+    const result = await insertEpisodeHealthMarkerForLine(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line,
@@ -83,7 +83,7 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       }),
     } as unknown as AbstrackSupabaseClient;
 
-    const nanResult = await upsertEpisodeHealthMarkerForLine(client, {
+    const nanResult = await insertEpisodeHealthMarkerForLine(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line,
@@ -94,7 +94,7 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       expect(nanResult.error.message).toContain('valid number');
     }
 
-    const infResult = await upsertEpisodeHealthMarkerForLine(client, {
+    const infResult = await insertEpisodeHealthMarkerForLine(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line,
@@ -114,7 +114,7 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       }),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await upsertEpisodeHealthMarkerForLine(client, {
+    const result = await insertEpisodeHealthMarkerForLine(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line,
@@ -138,7 +138,7 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       }),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await upsertEpisodeHealthMarkerForLine(client, {
+    const result = await insertEpisodeHealthMarkerForLine(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line: { ...line, marker_kind: 'blood_pressure' },
@@ -162,7 +162,7 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       }),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await upsertEpisodeHealthMarkerForLine(client, {
+    const result = await insertEpisodeHealthMarkerForLine(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line: { ...line, marker_kind: 'blood_pressure' },
@@ -177,7 +177,7 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
     expect(client.from).not.toHaveBeenCalled();
   });
 
-  it('upserts blood_pressure with systolic/diastolic and null value_numeric', async () => {
+  it('inserts blood_pressure with systolic/diastolic and null value_numeric', async () => {
     const bpLine: PresetHealthMarkerRow = {
       ...line,
       marker_kind: 'blood_pressure',
@@ -200,18 +200,18 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       created_at: '2026-04-18T12:05:00.000Z',
       updated_at: '2026-04-18T12:05:00.000Z',
     };
-    const upsertMock = vi.fn((_payload: unknown, _opts: unknown) => ({
+    const insertMock = vi.fn(() => ({
       select: vi.fn(() => ({
         single: vi.fn(async () => ({ data: updated, error: null })),
       })),
     }));
     const client = {
       from: vi.fn(() => ({
-        upsert: upsertMock,
+        insert: insertMock,
       })),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await upsertEpisodeHealthMarkerForLine(client, {
+    const result = await insertEpisodeHealthMarkerForLine(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line: bpLine,
@@ -220,14 +220,13 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(upsertMock).toHaveBeenCalledWith(
+    expect(insertMock).toHaveBeenCalledWith(
       expect.objectContaining({
         marker_kind: 'blood_pressure',
         value_numeric: null,
         systolic_numeric: 118,
         diastolic_numeric: 76,
       }),
-      expect.any(Object),
     );
   });
 
@@ -238,7 +237,7 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       }),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await upsertEpisodeHealthMarkerForLine(client, {
+    const result = await insertEpisodeHealthMarkerForLine(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line: {
@@ -258,10 +257,10 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
     expect(client.from).not.toHaveBeenCalled();
   });
 
-  it('upserts (updates on conflict) when a row already exists for the line signature', async () => {
-    const existingId = 'hm-existing';
+  it('inserts a new row for each save (no upsert)', async () => {
+    const newId = 'hm-existing';
     const updated = {
-      id: existingId,
+      id: newId,
       user_id: 'u1',
       episode_id: 'ep-1',
       preset_health_marker_id: 'phm-1',
@@ -278,18 +277,18 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       created_at: '2026-04-18T12:05:00.000Z',
       updated_at: '2026-04-18T12:05:00.000Z',
     };
-    const upsertMock = vi.fn((_payload: unknown, _opts: unknown) => ({
+    const insertMock = vi.fn(() => ({
       select: vi.fn(() => ({
         single: vi.fn(async () => ({ data: updated, error: null })),
       })),
     }));
     const client = {
       from: vi.fn(() => ({
-        upsert: upsertMock,
+        insert: insertMock,
       })),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await upsertEpisodeHealthMarkerForLine(client, {
+    const result = await insertEpisodeHealthMarkerForLine(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line,
@@ -298,11 +297,11 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.data.id).toBe(existingId);
+      expect(result.data.id).toBe(newId);
       expect(result.data.value_numeric).toBe(120);
     }
-    expect(upsertMock).toHaveBeenCalledTimes(1);
-    expect(upsertMock).toHaveBeenCalledWith(
+    expect(insertMock).toHaveBeenCalledTimes(1);
+    expect(insertMock).toHaveBeenCalledWith(
       expect.objectContaining({
         user_id: 'u1',
         episode_id: 'ep-1',
@@ -312,17 +311,10 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
         custom_unit: null,
         value_numeric: 120,
       }),
-      {
-        onConflict: 'episode_id,preset_health_marker_id',
-      },
     );
   });
 
-  /**
-   * First time saving a line, Postgres performs an INSERT as part of ON CONFLICT upsert.
-   * The client always sends one `.upsert` payload (no separate `.insert()` branch).
-   */
-  it('performs first save via upsert with full episode payload (insert branch inside Postgres)', async () => {
+  it('inserts a row with the full episode payload', async () => {
     const inserted = {
       id: 'hm-new',
       user_id: 'u1',
@@ -341,7 +333,7 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       created_at: '2026-04-18T12:00:00.000Z',
       updated_at: '2026-04-18T12:00:00.000Z',
     };
-    const upsertMock = vi.fn((payload: Record<string, unknown>) => {
+    const insertMock = vi.fn((payload: Record<string, unknown>) => {
       expect(payload).toEqual(
         expect.objectContaining({
           user_id: 'u1',
@@ -365,11 +357,11 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
 
     const client = {
       from: vi.fn(() => ({
-        upsert: upsertMock,
+        insert: insertMock,
       })),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await upsertEpisodeHealthMarkerForLine(client, {
+    const result = await insertEpisodeHealthMarkerForLine(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line,
@@ -383,13 +375,10 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       expect(result.data.id).toBe('hm-new');
       expect(result.data.value_numeric).toBe(88);
     }
-    expect(upsertMock).toHaveBeenCalledTimes(1);
-    expect(upsertMock).toHaveBeenCalledWith(expect.any(Object), {
-      onConflict: 'episode_id,preset_health_marker_id',
-    });
+    expect(insertMock).toHaveBeenCalledTimes(1);
   });
 
-  it('first save normalizes trimmed custom_name and custom_unit on the upsert payload', async () => {
+  it('first save normalizes trimmed custom_name and custom_unit on the insert payload', async () => {
     const customLine: PresetHealthMarkerRow = {
       ...line,
       id: 'phm-custom',
@@ -415,7 +404,7 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
       created_at: '2026-04-18T12:00:00.000Z',
       updated_at: '2026-04-18T12:00:00.000Z',
     };
-    const upsertMock = vi.fn((payload: Record<string, unknown>) => {
+    const insertMock = vi.fn((payload: Record<string, unknown>) => {
       expect(payload).toEqual({
         user_id: 'u1',
         episode_id: 'ep-1',
@@ -437,11 +426,11 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
     });
     const client = {
       from: vi.fn(() => ({
-        upsert: upsertMock,
+        insert: insertMock,
       })),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await upsertEpisodeHealthMarkerForLine(client, {
+    const result = await insertEpisodeHealthMarkerForLine(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line: customLine,
@@ -450,10 +439,7 @@ describe('upsertEpisodeHealthMarkerForLine', () => {
     });
 
     expect(result.ok).toBe(true);
-    expect(upsertMock).toHaveBeenCalledTimes(1);
-    expect(upsertMock).toHaveBeenCalledWith(expect.any(Object), {
-      onConflict: 'episode_id,preset_health_marker_id',
-    });
+    expect(insertMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/supabase/src/lib/episode-health-marker-data.ts
+++ b/packages/supabase/src/lib/episode-health-marker-data.ts
@@ -68,19 +68,28 @@ function validateHealthMarkerNumericPayload(
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - `episodes.id`.
+ * @param options - Optional cap (`limit`) for newest rows after source ordering.
  */
 export async function listEpisodeHealthMarkersForEpisode(
   client: AbstrackSupabaseClient,
   episodeId: Uuid,
+  options: {
+    limit?: number;
+  } = {},
 ): Promise<PresetDataResult<HealthMarkerRow[]>> {
+  const limit = options.limit;
   return wrap(async () => {
-    const r = await client
+    let query = client
       .from('health_markers')
       .select('*')
       .eq('episode_id', episodeId)
       .order('recorded_at', { ascending: false })
       .order('created_at', { ascending: false })
       .order('id', { ascending: false });
+    if (limit != null) {
+      query = query.limit(limit);
+    }
+    const r = await query;
     return {
       data: (r.data ?? []) as HealthMarkerRow[],
       error: r.error,

--- a/packages/supabase/src/lib/episode-health-marker-data.ts
+++ b/packages/supabase/src/lib/episode-health-marker-data.ts
@@ -167,6 +167,8 @@ export async function deleteHealthMarkerById(
 /**
  * Inserts one `health_markers` row for the current episode + preset line (a new observation per
  * pass; prior rows are kept and ordered by `recorded_at` / `id`).
+ * Intentional: episode observations are append-only for auditability/history, so this helper is
+ * insert-only (no upsert path).
  *
  * @param client - Supabase client (RLS applies).
  * @param args.userId - Must match the episode owner (`episodes.user_id`) under RLS.

--- a/packages/supabase/src/lib/episode-health-marker-data.ts
+++ b/packages/supabase/src/lib/episode-health-marker-data.ts
@@ -165,15 +165,8 @@ export async function deleteHealthMarkerById(
 }
 
 /**
- * Inserts or updates one `health_markers` row for the current episode + preset line.
- *
- * Episode-bound rows are keyed by `(episode_id, preset_health_marker_id)` where
- * `preset_health_marker_id` is {@link PresetHealthMarkerRow.id}. That allows multiple template lines
- * with the same `marker_kind` (e.g. two glucose steps) without colliding. A non-partial unique
- * constraint on `(episode_id, preset_health_marker_id)` (see migration
- * `20260421120000_health_markers_episode_line_unique.sql`) is required so PostgREST can infer
- * `onConflict`; partial unique indexes do not match. Wellness rows stay allowed (NULL distinctness).
- * This function uses one `upsert` so concurrent clients cannot double-insert the same line.
+ * Inserts one `health_markers` row for the current episode + preset line (a new observation per
+ * pass; prior rows are kept and ordered by `recorded_at` / `id`).
  *
  * @param client - Supabase client (RLS applies).
  * @param args.userId - Must match the episode owner (`episodes.user_id`) under RLS.
@@ -190,7 +183,7 @@ export async function deleteHealthMarkerById(
  * leaves `value_numeric` empty; other kinds use `value_numeric` only). Otherwise returns
  * `validation_error`.
  */
-export async function upsertEpisodeHealthMarkerForLine(
+export async function insertEpisodeHealthMarkerForLine(
   client: AbstrackSupabaseClient,
   args: {
     userId: Uuid;
@@ -257,9 +250,7 @@ export async function upsertEpisodeHealthMarkerForLine(
 
     const r = await client
       .from('health_markers')
-      .upsert(row, {
-        onConflict: 'episode_id,preset_health_marker_id',
-      })
+      .insert(row)
       .select('*')
       .single();
     return {

--- a/packages/supabase/src/lib/episode-observation-timeline.spec.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.spec.ts
@@ -1,5 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { PRESET_HEALTH_MARKER_KIND_LABELS } from '@abstrack/types';
+import {
+  PRESET_HEALTH_MARKER_KIND_LABELS,
+  type HealthMarkerRow,
+} from '@abstrack/types';
 import { listEpisodeObservationTimeline } from './episode-observation-timeline.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
@@ -190,5 +193,50 @@ describe('listEpisodeObservationTimeline', () => {
       'id-b:food',
       'id-c:symptom',
     ]);
+  });
+
+  it('reuses prefetched health markers when provided', async () => {
+    listEpisodeSymptomsForEpisode.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+    listFoodDiaryEntriesForEpisode.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+
+    const result = await listEpisodeObservationTimeline(
+      {} as AbstrackSupabaseClient,
+      'ep-1',
+      {
+        prefetchedHealthMarkers: [
+          {
+            id: 'hm-prefetched',
+            user_id: 'user-1',
+            episode_id: 'ep-1',
+            preset_health_marker_id: 'phm-1',
+            marker_kind: 'heart_rate',
+            custom_name: null,
+            custom_name_key: null,
+            custom_unit: null,
+            custom_unit_key: null,
+            value_numeric: 72,
+            systolic_numeric: null,
+            diastolic_numeric: null,
+            notes: null,
+            recorded_at: '2026-04-24T10:00:00.000Z',
+            created_at: '2026-04-24T10:00:00.000Z',
+            updated_at: '2026-04-24T10:00:00.000Z',
+          },
+        ] satisfies HealthMarkerRow[],
+      },
+    );
+
+    expect(result.ok).toBe(true);
+    expect(listEpisodeHealthMarkersForEpisode).not.toHaveBeenCalled();
+    if (!result.ok) {
+      return;
+    }
+    expect(result.data.map((r) => r.id)).toContain('hm-prefetched');
   });
 });

--- a/packages/supabase/src/lib/episode-observation-timeline.spec.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PRESET_HEALTH_MARKER_KIND_LABELS } from '@abstrack/types';
 import { listEpisodeObservationTimeline } from './episode-observation-timeline.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
@@ -77,6 +78,9 @@ describe('listEpisodeObservationTimeline', () => {
       return;
     }
     expect(result.data.map((r) => r.id)).toEqual(['fd-1', 'hm-1', 'sym-1']);
+    expect(result.data.find((r) => r.id === 'hm-1')?.label).toBe(
+      PRESET_HEALTH_MARKER_KIND_LABELS.heart_rate,
+    );
   });
 
   it('uses id as tie-breaker when timestamps are equal instants', async () => {

--- a/packages/supabase/src/lib/episode-observation-timeline.spec.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.spec.ts
@@ -239,4 +239,49 @@ describe('listEpisodeObservationTimeline', () => {
     }
     expect(result.data.map((r) => r.id)).toContain('hm-prefetched');
   });
+
+  it('keeps symptom timeline rows when preset_symptom_id is null', async () => {
+    listEpisodeSymptomsForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'sym-null-link',
+          preset_symptom_id: null,
+          symptom_name: 'Legacy symptom',
+          response_type: 'free_text',
+          response_boolean: null,
+          response_severity: null,
+          response_text: 'Still include me',
+          created_at: '2026-04-24T12:00:00.000Z',
+        },
+      ],
+    });
+    listEpisodeHealthMarkersForEpisode.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+    listFoodDiaryEntriesForEpisode.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+
+    const result = await listEpisodeObservationTimeline(
+      {} as AbstrackSupabaseClient,
+      'ep-1',
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.data).toEqual([
+      {
+        kind: 'symptom',
+        sortAt: '2026-04-24T12:00:00.000Z',
+        id: 'sym-null-link',
+        label: 'Legacy symptom',
+        detail: 'Still include me',
+      },
+    ]);
+  });
 });

--- a/packages/supabase/src/lib/episode-observation-timeline.spec.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.spec.ts
@@ -1,0 +1,190 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { listEpisodeObservationTimeline } from './episode-observation-timeline.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+const listEpisodeSymptomsForEpisode = vi.hoisted(() => vi.fn());
+const listEpisodeHealthMarkersForEpisode = vi.hoisted(() => vi.fn());
+const listFoodDiaryEntriesForEpisode = vi.hoisted(() => vi.fn());
+
+vi.mock('./episode-symptom-data.js', () => ({
+  listEpisodeSymptomsForEpisode,
+}));
+
+vi.mock('./episode-health-marker-data.js', () => ({
+  listEpisodeHealthMarkersForEpisode,
+}));
+
+vi.mock('./food-diary-data.js', () => ({
+  listFoodDiaryEntriesForEpisode,
+}));
+
+describe('listEpisodeObservationTimeline', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sorts oldest first by parsed timestamp across mixed ISO formats', async () => {
+    listEpisodeSymptomsForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'sym-1',
+          preset_symptom_id: 'ps-1',
+          symptom_name: 'Nausea',
+          response_type: 'yes_no',
+          response_boolean: true,
+          response_severity: null,
+          response_text: null,
+          created_at: '2026-04-24T12:00:00.9Z',
+        },
+      ],
+    });
+    listEpisodeHealthMarkersForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'hm-1',
+          marker_kind: 'heart_rate',
+          custom_name: null,
+          custom_unit: null,
+          value_numeric: 90,
+          systolic_numeric: null,
+          diastolic_numeric: null,
+          notes: null,
+          recorded_at: '2026-04-24T12:00:00.123+00:00',
+        },
+      ],
+    });
+    listFoodDiaryEntriesForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'fd-1',
+          meal_tag: 'Lunch',
+          food_note: 'Soup',
+          logged_at: '2026-04-24T12:00:00.023Z',
+        },
+      ],
+    });
+
+    const result = await listEpisodeObservationTimeline(
+      {} as AbstrackSupabaseClient,
+      'ep-1',
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.data.map((r) => r.id)).toEqual(['fd-1', 'hm-1', 'sym-1']);
+  });
+
+  it('uses id as tie-breaker when timestamps are equal instants', async () => {
+    listEpisodeSymptomsForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'b-id',
+          preset_symptom_id: 'ps-1',
+          symptom_name: 'Headache',
+          response_type: 'yes_no',
+          response_boolean: false,
+          response_severity: null,
+          response_text: null,
+          created_at: '2026-04-24T12:00:00.000Z',
+        },
+      ],
+    });
+    listEpisodeHealthMarkersForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'a-id',
+          marker_kind: 'heart_rate',
+          custom_name: null,
+          custom_unit: null,
+          value_numeric: 70,
+          systolic_numeric: null,
+          diastolic_numeric: null,
+          notes: null,
+          recorded_at: '2026-04-24T12:00:00+00:00',
+        },
+      ],
+    });
+    listFoodDiaryEntriesForEpisode.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+
+    const result = await listEpisodeObservationTimeline(
+      {} as AbstrackSupabaseClient,
+      'ep-1',
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.data.map((r) => r.id)).toEqual(['a-id', 'b-id']);
+  });
+
+  it('merges mixed kinds and applies id tie-break across same-time rows', async () => {
+    listEpisodeSymptomsForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'id-c',
+          preset_symptom_id: 'ps-1',
+          symptom_name: 'Cramping',
+          response_type: 'yes_no',
+          response_boolean: true,
+          response_severity: null,
+          response_text: null,
+          created_at: '2026-04-24T12:00:00Z',
+        },
+      ],
+    });
+    listEpisodeHealthMarkersForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'id-a',
+          marker_kind: 'heart_rate',
+          custom_name: null,
+          custom_unit: null,
+          value_numeric: 88,
+          systolic_numeric: null,
+          diastolic_numeric: null,
+          notes: null,
+          recorded_at: '2026-04-24T12:00:00.000+00:00',
+        },
+      ],
+    });
+    listFoodDiaryEntriesForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          id: 'id-b',
+          meal_tag: 'Dinner',
+          food_note: 'Rice bowl',
+          logged_at: '2026-04-24T12:00:00.000Z',
+        },
+      ],
+    });
+
+    const result = await listEpisodeObservationTimeline(
+      {} as AbstrackSupabaseClient,
+      'ep-1',
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+    expect(result.data.map((r) => `${r.id}:${r.kind}`)).toEqual([
+      'id-a:health_marker',
+      'id-b:food',
+      'id-c:symptom',
+    ]);
+  });
+});

--- a/packages/supabase/src/lib/episode-observation-timeline.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.ts
@@ -21,10 +21,23 @@ function compareTimeline(
   a: EpisodeTimelineItem,
   b: EpisodeTimelineItem,
 ): number {
-  const c = a.sortAt.localeCompare(b.sortAt);
-  if (c !== 0) {
-    return c;
+  const aMs = Date.parse(a.sortAt);
+  const bMs = Date.parse(b.sortAt);
+  const aValid = Number.isFinite(aMs);
+  const bValid = Number.isFinite(bMs);
+  if (aValid && bValid) {
+    const c = aMs - bMs;
+    if (c !== 0) {
+      return c;
+    }
+  } else {
+    // Defensive fallback for unexpected timestamp serialization.
+    const c = a.sortAt.localeCompare(b.sortAt);
+    if (c !== 0) {
+      return c;
+    }
   }
+  // Stable tie-break so merged timeline order is deterministic.
   return a.id.localeCompare(b.id);
 }
 

--- a/packages/supabase/src/lib/episode-observation-timeline.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.ts
@@ -35,7 +35,7 @@ function healthMarkerTimelineLabel(
   if (kind === 'wellness_mood') {
     return 'Wellness mood';
   }
-  if (kind in PRESET_HEALTH_MARKER_KIND_LABELS) {
+  if (Object.hasOwn(PRESET_HEALTH_MARKER_KIND_LABELS, kind)) {
     return PRESET_HEALTH_MARKER_KIND_LABELS[
       kind as keyof typeof PRESET_HEALTH_MARKER_KIND_LABELS
     ];
@@ -128,6 +128,7 @@ export async function listEpisodeObservationTimeline(
     const items: EpisodeTimelineItem[] = [];
 
     for (const s of sy.data) {
+      const symptomLabel = s.symptom_name.trim();
       let detail = '—';
       if (s.response_type === 'yes_no' && s.response_boolean != null) {
         detail = s.response_boolean ? 'Yes' : 'No';
@@ -148,8 +149,7 @@ export async function listEpisodeObservationTimeline(
         kind: 'symptom',
         sortAt: s.created_at,
         id: s.id,
-        label:
-          s.symptom_name.trim().length > 0 ? s.symptom_name : 'Symptom entry',
+        label: symptomLabel.length > 0 ? symptomLabel : 'Symptom entry',
         detail,
       });
     }

--- a/packages/supabase/src/lib/episode-observation-timeline.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.ts
@@ -113,6 +113,7 @@ export async function listEpisodeObservationTimeline(
     const [sy, fd] = await Promise.all([
       listEpisodeSymptomsForEpisode(client, episodeId, {
         limit: EPISODE_TIMELINE_SOURCE_LIMIT,
+        orderBy: 'recent',
       }),
       listFoodDiaryEntriesForEpisode(client, episodeId, {
         limit: EPISODE_TIMELINE_SOURCE_LIMIT,

--- a/packages/supabase/src/lib/episode-observation-timeline.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.ts
@@ -10,6 +10,8 @@ import { listEpisodeHealthMarkersForEpisode } from './episode-health-marker-data
 import { listEpisodeSymptomsForEpisode } from './episode-symptom-data.js';
 import { listFoodDiaryEntriesForEpisode } from './food-diary-data.js';
 
+const EPISODE_TIMELINE_SOURCE_LIMIT = 200;
+
 /**
  * One row in a merged, time-ordered episode view (symptoms, health markers, food).
  */
@@ -93,9 +95,9 @@ export function upsertEpisodeTimelineItem(
 }
 
 /**
- * Loads episode-tied symptoms, health markers, and up to 200 episode-tied food entries (newest
- * food rows from the source query) and returns them in one merged list ordered by product
- * timestamps (oldest first, `id` as tie-breaker) — a minimal “history” surface.
+ * Loads a bounded recent slice of episode-tied symptoms, health markers, and food entries
+ * (currently up to 200 from each source query) and returns them in one merged list ordered by
+ * product timestamps (oldest first, `id` as tie-breaker) — a minimal “history” surface.
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - `episodes.id`.
@@ -109,13 +111,25 @@ export async function listEpisodeObservationTimeline(
 ): Promise<PresetDataResult<EpisodeTimelineItem[]>> {
   return wrap(async () => {
     const [sy, fd] = await Promise.all([
-      listEpisodeSymptomsForEpisode(client, episodeId),
-      listFoodDiaryEntriesForEpisode(client, episodeId, { limit: 200 }),
+      listEpisodeSymptomsForEpisode(client, episodeId, {
+        limit: EPISODE_TIMELINE_SOURCE_LIMIT,
+      }),
+      listFoodDiaryEntriesForEpisode(client, episodeId, {
+        limit: EPISODE_TIMELINE_SOURCE_LIMIT,
+      }),
     ]);
     const hm =
       options.prefetchedHealthMarkers != null
-        ? ({ ok: true, data: options.prefetchedHealthMarkers } as const)
-        : await listEpisodeHealthMarkersForEpisode(client, episodeId);
+        ? ({
+            ok: true,
+            data: options.prefetchedHealthMarkers.slice(
+              0,
+              EPISODE_TIMELINE_SOURCE_LIMIT,
+            ),
+          } as const)
+        : await listEpisodeHealthMarkersForEpisode(client, episodeId, {
+            limit: EPISODE_TIMELINE_SOURCE_LIMIT,
+          });
     if (!sy.ok) {
       return { data: null, error: sy.error };
     }

--- a/packages/supabase/src/lib/episode-observation-timeline.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.ts
@@ -43,7 +43,15 @@ function healthMarkerTimelineLabel(
   return custom && custom.length > 0 ? custom : kind;
 }
 
-function compareTimeline(
+/**
+ * Compares two timeline items using the canonical merged-history ordering: oldest timestamp first,
+ * then `id` as a stable tie-breaker.
+ *
+ * @param a - Left timeline item.
+ * @param b - Right timeline item.
+ * @returns Negative when `a` sorts before `b`.
+ */
+export function compareEpisodeTimelineItems(
   a: EpisodeTimelineItem,
   b: EpisodeTimelineItem,
 ): number {
@@ -65,6 +73,23 @@ function compareTimeline(
   }
   // Stable tie-break so merged timeline order is deterministic.
   return a.id.localeCompare(b.id);
+}
+
+/**
+ * Inserts or replaces one timeline row in-memory and returns a canonically sorted copy.
+ *
+ * @param prev - Existing timeline rows.
+ * @param next - Row to insert/replace by (`kind`, `id`).
+ * @returns New sorted timeline rows.
+ */
+export function upsertEpisodeTimelineItem(
+  prev: EpisodeTimelineItem[],
+  next: EpisodeTimelineItem,
+): EpisodeTimelineItem[] {
+  const rows = prev.filter((r) => !(r.kind === next.kind && r.id === next.id));
+  rows.push(next);
+  rows.sort(compareEpisodeTimelineItems);
+  return rows;
 }
 
 /**
@@ -169,7 +194,7 @@ export async function listEpisodeObservationTimeline(
       });
     }
 
-    items.sort(compareTimeline);
+    items.sort(compareEpisodeTimelineItems);
     return { data: items, error: null };
   });
 }

--- a/packages/supabase/src/lib/episode-observation-timeline.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.ts
@@ -103,9 +103,6 @@ export async function listEpisodeObservationTimeline(
     const items: EpisodeTimelineItem[] = [];
 
     for (const s of sy.data) {
-      if (!s.preset_symptom_id) {
-        continue;
-      }
       let detail = '—';
       if (s.response_type === 'yes_no' && s.response_boolean != null) {
         detail = s.response_boolean ? 'Yes' : 'No';
@@ -126,7 +123,8 @@ export async function listEpisodeObservationTimeline(
         kind: 'symptom',
         sortAt: s.created_at,
         id: s.id,
-        label: s.symptom_name,
+        label:
+          s.symptom_name.trim().length > 0 ? s.symptom_name : 'Symptom entry',
         detail,
       });
     }

--- a/packages/supabase/src/lib/episode-observation-timeline.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.ts
@@ -1,0 +1,129 @@
+import type { Uuid } from '@abstrack/types';
+import type { PresetDataResult } from './preset-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+import { listEpisodeHealthMarkersForEpisode } from './episode-health-marker-data.js';
+import { listEpisodeSymptomsForEpisode } from './episode-symptom-data.js';
+import { listFoodDiaryEntriesForEpisode } from './food-diary-data.js';
+
+/**
+ * One row in a merged, time-ordered episode view (symptoms, health markers, food).
+ */
+export type EpisodeTimelineItem = {
+  kind: 'symptom' | 'health_marker' | 'food';
+  /** ISO string used for ordering (`created_at` / `recorded_at` / `logged_at`). */
+  sortAt: string;
+  id: string;
+  label: string;
+  detail: string;
+};
+
+function compareTimeline(
+  a: EpisodeTimelineItem,
+  b: EpisodeTimelineItem,
+): number {
+  const c = a.sortAt.localeCompare(b.sortAt);
+  if (c !== 0) {
+    return c;
+  }
+  return a.id.localeCompare(b.id);
+}
+
+/**
+ * Loads all episode-tied symptoms, health markers, and food entries and returns them in one list
+ * ordered by product timestamps (oldest first, `id` as tie-breaker) — a minimal “history” surface.
+ *
+ * @param client - Supabase client (RLS applies).
+ * @param episodeId - `episodes.id`.
+ */
+export async function listEpisodeObservationTimeline(
+  client: AbstrackSupabaseClient,
+  episodeId: Uuid,
+): Promise<PresetDataResult<EpisodeTimelineItem[]>> {
+  const [sy, hm, fd] = await Promise.all([
+    listEpisodeSymptomsForEpisode(client, episodeId),
+    listEpisodeHealthMarkersForEpisode(client, episodeId),
+    listFoodDiaryEntriesForEpisode(client, episodeId, { limit: 200 }),
+  ]);
+  if (!sy.ok) {
+    return sy;
+  }
+  if (!hm.ok) {
+    return hm;
+  }
+  if (!fd.ok) {
+    return fd;
+  }
+  const items: EpisodeTimelineItem[] = [];
+
+  for (const s of sy.data) {
+    if (!s.preset_symptom_id) {
+      continue;
+    }
+    let detail = '—';
+    if (s.response_type === 'yes_no' && s.response_boolean != null) {
+      detail = s.response_boolean ? 'Yes' : 'No';
+    } else if (
+      s.response_type === 'severity_scale' &&
+      s.response_severity != null
+    ) {
+      detail = `Severity ${s.response_severity}`;
+    } else if (s.response_type === 'free_text' && s.response_text) {
+      const t = s.response_text.trim();
+      detail = t.length > 80 ? `${t.slice(0, 77)}…` : t;
+    } else if (s.response_type === 'photo') {
+      detail = 'Photo';
+    } else if (s.response_type === 'video') {
+      detail = 'Video';
+    }
+    items.push({
+      kind: 'symptom',
+      sortAt: s.created_at,
+      id: s.id,
+      label: s.symptom_name,
+      detail,
+    });
+  }
+
+  for (const m of hm.data) {
+    let detail = '—';
+    if (m.marker_kind === 'blood_pressure') {
+      if (m.systolic_numeric != null && m.diastolic_numeric != null) {
+        detail = `${m.systolic_numeric}/${m.diastolic_numeric}`;
+      }
+    } else if (m.value_numeric != null) {
+      detail = String(m.value_numeric);
+      if (m.custom_unit) {
+        detail = `${detail} ${m.custom_unit}`;
+      } else if (m.marker_kind === 'bac') {
+        detail = `${detail} g/dL`;
+      }
+    } else {
+      const n = m.notes?.trim();
+      if (n) {
+        detail = n.length > 80 ? `${n.slice(0, 77)}…` : n;
+      }
+    }
+    const kindLabel = m.custom_name?.trim() || m.marker_kind;
+    items.push({
+      kind: 'health_marker',
+      sortAt: m.recorded_at,
+      id: m.id,
+      label: kindLabel,
+      detail,
+    });
+  }
+
+  for (const f of fd.data) {
+    const note = f.food_note.trim();
+    items.push({
+      kind: 'food',
+      sortAt: f.logged_at,
+      id: f.id,
+      label: f.meal_tag,
+      detail: note.length > 100 ? `${note.slice(0, 97)}…` : note,
+    });
+  }
+
+  items.sort(compareTimeline);
+  return { ok: true, data: items };
+}

--- a/packages/supabase/src/lib/episode-observation-timeline.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.ts
@@ -1,4 +1,8 @@
-import { PRESET_HEALTH_MARKER_KIND_LABELS, type Uuid } from '@abstrack/types';
+import {
+  PRESET_HEALTH_MARKER_KIND_LABELS,
+  type HealthMarkerRow,
+  type Uuid,
+} from '@abstrack/types';
 import type { PresetDataResult } from './preset-data.js';
 import { wrap } from './preset-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
@@ -74,13 +78,19 @@ function compareTimeline(
 export async function listEpisodeObservationTimeline(
   client: AbstrackSupabaseClient,
   episodeId: Uuid,
+  options: {
+    prefetchedHealthMarkers?: HealthMarkerRow[];
+  } = {},
 ): Promise<PresetDataResult<EpisodeTimelineItem[]>> {
   return wrap(async () => {
-    const [sy, hm, fd] = await Promise.all([
+    const [sy, fd] = await Promise.all([
       listEpisodeSymptomsForEpisode(client, episodeId),
-      listEpisodeHealthMarkersForEpisode(client, episodeId),
       listFoodDiaryEntriesForEpisode(client, episodeId, { limit: 200 }),
     ]);
+    const hm =
+      options.prefetchedHealthMarkers != null
+        ? ({ ok: true, data: options.prefetchedHealthMarkers } as const)
+        : await listEpisodeHealthMarkersForEpisode(client, episodeId);
     if (!sy.ok) {
       return { data: null, error: sy.error };
     }

--- a/packages/supabase/src/lib/episode-observation-timeline.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.ts
@@ -1,4 +1,4 @@
-import type { Uuid } from '@abstrack/types';
+import { PRESET_HEALTH_MARKER_KIND_LABELS, type Uuid } from '@abstrack/types';
 import type { PresetDataResult } from './preset-data.js';
 import { wrap } from './preset-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
@@ -17,6 +17,27 @@ export type EpisodeTimelineItem = {
   label: string;
   detail: string;
 };
+
+function healthMarkerTimelineLabel(
+  kind: string,
+  customName: string | null,
+): string {
+  const custom = customName?.trim();
+  if (kind === 'custom') {
+    return custom && custom.length > 0
+      ? custom
+      : PRESET_HEALTH_MARKER_KIND_LABELS.custom;
+  }
+  if (kind === 'wellness_mood') {
+    return 'Wellness mood';
+  }
+  if (kind in PRESET_HEALTH_MARKER_KIND_LABELS) {
+    return PRESET_HEALTH_MARKER_KIND_LABELS[
+      kind as keyof typeof PRESET_HEALTH_MARKER_KIND_LABELS
+    ];
+  }
+  return custom && custom.length > 0 ? custom : kind;
+}
 
 function compareTimeline(
   a: EpisodeTimelineItem,
@@ -119,7 +140,7 @@ export async function listEpisodeObservationTimeline(
           detail = n.length > 80 ? `${n.slice(0, 77)}…` : n;
         }
       }
-      const kindLabel = m.custom_name?.trim() || m.marker_kind;
+      const kindLabel = healthMarkerTimelineLabel(m.marker_kind, m.custom_name);
       items.push({
         kind: 'health_marker',
         sortAt: m.recorded_at,

--- a/packages/supabase/src/lib/episode-observation-timeline.ts
+++ b/packages/supabase/src/lib/episode-observation-timeline.ts
@@ -1,5 +1,6 @@
 import type { Uuid } from '@abstrack/types';
 import type { PresetDataResult } from './preset-data.js';
+import { wrap } from './preset-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 import { listEpisodeHealthMarkersForEpisode } from './episode-health-marker-data.js';
 import { listEpisodeSymptomsForEpisode } from './episode-symptom-data.js';
@@ -42,8 +43,9 @@ function compareTimeline(
 }
 
 /**
- * Loads all episode-tied symptoms, health markers, and food entries and returns them in one list
- * ordered by product timestamps (oldest first, `id` as tie-breaker) — a minimal “history” surface.
+ * Loads episode-tied symptoms, health markers, and up to 200 episode-tied food entries (newest
+ * food rows from the source query) and returns them in one merged list ordered by product
+ * timestamps (oldest first, `id` as tie-breaker) — a minimal “history” surface.
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - `episodes.id`.
@@ -52,91 +54,93 @@ export async function listEpisodeObservationTimeline(
   client: AbstrackSupabaseClient,
   episodeId: Uuid,
 ): Promise<PresetDataResult<EpisodeTimelineItem[]>> {
-  const [sy, hm, fd] = await Promise.all([
-    listEpisodeSymptomsForEpisode(client, episodeId),
-    listEpisodeHealthMarkersForEpisode(client, episodeId),
-    listFoodDiaryEntriesForEpisode(client, episodeId, { limit: 200 }),
-  ]);
-  if (!sy.ok) {
-    return sy;
-  }
-  if (!hm.ok) {
-    return hm;
-  }
-  if (!fd.ok) {
-    return fd;
-  }
-  const items: EpisodeTimelineItem[] = [];
-
-  for (const s of sy.data) {
-    if (!s.preset_symptom_id) {
-      continue;
+  return wrap(async () => {
+    const [sy, hm, fd] = await Promise.all([
+      listEpisodeSymptomsForEpisode(client, episodeId),
+      listEpisodeHealthMarkersForEpisode(client, episodeId),
+      listFoodDiaryEntriesForEpisode(client, episodeId, { limit: 200 }),
+    ]);
+    if (!sy.ok) {
+      return { data: null, error: sy.error };
     }
-    let detail = '—';
-    if (s.response_type === 'yes_no' && s.response_boolean != null) {
-      detail = s.response_boolean ? 'Yes' : 'No';
-    } else if (
-      s.response_type === 'severity_scale' &&
-      s.response_severity != null
-    ) {
-      detail = `Severity ${s.response_severity}`;
-    } else if (s.response_type === 'free_text' && s.response_text) {
-      const t = s.response_text.trim();
-      detail = t.length > 80 ? `${t.slice(0, 77)}…` : t;
-    } else if (s.response_type === 'photo') {
-      detail = 'Photo';
-    } else if (s.response_type === 'video') {
-      detail = 'Video';
+    if (!hm.ok) {
+      return { data: null, error: hm.error };
     }
-    items.push({
-      kind: 'symptom',
-      sortAt: s.created_at,
-      id: s.id,
-      label: s.symptom_name,
-      detail,
-    });
-  }
-
-  for (const m of hm.data) {
-    let detail = '—';
-    if (m.marker_kind === 'blood_pressure') {
-      if (m.systolic_numeric != null && m.diastolic_numeric != null) {
-        detail = `${m.systolic_numeric}/${m.diastolic_numeric}`;
-      }
-    } else if (m.value_numeric != null) {
-      detail = String(m.value_numeric);
-      if (m.custom_unit) {
-        detail = `${detail} ${m.custom_unit}`;
-      } else if (m.marker_kind === 'bac') {
-        detail = `${detail} g/dL`;
-      }
-    } else {
-      const n = m.notes?.trim();
-      if (n) {
-        detail = n.length > 80 ? `${n.slice(0, 77)}…` : n;
-      }
+    if (!fd.ok) {
+      return { data: null, error: fd.error };
     }
-    const kindLabel = m.custom_name?.trim() || m.marker_kind;
-    items.push({
-      kind: 'health_marker',
-      sortAt: m.recorded_at,
-      id: m.id,
-      label: kindLabel,
-      detail,
-    });
-  }
+    const items: EpisodeTimelineItem[] = [];
 
-  for (const f of fd.data) {
-    const note = f.food_note.trim();
-    items.push({
-      kind: 'food',
-      sortAt: f.logged_at,
-      id: f.id,
-      label: f.meal_tag,
-      detail: note.length > 100 ? `${note.slice(0, 97)}…` : note,
-    });
-  }
+    for (const s of sy.data) {
+      if (!s.preset_symptom_id) {
+        continue;
+      }
+      let detail = '—';
+      if (s.response_type === 'yes_no' && s.response_boolean != null) {
+        detail = s.response_boolean ? 'Yes' : 'No';
+      } else if (
+        s.response_type === 'severity_scale' &&
+        s.response_severity != null
+      ) {
+        detail = `Severity ${s.response_severity}`;
+      } else if (s.response_type === 'free_text' && s.response_text) {
+        const t = s.response_text.trim();
+        detail = t.length > 80 ? `${t.slice(0, 77)}…` : t;
+      } else if (s.response_type === 'photo') {
+        detail = 'Photo';
+      } else if (s.response_type === 'video') {
+        detail = 'Video';
+      }
+      items.push({
+        kind: 'symptom',
+        sortAt: s.created_at,
+        id: s.id,
+        label: s.symptom_name,
+        detail,
+      });
+    }
 
-  items.sort(compareTimeline);
-  return { ok: true, data: items };
+    for (const m of hm.data) {
+      let detail = '—';
+      if (m.marker_kind === 'blood_pressure') {
+        if (m.systolic_numeric != null && m.diastolic_numeric != null) {
+          detail = `${m.systolic_numeric}/${m.diastolic_numeric}`;
+        }
+      } else if (m.value_numeric != null) {
+        detail = String(m.value_numeric);
+        if (m.custom_unit) {
+          detail = `${detail} ${m.custom_unit}`;
+        } else if (m.marker_kind === 'bac') {
+          detail = `${detail} g/dL`;
+        }
+      } else {
+        const n = m.notes?.trim();
+        if (n) {
+          detail = n.length > 80 ? `${n.slice(0, 77)}…` : n;
+        }
+      }
+      const kindLabel = m.custom_name?.trim() || m.marker_kind;
+      items.push({
+        kind: 'health_marker',
+        sortAt: m.recorded_at,
+        id: m.id,
+        label: kindLabel,
+        detail,
+      });
+    }
+
+    for (const f of fd.data) {
+      const note = f.food_note.trim();
+      items.push({
+        kind: 'food',
+        sortAt: f.logged_at,
+        id: f.id,
+        label: f.meal_tag,
+        detail: note.length > 100 ? `${note.slice(0, 97)}…` : note,
+      });
+    }
+
+    items.sort(compareTimeline);
+    return { data: items, error: null };
+  });
 }

--- a/packages/supabase/src/lib/episode-symptom-data.spec.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { PresetSymptomRow } from '@abstrack/types';
 import {
-  deleteEpisodeSymptomAnswer,
+  deleteCurrentPassEpisodeSymptomAnswer,
+  insertEpisodeSymptomAnswer,
   listEpisodeSymptomsForEpisode,
-  upsertEpisodeSymptomAnswer,
 } from './episode-symptom-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
@@ -17,21 +17,6 @@ const line: PresetSymptomRow = {
   created_at: '2026-04-18T12:00:00.000Z',
   updated_at: '2026-04-18T12:00:00.000Z',
 };
-
-/** Matches `.select().eq().eq().order(created_at desc).order(id desc)` from `fetchEpisodeSymptomRowsForLine`. */
-function chainSelectEpisodeLine(data: unknown): Record<string, unknown> {
-  return {
-    select: vi.fn(() => ({
-      eq: vi.fn(() => ({
-        eq: vi.fn(() => ({
-          order: vi.fn(() => ({
-            order: vi.fn(async () => ({ data, error: null })),
-          })),
-        })),
-      })),
-    })),
-  };
-}
 
 describe('listEpisodeSymptomsForEpisode', () => {
   it('orders by sort_order asc, then created_at desc, then id desc', async () => {
@@ -67,7 +52,7 @@ describe('listEpisodeSymptomsForEpisode', () => {
   });
 });
 
-describe('upsertEpisodeSymptomAnswer', () => {
+describe('insertEpisodeSymptomAnswer', () => {
   it('returns validation_error when answer.type does not match line.response_type', async () => {
     const client = {
       from: vi.fn(() => {
@@ -75,7 +60,7 @@ describe('upsertEpisodeSymptomAnswer', () => {
       }),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await upsertEpisodeSymptomAnswer(client, {
+    const result = await insertEpisodeSymptomAnswer(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line: { ...line, response_type: 'free_text' },
@@ -90,7 +75,7 @@ describe('upsertEpisodeSymptomAnswer', () => {
     expect(client.from).not.toHaveBeenCalled();
   });
 
-  it('inserts when no existing row', async () => {
+  it('inserts a new row', async () => {
     const inserted = {
       id: 'es-1',
       user_id: 'u1',
@@ -105,14 +90,9 @@ describe('upsertEpisodeSymptomAnswer', () => {
       created_at: '2026-04-18T12:00:00.000Z',
       updated_at: '2026-04-18T12:00:00.000Z',
     };
-    let fromCalls = 0;
     const client = {
       from: vi.fn((table: string) => {
-        fromCalls += 1;
-        if (fromCalls === 1) {
-          expect(table).toBe('episode_symptoms');
-          return chainSelectEpisodeLine([]);
-        }
+        expect(table).toBe('episode_symptoms');
         return {
           insert: vi.fn(() => ({
             select: vi.fn(() => ({
@@ -126,7 +106,7 @@ describe('upsertEpisodeSymptomAnswer', () => {
       }),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await upsertEpisodeSymptomAnswer(client, {
+    const result = await insertEpisodeSymptomAnswer(client, {
       userId: 'u1',
       episodeId: 'ep-1',
       line,
@@ -137,258 +117,47 @@ describe('upsertEpisodeSymptomAnswer', () => {
     if (result.ok) {
       expect(result.data.response_boolean).toBe(true);
     }
-    expect(fromCalls).toBe(2);
-  });
-
-  it('updates when a row exists', async () => {
-    const existingId = 'existing-es';
-    const updated = {
-      id: existingId,
-      user_id: 'u1',
-      episode_id: 'ep-1',
-      preset_symptom_id: line.id,
-      symptom_name: line.symptom_name,
-      response_type: 'yes_no',
-      response_boolean: false,
-      response_severity: null,
-      response_text: null,
-      sort_order: 0,
-      created_at: '2026-04-18T12:00:00.000Z',
-      updated_at: '2026-04-18T12:01:00.000Z',
-    };
-    let fromCalls = 0;
-    const client = {
-      from: vi.fn(() => {
-        fromCalls += 1;
-        if (fromCalls === 1) {
-          return chainSelectEpisodeLine([
-            {
-              id: existingId,
-              user_id: 'u1',
-              episode_id: 'ep-1',
-              preset_symptom_id: line.id,
-              created_at: '2026-04-18T12:00:00.000Z',
-            },
-          ]);
-        }
-        return {
-          update: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              select: vi.fn(() => ({
-                single: vi.fn(async () => ({
-                  data: updated,
-                  error: null,
-                })),
-              })),
-            })),
-          })),
-        };
-      }),
-    } as unknown as AbstrackSupabaseClient;
-
-    const result = await upsertEpisodeSymptomAnswer(client, {
-      userId: 'u1',
-      episodeId: 'ep-1',
-      line,
-      answer: { type: 'yes_no', value: false },
-    });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.data.response_boolean).toBe(false);
-    }
-    expect(fromCalls).toBe(2);
-  });
-
-  it('deletes duplicate rows then updates the newest', async () => {
-    const newestId = 'es-newest';
-    const olderId = 'es-older';
-    const updated = {
-      id: newestId,
-      user_id: 'u1',
-      episode_id: 'ep-1',
-      preset_symptom_id: line.id,
-      symptom_name: line.symptom_name,
-      response_type: 'yes_no',
-      response_boolean: true,
-      response_severity: null,
-      response_text: null,
-      sort_order: 0,
-      created_at: '2026-04-18T12:00:00.000Z',
-      updated_at: '2026-04-18T12:02:00.000Z',
-    };
-    let fromCalls = 0;
-    const client = {
-      from: vi.fn((table: string) => {
-        fromCalls += 1;
-        if (fromCalls === 1) {
-          expect(table).toBe('episode_symptoms');
-          return chainSelectEpisodeLine([
-            {
-              id: newestId,
-              user_id: 'u1',
-              episode_id: 'ep-1',
-              preset_symptom_id: line.id,
-              created_at: '2026-04-18T12:00:01.000Z',
-            },
-            {
-              id: olderId,
-              user_id: 'u1',
-              episode_id: 'ep-1',
-              preset_symptom_id: line.id,
-              created_at: '2026-04-18T12:00:00.000Z',
-            },
-          ]);
-        }
-        if (fromCalls === 2) {
-          expect(table).toBe('episode_media');
-          return {
-            update: vi.fn((payload: { episode_symptom_id: string }) => {
-              expect(payload).toEqual({ episode_symptom_id: newestId });
-              return {
-                eq: vi.fn(() => ({
-                  in: vi.fn(async () => ({ error: null })),
-                })),
-              };
-            }),
-          };
-        }
-        if (fromCalls === 3) {
-          expect(table).toBe('episode_symptoms');
-          return {
-            delete: vi.fn(() => ({
-              in: vi.fn(async () => ({ error: null })),
-            })),
-          };
-        }
-        return {
-          update: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              select: vi.fn(() => ({
-                single: vi.fn(async () => ({
-                  data: updated,
-                  error: null,
-                })),
-              })),
-            })),
-          })),
-        };
-      }),
-    } as unknown as AbstrackSupabaseClient;
-
-    const result = await upsertEpisodeSymptomAnswer(client, {
-      userId: 'u1',
-      episodeId: 'ep-1',
-      line,
-      answer: { type: 'yes_no', value: true },
-    });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.data.id).toBe(newestId);
-    }
-    expect(fromCalls).toBe(4);
-  });
-
-  it('on insert unique violation (23505), refetches and updates the concurrent row', async () => {
-    const raceRowId = 'es-concurrent';
-    const afterUpdate = {
-      id: raceRowId,
-      user_id: 'u1',
-      episode_id: 'ep-1',
-      preset_symptom_id: line.id,
-      symptom_name: line.symptom_name,
-      response_type: 'yes_no' as const,
-      response_boolean: true,
-      response_severity: null,
-      response_text: null,
-      sort_order: 0,
-      created_at: '2026-04-18T12:00:00.000Z',
-      updated_at: '2026-04-18T12:00:01.000Z',
-    };
-    let fromCalls = 0;
-    const client = {
-      from: vi.fn(() => {
-        fromCalls += 1;
-        if (fromCalls === 1) {
-          return chainSelectEpisodeLine([]);
-        }
-        if (fromCalls === 2) {
-          return {
-            insert: vi.fn(() => ({
-              select: vi.fn(() => ({
-                single: vi.fn(async () => ({
-                  data: null,
-                  error: { code: '23505', message: 'duplicate key value' },
-                })),
-              })),
-            })),
-          };
-        }
-        if (fromCalls === 3) {
-          return chainSelectEpisodeLine([
-            {
-              id: raceRowId,
-              user_id: 'u1',
-              episode_id: 'ep-1',
-              preset_symptom_id: line.id,
-              created_at: '2026-04-18T12:00:00.000Z',
-            },
-          ]);
-        }
-        return {
-          update: vi.fn(() => ({
-            eq: vi.fn(() => ({
-              select: vi.fn(() => ({
-                single: vi.fn(async () => ({
-                  data: afterUpdate,
-                  error: null,
-                })),
-              })),
-            })),
-          })),
-        };
-      }),
-    } as unknown as AbstrackSupabaseClient;
-
-    const result = await upsertEpisodeSymptomAnswer(client, {
-      userId: 'u1',
-      episodeId: 'ep-1',
-      line,
-      answer: { type: 'yes_no', value: true },
-    });
-
-    expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.data.id).toBe(raceRowId);
-      expect(result.data.response_boolean).toBe(true);
-    }
-    expect(fromCalls).toBe(4);
   });
 });
 
-describe('deleteEpisodeSymptomAnswer', () => {
-  it('deletes rows by episode_id and preset_symptom_id', async () => {
-    const eqPreset = vi.fn(() => ({ error: null }));
-    const eqEpisode = vi.fn(() => ({ eq: eqPreset }));
+describe('deleteCurrentPassEpisodeSymptomAnswer', () => {
+  it('deletes all rows in the current pass for that preset line', async () => {
+    const inDelete = vi.fn(async () => ({ error: null }));
+    let fromCalls = 0;
     const client = {
-      from: vi.fn(() => ({
-        delete: vi.fn(() => ({
-          eq: eqEpisode,
-        })),
-      })),
+      from: vi.fn((table: string) => {
+        expect(table).toBe('episode_symptoms');
+        fromCalls += 1;
+        if (fromCalls === 1) {
+          return {
+            select: vi.fn(() => ({
+              eq: vi.fn(() => ({
+                eq: vi.fn(async () => ({
+                  data: [
+                    { id: 'a', created_at: '2026-04-20T12:00:00.000Z' },
+                    { id: 'b', created_at: '2026-04-21T12:00:00.000Z' },
+                  ],
+                  error: null,
+                })),
+              })),
+            })),
+          };
+        }
+        return {
+          delete: vi.fn(() => ({
+            in: inDelete,
+          })),
+        };
+      }),
     } as unknown as AbstrackSupabaseClient;
 
-    const result = await deleteEpisodeSymptomAnswer(client, {
+    const result = await deleteCurrentPassEpisodeSymptomAnswer(client, {
       episodeId: 'ep-1',
       presetSymptomId: 'ps-line-1',
+      lastPostMarkerStepCompletedAt: '2026-04-19T00:00:00.000Z',
     });
 
     expect(result.ok).toBe(true);
-    if (result.ok) {
-      expect(result.data).toBe(true);
-    }
-    expect(eqEpisode).toHaveBeenCalledWith('episode_id', 'ep-1');
-    expect(eqPreset).toHaveBeenCalledWith('preset_symptom_id', 'ps-line-1');
+    expect(inDelete).toHaveBeenCalledWith('id', ['a', 'b']);
   });
 });

--- a/packages/supabase/src/lib/episode-symptom-data.spec.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.spec.ts
@@ -121,32 +121,19 @@ describe('insertEpisodeSymptomAnswer', () => {
 });
 
 describe('deleteCurrentPassEpisodeSymptomAnswer', () => {
-  it('deletes all rows in the current pass for that preset line', async () => {
-    const inDelete = vi.fn(async () => ({ error: null }));
-    let fromCalls = 0;
+  it('deletes rows in the first pass when boundary is null', async () => {
+    const eqPreset = vi.fn(async () => ({ error: null }));
+    const eqEpisode = vi.fn(() => ({
+      eq: eqPreset,
+    }));
+    const del = vi.fn(() => ({
+      eq: eqEpisode,
+    }));
     const client = {
       from: vi.fn((table: string) => {
         expect(table).toBe('episode_symptoms');
-        fromCalls += 1;
-        if (fromCalls === 1) {
-          return {
-            select: vi.fn(() => ({
-              eq: vi.fn(() => ({
-                eq: vi.fn(async () => ({
-                  data: [
-                    { id: 'a', created_at: '2026-04-20T12:00:00.000Z' },
-                    { id: 'b', created_at: '2026-04-21T12:00:00.000Z' },
-                  ],
-                  error: null,
-                })),
-              })),
-            })),
-          };
-        }
         return {
-          delete: vi.fn(() => ({
-            in: inDelete,
-          })),
+          delete: del,
         };
       }),
     } as unknown as AbstrackSupabaseClient;
@@ -154,10 +141,45 @@ describe('deleteCurrentPassEpisodeSymptomAnswer', () => {
     const result = await deleteCurrentPassEpisodeSymptomAnswer(client, {
       episodeId: 'ep-1',
       presetSymptomId: 'ps-line-1',
-      lastPostMarkerStepCompletedAt: '2026-04-19T00:00:00.000Z',
+      lastPostMarkerStepCompletedAt: null,
     });
 
     expect(result.ok).toBe(true);
-    expect(inDelete).toHaveBeenCalledWith('id', ['a', 'b']);
+    expect(del).toHaveBeenCalledTimes(1);
+    expect(eqEpisode).toHaveBeenCalledWith('episode_id', 'ep-1');
+    expect(eqPreset).toHaveBeenCalledWith('preset_symptom_id', 'ps-line-1');
+  });
+
+  it('adds created_at boundary when deleting current pass rows', async () => {
+    const gtBoundary = vi.fn(async () => ({ error: null }));
+    const eqPreset = vi.fn(() => ({
+      gt: gtBoundary,
+    }));
+    const eqEpisode = vi.fn(() => ({
+      eq: eqPreset,
+    }));
+    const del = vi.fn(() => ({
+      eq: eqEpisode,
+    }));
+    const client = {
+      from: vi.fn((table: string) => {
+        expect(table).toBe('episode_symptoms');
+        return {
+          delete: del,
+        };
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await deleteCurrentPassEpisodeSymptomAnswer(client, {
+      episodeId: 'ep-1',
+      presetSymptomId: 'ps-line-1',
+      lastPostMarkerStepCompletedAt: '2026-04-19T00:00:00.000+00:00',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(gtBoundary).toHaveBeenCalledWith(
+      'created_at',
+      '2026-04-19T00:00:00.000+00:00',
+    );
   });
 });

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -10,143 +10,67 @@ import type { PresetDataResult } from './preset-data.js';
 import { wrap } from './preset-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
-function isPostgresUniqueViolation(error: unknown): boolean {
-  return (
-    typeof error === 'object' &&
-    error !== null &&
-    'code' in error &&
-    (error as { code?: string }).code === '23505'
-  );
-}
-
 /**
- * Loads all `episode_symptoms` rows for one episode step, newest first (canonical row is first).
+ * Inserts a new `episode_symptoms` row for one preset line (one observation per pass; time-ordered
+ * history is `created_at` with `id` as tie-breaker). Does not update prior pass rows.
  *
- * @internal
+ * @param client - Supabase client (RLS applies).
+ * @param args.userId - Must match the episode owner (`episodes.user_id`) for patient-owned episodes.
+ * @param args.episodeId - `episodes.id`.
+ * @param args.line - Active preset symptom line (defines `preset_symptom_id`, name, sort order).
+ * @param args.answer - Current answer for that line (`answer.type` must match `line.response_type`).
  */
-async function fetchEpisodeSymptomRowsForLine(
-  client: AbstrackSupabaseClient,
-  episodeId: Uuid,
-  presetSymptomId: Uuid,
-): Promise<{ data: EpisodeSymptomRow[]; error: unknown }> {
-  const r = await client
-    .from('episode_symptoms')
-    .select('*')
-    .eq('episode_id', episodeId)
-    .eq('preset_symptom_id', presetSymptomId)
-    .order('created_at', { ascending: false })
-    .order('id', { ascending: false });
-  return {
-    data: (r.data ?? []) as EpisodeSymptomRow[],
-    error: r.error,
-  };
-}
-
-/**
- * Moves `episode_media` rows off duplicate `episode_symptoms` ids before those rows are deleted.
- * `episode_media_symptom_step_fk` is `ON DELETE CASCADE`; without this, storage metadata would be
- * dropped with the duplicate symptom row.
- *
- * @internal
- */
-async function reassignEpisodeMediaToCanonicalSymptomRow(
+export async function insertEpisodeSymptomAnswer(
   client: AbstrackSupabaseClient,
   args: {
+    userId: Uuid;
     episodeId: Uuid;
-    canonicalEpisodeSymptomId: Uuid;
-    duplicateEpisodeSymptomIds: Uuid[];
+    line: PresetSymptomRow;
+    answer: SymptomPromptAnswer;
   },
-): Promise<{ error: unknown }> {
-  const { episodeId, canonicalEpisodeSymptomId, duplicateEpisodeSymptomIds } =
-    args;
-  if (duplicateEpisodeSymptomIds.length === 0) {
-    return { error: null };
-  }
-  const r = await client
-    .from('episode_media')
-    .update({ episode_symptom_id: canonicalEpisodeSymptomId })
-    .eq('episode_id', episodeId)
-    .in('episode_symptom_id', duplicateEpisodeSymptomIds);
-  return { error: r.error };
-}
+): Promise<PresetDataResult<EpisodeSymptomRow>> {
+  const { userId, episodeId, line, answer } = args;
 
-/**
- * Deletes duplicate rows by id (keeps the canonical row outside this call).
- *
- * @internal
- */
-async function deleteEpisodeSymptomRowsByIds(
-  client: AbstrackSupabaseClient,
-  ids: Uuid[],
-): Promise<{ error: unknown }> {
-  if (ids.length === 0) {
-    return { error: null };
-  }
-  return client.from('episode_symptoms').delete().in('id', ids);
-}
-
-/** User-facing copy when dedupe fails on the initial fetch path. */
-const DUPLICATE_SYMPTOM_CONFLICT_FIX =
-  'Could not fix duplicate symptom entries. Try again or contact support.';
-
-/** User-facing copy when dedupe fails after a unique race on insert. */
-const DUPLICATE_SYMPTOM_CONFLICT_SAVE =
-  'Could not save this symptom answer. Try again.';
-
-/**
- * If `rows` has more than one line for the same preset step (newest first), repoints
- * `episode_media`, deletes duplicate `episode_symptoms` rows, and returns `[canonical]`.
- * Otherwise returns `rows` unchanged.
- *
- * @internal
- */
-async function dedupeEpisodeSymptomRowsForLine(
-  client: AbstrackSupabaseClient,
-  episodeId: Uuid,
-  rows: EpisodeSymptomRow[],
-  conflictMessage: string,
-): Promise<
-  | { ok: true; rows: EpisodeSymptomRow[] }
-  | { ok: false; error: PresetDataError }
-> {
-  if (rows.length <= 1) {
-    return { ok: true, rows };
-  }
-  const canonicalId = rows[0].id;
-  const duplicateIds = rows.slice(1).map((r) => r.id);
-
-  const { error: mediaError } = await reassignEpisodeMediaToCanonicalSymptomRow(
-    client,
-    {
-      episodeId,
-      canonicalEpisodeSymptomId: canonicalId,
-      duplicateEpisodeSymptomIds: duplicateIds,
-    },
-  );
-  if (mediaError) {
+  if (answer.type !== line.response_type) {
     return {
       ok: false,
-      error: new PresetDataError('conflict', conflictMessage, mediaError),
+      error: new PresetDataError(
+        'validation_error',
+        'Answer type does not match this symptom line.',
+      ),
     };
   }
-  const { error: delError } = await deleteEpisodeSymptomRowsByIds(
-    client,
-    duplicateIds,
-  );
-  if (delError) {
+
+  const response = symptomPromptAnswerToResponseColumns(answer);
+  const responsePayload = {
+    symptom_name: line.symptom_name,
+    sort_order: line.sort_order,
+    response_type: response.response_type,
+    response_boolean: response.response_boolean,
+    response_severity: response.response_severity,
+    response_text: response.response_text,
+  };
+
+  return wrap(async () => {
+    const ins = await client
+      .from('episode_symptoms')
+      .insert({
+        user_id: userId,
+        episode_id: episodeId,
+        preset_symptom_id: line.id,
+        ...responsePayload,
+      })
+      .select('*')
+      .single();
     return {
-      ok: false,
-      error: new PresetDataError('conflict', conflictMessage, delError),
+      data: ins.data as EpisodeSymptomRow | null,
+      error: ins.error,
     };
-  }
-  return { ok: true, rows: [rows[0]] };
+  });
 }
 
 /**
- * Lists logged symptom rows for one episode (preset order, then stable duplicate ordering).
- *
- * Orders by `sort_order` ASC, then `created_at` DESC, then `id` DESC so legacy duplicate rows for the
- * same preset line list the canonical row first (same tie-break as upsert / migration / client map).
+ * Lists logged symptom rows for one episode (preset order, then newest duplicate ordering).
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - `episodes.id`.
@@ -171,163 +95,49 @@ export async function listEpisodeSymptomsForEpisode(
 }
 
 /**
- * Inserts or updates one `episode_symptoms` row for a preset line (one row per episode + preset line).
- * If multiple rows exist for the same pair (legacy data or pre-migration races), keeps the newest row
- * by `created_at` / `id`, repoints `episode_media` off duplicate ids (CASCADE), deletes the rest,
- * then updates. Values are plaintext columns under RLS.
- *
- * @param client - Supabase client (RLS applies).
- * @param args.userId - Must match the episode owner (`episodes.user_id`) for patient-owned episodes.
- * @param args.episodeId - `episodes.id`.
- * @param args.line - Active preset symptom line (defines `preset_symptom_id`, name, sort order).
- * @param args.answer - Current answer for that line (`answer.type` must match `line.response_type`).
- */
-export async function upsertEpisodeSymptomAnswer(
-  client: AbstrackSupabaseClient,
-  args: {
-    userId: Uuid;
-    episodeId: Uuid;
-    line: PresetSymptomRow;
-    answer: SymptomPromptAnswer;
-  },
-): Promise<PresetDataResult<EpisodeSymptomRow>> {
-  const { userId, episodeId, line, answer } = args;
-
-  if (answer.type !== line.response_type) {
-    return {
-      ok: false,
-      error: new PresetDataError(
-        'validation_error',
-        'Answer type does not match this symptom line.',
-      ),
-    };
-  }
-
-  const response = symptomPromptAnswerToResponseColumns(answer);
-
-  const responsePayload = {
-    symptom_name: line.symptom_name,
-    sort_order: line.sort_order,
-    response_type: response.response_type,
-    response_boolean: response.response_boolean,
-    response_severity: response.response_severity,
-    response_text: response.response_text,
-  };
-
-  return wrap(async () => {
-    const fetched = await fetchEpisodeSymptomRowsForLine(
-      client,
-      episodeId,
-      line.id,
-    );
-    if (fetched.error) {
-      return { data: null, error: fetched.error };
-    }
-
-    let rows = fetched.data;
-
-    const initialDedupe = await dedupeEpisodeSymptomRowsForLine(
-      client,
-      episodeId,
-      rows,
-      DUPLICATE_SYMPTOM_CONFLICT_FIX,
-    );
-    if (!initialDedupe.ok) {
-      return { data: null, error: initialDedupe.error };
-    }
-    rows = initialDedupe.rows;
-
-    if (rows.length === 1) {
-      const upd = await client
-        .from('episode_symptoms')
-        .update(responsePayload)
-        .eq('id', rows[0].id)
-        .select('*')
-        .single();
-      return {
-        data: upd.data as EpisodeSymptomRow | null,
-        error: upd.error,
-      };
-    }
-
-    const ins = await client
-      .from('episode_symptoms')
-      .insert({
-        user_id: userId,
-        episode_id: episodeId,
-        preset_symptom_id: line.id,
-        ...responsePayload,
-      })
-      .select('*')
-      .single();
-
-    if (ins.error && isPostgresUniqueViolation(ins.error)) {
-      const afterRace = await fetchEpisodeSymptomRowsForLine(
-        client,
-        episodeId,
-        line.id,
-      );
-      if (afterRace.error) {
-        return { data: null, error: afterRace.error };
-      }
-      let r2 = afterRace.data;
-      const raceDedupe = await dedupeEpisodeSymptomRowsForLine(
-        client,
-        episodeId,
-        r2,
-        DUPLICATE_SYMPTOM_CONFLICT_SAVE,
-      );
-      if (!raceDedupe.ok) {
-        return { data: null, error: raceDedupe.error };
-      }
-      r2 = raceDedupe.rows;
-      if (r2.length === 0) {
-        return { data: null, error: ins.error };
-      }
-      const upd = await client
-        .from('episode_symptoms')
-        .update(responsePayload)
-        .eq('id', r2[0].id)
-        .select('*')
-        .single();
-      return {
-        data: upd.data as EpisodeSymptomRow | null,
-        error: upd.error,
-      };
-    }
-
-    return {
-      data: ins.data as EpisodeSymptomRow | null,
-      error: ins.error,
-    };
-  });
-}
-
-/**
- * Deletes any persisted `episode_symptoms` rows for one preset line in an episode.
- * Used when a user intentionally skips/clears a symptom so blank rows are not kept.
+ * Deletes all `episode_symptoms` rows for a preset line that belong to the current open pass
+ * (used when the user skips a symptom in that pass, so the pass has no answer for the line).
  *
  * @param client - Supabase client (RLS applies).
  * @param args.episodeId - `episodes.id`.
  * @param args.presetSymptomId - `preset_symptoms.id` for the current prompt line.
+ * @param args.lastPostMarkerStepCompletedAt - `episodes.post_marker_step_completed_at` (or null
+ *   for the first pass before any “Save and continue” on episode details).
  */
-export async function deleteEpisodeSymptomAnswer(
+export async function deleteCurrentPassEpisodeSymptomAnswer(
   client: AbstrackSupabaseClient,
   args: {
     episodeId: Uuid;
     presetSymptomId: Uuid;
+    lastPostMarkerStepCompletedAt: string | null;
   },
 ): Promise<PresetDataResult<boolean>> {
-  const { episodeId, presetSymptomId } = args;
+  const { episodeId, presetSymptomId, lastPostMarkerStepCompletedAt } = args;
   return wrap(async () => {
-    const r = await client
+    const { data, error: fetchError } = await client
       .from('episode_symptoms')
-      .delete()
+      .select('id, created_at')
       .eq('episode_id', episodeId)
       .eq('preset_symptom_id', presetSymptomId);
+    if (fetchError) {
+      return { data: null, error: fetchError };
+    }
+    const rows = (data ?? []) as { id: string; created_at: string }[];
+    const inPass =
+      lastPostMarkerStepCompletedAt == null
+        ? rows
+        : rows.filter((r) => r.created_at > lastPostMarkerStepCompletedAt);
+    if (inPass.length === 0) {
+      return { data: true, error: null };
+    }
+    const ids = inPass.map((row) => row.id);
+    const { error: delError } = await client
+      .from('episode_symptoms')
+      .delete()
+      .in('id', ids);
     return {
-      data: r.error ? null : true,
-      error: r.error,
+      data: delError ? null : true,
+      error: delError,
     };
   });
 }

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -13,6 +13,8 @@ import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 /**
  * Inserts a new `episode_symptoms` row for one preset line (one observation per pass; time-ordered
  * history is `created_at` with `id` as tie-breaker). Does not update prior pass rows.
+ * Intentional: episode observations are append-only for auditability/history, so this helper is
+ * insert-only (no upsert path).
  *
  * @param client - Supabase client (RLS applies).
  * @param args.userId - Must match the episode owner (`episodes.user_id`) for patient-owned episodes.

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -95,8 +95,9 @@ export async function listEpisodeSymptomsForEpisode(
 }
 
 /**
- * Deletes all `episode_symptoms` rows for a preset line that belong to the current open pass
- * (used when the user skips a symptom in that pass, so the pass has no answer for the line).
+ * Deletes all `episode_symptoms` rows for a preset line that belong to the current open pass in
+ * one SQL statement (used when the user skips a symptom in that pass, so the pass has no answer
+ * for the line).
  *
  * @param client - Supabase client (RLS applies).
  * @param args.episodeId - `episodes.id`.
@@ -114,27 +115,17 @@ export async function deleteCurrentPassEpisodeSymptomAnswer(
 ): Promise<PresetDataResult<boolean>> {
   const { episodeId, presetSymptomId, lastPostMarkerStepCompletedAt } = args;
   return wrap(async () => {
-    const { data, error: fetchError } = await client
-      .from('episode_symptoms')
-      .select('id, created_at')
-      .eq('episode_id', episodeId)
-      .eq('preset_symptom_id', presetSymptomId);
-    if (fetchError) {
-      return { data: null, error: fetchError };
-    }
-    const rows = (data ?? []) as { id: string; created_at: string }[];
-    const inPass =
-      lastPostMarkerStepCompletedAt == null
-        ? rows
-        : rows.filter((r) => r.created_at > lastPostMarkerStepCompletedAt);
-    if (inPass.length === 0) {
-      return { data: true, error: null };
-    }
-    const ids = inPass.map((row) => row.id);
-    const { error: delError } = await client
+    let delQuery = client
       .from('episode_symptoms')
       .delete()
-      .in('id', ids);
+      .eq('episode_id', episodeId)
+      .eq('preset_symptom_id', presetSymptomId);
+
+    if (lastPostMarkerStepCompletedAt != null) {
+      delQuery = delQuery.gt('created_at', lastPostMarkerStepCompletedAt);
+    }
+
+    const { error: delError } = await delQuery;
     return {
       data: delError ? null : true,
       error: delError,

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -76,19 +76,28 @@ export async function insertEpisodeSymptomAnswer(
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - `episodes.id`.
+ * @param options - Optional cap (`limit`) for newest rows after source ordering.
  */
 export async function listEpisodeSymptomsForEpisode(
   client: AbstrackSupabaseClient,
   episodeId: Uuid,
+  options: {
+    limit?: number;
+  } = {},
 ): Promise<PresetDataResult<EpisodeSymptomRow[]>> {
+  const limit = options.limit;
   return wrap(async () => {
-    const r = await client
+    let query = client
       .from('episode_symptoms')
       .select('*')
       .eq('episode_id', episodeId)
       .order('sort_order', { ascending: true })
       .order('created_at', { ascending: false })
       .order('id', { ascending: false });
+    if (limit != null) {
+      query = query.limit(limit);
+    }
+    const r = await query;
     return {
       data: (r.data ?? []) as EpisodeSymptomRow[],
       error: r.error,

--- a/packages/supabase/src/lib/episode-symptom-data.ts
+++ b/packages/supabase/src/lib/episode-symptom-data.ts
@@ -76,24 +76,34 @@ export async function insertEpisodeSymptomAnswer(
  *
  * @param client - Supabase client (RLS applies).
  * @param episodeId - `episodes.id`.
- * @param options - Optional cap (`limit`) for newest rows after source ordering.
+ * @param options - Optional row ordering (`orderBy`: `preset` default, or `recent` for
+ *   timeline-style newest-first reads) and optional cap (`limit`) applied after that ordering.
  */
 export async function listEpisodeSymptomsForEpisode(
   client: AbstrackSupabaseClient,
   episodeId: Uuid,
   options: {
     limit?: number;
+    orderBy?: 'preset' | 'recent';
   } = {},
 ): Promise<PresetDataResult<EpisodeSymptomRow[]>> {
   const limit = options.limit;
+  const orderBy = options.orderBy ?? 'preset';
   return wrap(async () => {
     let query = client
       .from('episode_symptoms')
       .select('*')
-      .eq('episode_id', episodeId)
-      .order('sort_order', { ascending: true })
-      .order('created_at', { ascending: false })
-      .order('id', { ascending: false });
+      .eq('episode_id', episodeId);
+    if (orderBy === 'recent') {
+      query = query
+        .order('created_at', { ascending: false })
+        .order('id', { ascending: false });
+    } else {
+      query = query
+        .order('sort_order', { ascending: true })
+        .order('created_at', { ascending: false })
+        .order('id', { ascending: false });
+    }
     if (limit != null) {
       query = query.limit(limit);
     }

--- a/packages/supabase/src/lib/food-diary-data.ts
+++ b/packages/supabase/src/lib/food-diary-data.ts
@@ -284,6 +284,8 @@ export async function listFoodDiaryEntriesForEpisode(
 
 /**
  * Creates one food diary entry. `episode_id` can be `null` for standalone home entries.
+ * In episode flows, this is the preferred append-only observation write (new entries insert rows
+ * rather than overwriting prior logs).
  *
  * @param client - Supabase client (RLS applies).
  * @param row - Insert payload.

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,6 +4,7 @@ export * from './lib/episode-template.js';
 export * from './lib/symptom-prompt-session.js';
 export * from './lib/symptom-prompt-session-sanitize.js';
 export * from './lib/episode-symptom-mapping.js';
+export * from './lib/episode-open-pass.js';
 export * from './lib/episode-bac-suggestion.js';
 export * from './lib/types.js';
 export * from './lib/marker-draft.js';

--- a/packages/types/src/lib/episode-open-pass.spec.ts
+++ b/packages/types/src/lib/episode-open-pass.spec.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  EpisodeSymptomRow,
+  HealthMarkerRow,
+  PresetHealthMarkerRow,
+} from './types.js';
+import {
+  filterEpisodeSymptomRowsForOpenPass,
+  filterHealthMarkerRowsForOpenPass,
+  findLatestHealthMarkerForLineInPass,
+} from './episode-open-pass.js';
+
+function makeSymptomRow(id: string, createdAt: string): EpisodeSymptomRow {
+  return {
+    id,
+    user_id: 'u-1',
+    episode_id: 'ep-1',
+    preset_symptom_id: 'ps-1',
+    symptom_name: 'Nausea',
+    response_type: 'yes_no',
+    response_boolean: true,
+    response_severity: null,
+    response_text: null,
+    sort_order: 0,
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+}
+
+function makeHealthMarkerRow(id: string, createdAt: string): HealthMarkerRow {
+  return {
+    id,
+    user_id: 'u-1',
+    episode_id: 'ep-1',
+    preset_health_marker_id: 'phm-1',
+    marker_kind: 'heart_rate',
+    custom_name: null,
+    custom_name_key: null,
+    custom_unit: null,
+    custom_unit_key: null,
+    value_numeric: 90,
+    systolic_numeric: null,
+    diastolic_numeric: null,
+    notes: null,
+    recorded_at: createdAt,
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+}
+
+const markerLine: PresetHealthMarkerRow = {
+  id: 'phm-1',
+  preset_id: 'hm-preset-1',
+  sort_order: 0,
+  marker_kind: 'heart_rate',
+  custom_name: null,
+  custom_unit: null,
+  created_at: '2026-04-24T00:00:00.000Z',
+  updated_at: '2026-04-24T00:00:00.000Z',
+};
+
+describe('filterEpisodeSymptomRowsForOpenPass', () => {
+  it('uses parsed timestamps for pass-boundary filtering across mixed formats', () => {
+    const boundary = '2026-04-24T12:00:00.123+00:00';
+    const rows = [
+      makeSymptomRow('before', '2026-04-24T12:00:00.100Z'),
+      makeSymptomRow('at', '2026-04-24T12:00:00.123Z'),
+      makeSymptomRow('after', '2026-04-24T12:00:00.124Z'),
+    ];
+
+    const filtered = filterEpisodeSymptomRowsForOpenPass(rows, boundary);
+    expect(filtered.map((r) => r.id)).toEqual(['after']);
+  });
+});
+
+describe('filterHealthMarkerRowsForOpenPass', () => {
+  it('uses parsed timestamps for pass-boundary filtering across mixed formats', () => {
+    const boundary = '2026-04-24T12:00:00.500+00:00';
+    const rows = [
+      makeHealthMarkerRow('before', '2026-04-24T12:00:00.499Z'),
+      makeHealthMarkerRow('at', '2026-04-24T12:00:00.500Z'),
+      makeHealthMarkerRow('after', '2026-04-24T12:00:00.501Z'),
+    ];
+
+    const filtered = filterHealthMarkerRowsForOpenPass(rows, boundary);
+    expect(filtered.map((r) => r.id)).toEqual(['after']);
+  });
+});
+
+describe('findLatestHealthMarkerForLineInPass', () => {
+  it('chooses latest by parsed recorded_at with mixed timestamp formats', () => {
+    const rows: HealthMarkerRow[] = [
+      {
+        ...makeHealthMarkerRow('older', '2026-04-24T12:00:00.100Z'),
+        recorded_at: '2026-04-24T12:00:00.100Z',
+      },
+      {
+        ...makeHealthMarkerRow('newer', '2026-04-24T12:00:00.000Z'),
+        recorded_at: '2026-04-24T12:00:00.123+00:00',
+      },
+    ];
+
+    const latest = findLatestHealthMarkerForLineInPass(rows, markerLine);
+    expect(latest?.id).toBe('newer');
+  });
+
+  it('uses created_at then id tie-break when recorded_at instants match', () => {
+    const rows: HealthMarkerRow[] = [
+      {
+        ...makeHealthMarkerRow('b-id', '2026-04-24T12:00:00.700Z'),
+        recorded_at: '2026-04-24T12:00:00.500Z',
+      },
+      {
+        ...makeHealthMarkerRow('a-id', '2026-04-24T12:00:00.700+00:00'),
+        recorded_at: '2026-04-24T12:00:00.500+00:00',
+      },
+    ];
+
+    const latest = findLatestHealthMarkerForLineInPass(rows, markerLine);
+    expect(latest?.id).toBe('b-id');
+  });
+});

--- a/packages/types/src/lib/episode-open-pass.ts
+++ b/packages/types/src/lib/episode-open-pass.ts
@@ -82,20 +82,34 @@ export function findLatestHealthMarkerForLineInPass(
   passRows: HealthMarkerRow[],
   line: PresetHealthMarkerRow,
 ): HealthMarkerRow | null {
-  const forLine = passRows.filter((r) => r.preset_health_marker_id === line.id);
-  if (forLine.length === 0) {
-    return null;
+  let latest: HealthMarkerRow | null = null;
+  for (const row of passRows) {
+    if (row.preset_health_marker_id !== line.id) {
+      continue;
+    }
+    if (!latest) {
+      latest = row;
+      continue;
+    }
+    const c = compareTimestampDesc(row.recorded_at, latest.recorded_at);
+    if (c < 0) {
+      latest = row;
+      continue;
+    }
+    if (c > 0) {
+      continue;
+    }
+    const d = compareTimestampDesc(row.created_at, latest.created_at);
+    if (d < 0) {
+      latest = row;
+      continue;
+    }
+    if (d > 0) {
+      continue;
+    }
+    if (row.id.localeCompare(latest.id) > 0) {
+      latest = row;
+    }
   }
-  forLine.sort((a, b) => {
-    const c = compareTimestampDesc(a.recorded_at, b.recorded_at);
-    if (c !== 0) {
-      return c;
-    }
-    const d = compareTimestampDesc(a.created_at, b.created_at);
-    if (d !== 0) {
-      return d;
-    }
-    return b.id.localeCompare(a.id);
-  });
-  return forLine[0] ?? null;
+  return latest;
 }

--- a/packages/types/src/lib/episode-open-pass.ts
+++ b/packages/types/src/lib/episode-open-pass.ts
@@ -4,6 +4,33 @@ import type {
   PresetHealthMarkerRow,
 } from './types.js';
 
+function isAfterPassBoundary(
+  createdAt: string,
+  lastPostMarkerStepCompletedAt: string,
+): boolean {
+  const createdAtMs = Date.parse(createdAt);
+  const boundaryMs = Date.parse(lastPostMarkerStepCompletedAt);
+  const createdAtIsValid = Number.isFinite(createdAtMs);
+  const boundaryIsValid = Number.isFinite(boundaryMs);
+  if (createdAtIsValid && boundaryIsValid) {
+    return createdAtMs > boundaryMs;
+  }
+  // Defensive fallback for unexpected timestamp serialization.
+  return createdAt > lastPostMarkerStepCompletedAt;
+}
+
+function compareTimestampDesc(a: string, b: string): number {
+  const aMs = Date.parse(a);
+  const bMs = Date.parse(b);
+  const aValid = Number.isFinite(aMs);
+  const bValid = Number.isFinite(bMs);
+  if (aValid && bValid) {
+    return bMs - aMs;
+  }
+  // Defensive fallback for unexpected timestamp serialization.
+  return b.localeCompare(a);
+}
+
 /**
  * Returns episode symptom rows that belong to the **open pass** after the last time the user
  * finished the episode-details step (Save and continue). When that timestamp is null, the whole
@@ -19,7 +46,9 @@ export function filterEpisodeSymptomRowsForOpenPass(
   if (lastPostMarkerStepCompletedAt == null) {
     return rows;
   }
-  return rows.filter((r) => r.created_at > lastPostMarkerStepCompletedAt);
+  return rows.filter((r) =>
+    isAfterPassBoundary(r.created_at, lastPostMarkerStepCompletedAt),
+  );
 }
 
 /**
@@ -37,7 +66,9 @@ export function filterHealthMarkerRowsForOpenPass(
   if (lastPostMarkerStepCompletedAt == null) {
     return rows;
   }
-  return rows.filter((r) => r.created_at > lastPostMarkerStepCompletedAt);
+  return rows.filter((r) =>
+    isAfterPassBoundary(r.created_at, lastPostMarkerStepCompletedAt),
+  );
 }
 
 /**
@@ -56,11 +87,11 @@ export function findLatestHealthMarkerForLineInPass(
     return null;
   }
   forLine.sort((a, b) => {
-    const c = b.recorded_at.localeCompare(a.recorded_at);
+    const c = compareTimestampDesc(a.recorded_at, b.recorded_at);
     if (c !== 0) {
       return c;
     }
-    const d = b.created_at.localeCompare(a.created_at);
+    const d = compareTimestampDesc(a.created_at, b.created_at);
     if (d !== 0) {
       return d;
     }

--- a/packages/types/src/lib/episode-open-pass.ts
+++ b/packages/types/src/lib/episode-open-pass.ts
@@ -1,0 +1,70 @@
+import type {
+  EpisodeSymptomRow,
+  HealthMarkerRow,
+  PresetHealthMarkerRow,
+} from './types.js';
+
+/**
+ * Returns episode symptom rows that belong to the **open pass** after the last time the user
+ * finished the episode-details step (Save and continue). When that timestamp is null, the whole
+ * history is in one “first pass” context and nothing is filtered out.
+ *
+ * @param rows - All `episode_symptoms` rows for the episode (any sort order).
+ * @param lastPostMarkerStepCompletedAt - `episodes.post_marker_step_completed_at` (ISO), or null.
+ */
+export function filterEpisodeSymptomRowsForOpenPass(
+  rows: EpisodeSymptomRow[],
+  lastPostMarkerStepCompletedAt: string | null,
+): EpisodeSymptomRow[] {
+  if (lastPostMarkerStepCompletedAt == null) {
+    return rows;
+  }
+  return rows.filter((r) => r.created_at > lastPostMarkerStepCompletedAt);
+}
+
+/**
+ * Same as {@link filterEpisodeSymptomRowsForOpenPass} for `health_markers` rows, using
+ * `created_at` to align with when the row was written (not `recorded_at`, so backdated vitals
+ * still belong to the pass in which they were saved).
+ *
+ * @param rows - All episode-bound `health_markers` rows (wellness rows should be omitted by caller).
+ * @param lastPostMarkerStepCompletedAt - `episodes.post_marker_step_completed_at` (ISO), or null.
+ */
+export function filterHealthMarkerRowsForOpenPass(
+  rows: HealthMarkerRow[],
+  lastPostMarkerStepCompletedAt: string | null,
+): HealthMarkerRow[] {
+  if (lastPostMarkerStepCompletedAt == null) {
+    return rows;
+  }
+  return rows.filter((r) => r.created_at > lastPostMarkerStepCompletedAt);
+}
+
+/**
+ * Picks the latest marker row for a preset line within an already pass-filtered list
+ * (newest `recorded_at`, then `created_at`, then `id`).
+ *
+ * @param passRows - Episode health markers in the current pass (see {@link filterHealthMarkerRowsForOpenPass}).
+ * @param line - Preset line (`preset_health_markers.id` matches `preset_health_marker_id`).
+ */
+export function findLatestHealthMarkerForLineInPass(
+  passRows: HealthMarkerRow[],
+  line: PresetHealthMarkerRow,
+): HealthMarkerRow | null {
+  const forLine = passRows.filter((r) => r.preset_health_marker_id === line.id);
+  if (forLine.length === 0) {
+    return null;
+  }
+  forLine.sort((a, b) => {
+    const c = b.recorded_at.localeCompare(a.recorded_at);
+    if (c !== 0) {
+      return c;
+    }
+    const d = b.created_at.localeCompare(a.created_at);
+    if (d !== 0) {
+      return d;
+    }
+    return b.id.localeCompare(a.id);
+  });
+  return forLine[0] ?? null;
+}

--- a/packages/types/src/lib/episode-symptom-mapping.ts
+++ b/packages/types/src/lib/episode-symptom-mapping.ts
@@ -1,4 +1,5 @@
 import type { EpisodeSymptomRow, SymptomResponseType } from './types.js';
+import { filterEpisodeSymptomRowsForOpenPass } from './episode-open-pass.js';
 import type {
   SymptomPromptAnswer,
   SymptomPromptAnswers,
@@ -123,4 +124,20 @@ export function episodeSymptomRowsToAnswersMap(
     out[presetId] = episodeSymptomRowToPromptAnswer(row);
   }
   return out;
+}
+
+/**
+ * Like {@link episodeSymptomRowsToAnswersMap}, but only includes rows from the current open pass
+ * (after the last `post_marker_step_completed_at` Save and continue, if any).
+ *
+ * @param rows - All `episode_symptoms` rows for the episode.
+ * @param lastPostMarkerStepCompletedAt - `episodes.post_marker_step_completed_at` (ISO), or null.
+ */
+export function episodeSymptomRowsToAnswersMapForOpenPass(
+  rows: EpisodeSymptomRow[],
+  lastPostMarkerStepCompletedAt: string | null,
+): SymptomPromptAnswers {
+  return episodeSymptomRowsToAnswersMap(
+    filterEpisodeSymptomRowsForOpenPass(rows, lastPostMarkerStepCompletedAt),
+  );
 }

--- a/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
+++ b/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
@@ -87,7 +87,7 @@ BEGIN
   RAISE EXCEPTION
     'This episode has ended. You cannot add or change entries for it.' USING
       ERRCODE = 'check_violation';
-END
+END;
 $$;
 
 COMMENT ON FUNCTION public.assert_episode_child_not_after_episode_end () IS

--- a/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
+++ b/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
@@ -138,6 +138,6 @@ COMMENT ON FUNCTION public.stamp_episode_post_marker_boundary_from_updated_at ()
 
 DROP TRIGGER IF EXISTS zz_episode_post_marker_boundary_stamp ON public.episodes;
 CREATE TRIGGER zz_episode_post_marker_boundary_stamp
-  BEFORE UPDATE ON public.episodes
+  BEFORE UPDATE OF post_marker_step_completed_at ON public.episodes
   FOR EACH ROW
   EXECUTE FUNCTION public.stamp_episode_post_marker_boundary_from_updated_at ();

--- a/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
+++ b/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
@@ -62,7 +62,8 @@ BEGIN
       FROM
         public.episodes e
       WHERE
-        e.id = old_eid;
+        e.id = old_eid
+      FOR SHARE;
       IF old_ep_ended IS NOT NULL THEN
         RAISE EXCEPTION
           'This episode has ended. You cannot add or change entries for it.' USING
@@ -80,7 +81,8 @@ BEGIN
   FROM
     public.episodes e
   WHERE
-    e.id = new_eid;
+    e.id = new_eid
+  FOR SHARE;
   IF new_ep_ended IS NULL THEN
     RETURN NEW;
   END IF;

--- a/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
+++ b/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
@@ -110,3 +110,32 @@ CREATE TRIGGER food_diary_block_after_end
   BEFORE INSERT OR UPDATE ON public.food_diary_entries
   FOR EACH ROW
   EXECUTE FUNCTION public.assert_episode_child_not_after_episode_end ();
+
+-- ---------------------------------------------------------------------------
+-- 4) Episodes: stamp post-marker boundary from server timestamp atomically
+-- ---------------------------------------------------------------------------
+-- When post_marker_step_completed_at is set (completion signal), stamp it from NEW.updated_at in
+-- the same UPDATE statement so pass-boundary comparisons stay in DB time.
+CREATE OR REPLACE FUNCTION public.stamp_episode_post_marker_boundary_from_updated_at ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  IF
+    NEW.post_marker_step_completed_at IS NOT NULL
+    AND NEW.post_marker_step_completed_at IS DISTINCT FROM OLD.post_marker_step_completed_at
+  THEN
+    NEW.post_marker_step_completed_at := NEW.updated_at;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.stamp_episode_post_marker_boundary_from_updated_at () IS
+  'When post_marker_step_completed_at changes, stamps it from NEW.updated_at so pass boundary and row update share one server timestamp.';
+
+DROP TRIGGER IF EXISTS zz_episode_post_marker_boundary_stamp ON public.episodes;
+CREATE TRIGGER zz_episode_post_marker_boundary_stamp
+  BEFORE UPDATE ON public.episodes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.stamp_episode_post_marker_boundary_from_updated_at ();

--- a/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
+++ b/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
@@ -33,7 +33,7 @@ CREATE INDEX IF NOT EXISTS health_markers_episode_preset_line_idx
     AND preset_health_marker_id IS NOT NULL;
 
 COMMENT ON INDEX public.health_markers_episode_preset_line_idx IS
-  'Non-unique lookup for episode + preset line; multiple rows per pair are allowed (ordered by recorded_at, id).';
+  'Non-unique lookup for episode + preset line; multiple rows per pair are allowed (ordered by recorded_at, created_at, id).';
 
 -- food_diary_entries: no unique on episode; no change.
 

--- a/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
+++ b/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
@@ -1,5 +1,7 @@
 -- Multiple time-ordered observations per (episode, preset line) for open-episode repeat passes.
 -- Drop uniqueness that forced a single row per line; add non-unique indexes for lookups.
+-- Intentional product rule: episode observations are append-only (new logs INSERT new rows; no
+-- in-place overwrite of prior episode observations).
 -- Triggers: block INSERT/UPDATE of episode-tied rows when episodes.ended_at is set.
 --
 -- Note: `database.types.ts` is generated after cloud apply; no hand-edits in repo.
@@ -43,23 +45,43 @@ CREATE OR REPLACE FUNCTION public.assert_episode_child_not_after_episode_end ()
   LANGUAGE plpgsql
   AS $$
 DECLARE
-  ep_ended timestamptz;
-  eid uuid;
+  old_ep_ended timestamptz;
+  new_ep_ended timestamptz;
+  old_eid uuid;
+  new_eid uuid;
 BEGIN
   IF TG_OP = 'DELETE' THEN
     RETURN OLD;
   END IF;
-  eid := NEW.episode_id;
-  IF eid IS NULL THEN
+
+  IF TG_OP = 'UPDATE' THEN
+    old_eid := OLD.episode_id;
+    IF old_eid IS NOT NULL THEN
+      SELECT
+        e.ended_at INTO old_ep_ended
+      FROM
+        public.episodes e
+      WHERE
+        e.id = old_eid;
+      IF old_ep_ended IS NOT NULL THEN
+        RAISE EXCEPTION
+          'This episode has ended. You cannot add or change entries for it.' USING
+            ERRCODE = 'check_violation';
+      END IF;
+    END IF;
+  END IF;
+
+  new_eid := NEW.episode_id;
+  IF new_eid IS NULL THEN
     RETURN NEW;
   END IF;
   SELECT
-    e.ended_at INTO ep_ended
+    e.ended_at INTO new_ep_ended
   FROM
     public.episodes e
   WHERE
-    e.id = eid;
-  IF ep_ended IS NULL THEN
+    e.id = new_eid;
+  IF new_ep_ended IS NULL THEN
     RETURN NEW;
   END IF;
   RAISE EXCEPTION

--- a/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
+++ b/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
@@ -1,0 +1,90 @@
+-- Multiple time-ordered observations per (episode, preset line) for open-episode repeat passes.
+-- Drop uniqueness that forced a single row per line; add non-unique indexes for lookups.
+-- Triggers: block INSERT/UPDATE of episode-tied rows when episodes.ended_at is set.
+--
+-- Note: `database.types.ts` is generated after cloud apply; no hand-edits in repo.
+
+-- ---------------------------------------------------------------------------
+-- 1) episode_symptoms: drop partial unique (one row per episode + preset line)
+-- ---------------------------------------------------------------------------
+DROP INDEX IF EXISTS public.episode_symptoms_episode_id_preset_symptom_id_uidx;
+
+CREATE INDEX IF NOT EXISTS episode_symptoms_episode_preset_line_idx
+  ON public.episode_symptoms (episode_id, preset_symptom_id)
+  WHERE
+    episode_id IS NOT NULL
+    AND preset_symptom_id IS NOT NULL;
+
+COMMENT ON INDEX public.episode_symptoms_episode_preset_line_idx IS
+  'Non-unique lookup for episode + preset line; multiple rows per pair are allowed (ordered by created_at, id).';
+
+-- ---------------------------------------------------------------------------
+-- 2) health_markers: drop unique (episode_id, preset_health_marker_id)
+-- ---------------------------------------------------------------------------
+ALTER TABLE public.health_markers
+  DROP CONSTRAINT IF EXISTS health_markers_episode_preset_line_uidx;
+
+CREATE INDEX IF NOT EXISTS health_markers_episode_preset_line_idx
+  ON public.health_markers (episode_id, preset_health_marker_id)
+  WHERE
+    episode_id IS NOT NULL
+    AND preset_health_marker_id IS NOT NULL;
+
+COMMENT ON INDEX public.health_markers_episode_preset_line_idx IS
+  'Non-unique lookup for episode + preset line; multiple rows per pair are allowed (ordered by recorded_at, id).';
+
+-- food_diary_entries: no unique on episode; no change.
+
+-- ---------------------------------------------------------------------------
+-- 3) Triggers: no new or changed episode-tied data after the episode ends
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.assert_episode_child_not_after_episode_end ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  AS $$
+DECLARE
+  ep_ended timestamptz;
+  eid uuid;
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RETURN OLD;
+  END IF;
+  eid := NEW.episode_id;
+  IF eid IS NULL THEN
+    RETURN NEW;
+  END IF;
+  SELECT
+    e.ended_at INTO ep_ended
+  FROM
+    public.episodes e
+  WHERE
+    e.id = eid;
+  IF ep_ended IS NULL THEN
+    RETURN NEW;
+  END IF;
+  RAISE EXCEPTION
+    'This episode has ended. You cannot add or change entries for it.' USING
+      ERRCODE = 'check_violation';
+END
+$$;
+
+COMMENT ON FUNCTION public.assert_episode_child_not_after_episode_end () IS
+  'Blocks INSERT/UPDATE on episode_id–linked child rows when episodes.ended_at is not null. DELETE is allowed.';
+
+DROP TRIGGER IF EXISTS episode_symptoms_block_after_end ON public.episode_symptoms;
+CREATE TRIGGER episode_symptoms_block_after_end
+  BEFORE INSERT OR UPDATE ON public.episode_symptoms
+  FOR EACH ROW
+  EXECUTE FUNCTION public.assert_episode_child_not_after_episode_end ();
+
+DROP TRIGGER IF EXISTS health_markers_block_after_end ON public.health_markers;
+CREATE TRIGGER health_markers_block_after_end
+  BEFORE INSERT OR UPDATE ON public.health_markers
+  FOR EACH ROW
+  EXECUTE FUNCTION public.assert_episode_child_not_after_episode_end ();
+
+DROP TRIGGER IF EXISTS food_diary_block_after_end ON public.food_diary_entries;
+CREATE TRIGGER food_diary_block_after_end
+  BEFORE INSERT OR UPDATE ON public.food_diary_entries
+  FOR EACH ROW
+  EXECUTE FUNCTION public.assert_episode_child_not_after_episode_end ();

--- a/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
+++ b/supabase/migrations/20260424120000_episode_multi_pass_observations.sql
@@ -45,31 +45,11 @@ CREATE OR REPLACE FUNCTION public.assert_episode_child_not_after_episode_end ()
   LANGUAGE plpgsql
   AS $$
 DECLARE
-  old_ep_ended timestamptz;
   new_ep_ended timestamptz;
-  old_eid uuid;
   new_eid uuid;
 BEGIN
   IF TG_OP = 'DELETE' THEN
     RETURN OLD;
-  END IF;
-
-  IF TG_OP = 'UPDATE' THEN
-    old_eid := OLD.episode_id;
-    IF old_eid IS NOT NULL THEN
-      SELECT
-        e.ended_at INTO old_ep_ended
-      FROM
-        public.episodes e
-      WHERE
-        e.id = old_eid
-      FOR SHARE;
-      IF old_ep_ended IS NOT NULL THEN
-        RAISE EXCEPTION
-          'This episode has ended. You cannot add or change entries for it.' USING
-            ERRCODE = 'check_violation';
-      END IF;
-    END IF;
   END IF;
 
   new_eid := NEW.episode_id;
@@ -93,7 +73,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION public.assert_episode_child_not_after_episode_end () IS
-  'Blocks INSERT/UPDATE on episode_id–linked child rows when episodes.ended_at is not null. DELETE is allowed.';
+  'Blocks INSERT/UPDATE when NEW.episode_id points at an ended episode. UPDATE paths that detach rows (NEW.episode_id is null), including FK ON DELETE SET NULL, are allowed. DELETE is allowed.';
 
 DROP TRIGGER IF EXISTS episode_symptoms_block_after_end ON public.episode_symptoms;
 CREATE TRIGGER episode_symptoms_block_after_end


### PR DESCRIPTION
Closes #126

## Summary

Enables **multiple guided check-ins (“passes”)** on a **single open episode** (`ended_at` null): symptoms → health markers → food (when in template) → episode details → **Save and continue**, then **append** new rows (no overwrite) for preset-linked symptoms and markers, with ordering by existing timestamps + `id`. Adds **guards** so episode-tied rows are not inserted/updated after the episode ends, and introduces an **episode hub** after each saved pass and when resuming from home/Manage after `post_marker_step_completed_at` is set.

## Database

- New migration: relaxes uniqueness that blocked multiple `episode_symptoms` / `health_markers` rows per `(episode, preset line)`; adds lookup indexes; **BEFORE INSERT OR UPDATE** triggers on `episode_symptoms`, `health_markers`, and `food_diary_entries` when `episode_id` is set and `episodes.ended_at` is set.
- **`database.types.ts`**: regenerate with `supabase gen types typescript --linked` after `db push` (no hand-edits). See `AGENTS.md` / `docs/SUPABASE_CLOUD_DEVELOPER.md`.

## App / packages

- **`@abstrack/types`**: pass-boundary helpers from `post_marker_step_completed_at`, symptom row filtering/mapping for the current pass.
- **`@abstrack/supabase`**: insert-only episode symptom/health-marker writes, pass-scoped delete where needed, `listEpisodeObservationTimeline` for minimal time-ordered history.
- **Web**: `HealthMarkerPromptFlow` — pass-aware markers/food/details; after save → **hub** (timeline, **Log another check-in**, **Back to dashboard**, **End episode**); resume after a completed pass uses `?resume=1&hub=1` via `buildResumeEpisodeHref`; `SymptomPromptFlow` aligned with insert/pass semantics.
- **Mobile**: same hub and navigation params (`hub: true` when resuming at post-marker); parallel marker/symptom behavior.

## Testing

- Updated/added unit tests (e.g. resume href, health marker / episodes screens); `web:build` and targeted Jest suites pass locally.

## Notes for reviewers

- Single **Continue** entry path: hub is not a separate product surface beyond health-markers + query flag.
- Full repeat UX polish for every response type remains out of scope for follow-up issues as already tracked.