### PR TITLE
feat(episode-flow): complete multi-pass check-in UX with dedicated saved route, symptom history, and mobile/web food-diary + action-layout fixes

### DIFF
--- a/apps/mobile/src/app/components/episode-flow/EpisodeFlowSecondaryActionsSection.tsx
+++ b/apps/mobile/src/app/components/episode-flow/EpisodeFlowSecondaryActionsSection.tsx
@@ -1,0 +1,20 @@
+import type { ReactNode } from 'react';
+import { View } from 'react-native';
+
+export type EpisodeFlowSecondaryActionsSectionProps = {
+  children: ReactNode;
+};
+
+/**
+ * Shared in-scroll container for low-priority / destructive episode-flow actions.
+ * Keeps spacing and divider styling consistent across mobile round screens.
+ */
+export function EpisodeFlowSecondaryActionsSection({
+  children,
+}: EpisodeFlowSecondaryActionsSectionProps) {
+  return (
+    <View className="mt-6 border-t border-app-border pt-4 dark:border-app-border-dark">
+      {children}
+    </View>
+  );
+}

--- a/apps/mobile/src/app/screens/HealthMarkerFoodDiaryStep.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerFoodDiaryStep.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 import type { AppThemeColors } from '../theme/app-colors';
 import { nw } from '../theme/app-nativewind-classes';
+import { EpisodeFlowSecondaryActionsSection } from '../components/episode-flow/EpisodeFlowSecondaryActionsSection';
 import type { HealthMarkerFoodDiaryHookResult } from './use-health-marker-food-diary';
 
 function formatFoodDiaryLoggedAtForDisplay(iso: string): string {
@@ -48,6 +49,7 @@ export function HealthMarkerFoodDiaryStep({
       <ScrollView
         className="flex-1"
         keyboardShouldPersistTaps="handled"
+        showsVerticalScrollIndicator
         contentContainerStyle={{ paddingBottom: 24 }}
       >
         <Text
@@ -615,6 +617,22 @@ export function HealthMarkerFoodDiaryStep({
             {fd.foodEntries.length === 0 ? 'Skip for now' : 'Continue'}
           </Text>
         </Pressable>
+        <EpisodeFlowSecondaryActionsSection>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Cancel episode"
+            onPress={onCancelEpisodePress}
+            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+            className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
+          >
+            <Text
+              className="text-sm font-medium text-red-700 dark:text-red-300"
+              maxFontSizeMultiplier={2}
+            >
+              Cancel episode
+            </Text>
+          </Pressable>
+        </EpisodeFlowSecondaryActionsSection>
       </ScrollView>
       {fd.foodDatePickerOpen ? (
         <DateTimePicker
@@ -633,20 +651,6 @@ export function HealthMarkerFoodDiaryStep({
           onChange={fd.onFoodTimePickerChange}
         />
       ) : null}
-      <Pressable
-        accessibilityRole="button"
-        accessibilityLabel="Cancel episode"
-        onPress={onCancelEpisodePress}
-        style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-        className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
-      >
-        <Text
-          className="text-sm font-medium text-red-700 dark:text-red-300"
-          maxFontSizeMultiplier={2}
-        >
-          Cancel episode
-        </Text>
-      </Pressable>
     </>
   );
 }

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -51,6 +51,7 @@ import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-ses
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
 import { ScreenShell } from '../components/ScreenShell';
+import { EpisodeFlowSecondaryActionsSection } from '../components/episode-flow/EpisodeFlowSecondaryActionsSection';
 import type { MainStackParamList } from '../navigation/types';
 import { useAppTheme } from '../theme/AppThemeContext';
 import { nw } from '../theme/app-nativewind-classes';
@@ -990,6 +991,7 @@ export function HealthMarkerPromptScreen() {
             <ScrollView
               className="flex-1"
               keyboardShouldPersistTaps="handled"
+              showsVerticalScrollIndicator
               contentContainerStyle={{ paddingBottom: 24 }}
             >
               <Text
@@ -1166,21 +1168,23 @@ export function HealthMarkerPromptScreen() {
                   {savingPost ? 'Saving…' : 'Save and continue'}
                 </Text>
               </Pressable>
+              <EpisodeFlowSecondaryActionsSection>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Cancel episode"
+                  onPress={onCancelEpisodePress}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
+                >
+                  <Text
+                    className="text-sm font-medium text-red-700 dark:text-red-300"
+                    maxFontSizeMultiplier={2}
+                  >
+                    Cancel episode
+                  </Text>
+                </Pressable>
+              </EpisodeFlowSecondaryActionsSection>
             </ScrollView>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Cancel episode"
-              onPress={onCancelEpisodePress}
-              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-              className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
-            >
-              <Text
-                className="text-sm font-medium text-red-700 dark:text-red-300"
-                maxFontSizeMultiplier={2}
-              >
-                Cancel episode
-              </Text>
-            </Pressable>
           </>
         ) : (
           <>
@@ -1196,6 +1200,7 @@ export function HealthMarkerPromptScreen() {
               <ScrollView
                 className="flex-1"
                 keyboardShouldPersistTaps="handled"
+                showsVerticalScrollIndicator
                 contentContainerStyle={{ paddingBottom: 24 }}
               >
                 <Text
@@ -1365,7 +1370,7 @@ export function HealthMarkerPromptScreen() {
                 {observationTimeline.length > 0 ? (
                   <View
                     accessibilityLabel="Recent log entries in this episode, oldest first within this slice"
-                    className="mt-6 rounded-xl border border-app-border bg-app-surface/60 p-4"
+                    className="mt-6 rounded-xl border border-app-border bg-app-surface p-4 dark:border-app-border-dark dark:bg-app-bg-dark"
                   >
                     <Text
                       className={`text-sm font-semibold ${nw.textInk}`}
@@ -1392,22 +1397,24 @@ export function HealthMarkerPromptScreen() {
                     ))}
                   </View>
                 ) : null}
+                <EpisodeFlowSecondaryActionsSection>
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Cancel episode"
+                    onPress={onCancelEpisodePress}
+                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                    className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
+                  >
+                    <Text
+                      className="text-sm font-medium text-red-700 dark:text-red-300"
+                      maxFontSizeMultiplier={2}
+                    >
+                      Cancel episode
+                    </Text>
+                  </Pressable>
+                </EpisodeFlowSecondaryActionsSection>
               </ScrollView>
             </AsyncScreenContainer>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Cancel episode"
-              onPress={onCancelEpisodePress}
-              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-              className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
-            >
-              <Text
-                className="text-sm font-medium text-red-700 dark:text-red-300"
-                maxFontSizeMultiplier={2}
-              >
-                Cancel episode
-              </Text>
-            </Pressable>
           </>
         )}
       </View>

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -21,9 +21,11 @@ import type {
   SymptomPromptAnswers,
 } from '@abstrack/types';
 import {
+  compareEpisodeSymptomRowsForHistory,
   computeSymptomResumePlacement,
   createDefaultSymptomPromptAnswer,
   episodeSymptomRowsToAnswersMapForOpenPass,
+  formatEpisodeSymptomHistoryDetail,
   formatEpisodeDurationSimple,
   symptomPromptAnswerHasValue,
 } from '@abstrack/types';
@@ -71,48 +73,6 @@ function clampIndex(index: number, length: number): number {
 /** Queue key so the same preset symptom id does not serialize writes across episodes. */
 function lineWriteQueueKey(episodeId: string, presetSymptomId: string): string {
   return `${episodeId}:${presetSymptomId}`;
-}
-
-function compareSymptomRowsForHistory(
-  a: EpisodeSymptomRow,
-  b: EpisodeSymptomRow,
-): number {
-  const aMs = Date.parse(a.created_at);
-  const bMs = Date.parse(b.created_at);
-  const aValid = Number.isFinite(aMs);
-  const bValid = Number.isFinite(bMs);
-  if (aValid && bValid) {
-    const byTime = aMs - bMs;
-    if (byTime !== 0) {
-      return byTime;
-    }
-  } else {
-    const byText = a.created_at.localeCompare(b.created_at);
-    if (byText !== 0) {
-      return byText;
-    }
-  }
-  return a.id.localeCompare(b.id);
-}
-
-function symptomHistoryDetail(row: EpisodeSymptomRow): string {
-  if (row.response_type === 'yes_no' && row.response_boolean != null) {
-    return row.response_boolean ? 'Yes' : 'No';
-  }
-  if (row.response_type === 'severity_scale' && row.response_severity != null) {
-    return `Severity ${row.response_severity}`;
-  }
-  if (row.response_type === 'free_text') {
-    const text = row.response_text?.trim() ?? '';
-    return text.length > 0 ? text : '—';
-  }
-  if (row.response_type === 'photo') {
-    return 'Photo';
-  }
-  if (row.response_type === 'video') {
-    return 'Video';
-  }
-  return '—';
 }
 
 function formatSymptomHistoryInstant(isoLike: string): string {
@@ -488,7 +448,7 @@ export function SymptomPromptScreen() {
         : {};
       if (fromServer.ok) {
         setSymptomHistory(
-          fromServer.data.slice().sort(compareSymptomRowsForHistory),
+          fromServer.data.slice().sort(compareEpisodeSymptomRowsForHistory),
         );
       } else {
         setSymptomHistory([]);
@@ -928,7 +888,7 @@ export function SymptomPromptScreen() {
                     maxFontSizeMultiplier={2}
                   >
                     {formatSymptomHistoryInstant(row.created_at)} —{' '}
-                    {row.symptom_name}: {symptomHistoryDetail(row)}
+                    {row.symptom_name}: {formatEpisodeSymptomHistoryDetail(row)}
                   </Text>
                 ))}
               </View>

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -15,6 +15,7 @@ import {
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type {
   EpisodeRow,
+  EpisodeSymptomRow,
   PresetSymptomRow,
   SymptomPromptAnswer,
   SymptomPromptAnswers,
@@ -46,6 +47,7 @@ import {
 import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
 import { SymptomPromptResponseField } from '../components/episode-flow/SymptomPromptResponseField';
 import { ScreenShell } from '../components/ScreenShell';
+import { EpisodeFlowSecondaryActionsSection } from '../components/episode-flow/EpisodeFlowSecondaryActionsSection';
 import type { MainStackParamList } from '../navigation/types';
 import { nw } from '../theme/app-nativewind-classes';
 
@@ -71,6 +73,56 @@ function lineWriteQueueKey(episodeId: string, presetSymptomId: string): string {
   return `${episodeId}:${presetSymptomId}`;
 }
 
+function compareSymptomRowsForHistory(
+  a: EpisodeSymptomRow,
+  b: EpisodeSymptomRow,
+): number {
+  const aMs = Date.parse(a.created_at);
+  const bMs = Date.parse(b.created_at);
+  const aValid = Number.isFinite(aMs);
+  const bValid = Number.isFinite(bMs);
+  if (aValid && bValid) {
+    const byTime = aMs - bMs;
+    if (byTime !== 0) {
+      return byTime;
+    }
+  } else {
+    const byText = a.created_at.localeCompare(b.created_at);
+    if (byText !== 0) {
+      return byText;
+    }
+  }
+  return a.id.localeCompare(b.id);
+}
+
+function symptomHistoryDetail(row: EpisodeSymptomRow): string {
+  if (row.response_type === 'yes_no' && row.response_boolean != null) {
+    return row.response_boolean ? 'Yes' : 'No';
+  }
+  if (row.response_type === 'severity_scale' && row.response_severity != null) {
+    return `Severity ${row.response_severity}`;
+  }
+  if (row.response_type === 'free_text') {
+    const text = row.response_text?.trim() ?? '';
+    return text.length > 0 ? text : '—';
+  }
+  if (row.response_type === 'photo') {
+    return 'Photo';
+  }
+  if (row.response_type === 'video') {
+    return 'Video';
+  }
+  return '—';
+}
+
+function formatSymptomHistoryInstant(isoLike: string): string {
+  const ms = Date.parse(isoLike);
+  if (!Number.isFinite(ms)) {
+    return isoLike;
+  }
+  return new Date(ms).toLocaleString();
+}
+
 /**
  * Linear symptom stepper for the active episode’s selected preset (Week 5 skeleton).
  *
@@ -94,6 +146,7 @@ export function SymptomPromptScreen() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [persistError, setPersistError] = useState<string | null>(null);
   const [lines, setLines] = useState<PresetSymptomRow[]>([]);
+  const [symptomHistory, setSymptomHistory] = useState<EpisodeSymptomRow[]>([]);
 
   const [activeIndex, setActiveIndex] = useState(
     () => getSymptomPromptSession(episodeId).activeIndex,
@@ -420,6 +473,9 @@ export function SymptomPromptScreen() {
       const fromServer = await listEpisodeSymptomsForEpisode(
         supabase,
         episodeId,
+        {
+          orderBy: 'recent',
+        },
       );
       if (stale()) {
         return;
@@ -430,6 +486,13 @@ export function SymptomPromptScreen() {
             passBoundary,
           )
         : {};
+      if (fromServer.ok) {
+        setSymptomHistory(
+          fromServer.data.slice().sort(compareSymptomRowsForHistory),
+        );
+      } else {
+        setSymptomHistory([]);
+      }
       const session = getSymptomPromptSession(episodeId);
       // Session overlays server so local drafts survive hydrate (debounced/offline/failed sync).
       const mergedAnswers = { ...serverAnswers, ...session.answers };
@@ -493,6 +556,7 @@ export function SymptomPromptScreen() {
     setErrorMessage(null);
     setPersistError(null);
     setLines([]);
+    setSymptomHistory([]);
   }, [episodeId, symptomPresetId, resumeFromEntry, flushPendingServerPersist]);
 
   const currentLine = lines[activeIndex] ?? null;
@@ -795,6 +859,7 @@ export function SymptomPromptScreen() {
           <ScrollView
             className="flex-1"
             keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator
             contentContainerStyle={{ paddingBottom: 24 }}
           >
             <Text
@@ -836,6 +901,36 @@ export function SymptomPromptScreen() {
                   onChange={onChangeAnswer}
                   disabled={status !== 'ready'}
                 />
+              </View>
+            ) : null}
+
+            {symptomHistory.length > 0 ? (
+              <View
+                accessibilityLabel="Symptom history in this episode, oldest first"
+                className="mt-6 rounded-xl border border-app-border bg-app-surface p-4 dark:border-app-border-dark dark:bg-app-bg-dark"
+              >
+                <Text
+                  className={`text-sm font-semibold ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Symptom history in this episode
+                </Text>
+                <Text
+                  className={`mb-2 text-xs ${nw.textMuted}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Oldest first. Each entry is saved as its own row.
+                </Text>
+                {symptomHistory.map((row) => (
+                  <Text
+                    key={row.id}
+                    className={`mb-2 text-sm ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {formatSymptomHistoryInstant(row.created_at)} —{' '}
+                    {row.symptom_name}: {symptomHistoryDetail(row)}
+                  </Text>
+                ))}
               </View>
             ) : null}
 
@@ -896,55 +991,58 @@ export function SymptomPromptScreen() {
                 </Text>
               </Pressable>
             </View>
+
+            <EpisodeFlowSecondaryActionsSection>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Exit symptom flow"
+                onPress={onExitFlowPress}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
+              >
+                <Text
+                  className={`text-base font-medium ${nw.textMuted}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Exit symptom flow
+                </Text>
+              </Pressable>
+              {episodeForEndCta?.post_marker_step_completed_at &&
+              !episodeForEndCta.ended_at ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="End this episode"
+                  accessibilityState={{ disabled: endingEpisode }}
+                  disabled={endingEpisode}
+                  onPress={onEndEpisodePress}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="mt-3 w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
+                >
+                  <Text
+                    className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {endingEpisode ? 'Ending…' : 'End this episode'}
+                  </Text>
+                </Pressable>
+              ) : null}
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Cancel episode"
+                onPress={onCancelEpisodePress}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className="mt-3 w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
+              >
+                <Text
+                  className="text-sm font-medium text-red-700 dark:text-red-300"
+                  maxFontSizeMultiplier={2}
+                >
+                  Cancel episode
+                </Text>
+              </Pressable>
+            </EpisodeFlowSecondaryActionsSection>
           </ScrollView>
         </AsyncScreenContainer>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Exit symptom flow"
-          onPress={onExitFlowPress}
-          style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-          className="mt-auto w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
-        >
-          <Text
-            className={`text-base font-medium ${nw.textMuted}`}
-            maxFontSizeMultiplier={2}
-          >
-            Exit symptom flow
-          </Text>
-        </Pressable>
-        {episodeForEndCta?.post_marker_step_completed_at &&
-        !episodeForEndCta.ended_at ? (
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="End this episode"
-            accessibilityState={{ disabled: endingEpisode }}
-            disabled={endingEpisode}
-            onPress={onEndEpisodePress}
-            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-            className="w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
-          >
-            <Text
-              className={`text-center text-[17px] font-semibold ${nw.textInk}`}
-              maxFontSizeMultiplier={2}
-            >
-              {endingEpisode ? 'Ending…' : 'End this episode'}
-            </Text>
-          </Pressable>
-        ) : null}
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Cancel episode"
-          onPress={onCancelEpisodePress}
-          style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-          className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
-        >
-          <Text
-            className="text-sm font-medium text-red-700 dark:text-red-300"
-            maxFontSizeMultiplier={2}
-          >
-            Cancel episode
-          </Text>
-        </Pressable>
       </View>
     </ScreenShell>
   );

--- a/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
+++ b/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
@@ -152,7 +152,7 @@ export function useHealthMarkerFoodDiary({
   const [deletingFoodEntryId, setDeletingFoodEntryId] = useState<string | null>(
     null,
   );
-  const [isAddFoodEntryOpen, setIsAddFoodEntryOpen] = useState(true);
+  const [isAddFoodEntryOpen, setIsAddFoodEntryOpen] = useState(false);
   const [isAddFoodEntryDirty, setIsAddFoodEntryDirty] = useState(false);
   const [foodDatePickerOpen, setFoodDatePickerOpen] = useState(false);
   const [foodTimePickerOpen, setFoodTimePickerOpen] = useState(false);
@@ -173,7 +173,7 @@ export function useHealthMarkerFoodDiary({
     setFoodDiaryFeedback(null);
     setEditingFoodEntryId(null);
     setDeletingFoodEntryId(null);
-    setIsAddFoodEntryOpen(true);
+    setIsAddFoodEntryOpen(false);
     setIsAddFoodEntryDirty(false);
     setFoodDatePickerOpen(false);
     setFoodTimePickerOpen(false);
@@ -300,6 +300,13 @@ export function useHealthMarkerFoodDiary({
       return;
     }
     const editingId = editingFoodEntryId;
+    const useCurrentTimestampForDefaultAdd =
+      editingId == null &&
+      foodLoggedDate === addFoodInitialDate &&
+      foodLoggedTime === addFoodInitialTime;
+    const createLoggedAtIso = useCurrentTimestampForDefaultAdd
+      ? new Date().toISOString()
+      : loggedAtIso;
     const result =
       editingId == null
         ? await createFoodDiaryEntry(supabase, {
@@ -307,7 +314,7 @@ export function useHealthMarkerFoodDiary({
             episode_id: episodeId,
             meal_tag: mealTag,
             food_note: foodNote,
-            logged_at: loggedAtIso,
+            logged_at: createLoggedAtIso,
           })
         : await updateFoodDiaryEntry(supabase, editingId, {
             meal_tag: mealTag,
@@ -353,6 +360,8 @@ export function useHealthMarkerFoodDiary({
     savingFoodDiary,
     supabase,
     userId,
+    addFoodInitialDate,
+    addFoodInitialTime,
   ]);
 
   const foodDiaryContinueDisabled =

--- a/apps/web/src/app/(app)/episode/[episodeId]/check-in-saved/page.tsx
+++ b/apps/web/src/app/(app)/episode/[episodeId]/check-in-saved/page.tsx
@@ -1,0 +1,23 @@
+import { HealthMarkerPromptFlow } from '@/components/episode-flow/HealthMarkerPromptFlow';
+
+type PageProps = {
+  /** Next.js 16 passes dynamic route params as a Promise (await before use). */
+  params: Promise<{ episodeId: string }>;
+};
+
+/**
+ * Episode check-in completion hub (after Save and continue).
+ *
+ * @param props - Route params.
+ * @returns Check-in saved actions + recent timeline.
+ */
+export default async function EpisodeCheckInSavedPage({ params }: PageProps) {
+  const { episodeId } = await params;
+  return (
+    <HealthMarkerPromptFlow
+      episodeId={episodeId}
+      resumeFromEntry
+      resumeToEpisodeHub
+    />
+  );
+}

--- a/apps/web/src/app/(app)/episode/[episodeId]/check-in-saved/page.tsx
+++ b/apps/web/src/app/(app)/episode/[episodeId]/check-in-saved/page.tsx
@@ -1,4 +1,6 @@
+import { redirect } from 'next/navigation';
 import { HealthMarkerPromptFlow } from '@/components/episode-flow/HealthMarkerPromptFlow';
+import { createServerClient } from '@/lib/supabase/server-client';
 
 type PageProps = {
   /** Next.js 16 passes dynamic route params as a Promise (await before use). */
@@ -13,6 +15,21 @@ type PageProps = {
  */
 export default async function EpisodeCheckInSavedPage({ params }: PageProps) {
   const { episodeId } = await params;
+  const supabase = await createServerClient();
+  const { data: episode, error } = await supabase
+    .from('episodes')
+    .select('id,post_marker_step_completed_at')
+    .eq('id', episodeId)
+    .maybeSingle();
+
+  if (error || !episode) {
+    redirect('/dashboard');
+  }
+
+  if (!episode.post_marker_step_completed_at) {
+    redirect(`/episode/${episodeId}/health-markers?resume=1`);
+  }
+
   return (
     <HealthMarkerPromptFlow
       episodeId={episodeId}

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -469,6 +469,9 @@ export function HealthMarkerPromptFlow({
       announce(result.error.message, { politeness: 'assertive' });
       return;
     }
+    announce('Check-in saved. Opening your check-in summary.', {
+      politeness: 'polite',
+    });
     router.replace(`/episode/${episodeId}/check-in-saved`);
   };
 
@@ -853,6 +856,18 @@ export function HealthMarkerPromptFlow({
                 ))}
               </ol>
             </section>
+          ) : null}
+          {!endedSummary ? (
+            <div
+              className="rounded-xl border border-app-border/80 bg-app-surface px-4 py-3"
+              role="status"
+              aria-live="polite"
+            >
+              <p className="text-sm text-app-ink">
+                This check-in is saved. You can log another check-in, return to
+                the dashboard, or end this episode.
+              </p>
+            </div>
           ) : null}
           {endedSummary ? (
             <div

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -71,10 +71,7 @@ function healthMarkerDetailForTimeline(row: HealthMarkerRow): string {
 export type HealthMarkerPromptFlowProps = {
   episodeId: string;
   resumeFromEntry?: boolean;
-  /**
-   * When true with `resumeFromEntry`, opens the episode hub (after a saved pass) instead of the
-   * marker stepper or food diary.
-   */
+  /** When true with `resumeFromEntry`, opens the check-in-saved hub when available. */
   resumeToEpisodeHub?: boolean;
 };
 
@@ -472,17 +469,7 @@ export function HealthMarkerPromptFlow({
       announce(result.error.message, { politeness: 'assertive' });
       return;
     }
-    setEpisodeRow(result.data);
-    setEndFeedback(null);
-    setEndedSummary(null);
-    await refreshObservationTimeline();
-    setPhase('complete');
-    announce(
-      result.data.symptom_preset_id
-        ? 'This check-in is saved. You can log another when you are ready, or return to the dashboard.'
-        : 'Episode details saved.',
-      { politeness: 'polite' },
-    );
+    router.replace(`/episode/${episodeId}/check-in-saved`);
   };
 
   const onLogAnotherCheckIn = useCallback(() => {
@@ -867,12 +854,12 @@ export function HealthMarkerPromptFlow({
               </ol>
             </section>
           ) : null}
-          <div
-            className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
-            role="status"
-            aria-live="polite"
-          >
-            {endedSummary ? (
+          {endedSummary ? (
+            <div
+              className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+              role="status"
+              aria-live="polite"
+            >
               <div className="space-y-2">
                 <p className="text-sm leading-relaxed text-app-ink">
                   This episode is ended and saved.
@@ -884,19 +871,8 @@ export function HealthMarkerPromptFlow({
                   Duration {endedSummary.durationText ?? '—'}
                 </p>
               </div>
-            ) : (
-              <div className="space-y-3 text-sm leading-relaxed text-app-ink">
-                <p>
-                  This round is saved: symptoms, health markers, any food diary
-                  entries you added, and episode details.
-                </p>
-                <p className="text-app-muted">
-                  Return to the dashboard, log another full check-in when you
-                  are ready, or end this episode when you are completely done.
-                </p>
-              </div>
-            )}
-          </div>
+            </div>
+          ) : null}
           {endFeedback ? (
             <p className="text-sm text-red-700 dark:text-red-300" role="alert">
               {endFeedback}

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -10,6 +10,7 @@ import {
   useState,
 } from 'react';
 import type {
+  EpisodeSymptomRow,
   PresetSymptomRow,
   SymptomPromptAnswer,
   SymptomPromptAnswers,
@@ -45,6 +46,7 @@ import {
 } from '@/lib/episode-flow/symptom-prompt-session-store';
 import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
 import { SymptomPromptResponseField } from './SymptomPromptResponseField';
+import { EpisodeLocaleInstant } from '../episodes/EpisodeLocaleInstant';
 
 export type SymptomPromptFlowProps = {
   /** `episodes.id` from the route. */
@@ -77,6 +79,48 @@ function lineWriteQueueKey(episodeId: string, presetSymptomId: string): string {
   return `${episodeId}:${presetSymptomId}`;
 }
 
+function compareSymptomRowsForHistory(
+  a: EpisodeSymptomRow,
+  b: EpisodeSymptomRow,
+): number {
+  const aMs = Date.parse(a.created_at);
+  const bMs = Date.parse(b.created_at);
+  const aValid = Number.isFinite(aMs);
+  const bValid = Number.isFinite(bMs);
+  if (aValid && bValid) {
+    const byTime = aMs - bMs;
+    if (byTime !== 0) {
+      return byTime;
+    }
+  } else {
+    const byText = a.created_at.localeCompare(b.created_at);
+    if (byText !== 0) {
+      return byText;
+    }
+  }
+  return a.id.localeCompare(b.id);
+}
+
+function symptomHistoryDetail(row: EpisodeSymptomRow): string {
+  if (row.response_type === 'yes_no' && row.response_boolean != null) {
+    return row.response_boolean ? 'Yes' : 'No';
+  }
+  if (row.response_type === 'severity_scale' && row.response_severity != null) {
+    return `Severity ${row.response_severity}`;
+  }
+  if (row.response_type === 'free_text') {
+    const text = row.response_text?.trim() ?? '';
+    return text.length > 0 ? text : '—';
+  }
+  if (row.response_type === 'photo') {
+    return 'Photo';
+  }
+  if (row.response_type === 'video') {
+    return 'Video';
+  }
+  return '—';
+}
+
 /**
  * No form in this flow uses this id; the shared leave guard requires a truthy `exemptFormId` to
  * register submit capture so non-exempt forms (all of them, here) are intercepted.
@@ -105,6 +149,7 @@ export function SymptomPromptFlow({
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [persistError, setPersistError] = useState<string | null>(null);
   const [lines, setLines] = useState<PresetSymptomRow[]>([]);
+  const [symptomHistory, setSymptomHistory] = useState<EpisodeSymptomRow[]>([]);
 
   const [activeIndex, setActiveIndex] = useState(0);
   const [answers, setAnswers] = useState(
@@ -395,6 +440,7 @@ export function SymptomPromptFlow({
     setStatus('loading');
     setErrorMessage(null);
     setLines([]);
+    setSymptomHistory([]);
     setHydrated(true);
   }, [episodeId, symptomPresetId, flushPendingServerPersist]);
 
@@ -530,13 +576,26 @@ export function SymptomPromptFlow({
       return;
     }
     setLines(result.data);
-    const fromServer = await listEpisodeSymptomsForEpisode(supabase, episodeId);
+    const fromServer = await listEpisodeSymptomsForEpisode(
+      supabase,
+      episodeId,
+      {
+        orderBy: 'recent',
+      },
+    );
     if (stale()) {
       return;
     }
     const serverAnswers = fromServer.ok
       ? episodeSymptomRowsToAnswersMapForOpenPass(fromServer.data, passBoundary)
       : {};
+    if (fromServer.ok) {
+      setSymptomHistory(
+        fromServer.data.slice().sort(compareSymptomRowsForHistory),
+      );
+    } else {
+      setSymptomHistory([]);
+    }
     const session = getSymptomPromptSession(episodeId);
     // Session overlays server so local drafts survive hydrate (debounced/offline/failed sync).
     const mergedAnswers = { ...serverAnswers, ...session.answers };
@@ -935,6 +994,37 @@ export function SymptomPromptFlow({
               disabled={status !== 'ready'}
             />
           </div>
+        ) : null}
+
+        {symptomHistory.length > 0 ? (
+          <section
+            className="rounded-2xl border border-app-border/90 bg-app-surface/60 p-4"
+            aria-label="Symptom history in this episode"
+          >
+            <h2 className="text-sm font-semibold text-app-ink">
+              Symptom history in this episode
+            </h2>
+            <p
+              className="mt-1 text-xs text-app-muted"
+              id="ep-symptom-history-hint"
+            >
+              Oldest first. Each entry is saved as its own row.
+            </p>
+            <ol
+              className="mt-3 list-decimal space-y-2 pl-5 text-sm text-app-ink"
+              aria-describedby="ep-symptom-history-hint"
+            >
+              {symptomHistory.map((row) => (
+                <li key={row.id} className="break-words">
+                  <span className="text-app-muted">
+                    <EpisodeLocaleInstant iso={row.created_at} />
+                    {' — '}
+                  </span>
+                  {row.symptom_name}: {symptomHistoryDetail(row)}
+                </li>
+              ))}
+            </ol>
+          </section>
         ) : null}
 
         <div className="flex flex-col gap-3 sm:flex-row">

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -17,10 +17,12 @@ import type {
 } from '@abstrack/types';
 import type { EpisodeRow } from '@abstrack/types';
 import {
+  compareEpisodeSymptomRowsForHistory,
   computeSymptomResumePlacement,
   createDefaultSymptomPromptAnswer,
   createInitialSymptomPromptSession,
   episodeSymptomRowsToAnswersMapForOpenPass,
+  formatEpisodeSymptomHistoryDetail,
   formatEpisodeDurationSimple,
   symptomPromptAnswerHasValue,
 } from '@abstrack/types';
@@ -77,48 +79,6 @@ function clampIndex(index: number, length: number): number {
 /** Queue key so the same preset symptom id does not serialize writes across episodes. */
 function lineWriteQueueKey(episodeId: string, presetSymptomId: string): string {
   return `${episodeId}:${presetSymptomId}`;
-}
-
-function compareSymptomRowsForHistory(
-  a: EpisodeSymptomRow,
-  b: EpisodeSymptomRow,
-): number {
-  const aMs = Date.parse(a.created_at);
-  const bMs = Date.parse(b.created_at);
-  const aValid = Number.isFinite(aMs);
-  const bValid = Number.isFinite(bMs);
-  if (aValid && bValid) {
-    const byTime = aMs - bMs;
-    if (byTime !== 0) {
-      return byTime;
-    }
-  } else {
-    const byText = a.created_at.localeCompare(b.created_at);
-    if (byText !== 0) {
-      return byText;
-    }
-  }
-  return a.id.localeCompare(b.id);
-}
-
-function symptomHistoryDetail(row: EpisodeSymptomRow): string {
-  if (row.response_type === 'yes_no' && row.response_boolean != null) {
-    return row.response_boolean ? 'Yes' : 'No';
-  }
-  if (row.response_type === 'severity_scale' && row.response_severity != null) {
-    return `Severity ${row.response_severity}`;
-  }
-  if (row.response_type === 'free_text') {
-    const text = row.response_text?.trim() ?? '';
-    return text.length > 0 ? text : '—';
-  }
-  if (row.response_type === 'photo') {
-    return 'Photo';
-  }
-  if (row.response_type === 'video') {
-    return 'Video';
-  }
-  return '—';
 }
 
 /**
@@ -591,7 +551,7 @@ export function SymptomPromptFlow({
       : {};
     if (fromServer.ok) {
       setSymptomHistory(
-        fromServer.data.slice().sort(compareSymptomRowsForHistory),
+        fromServer.data.slice().sort(compareEpisodeSymptomRowsForHistory),
       );
     } else {
       setSymptomHistory([]);
@@ -1020,7 +980,7 @@ export function SymptomPromptFlow({
                     <EpisodeLocaleInstant iso={row.created_at} />
                     {' — '}
                   </span>
-                  {row.symptom_name}: {symptomHistoryDetail(row)}
+                  {row.symptom_name}: {formatEpisodeSymptomHistoryDetail(row)}
                 </li>
               ))}
             </ol>

--- a/apps/web/src/components/episode-flow/use-episode-food-diary.ts
+++ b/apps/web/src/components/episode-flow/use-episode-food-diary.ts
@@ -131,7 +131,7 @@ export function useEpisodeFoodDiary({
   const [deletingFoodEntryId, setDeletingFoodEntryId] = useState<string | null>(
     null,
   );
-  const [isAddFoodEntryOpen, setIsAddFoodEntryOpen] = useState(true);
+  const [isAddFoodEntryOpen, setIsAddFoodEntryOpen] = useState(false);
   const [isAddFoodEntryDirty, setIsAddFoodEntryDirty] = useState(false);
   const [discardAddFoodDraftDialogOpen, setDiscardAddFoodDraftDialogOpen] =
     useState(false);
@@ -168,7 +168,7 @@ export function useEpisodeFoodDiary({
     setDeletingFoodEntryId(null);
     setDiscardAddFoodDraftDialogOpen(false);
     setFoodEntryDeleteConfirmEntryId(null);
-    setIsAddFoodEntryOpen(true);
+    setIsAddFoodEntryOpen(false);
     setIsAddFoodEntryDirty(false);
   }, []);
 
@@ -266,6 +266,11 @@ export function useEpisodeFoodDiary({
     }
 
     const editingId = editingFoodEntryId;
+    const useCurrentTimestampForDefaultAdd =
+      editingId == null && foodLoggedAtLocal === addFoodInitialLoggedAtLocal;
+    const createLoggedAtIso = useCurrentTimestampForDefaultAdd
+      ? new Date().toISOString()
+      : loggedAtIso;
     const result =
       editingId == null
         ? await createFoodDiaryEntry(supabase, {
@@ -273,7 +278,7 @@ export function useEpisodeFoodDiary({
             episode_id: episodeId,
             meal_tag: foodMealTag,
             food_note: foodNote,
-            logged_at: loggedAtIso,
+            logged_at: createLoggedAtIso,
           })
         : await updateFoodDiaryEntry(supabase, editingId, {
             meal_tag: foodMealTag,
@@ -306,6 +311,7 @@ export function useEpisodeFoodDiary({
     resetFoodForm,
     supabase,
     userId,
+    addFoodInitialLoggedAtLocal,
   ]);
 
   const requestDeleteFoodEntry = useCallback(

--- a/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.spec.ts
@@ -9,14 +9,12 @@ describe('buildResumeEpisodeHref', () => {
     expect(url.searchParams.get('resume')).toBe('1');
   });
 
-  it('builds episode-hub health-marker resume link when requested', () => {
+  it('builds check-in-saved link when episode hub is requested', () => {
     const href = buildResumeEpisodeHref('ep-uuid', null, {
       toEpisodeHub: true,
     });
     const url = new URL(`https://example.test${href}`);
-    expect(url.pathname).toBe('/episode/ep-uuid/health-markers');
-    expect(url.searchParams.get('resume')).toBe('1');
-    expect(url.searchParams.get('hub')).toBe('1');
+    expect(url.pathname).toBe('/episode/ep-uuid/check-in-saved');
   });
 
   it('throws when symptom resume has no symptomPresetId', () => {

--- a/apps/web/src/lib/episode-flow/resume-episode-href.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.ts
@@ -1,7 +1,7 @@
 export type BuildResumeEpisodeHrefOptions = {
   /**
-   * When true, resume enters `/health-markers` with `hub=1`: the episode hub (dashboard / another
-   * check-in / end), not the marker stepper. Use when `post_marker_step_completed_at` is set.
+   * When true, resume enters `/check-in-saved`: the episode hub (dashboard / another check-in /
+   * end), not the marker stepper. Use when `post_marker_step_completed_at` is set.
    */
   toEpisodeHub?: boolean;
 };
@@ -15,8 +15,7 @@ export type BuildResumeEpisodeHrefOptions = {
  * @param episodeId - `episodes.id`.
  * @param symptomPresetId - `symptom_presets.id` on the episode row (ignored for health-marker resumes).
  * @param options - Optional destination override.
- * @returns Path under `/episode/[id]/symptoms` or `/episode/[id]/health-markers` (with `hub=1`
- * when resuming to the episode hub after a completed pass).
+ * @returns Path under `/episode/[id]/symptoms` or `/episode/[id]/check-in-saved`.
  */
 export function buildResumeEpisodeHref(
   episodeId: string,
@@ -26,8 +25,7 @@ export function buildResumeEpisodeHref(
   const q = new URLSearchParams();
   q.set('resume', '1');
   if (options.toEpisodeHub) {
-    q.set('hub', '1');
-    return `/episode/${episodeId}/health-markers?${q.toString()}`;
+    return `/episode/${episodeId}/check-in-saved`;
   }
   if (!symptomPresetId) {
     throw new Error(

--- a/apps/web/src/lib/episode-flow/resume-episode-href.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.ts
@@ -9,8 +9,9 @@ export type BuildResumeEpisodeHrefOptions = {
 /**
  * Builds a resume URL for an active episode.
  *
- * `resume=1` tells flows to hydrate with resume logic. The symptom step index is not encoded in the
- * URL; the symptom flow computes it from merged server + session answers.
+ * Symptom resumes include `resume=1` so the symptom flow hydrates merged server + session answers;
+ * the step index itself is not encoded in the URL. Episode-hub resumes go directly to
+ * `/check-in-saved` and do not require resume query flags.
  *
  * @param episodeId - `episodes.id`.
  * @param symptomPresetId - `symptom_presets.id` on the episode row (ignored for health-marker resumes).
@@ -22,8 +23,6 @@ export function buildResumeEpisodeHref(
   symptomPresetId: string | null,
   options: BuildResumeEpisodeHrefOptions = {},
 ): string {
-  const q = new URLSearchParams();
-  q.set('resume', '1');
   if (options.toEpisodeHub) {
     return `/episode/${episodeId}/check-in-saved`;
   }
@@ -32,6 +31,8 @@ export function buildResumeEpisodeHref(
       'buildResumeEpisodeHref requires symptomPresetId when resuming to symptoms.',
     );
   }
+  const q = new URLSearchParams();
+  q.set('resume', '1');
   q.set('symptomPresetId', symptomPresetId);
   return `/episode/${episodeId}/symptoms?${q.toString()}`;
 }

--- a/apps/web/src/lib/episode-flow/resume-episode-href.ts
+++ b/apps/web/src/lib/episode-flow/resume-episode-href.ts
@@ -14,7 +14,7 @@ export type BuildResumeEpisodeHrefOptions = {
  * `/check-in-saved` and do not require resume query flags.
  *
  * @param episodeId - `episodes.id`.
- * @param symptomPresetId - `symptom_presets.id` on the episode row (ignored for health-marker resumes).
+ * @param symptomPresetId - `symptom_presets.id` on the episode row; required for symptom resumes and nullable only when `options.toEpisodeHub` is true.
  * @param options - Optional destination override.
  * @returns Path under `/episode/[id]/symptoms` or `/episode/[id]/check-in-saved`.
  */

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -96,7 +96,7 @@
 
 ---
 
-## Week 6: April 20-26 -- Episode Logging, Food Diary, and Standalone Health Marker Logging (foundation **complete**; multi-round **in progress**)
+## Week 6: April 20-26 -- Episode Logging, Food Diary, and Standalone Health Marker Logging (**complete**)
 
 **Goal:** Complete core daily logging flows: episode-first symptom capture, standalone health marker logging, and standalone food diary logging.
 
@@ -135,9 +135,9 @@
 
 **In progress — multiple guided passes:** While `ended_at IS NULL`, the user can complete one full pass of **Continue this episode** (symptom preset → health marker preset → food diary, through **Episode details** and **Save and continue**), then start **another pass** of the same steps. Data is **one row per observation** in the existing tables with **uniqueness on preset lines relaxed**; **timestamps** order the history (no required “round” id). Entry is **only** from **Resume / Continue this episode**. See [user story](user-stories/episode-and-health-marker-flows.md).
 
-- [ ] **Multiple passes in Continue + schema foundation:** **Save and continue** on **Episode details** re-enters the guided path for the next pass; migrate to allow **multiple** rows per `(episode, preset line)` on `episode_symptoms` and `health_markers` (review `food_diary_entries` if any constraint blocks it); new saves are **inserts** with `recorded_at` / `logged_at`; minimal time-ordered history; `ended_at` lock; a11y. (Full **repeat** UI and history polish per field type follow in the two items below, not in this item alone.)
-- [ ] **Preset symptoms (multiple `episode_symptoms` rows):** Re-capture and history for **preset symptom lines** only. Does **not** own preset health markers, episode-tied food, or ad-hoc non-preset lines.
-- [ ] **Preset health markers, episode-tied food, and ad-hoc lines:** `health_markers` and `food_diary_entries` with `episode_id` while the episode is active, plus ad-hoc symptom/marker content when the product includes it. Does **not** own **preset** `episode_symptoms` (previous item).
+- [x] **Multiple passes in Continue + schema foundation:** **Save and continue** on **Episode details** re-enters the guided path for the next pass; migrate to allow **multiple** rows per `(episode, preset line)` on `episode_symptoms` and `health_markers` (review `food_diary_entries` if any constraint blocks it); new saves are **inserts** with `recorded_at` / `logged_at`; minimal time-ordered history; `ended_at` lock; a11y. (Full **repeat** UI and history polish per field type follow in the two items below, not in this item alone.)
+- [x] **Preset symptoms (multiple `episode_symptoms` rows):** Re-capture and history for **preset symptom lines** only. Does **not** own preset health markers, episode-tied food, or ad-hoc non-preset lines.
+- [x] **Preset health markers, episode-tied food, and ad-hoc lines:** `health_markers` and `food_diary_entries` with `episode_id` while the episode is active, plus ad-hoc symptom/marker content when the product includes it. Does **not** own **preset** `episode_symptoms` (previous item).
 
 ---
 

--- a/docs/user-stories/episode-and-health-marker-flows.md
+++ b/docs/user-stories/episode-and-health-marker-flows.md
@@ -1,6 +1,6 @@
 # User story: Episode flows + standalone health and food logging
 
-**Status:** Draft (product intent; schedule on [ROADMAP.md](../ROADMAP.md) — **Week 5:** migrations (`health_marker_preset_id` + episode templates table), template settings UI, **I'm having an episode** + template picker; **Week 6 (shipped):** full symptom + marker + food-in-flow prompt, standalone health markers, standalone food diary, consolidated management; **Week 6+ (in progress):** [multiple guided passes](#multiple-guided-passes-while-the-episode-is-open) and the [data model](#data-model-for-repeat-observations) — see **Week 6** unchecked items on the roadmap.  
+**Status:** Draft (product intent; schedule on [ROADMAP.md](../ROADMAP.md) — **Week 5:** migrations (`health_marker_preset_id` + episode templates table), template settings UI, **I'm having an episode** + template picker; **Week 6 (shipped):** full symptom + marker + food-in-flow prompt, standalone health markers, standalone food diary, consolidated management, [multiple guided passes](#multiple-guided-passes-while-the-episode-is-open), and the [data model for repeat observations](#data-model-for-repeat-observations)).  
 **Related PRD:** [PRD.md](../PRD.md) — §3 Health Marker Presets, §4 Episode Logging, §5 General Wellness Logging
 
 This document expands the **user-facing flows** for:

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,6 +4,7 @@ export * from './lib/episode-template.js';
 export * from './lib/symptom-prompt-session.js';
 export * from './lib/symptom-prompt-session-sanitize.js';
 export * from './lib/episode-symptom-mapping.js';
+export * from './lib/episode-symptom-history.js';
 export * from './lib/episode-open-pass.js';
 export * from './lib/episode-bac-suggestion.js';
 export * from './lib/types.js';

--- a/packages/types/src/lib/episode-symptom-history.spec.ts
+++ b/packages/types/src/lib/episode-symptom-history.spec.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { EpisodeSymptomRow } from './types.js';
+import {
+  compareEpisodeSymptomRowsForHistory,
+  formatEpisodeSymptomHistoryDetail,
+} from './episode-symptom-history.js';
+
+function makeRow(
+  id: string,
+  createdAt: string,
+  responseType: EpisodeSymptomRow['response_type'],
+): EpisodeSymptomRow {
+  return {
+    id,
+    user_id: 'u-1',
+    episode_id: 'ep-1',
+    preset_symptom_id: 'ps-1',
+    symptom_name: 'Nausea',
+    response_type: responseType,
+    response_boolean: null,
+    response_severity: null,
+    response_text: null,
+    sort_order: 0,
+    created_at: createdAt,
+    updated_at: createdAt,
+  };
+}
+
+describe('compareEpisodeSymptomRowsForHistory', () => {
+  it('sorts oldest first by parsed created_at across mixed ISO formats', () => {
+    const rows = [
+      makeRow('r3', '2026-04-24T12:00:00.900Z', 'yes_no'),
+      makeRow('r1', '2026-04-24T12:00:00.123+00:00', 'yes_no'),
+      makeRow('r2', '2026-04-24T12:00:00.523Z', 'yes_no'),
+    ];
+
+    rows.sort(compareEpisodeSymptomRowsForHistory);
+    expect(rows.map((r) => r.id)).toEqual(['r1', 'r2', 'r3']);
+  });
+
+  it('uses id as tie-breaker when timestamps are equal instants', () => {
+    const rows = [
+      makeRow('b-id', '2026-04-24T12:00:00.000Z', 'yes_no'),
+      makeRow('a-id', '2026-04-24T12:00:00+00:00', 'yes_no'),
+    ];
+
+    rows.sort(compareEpisodeSymptomRowsForHistory);
+    expect(rows.map((r) => r.id)).toEqual(['a-id', 'b-id']);
+  });
+});
+
+describe('formatEpisodeSymptomHistoryDetail', () => {
+  it('formats yes_no and falls back when response_boolean is null', () => {
+    expect(
+      formatEpisodeSymptomHistoryDetail({
+        ...makeRow('yes', '2026-04-24T12:00:00.000Z', 'yes_no'),
+        response_boolean: true,
+      }),
+    ).toBe('Yes');
+    expect(
+      formatEpisodeSymptomHistoryDetail({
+        ...makeRow('no', '2026-04-24T12:00:00.000Z', 'yes_no'),
+        response_boolean: false,
+      }),
+    ).toBe('No');
+    expect(
+      formatEpisodeSymptomHistoryDetail({
+        ...makeRow('null', '2026-04-24T12:00:00.000Z', 'yes_no'),
+        response_boolean: null,
+      }),
+    ).toBe('—');
+  });
+
+  it('formats severity and falls back when response_severity is null', () => {
+    expect(
+      formatEpisodeSymptomHistoryDetail({
+        ...makeRow('sev', '2026-04-24T12:00:00.000Z', 'severity_scale'),
+        response_severity: 5,
+      }),
+    ).toBe('Severity 5');
+    expect(
+      formatEpisodeSymptomHistoryDetail({
+        ...makeRow('sev-null', '2026-04-24T12:00:00.000Z', 'severity_scale'),
+        response_severity: null,
+      }),
+    ).toBe('—');
+  });
+
+  it('formats free_text and trims/handles empty text', () => {
+    expect(
+      formatEpisodeSymptomHistoryDetail({
+        ...makeRow('text', '2026-04-24T12:00:00.000Z', 'free_text'),
+        response_text: '  severe nausea  ',
+      }),
+    ).toBe('severe nausea');
+    expect(
+      formatEpisodeSymptomHistoryDetail({
+        ...makeRow('text-empty', '2026-04-24T12:00:00.000Z', 'free_text'),
+        response_text: '   ',
+      }),
+    ).toBe('—');
+  });
+
+  it('formats media response types', () => {
+    expect(
+      formatEpisodeSymptomHistoryDetail(
+        makeRow('photo', '2026-04-24T12:00:00.000Z', 'photo'),
+      ),
+    ).toBe('Photo');
+    expect(
+      formatEpisodeSymptomHistoryDetail(
+        makeRow('video', '2026-04-24T12:00:00.000Z', 'video'),
+      ),
+    ).toBe('Video');
+  });
+});

--- a/packages/types/src/lib/episode-symptom-history.ts
+++ b/packages/types/src/lib/episode-symptom-history.ts
@@ -1,0 +1,59 @@
+import type { EpisodeSymptomRow } from './types.js';
+
+/**
+ * Compares episode symptom rows for deterministic history order: oldest timestamp first, then
+ * `id` ascending as a stable tie-breaker.
+ *
+ * @param a - Left symptom row.
+ * @param b - Right symptom row.
+ * @returns Negative when `a` should render before `b`.
+ */
+export function compareEpisodeSymptomRowsForHistory(
+  a: EpisodeSymptomRow,
+  b: EpisodeSymptomRow,
+): number {
+  const aMs = Date.parse(a.created_at);
+  const bMs = Date.parse(b.created_at);
+  const aValid = Number.isFinite(aMs);
+  const bValid = Number.isFinite(bMs);
+  if (aValid && bValid) {
+    const byTime = aMs - bMs;
+    if (byTime !== 0) {
+      return byTime;
+    }
+  } else {
+    const byText = a.created_at.localeCompare(b.created_at);
+    if (byText !== 0) {
+      return byText;
+    }
+  }
+  return a.id.localeCompare(b.id);
+}
+
+/**
+ * Formats one `episode_symptoms` row into a concise human-readable detail string for history UIs.
+ *
+ * @param row - Symptom row to describe.
+ * @returns Display-ready detail text.
+ */
+export function formatEpisodeSymptomHistoryDetail(
+  row: EpisodeSymptomRow,
+): string {
+  if (row.response_type === 'yes_no' && row.response_boolean != null) {
+    return row.response_boolean ? 'Yes' : 'No';
+  }
+  if (row.response_type === 'severity_scale' && row.response_severity != null) {
+    return `Severity ${row.response_severity}`;
+  }
+  if (row.response_type === 'free_text') {
+    const text = row.response_text?.trim() ?? '';
+    return text.length > 0 ? text : '—';
+  }
+  if (row.response_type === 'photo') {
+    return 'Photo';
+  }
+  if (row.response_type === 'video') {
+    return 'Video';
+  }
+  return '—';
+}


### PR DESCRIPTION
Closes #127
Closes #128

## Summary

- complete Week 6 multi-pass episode flow behavior across web/mobile, including repeat-pass symptom capture/history and consistency with `ended_at` write-lock rules
- add a dedicated web route for the post-save hub (`/episode/[episodeId]/check-in-saved`) and wire resume/save navigation to that route for clearer URL semantics
- improve episode-flow UX/accessibility consistency:
  - add symptom history surfaces in mobile/web symptom flows
  - remove sticky secondary/destructive actions in mobile episode flows and standardize in-scroll placement via shared `EpisodeFlowSecondaryActionsSection`
  - fix dark-mode token usage for history/timeline cards on mobile
  - default in-episode food diary “Add food entry” to collapsed on round re-entry (web + mobile)
  - fix food-entry timestamp ordering edge case by using current ISO timestamp when saving with untouched default datetime

- update docs to mark Week 6 multi-pass items complete:
  - `docs/ROADMAP.md`
  - `docs/user-stories/episode-and-health-marker-flows.md`

## Scope Mapping

### Issue #127 (preset symptom repeat rows)
- append-only symptom re-capture behavior preserved and surfaced in UI with symptom history cards
- per-row symptom identity remains intact for media linkage patterns
- continue-path symptom re-entry UX improved for mobile/web

### Issue #128 (markers/food/ad-hoc lane)
- marker/food repeat-pass behavior remains in place and was refined
- episode-tied food ordering/timestamp behavior corrected for timeline coherence
- no duplicate preset-symptom implementation moved into the marker/food lane

## Test Plan

- `pnpm -C "/home/sarah/dev/ABStrack" exec nx run @abstrack/mobile:test src/app/screens/SymptomPromptScreen.spec.tsx`
- `pnpm -C "/home/sarah/dev/ABStrack" exec nx run @abstrack/mobile:test src/app/screens/HealthMarkerPromptScreen.spec.tsx`
- `pnpm -C "/home/sarah/dev/ABStrack" exec nx run @abstrack/web:test src/lib/episode-flow/resume-episode-href.spec.ts`
- lint checks on touched files via IDE diagnostics (`ReadLints`) passed

## Manual QA Notes

- web: verify post-save hub URL is `/episode/:id/check-in-saved` and no longer `/health-markers`
- mobile: verify no sticky “Cancel episode” behavior in round 1/2 flows; actions appear at bottom of scroll content
- mobile + web: verify food diary add-entry card defaults collapsed on round re-entry
- mobile dark mode: verify symptom/timeline history cards have readable contrast
- timeline ordering: verify default-time food entries no longer appear before immediately preceding symptom/marker saves in the same minute