### PR TITLE
feat(episode-flow): add web and mobile in-flow photo capture with local prompt-state persistence and accessible camera controls

### DIFF
--- a/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
@@ -35,7 +35,7 @@ const VIDEO_MAX_DURATION_SECONDS = Math.floor(
 );
 
 /**
- * Renders the capture UI for one preset symptom line (Week 5 skeleton: no media pipeline).
+ * Renders the capture UI for one preset symptom line (local media refs only until upload ships).
  *
  * @param props - Line metadata, current answer, change handler, disabled flag.
  * @returns Response-type-specific controls.
@@ -47,6 +47,10 @@ export function SymptomPromptResponseField({
   disabled,
 }: SymptomPromptResponseFieldProps) {
   const { colors } = useAppTheme();
+  const [photoBusy, setPhotoBusy] = useState(false);
+  const [photoModalOpen, setPhotoModalOpen] = useState(false);
+  const [photoCameraReady, setPhotoCameraReady] = useState(false);
+  const [photoCapturing, setPhotoCapturing] = useState(false);
   const [videoBusy, setVideoBusy] = useState(false);
   const [cameraPermission, requestCameraPermission] = useCameraPermissions();
   const [microphonePermission, requestMicrophonePermission] =
@@ -144,6 +148,13 @@ export function SymptomPromptResponseField({
     }
     didCancelRecordingRef.current = false;
     void cameraRef.current?.stopRecording();
+  };
+  const closePhotoModal = () => {
+    if (photoCapturing) {
+      return;
+    }
+    setPhotoCameraReady(false);
+    setPhotoModalOpen(false);
   };
   const effective =
     answer ?? createDefaultSymptomPromptAnswer(line.response_type);
@@ -254,21 +265,231 @@ export function SymptomPromptResponseField({
         />
       );
     }
-    case 'photo':
+    case 'photo': {
+      const capturedPhoto = effective.type === 'photo' ? effective.value : null;
       return (
-        <View
-          accessibilityRole="text"
-          className="rounded-xl border border-dashed border-app-border bg-app-bg p-6 dark:border-app-border-dark dark:bg-app-bg-dark"
-        >
+        <View className="gap-3 rounded-xl border border-app-border bg-app-bg p-4 dark:border-app-border-dark dark:bg-app-bg-dark">
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={
+              capturedPhoto
+                ? `Take ${line.symptom_name} photo again`
+                : `Take ${line.symptom_name} photo`
+            }
+            accessibilityHint="Opens your device camera to take one photo for this symptom."
+            accessibilityState={{ disabled: disabled || photoBusy }}
+            disabled={disabled || photoBusy}
+            onPress={() => {
+              void (async () => {
+                setPhotoBusy(true);
+                try {
+                  if (Platform.OS === 'android' || Platform.OS === 'ios') {
+                    if (!cameraPermission?.granted) {
+                      const granted = await requestCameraPermission();
+                      if (!granted.granted) {
+                        return;
+                      }
+                    }
+                    setCameraFacing('front');
+                    setCameraZoom(0);
+                    setPhotoCameraReady(false);
+                    setPhotoModalOpen(true);
+                    return;
+                  }
+                  const permission =
+                    await ImagePicker.requestCameraPermissionsAsync();
+                  if (!permission.granted) {
+                    return;
+                  }
+                  const result = await ImagePicker.launchCameraAsync({
+                    mediaTypes: ['images'],
+                    cameraType: ImagePicker.CameraType.front,
+                    allowsEditing: false,
+                    quality: 0.75,
+                    legacy: true,
+                  });
+                  if (result.canceled || result.assets.length === 0) {
+                    return;
+                  }
+                  const asset = result.assets[0];
+                  onChange({
+                    type: 'photo',
+                    value: {
+                      localUri: asset.uri,
+                      capturedAt: new Date().toISOString(),
+                    },
+                  });
+                } finally {
+                  setPhotoBusy(false);
+                }
+              })();
+            }}
+            style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+            className={`items-center justify-center rounded-xl border-2 px-4 py-4 ${
+              disabled || photoBusy
+                ? 'border-app-border bg-app-bg opacity-60 dark:border-app-border-dark dark:bg-app-bg-dark'
+                : 'border-app-primary bg-app-primary/15 active:opacity-90 dark:border-app-primary'
+            }`}
+          >
+            <Text
+              className={`text-[17px] font-semibold ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              {photoBusy
+                ? 'Opening camera…'
+                : capturedPhoto
+                  ? 'Take photo again'
+                  : 'Take photo'}
+            </Text>
+          </Pressable>
           <Text
-            className={`text-center text-base leading-relaxed ${nw.textInk}`}
+            accessibilityRole="text"
+            accessibilityLiveRegion="polite"
+            className={`text-sm leading-relaxed ${nw.textMuted}`}
             maxFontSizeMultiplier={2}
           >
-            Photo symptom capture is coming in a later update. For now, use Next
-            or Skip to continue this episode flow.
+            {capturedPhoto
+              ? 'Photo saved on this device for this step. Continue when you are ready.'
+              : 'Use a large button to open the camera, take one photo, then return here.'}
+          </Text>
+          <Modal
+            visible={photoModalOpen}
+            animationType="slide"
+            presentationStyle="fullScreen"
+            onRequestClose={closePhotoModal}
+          >
+            <View className="flex-1 bg-black">
+              <View
+                className="flex-1"
+                onTouchStart={(event) => {
+                  const distance = pinchDistance(event);
+                  if (distance === null) {
+                    pinchStartDistanceRef.current = null;
+                    return;
+                  }
+                  pinchStartDistanceRef.current = distance;
+                  pinchStartZoomRef.current = cameraZoom;
+                }}
+                onTouchMove={(event) => {
+                  const startDistance = pinchStartDistanceRef.current;
+                  const distance = pinchDistance(event);
+                  if (startDistance === null || distance === null) {
+                    return;
+                  }
+                  const delta = (distance - startDistance) / 250;
+                  setCameraZoom(clampZoom(pinchStartZoomRef.current + delta));
+                }}
+                onTouchEnd={() => {
+                  pinchStartDistanceRef.current = null;
+                }}
+                onTouchCancel={() => {
+                  pinchStartDistanceRef.current = null;
+                }}
+              >
+                <CameraView
+                  ref={cameraRef}
+                  facing={cameraFacing}
+                  mode="picture"
+                  zoom={cameraZoom}
+                  style={{ flex: 1 }}
+                  onCameraReady={() => {
+                    setPhotoCameraReady(true);
+                  }}
+                />
+              </View>
+              <View className="absolute left-0 right-0 top-0 flex-row items-center justify-between px-4 pt-12">
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Switch camera"
+                  onPress={() => {
+                    setCameraFacing((v) => (v === 'front' ? 'back' : 'front'));
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="items-center justify-center rounded-md bg-black/70 px-3 py-2"
+                >
+                  <Ionicons
+                    name="camera-reverse-outline"
+                    size={22}
+                    color="white"
+                  />
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Close camera"
+                  accessibilityState={{ disabled: photoCapturing }}
+                  disabled={photoCapturing}
+                  onPress={closePhotoModal}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="items-center justify-center rounded-md bg-black/70 px-4 py-2"
+                >
+                  <Text className="text-base font-semibold text-white">
+                    Close
+                  </Text>
+                </Pressable>
+              </View>
+              <View className="absolute bottom-12 left-0 right-0 items-center">
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Capture ${line.symptom_name} photo`}
+                  accessibilityState={{
+                    disabled: !photoCameraReady || photoCapturing,
+                  }}
+                  disabled={!photoCameraReady || photoCapturing}
+                  onPress={() => {
+                    void (async () => {
+                      if (
+                        !cameraRef.current ||
+                        !photoCameraReady ||
+                        photoCapturing
+                      ) {
+                        return;
+                      }
+                      setPhotoCapturing(true);
+                      try {
+                        const result = await cameraRef.current.takePictureAsync(
+                          {
+                            quality: 0.75,
+                          },
+                        );
+                        if (!result?.uri) {
+                          return;
+                        }
+                        setPhotoModalOpen(false);
+                        setPhotoCameraReady(false);
+                        onChange({
+                          type: 'photo',
+                          value: {
+                            localUri: result.uri,
+                            capturedAt: new Date().toISOString(),
+                          },
+                        });
+                      } finally {
+                        setPhotoCapturing(false);
+                      }
+                    })();
+                  }}
+                  style={{
+                    minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+                    minWidth: COMFORTABLE_TOUCH_TARGET_DP,
+                  }}
+                  className={`items-center justify-center ${!photoCameraReady || photoCapturing ? 'opacity-50' : ''}`}
+                >
+                  <View className="h-20 w-20 items-center justify-center rounded-full border-4 border-white bg-transparent">
+                    <View className="h-12 w-12 rounded-full bg-white" />
+                  </View>
+                </Pressable>
+              </View>
+            </View>
+          </Modal>
+          <Text
+            className={`text-xs leading-relaxed ${nw.textMuted}`}
+            maxFontSizeMultiplier={2}
+          >
+            Temporary local capture only. Upload is not part of this step.
           </Text>
         </View>
       );
+    }
     case 'video': {
       const captured = effective.type === 'video' ? effective.value : null;
       const elapsedLabel = `${String(Math.floor(elapsedSeconds / 60)).padStart(

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -28,6 +28,7 @@ import * as ImagePicker from 'expo-image-picker';
 const mockRecordAsync = jest.fn();
 const mockStopRecording = jest.fn();
 const mockToggleRecordingAsync = jest.fn();
+const mockTakePictureAsync = jest.fn();
 const mockGetSupportedFeatures = jest.fn(() => ({
   toggleRecordingAsyncAvailable: true,
 }));
@@ -95,6 +96,7 @@ jest.mock('expo-camera', () => {
       recordAsync: mockRecordAsync,
       stopRecording: mockStopRecording,
       toggleRecordingAsync: mockToggleRecordingAsync,
+      takePictureAsync: mockTakePictureAsync,
       getSupportedFeatures: mockGetSupportedFeatures,
     }));
     React.useEffect(() => {
@@ -148,6 +150,7 @@ describe('SymptomPromptScreen', () => {
   const lineB = makeLine('line-b', 1, 'Headache', 'severity_scale');
   const lineSeverityOnly = makeLine('line-sev', 0, 'Pain', 'severity_scale');
   const lineVideoOnly = makeLine('line-video', 0, 'Dizziness', 'video');
+  const linePhotoOnly = makeLine('line-photo', 0, 'Facial droop', 'photo');
 
   /** Single free-text line for debounce / flush tests. */
   const lineFreeOnly = makeLine('line-ft', 0, 'Notes', 'free_text');
@@ -241,6 +244,7 @@ describe('SymptomPromptScreen', () => {
       assets: [],
     } as never);
     mockRecordAsync.mockResolvedValue({ uri: 'file:///tmp/video.mp4' });
+    mockTakePictureAsync.mockResolvedValue({ uri: 'file:///tmp/photo.jpg' });
     mockStopRecording.mockReset();
     mockToggleRecordingAsync.mockReset();
     mockRequestCameraPermission.mockResolvedValue({ granted: true });
@@ -715,6 +719,61 @@ describe('SymptomPromptScreen', () => {
             value: {
               localUri: 'file:///tmp/video.mp4',
               durationMs: expect.any(Number),
+              capturedAt: expect.any(String),
+            },
+          },
+        }),
+      }),
+    );
+  });
+
+  test('photo capture stores local answer and does not upsert to Supabase yet', async () => {
+    jest.mocked(listPresetSymptomsForPreset).mockResolvedValue({
+      ok: true,
+      data: [linePhotoOnly],
+    });
+
+    const screen = render(<SymptomPromptScreen />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Step 1 of 1')).toBeTruthy();
+    });
+
+    expect(
+      screen.getByLabelText('Next symptom').props.accessibilityState,
+    ).toEqual({
+      disabled: true,
+    });
+
+    jest.mocked(insertEpisodeSymptomAnswer).mockClear();
+    fireEvent.press(screen.getByLabelText('Take Facial droop photo'));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Capture Facial droop photo')).toBeTruthy();
+    });
+    fireEvent.press(screen.getByLabelText('Capture Facial droop photo'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Next symptom').props.accessibilityState,
+      ).toEqual({
+        disabled: false,
+      });
+    });
+    expect(mockTakePictureAsync).toHaveBeenCalledWith(
+      expect.objectContaining({
+        quality: 0.75,
+      }),
+    );
+
+    expect(insertEpisodeSymptomAnswer).not.toHaveBeenCalled();
+    expect(setSymptomPromptSession).toHaveBeenLastCalledWith(
+      episodeId,
+      expect.objectContaining({
+        answers: expect.objectContaining({
+          [linePhotoOnly.id]: {
+            type: 'photo',
+            value: {
+              localUri: 'file:///tmp/photo.jpg',
               capturedAt: expect.any(String),
             },
           },

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
@@ -510,4 +510,40 @@ describe('SymptomPromptResponseField photo capture', () => {
     expect(toBlobSpy).toHaveBeenCalled();
     expect(stopTrackMock).toHaveBeenCalled();
   });
+
+  it('does not revoke the active photo object URL on unmount', async () => {
+    const onChange = jest.fn();
+    const { unmount } = render(
+      <SymptomPromptResponseField
+        line={makePhotoLine('Ptosis')}
+        answer={undefined}
+        onChange={onChange}
+        disabled={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Take Ptosis photo'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Ptosis photo camera')).toBeTruthy();
+    });
+    const video = document.querySelector('video');
+    expect(video).toBeTruthy();
+    Object.defineProperty(video!, 'videoWidth', {
+      configurable: true,
+      value: 640,
+    });
+    Object.defineProperty(video!, 'videoHeight', {
+      configurable: true,
+      value: 480,
+    });
+
+    fireEvent.click(screen.getByLabelText('Save Ptosis photo and return'));
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    unmount();
+    expect(revokeObjectUrlMock).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
@@ -566,4 +566,45 @@ describe('SymptomPromptResponseField photo capture', () => {
     unmount();
     expect(revokeObjectUrlMock).not.toHaveBeenCalled();
   });
+
+  it('renders capture failure errors inside the open photo dialog', async () => {
+    const onChange = jest.fn();
+    toBlobSpy.mockImplementationOnce((cb: BlobCallback) => {
+      cb(null);
+    });
+    render(
+      <SymptomPromptResponseField
+        line={makePhotoLine('Smile')}
+        answer={undefined}
+        onChange={onChange}
+        disabled={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Take Smile photo'));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Smile photo camera')).toBeTruthy();
+    });
+    const video = document.querySelector('video');
+    expect(video).toBeTruthy();
+    Object.defineProperty(video!, 'videoWidth', {
+      configurable: true,
+      value: 640,
+    });
+    Object.defineProperty(video!, 'videoHeight', {
+      configurable: true,
+      value: 480,
+    });
+    fireEvent.loadedMetadata(video!);
+
+    fireEvent.click(screen.getByLabelText('Save Smile photo and return'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Photo capture failed. Please try again.'),
+      ).toBeTruthy();
+    });
+    expect(screen.getByLabelText('Smile photo camera')).toBeTruthy();
+    expect(onChange).not.toHaveBeenCalled();
+  });
 });

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
@@ -387,6 +387,27 @@ describe('SymptomPromptResponseField photo capture', () => {
   >;
   let toBlobSpy: jest.SpiedFunction<typeof HTMLCanvasElement.prototype.toBlob>;
 
+  beforeAll(() => {
+    if (!originalNavigatorDescriptor) {
+      originalNavigatorDescriptor = Object.getOwnPropertyDescriptor(
+        globalThis,
+        'navigator',
+      );
+    }
+    if (!originalCreateObjectUrlDescriptor) {
+      originalCreateObjectUrlDescriptor = Object.getOwnPropertyDescriptor(
+        globalThis.URL,
+        'createObjectURL',
+      );
+    }
+    if (!originalRevokeObjectUrlDescriptor) {
+      originalRevokeObjectUrlDescriptor = Object.getOwnPropertyDescriptor(
+        globalThis.URL,
+        'revokeObjectURL',
+      );
+    }
+  });
+
   beforeEach(() => {
     jest.clearAllMocks();
     getUserMediaMock.mockResolvedValue(mockStream);

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
@@ -469,16 +469,6 @@ describe('SymptomPromptResponseField photo capture', () => {
         audio: false,
       });
     });
-    await waitFor(() => {
-      expect(
-        screen.getByLabelText('Save Facial droop photo and return'),
-      ).toBeTruthy();
-      expect(
-        screen
-          .getByLabelText('Save Facial droop photo and return')
-          .hasAttribute('disabled'),
-      ).toBe(false);
-    });
 
     const video = document.querySelector('video');
     expect(video).toBeTruthy();
@@ -489,6 +479,14 @@ describe('SymptomPromptResponseField photo capture', () => {
     Object.defineProperty(video!, 'videoHeight', {
       configurable: true,
       value: 480,
+    });
+    fireEvent.loadedMetadata(video!);
+    await waitFor(() => {
+      expect(
+        screen
+          .getByLabelText('Save Facial droop photo and return')
+          .hasAttribute('disabled'),
+      ).toBe(false);
     });
 
     fireEvent.click(
@@ -537,6 +535,7 @@ describe('SymptomPromptResponseField photo capture', () => {
       configurable: true,
       value: 480,
     });
+    fireEvent.loadedMetadata(video!);
 
     fireEvent.click(screen.getByLabelText('Save Ptosis photo and return'));
     await waitFor(() => {

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
@@ -367,3 +367,147 @@ describe('SymptomPromptResponseField video capture', () => {
     expect(onChange).not.toHaveBeenCalled();
   });
 });
+
+function makePhotoLine(symptomName = 'Facial droop'): PresetSymptomRow {
+  return {
+    id: 'line-photo',
+    preset_id: 'preset-1',
+    sort_order: 0,
+    symptom_name: symptomName,
+    response_type: 'photo',
+    prompt_instruction: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
+describe('SymptomPromptResponseField photo capture', () => {
+  let getContextSpy: jest.SpiedFunction<
+    typeof HTMLCanvasElement.prototype.getContext
+  >;
+  let toBlobSpy: jest.SpiedFunction<typeof HTMLCanvasElement.prototype.toBlob>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getUserMediaMock.mockResolvedValue(mockStream);
+    createObjectUrlMock.mockReturnValue('blob:local-photo');
+    Object.defineProperty(globalThis, 'navigator', {
+      value: {
+        mediaDevices: {
+          getUserMedia: getUserMediaMock,
+        },
+      },
+      configurable: true,
+    });
+    Object.defineProperty(globalThis.URL, 'createObjectURL', {
+      value: createObjectUrlMock,
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(globalThis.URL, 'revokeObjectURL', {
+      value: revokeObjectUrlMock,
+      configurable: true,
+      writable: true,
+    });
+    getContextSpy = jest
+      .spyOn(HTMLCanvasElement.prototype, 'getContext')
+      .mockReturnValue({
+        drawImage: jest.fn(),
+      } as unknown as CanvasRenderingContext2D);
+    toBlobSpy = jest
+      .spyOn(HTMLCanvasElement.prototype, 'toBlob')
+      .mockImplementation((cb: BlobCallback) => {
+        cb(new Blob(['jpeg-bytes'], { type: 'image/jpeg' }));
+      });
+  });
+
+  afterEach(() => {
+    getContextSpy.mockRestore();
+    toBlobSpy.mockRestore();
+    if (originalNavigatorDescriptor) {
+      Object.defineProperty(
+        globalThis,
+        'navigator',
+        originalNavigatorDescriptor,
+      );
+    }
+    if (originalCreateObjectUrlDescriptor) {
+      Object.defineProperty(
+        globalThis.URL,
+        'createObjectURL',
+        originalCreateObjectUrlDescriptor,
+      );
+    }
+    if (originalRevokeObjectUrlDescriptor) {
+      Object.defineProperty(
+        globalThis.URL,
+        'revokeObjectURL',
+        originalRevokeObjectUrlDescriptor,
+      );
+    }
+  });
+
+  it('captures a still photo and stores a local blob URL', async () => {
+    const onChange = jest.fn();
+    render(
+      <SymptomPromptResponseField
+        line={makePhotoLine()}
+        answer={undefined}
+        onChange={onChange}
+        disabled={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Take Facial droop photo'));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Facial droop photo camera')).toBeTruthy();
+    });
+    await waitFor(() => {
+      expect(getUserMediaMock).toHaveBeenCalledWith({
+        video: true,
+        audio: false,
+      });
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Save Facial droop photo and return'),
+      ).toBeTruthy();
+      expect(
+        screen
+          .getByLabelText('Save Facial droop photo and return')
+          .hasAttribute('disabled'),
+      ).toBe(false);
+    });
+
+    const video = document.querySelector('video');
+    expect(video).toBeTruthy();
+    Object.defineProperty(video!, 'videoWidth', {
+      configurable: true,
+      value: 640,
+    });
+    Object.defineProperty(video!, 'videoHeight', {
+      configurable: true,
+      value: 480,
+    });
+
+    fireEvent.click(
+      screen.getByLabelText('Save Facial droop photo and return'),
+    );
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+
+    expect(onChange).toHaveBeenCalledWith({
+      type: 'photo',
+      value: expect.objectContaining({
+        localUri: 'blob:local-photo',
+        capturedAt: expect.any(String),
+      }),
+    });
+    expect(getContextSpy).toHaveBeenCalled();
+    expect(toBlobSpy).toHaveBeenCalled();
+    expect(stopTrackMock).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -301,6 +301,7 @@ function SymptomPhotoCaptureField({
   const [capturing, setCapturing] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [previewAspectRatio, setPreviewAspectRatio] = useState<number>(16 / 9);
+  const modalErrorId = `symptom-photo-error-${line.id}`;
 
   const captured = answer.type === 'photo' ? answer.value : null;
 
@@ -470,6 +471,7 @@ function SymptomPhotoCaptureField({
             role="dialog"
             aria-modal="true"
             aria-label={`${line.symptom_name} photo camera`}
+            aria-describedby={error ? modalErrorId : undefined}
             className="w-full max-w-2xl rounded-2xl border border-app-border bg-app-surface p-4 shadow-xl"
           >
             <div className="mb-3 flex items-center justify-between gap-2">
@@ -541,6 +543,15 @@ function SymptomPhotoCaptureField({
                     : 'Save photo'}
               </button>
             </div>
+            {error ? (
+              <p
+                id={modalErrorId}
+                className="mt-3 text-sm text-red-700 dark:text-red-300"
+                role="alert"
+              >
+                {error}
+              </p>
+            ) : null}
           </div>
         </div>
       ) : null}
@@ -549,7 +560,7 @@ function SymptomPhotoCaptureField({
           ? 'Photo saved on this device for this step. You can go to the next symptom when you are ready.'
           : 'Opens your camera so you can take one photo for this symptom. Large buttons are for easier tapping.'}
       </p>
-      {error ? (
+      {!pickerOpen && error ? (
         <p className="text-sm text-red-700 dark:text-red-300" role="alert">
           {error}
         </p>

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -365,7 +365,6 @@ function SymptomPhotoCaptureField({
         if (previewRef.current) {
           previewRef.current.srcObject = stream;
         }
-        setCameraReady(true);
       } catch (error: unknown) {
         if (!cancelled) {
           const errorName =
@@ -509,7 +508,13 @@ function SymptomPhotoCaptureField({
                     const v = event.currentTarget;
                     if (v.videoWidth > 0 && v.videoHeight > 0) {
                       setPreviewAspectRatio(v.videoWidth / v.videoHeight);
+                      setCameraReady(true);
+                    } else {
+                      setCameraReady(false);
                     }
+                  }}
+                  onEmptied={() => {
+                    setCameraReady(false);
                   }}
                 />
               </div>

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -334,7 +334,6 @@ function SymptomPhotoCaptureField({
     return () => {
       isUnmountedRef.current = true;
       stopAllTracks();
-      revokeCreatedObjectUrl();
     };
   }, []);
 

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -277,6 +277,286 @@ function SymptomSeverityRadiogroup({
   );
 }
 
+/**
+ * In-flow still photo capture using live camera preview (local blob URL only; no upload).
+ */
+function SymptomPhotoCaptureField({
+  line,
+  answer,
+  onChange,
+  disabled,
+}: {
+  line: PresetSymptomRow;
+  answer: SymptomPromptAnswer;
+  onChange: (next: SymptomPromptAnswer) => void;
+  disabled: boolean;
+}) {
+  const streamRef = useRef<MediaStream | null>(null);
+  const previewRef = useRef<HTMLVideoElement | null>(null);
+  const createdObjectUrlRef = useRef<string | null>(null);
+  const isUnmountedRef = useRef(false);
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [starting, setStarting] = useState(false);
+  const [cameraReady, setCameraReady] = useState(false);
+  const [capturing, setCapturing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [previewAspectRatio, setPreviewAspectRatio] = useState<number>(16 / 9);
+
+  const captured = answer.type === 'photo' ? answer.value : null;
+
+  const revokeCreatedObjectUrl = () => {
+    if (!createdObjectUrlRef.current) {
+      return;
+    }
+    URL.revokeObjectURL(createdObjectUrlRef.current);
+    createdObjectUrlRef.current = null;
+  };
+
+  const stopAllTracks = () => {
+    const stream = streamRef.current;
+    if (!stream) {
+      return;
+    }
+    stream.getTracks().forEach((track) => {
+      track.stop();
+    });
+    streamRef.current = null;
+    if (!isUnmountedRef.current) {
+      setCameraReady(false);
+    }
+    if (previewRef.current) {
+      previewRef.current.srcObject = null;
+    }
+  };
+
+  useEffect(() => {
+    isUnmountedRef.current = false;
+    return () => {
+      isUnmountedRef.current = true;
+      stopAllTracks();
+      revokeCreatedObjectUrl();
+    };
+  }, []);
+
+  useEffect(() => {
+    if (!pickerOpen) {
+      stopAllTracks();
+      return;
+    }
+    if (streamRef.current) {
+      return;
+    }
+    let cancelled = false;
+    void (async () => {
+      setError(null);
+      setStarting(true);
+      try {
+        if (typeof navigator?.mediaDevices?.getUserMedia !== 'function') {
+          throw new Error('UNSUPPORTED_MEDIA_DEVICES');
+        }
+        const stream = await navigator.mediaDevices.getUserMedia({
+          video: true,
+          audio: false,
+        });
+        if (cancelled) {
+          stream.getTracks().forEach((track) => track.stop());
+          return;
+        }
+        streamRef.current = stream;
+        if (previewRef.current) {
+          previewRef.current.srcObject = stream;
+        }
+        setCameraReady(true);
+      } catch (error: unknown) {
+        if (!cancelled) {
+          const errorName =
+            typeof error === 'object' && error !== null && 'name' in error
+              ? String((error as { name?: unknown }).name ?? '')
+              : '';
+          if (
+            errorName === 'NotAllowedError' ||
+            errorName === 'PermissionDeniedError'
+          ) {
+            setError(
+              'Camera access was denied. Please enable permissions and try again.',
+            );
+          } else if (
+            errorName === 'NotFoundError' ||
+            errorName === 'DevicesNotFoundError'
+          ) {
+            setError('No camera was found. Connect one and try again.');
+          } else {
+            setError('Camera is not supported in this browser or environment.');
+          }
+          setPickerOpen(false);
+        }
+      } finally {
+        if (!cancelled) {
+          setStarting(false);
+        }
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [pickerOpen]);
+
+  const takePhotoFromPreview = async () => {
+    const video = previewRef.current;
+    if (!video || video.videoWidth === 0 || video.videoHeight === 0) {
+      setError('Camera is not ready yet. Try again in a moment.');
+      return;
+    }
+    setError(null);
+    setCapturing(true);
+    try {
+      const canvas = document.createElement('canvas');
+      canvas.width = video.videoWidth;
+      canvas.height = video.videoHeight;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) {
+        setError('Could not capture this image in your browser.');
+        return;
+      }
+      ctx.drawImage(video, 0, 0, canvas.width, canvas.height);
+      const blob = await new Promise<Blob | null>((resolve) => {
+        canvas.toBlob((b) => resolve(b), 'image/jpeg', 0.88);
+      });
+      if (!blob || blob.size === 0) {
+        setError('Photo capture failed. Please try again.');
+        return;
+      }
+      revokeCreatedObjectUrl();
+      const localUri = URL.createObjectURL(blob);
+      createdObjectUrlRef.current = localUri;
+      onChange({
+        type: 'photo',
+        value: {
+          localUri,
+          capturedAt: new Date().toISOString(),
+        },
+      });
+      stopAllTracks();
+      setPickerOpen(false);
+    } finally {
+      setCapturing(false);
+    }
+  };
+
+  return (
+    <div className="space-y-3 rounded-xl border border-app-border/90 bg-app-surface p-4">
+      <div className="flex flex-col gap-3 sm:flex-row">
+        <button
+          type="button"
+          disabled={disabled}
+          aria-label={
+            captured
+              ? `Take ${line.symptom_name} photo again`
+              : `Take ${line.symptom_name} photo`
+          }
+          className={`inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border-2 px-4 text-base font-semibold transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg ${
+            disabled
+              ? 'cursor-not-allowed border-app-border bg-app-surface text-app-muted opacity-60'
+              : 'border-app-primary bg-app-primary/10 text-app-ink hover:border-app-primary/80'
+          }`}
+          onClick={() => {
+            setPickerOpen(true);
+          }}
+        >
+          {captured ? 'Take photo again' : 'Take photo'}
+        </button>
+      </div>
+      {pickerOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 p-4">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-label={`${line.symptom_name} photo camera`}
+            className="w-full max-w-2xl rounded-2xl border border-app-border bg-app-surface p-4 shadow-xl"
+          >
+            <div className="mb-3 flex items-center justify-between gap-2">
+              <h3 className="text-base font-semibold text-app-ink">
+                Take a photo
+              </h3>
+              <button
+                type="button"
+                aria-label="Close camera"
+                aria-disabled={capturing}
+                className="inline-flex min-h-[44px] shrink-0 items-center justify-center rounded-lg border border-app-border px-3 text-sm font-medium text-app-ink"
+                disabled={capturing}
+                onClick={() => {
+                  if (capturing) {
+                    return;
+                  }
+                  setPickerOpen(false);
+                }}
+              >
+                Close
+              </button>
+            </div>
+            <div className="rounded-xl border border-app-border/90 bg-app-bg p-2">
+              <div
+                className="w-full overflow-hidden rounded-lg bg-black"
+                style={{ aspectRatio: previewAspectRatio }}
+              >
+                <video
+                  ref={previewRef}
+                  aria-label={`${line.symptom_name} live camera preview`}
+                  className="h-full w-full bg-black object-contain"
+                  autoPlay
+                  muted
+                  playsInline
+                  onLoadedMetadata={(event) => {
+                    const v = event.currentTarget;
+                    if (v.videoWidth > 0 && v.videoHeight > 0) {
+                      setPreviewAspectRatio(v.videoWidth / v.videoHeight);
+                    }
+                  }}
+                />
+              </div>
+            </div>
+            <div className="mt-4 flex items-center justify-center">
+              <button
+                type="button"
+                aria-disabled={starting || !cameraReady || capturing}
+                aria-label={`Save ${line.symptom_name} photo and return`}
+                className={`inline-flex min-h-[56px] min-w-[200px] items-center justify-center rounded-full px-6 text-base font-semibold text-white ${
+                  starting || !cameraReady || capturing
+                    ? 'cursor-not-allowed bg-slate-400 dark:bg-slate-600'
+                    : 'bg-app-primary hover:opacity-95'
+                }`}
+                disabled={starting || !cameraReady || capturing}
+                onClick={() => {
+                  void takePhotoFromPreview();
+                }}
+              >
+                {starting
+                  ? 'Starting camera…'
+                  : capturing
+                    ? 'Saving photo…'
+                    : 'Save photo'}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
+      <p className="text-sm text-app-muted" role="status">
+        {captured
+          ? 'Photo saved on this device for this step. You can go to the next symptom when you are ready.'
+          : 'Opens your camera so you can take one photo for this symptom. Large buttons are for easier tapping.'}
+      </p>
+      {error ? (
+        <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <p className="text-xs text-app-muted">
+        Temporary local capture only. Upload is not part of this step.
+      </p>
+    </div>
+  );
+}
+
 function SymptomVideoCaptureField({
   line,
   answer,
@@ -691,7 +971,7 @@ function SymptomVideoCaptureField({
 }
 
 /**
- * Renders the capture UI for one preset symptom line (Week 5 skeleton: no media pipeline).
+ * Renders the capture UI for one preset symptom line (local media refs only until upload ships).
  *
  * @param props - Line metadata, current answer, change handler, disabled flag.
  * @returns Response-type-specific controls.
@@ -747,13 +1027,12 @@ export function SymptomPromptResponseField({
     }
     case 'photo':
       return (
-        <div
-          role="status"
-          className="rounded-xl border border-dashed border-app-border/90 bg-app-surface/80 p-6 text-center text-sm leading-relaxed text-app-ink"
-        >
-          Photo symptom capture is coming in a later update. For now, use Next
-          or Skip symptom to continue this episode flow.
-        </div>
+        <SymptomPhotoCaptureField
+          line={line}
+          answer={effective}
+          onChange={onChange}
+          disabled={disabled}
+        />
       );
     case 'video':
       return (

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
@@ -20,8 +20,36 @@ function setStoredRaw(episodeId: string, raw: string): void {
 }
 
 describe('symptom-prompt-session-store', () => {
+  let originalRevokeDescriptor: PropertyDescriptor | undefined;
+  let revokeMock: jest.Mock;
+
+  beforeAll(() => {
+    originalRevokeDescriptor = Object.getOwnPropertyDescriptor(
+      globalThis.URL,
+      'revokeObjectURL',
+    );
+  });
+
   beforeEach(() => {
     sessionStorage.clear();
+    revokeMock = jest.fn();
+    Object.defineProperty(globalThis.URL, 'revokeObjectURL', {
+      value: revokeMock,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    if (originalRevokeDescriptor) {
+      Object.defineProperty(
+        globalThis.URL,
+        'revokeObjectURL',
+        originalRevokeDescriptor,
+      );
+      return;
+    }
+    delete (globalThis.URL as { revokeObjectURL?: unknown }).revokeObjectURL;
   });
 
   it('getSymptomPromptSession returns initial state when activeIndex is null (JSON.stringify maps NaN/Infinity to null)', () => {
@@ -286,7 +314,46 @@ describe('symptom-prompt-session-store', () => {
       },
     });
     clearSymptomPromptSession('ep-1');
+    expect(revokeMock).toHaveBeenCalledWith('blob:https://example.test/abc');
     expect(getSymptomPromptSession('ep-1')).toEqual(initial);
+  });
+
+  it('setSymptomPromptSession revokes previous runtime media blob URLs when replacing cache', () => {
+    setSymptomPromptSession('ep-1', {
+      activeIndex: 0,
+      answers: {
+        photo: {
+          type: 'photo',
+          value: {
+            localUri: 'blob:https://example.test/photo-old',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
+        video: {
+          type: 'video',
+          value: {
+            localUri: 'blob:https://example.test/video-old',
+            durationMs: 5000,
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
+      },
+    });
+    revokeMock.mockClear();
+
+    setSymptomPromptSession('ep-1', {
+      activeIndex: 1,
+      answers: {
+        keep: { type: 'yes_no', value: true },
+      },
+    });
+
+    expect(revokeMock).toHaveBeenCalledWith(
+      'blob:https://example.test/photo-old',
+    );
+    expect(revokeMock).toHaveBeenCalledWith(
+      'blob:https://example.test/video-old',
+    );
   });
 
   it('getSymptomPromptSession drops non-durable blob photo answers after reload-like state', () => {

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
@@ -141,11 +141,18 @@ describe('symptom-prompt-session-store', () => {
     expect(getSymptomPromptSession('ep-1')).toEqual(initial);
   });
 
-  it('setSymptomPromptSession keeps media answers in runtime while omitting them from storage', () => {
+  it('setSymptomPromptSession keeps non-durable media in runtime while persisting durable photo refs', () => {
     setSymptomPromptSession('ep-1', {
       activeIndex: 1,
       answers: {
         keep: { type: 'yes_no', value: true },
+        durablePhoto: {
+          type: 'photo',
+          value: {
+            localUri: 'https://cdn.example.test/photo.jpg',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
         photo: {
           type: 'photo',
           value: {
@@ -169,12 +176,26 @@ describe('symptom-prompt-session-store', () => {
       activeIndex: 1,
       answers: {
         keep: { type: 'yes_no', value: true },
+        durablePhoto: {
+          type: 'photo',
+          value: {
+            localUri: 'https://cdn.example.test/photo.jpg',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
       },
     });
     expect(getSymptomPromptSession('ep-1')).toEqual({
       activeIndex: 1,
       answers: {
         keep: { type: 'yes_no', value: true },
+        durablePhoto: {
+          type: 'photo',
+          value: {
+            localUri: 'https://cdn.example.test/photo.jpg',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
         photo: {
           type: 'photo',
           value: {
@@ -268,7 +289,7 @@ describe('symptom-prompt-session-store', () => {
     expect(getSymptomPromptSession('ep-1')).toEqual(initial);
   });
 
-  it('getSymptomPromptSession drops durable photo blob answers after reload-like state', () => {
+  it('getSymptomPromptSession drops non-durable blob photo answers after reload-like state', () => {
     setStored('ep-1', {
       activeIndex: 0,
       answers: {
@@ -284,6 +305,33 @@ describe('symptom-prompt-session-store', () => {
     expect(getSymptomPromptSession('ep-1')).toEqual({
       activeIndex: 0,
       answers: {},
+    });
+  });
+
+  it('getSymptomPromptSession keeps durable photo answers after reload-like state', () => {
+    setStored('ep-1', {
+      activeIndex: 0,
+      answers: {
+        photo: {
+          type: 'photo',
+          value: {
+            localUri: 'https://cdn.example.test/photo.jpg',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
+      },
+    });
+    expect(getSymptomPromptSession('ep-1')).toEqual({
+      activeIndex: 0,
+      answers: {
+        photo: {
+          type: 'photo',
+          value: {
+            localUri: 'https://cdn.example.test/photo.jpg',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
+      },
     });
   });
 });

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
@@ -141,11 +141,18 @@ describe('symptom-prompt-session-store', () => {
     expect(getSymptomPromptSession('ep-1')).toEqual(initial);
   });
 
-  it('setSymptomPromptSession keeps video answers in runtime while omitting them from storage', () => {
+  it('setSymptomPromptSession keeps media answers in runtime while omitting them from storage', () => {
     setSymptomPromptSession('ep-1', {
       activeIndex: 1,
       answers: {
         keep: { type: 'yes_no', value: true },
+        photo: {
+          type: 'photo',
+          value: {
+            localUri: 'blob:https://example.test/photo',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
         drop: {
           type: 'video',
           value: {
@@ -168,6 +175,13 @@ describe('symptom-prompt-session-store', () => {
       activeIndex: 1,
       answers: {
         keep: { type: 'yes_no', value: true },
+        photo: {
+          type: 'photo',
+          value: {
+            localUri: 'blob:https://example.test/photo',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
         drop: {
           type: 'video',
           value: {
@@ -180,10 +194,17 @@ describe('symptom-prompt-session-store', () => {
     });
   });
 
-  it('setSymptomPromptSession clears runtime video cache when no video answers remain', () => {
+  it('setSymptomPromptSession clears runtime media cache when no media answers remain', () => {
     setSymptomPromptSession('ep-1', {
       activeIndex: 0,
       answers: {
+        photo: {
+          type: 'photo',
+          value: {
+            localUri: 'blob:https://example.test/photo',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
         drop: {
           type: 'video',
           value: {
@@ -197,6 +218,13 @@ describe('symptom-prompt-session-store', () => {
     expect(getSymptomPromptSession('ep-1')).toEqual({
       activeIndex: 0,
       answers: {
+        photo: {
+          type: 'photo',
+          value: {
+            localUri: 'blob:https://example.test/photo',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
         drop: {
           type: 'video',
           value: {
@@ -238,5 +266,24 @@ describe('symptom-prompt-session-store', () => {
     });
     clearSymptomPromptSession('ep-1');
     expect(getSymptomPromptSession('ep-1')).toEqual(initial);
+  });
+
+  it('getSymptomPromptSession drops durable photo blob answers after reload-like state', () => {
+    setStored('ep-1', {
+      activeIndex: 0,
+      answers: {
+        photo: {
+          type: 'photo',
+          value: {
+            localUri: 'blob:https://example.test/photo',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
+      },
+    });
+    expect(getSymptomPromptSession('ep-1')).toEqual({
+      activeIndex: 0,
+      answers: {},
+    });
   });
 });

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.spec.ts
@@ -38,6 +38,7 @@ describe('symptom-prompt-session-store', () => {
       configurable: true,
       writable: true,
     });
+    clearSymptomPromptSession('ep-1');
   });
 
   afterEach(() => {
@@ -354,6 +355,38 @@ describe('symptom-prompt-session-store', () => {
     expect(revokeMock).toHaveBeenCalledWith(
       'blob:https://example.test/video-old',
     );
+  });
+
+  it('setSymptomPromptSession does not revoke unchanged runtime media blob URLs', () => {
+    const stateWithMedia = {
+      activeIndex: 0,
+      answers: {
+        photo: {
+          type: 'photo' as const,
+          value: {
+            localUri: 'blob:https://example.test/photo-stable',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
+        video: {
+          type: 'video' as const,
+          value: {
+            localUri: 'blob:https://example.test/video-stable',
+            durationMs: 5000,
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
+      },
+    };
+    setSymptomPromptSession('ep-1', stateWithMedia);
+    revokeMock.mockClear();
+
+    setSymptomPromptSession('ep-1', {
+      ...stateWithMedia,
+      activeIndex: 1,
+    });
+
+    expect(revokeMock).not.toHaveBeenCalled();
   });
 
   it('getSymptomPromptSession drops non-durable blob photo answers after reload-like state', () => {

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -18,14 +18,28 @@ function storageKey(episodeId: string): string {
 
 /**
  * Blob URLs are document-scoped and not durable across reload/navigation.
- * Keep media answers in runtime state only; omit them from `sessionStorage`.
+ * Keep only non-durable media answers in runtime state; omit them from `sessionStorage`.
  */
+function photoRefIsNonDurable(localUri: string): boolean {
+  return localUri.startsWith('blob:');
+}
+
+function answerIsNonDurable(answer: SymptomPromptAnswer): boolean {
+  if (answer.type === 'video') {
+    return true;
+  }
+  if (answer.type === 'photo' && answer.value !== null) {
+    return photoRefIsNonDurable(answer.value.localUri);
+  }
+  return false;
+}
+
 function stripNonDurableAnswers(
   state: SymptomPromptSessionState,
 ): SymptomPromptSessionState {
   const answers = Object.fromEntries(
     Object.entries(state.answers).filter(
-      ([, answer]) => answer.type !== 'video' && answer.type !== 'photo',
+      ([, answer]) => !answerIsNonDurable(answer),
     ),
   );
   return {
@@ -40,9 +54,14 @@ function extractRuntimeMediaAnswers(
 ): SymptomPromptAnswers {
   const out = Object.create(null) as SymptomPromptAnswers;
   for (const [key, answer] of Object.entries(state.answers)) {
+    if (answer.type === 'video' && answer.value !== null) {
+      out[key] = answer as SymptomPromptAnswer;
+      continue;
+    }
     if (
-      (answer.type === 'video' || answer.type === 'photo') &&
-      answer.value !== null
+      answer.type === 'photo' &&
+      answer.value !== null &&
+      photoRefIsNonDurable(answer.value.localUri)
     ) {
       out[key] = answer as SymptomPromptAnswer;
     }

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -10,7 +10,7 @@ import {
 } from '@abstrack/types';
 
 const STORAGE_PREFIX = 'abstrack.symptomPrompt.';
-const runtimeVideoAnswersByEpisode = new Map<string, SymptomPromptAnswers>();
+const runtimeMediaAnswersByEpisode = new Map<string, SymptomPromptAnswers>();
 
 function storageKey(episodeId: string): string {
   return `${STORAGE_PREFIX}${episodeId}`;
@@ -18,14 +18,14 @@ function storageKey(episodeId: string): string {
 
 /**
  * Blob URLs are document-scoped and not durable across reload/navigation.
- * Keep video answers in runtime state only; omit them from `sessionStorage`.
+ * Keep media answers in runtime state only; omit them from `sessionStorage`.
  */
 function stripNonDurableAnswers(
   state: SymptomPromptSessionState,
 ): SymptomPromptSessionState {
   const answers = Object.fromEntries(
     Object.entries(state.answers).filter(
-      ([, answer]) => answer.type !== 'video',
+      ([, answer]) => answer.type !== 'video' && answer.type !== 'photo',
     ),
   );
   return {
@@ -34,13 +34,16 @@ function stripNonDurableAnswers(
   };
 }
 
-/** Keeps only non-null video entries for runtime-only remount resilience. */
-function extractRuntimeVideoAnswers(
+/** Keeps only non-null media entries for runtime-only remount resilience. */
+function extractRuntimeMediaAnswers(
   state: SymptomPromptSessionState,
 ): SymptomPromptAnswers {
   const out = Object.create(null) as SymptomPromptAnswers;
   for (const [key, answer] of Object.entries(state.answers)) {
-    if (answer.type === 'video' && answer.value !== null) {
+    if (
+      (answer.type === 'video' || answer.type === 'photo') &&
+      answer.value !== null
+    ) {
       out[key] = answer as SymptomPromptAnswer;
     }
   }
@@ -82,13 +85,13 @@ export function getSymptomPromptSession(
       activeIndex,
       answers: sanitizeSymptomPromptAnswers(parsed.answers),
     });
-    const runtimeVideoAnswers = runtimeVideoAnswersByEpisode.get(episodeId);
-    if (!runtimeVideoAnswers) {
+    const runtimeMediaAnswers = runtimeMediaAnswersByEpisode.get(episodeId);
+    if (!runtimeMediaAnswers) {
       return durable;
     }
     return {
       activeIndex: durable.activeIndex,
-      answers: { ...durable.answers, ...runtimeVideoAnswers },
+      answers: { ...durable.answers, ...runtimeMediaAnswers },
     };
   } catch {
     return createInitialSymptomPromptSession();
@@ -108,11 +111,11 @@ export function setSymptomPromptSession(
   if (typeof window === 'undefined') {
     return;
   }
-  const runtimeVideoAnswers = extractRuntimeVideoAnswers(state);
-  if (Object.keys(runtimeVideoAnswers).length === 0) {
-    runtimeVideoAnswersByEpisode.delete(episodeId);
+  const runtimeMediaAnswers = extractRuntimeMediaAnswers(state);
+  if (Object.keys(runtimeMediaAnswers).length === 0) {
+    runtimeMediaAnswersByEpisode.delete(episodeId);
   } else {
-    runtimeVideoAnswersByEpisode.set(episodeId, runtimeVideoAnswers);
+    runtimeMediaAnswersByEpisode.set(episodeId, runtimeMediaAnswers);
   }
   try {
     sessionStorage.setItem(
@@ -133,7 +136,7 @@ export function clearSymptomPromptSession(episodeId: string): void {
   if (typeof window === 'undefined') {
     return;
   }
-  runtimeVideoAnswersByEpisode.delete(episodeId);
+  runtimeMediaAnswersByEpisode.delete(episodeId);
   try {
     sessionStorage.removeItem(storageKey(episodeId));
   } catch {

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -69,6 +69,22 @@ function extractRuntimeMediaAnswers(
   return out;
 }
 
+function revokeBlobUris(answers: SymptomPromptAnswers): void {
+  for (const answer of Object.values(answers)) {
+    if (answer.type === 'video' && answer.value !== null) {
+      URL.revokeObjectURL(answer.value.localUri);
+      continue;
+    }
+    if (
+      answer.type === 'photo' &&
+      answer.value !== null &&
+      photoRefIsNonDurable(answer.value.localUri)
+    ) {
+      URL.revokeObjectURL(answer.value.localUri);
+    }
+  }
+}
+
 /**
  * Reads traversal state from `sessionStorage` for the current browser session.
  *
@@ -131,6 +147,10 @@ export function setSymptomPromptSession(
     return;
   }
   const runtimeMediaAnswers = extractRuntimeMediaAnswers(state);
+  const previousRuntimeMedia = runtimeMediaAnswersByEpisode.get(episodeId);
+  if (previousRuntimeMedia) {
+    revokeBlobUris(previousRuntimeMedia);
+  }
   if (Object.keys(runtimeMediaAnswers).length === 0) {
     runtimeMediaAnswersByEpisode.delete(episodeId);
   } else {
@@ -154,6 +174,10 @@ export function setSymptomPromptSession(
 export function clearSymptomPromptSession(episodeId: string): void {
   if (typeof window === 'undefined') {
     return;
+  }
+  const runtimeMediaAnswers = runtimeMediaAnswersByEpisode.get(episodeId);
+  if (runtimeMediaAnswers) {
+    revokeBlobUris(runtimeMediaAnswers);
   }
   runtimeMediaAnswersByEpisode.delete(episodeId);
   try {

--- a/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
+++ b/apps/web/src/lib/episode-flow/symptom-prompt-session-store.ts
@@ -85,6 +85,24 @@ function revokeBlobUris(answers: SymptomPromptAnswers): void {
   }
 }
 
+function runtimeMediaBlobUris(answers: SymptomPromptAnswers): Set<string> {
+  const out = new Set<string>();
+  for (const answer of Object.values(answers)) {
+    if (answer.type === 'video' && answer.value !== null) {
+      out.add(answer.value.localUri);
+      continue;
+    }
+    if (
+      answer.type === 'photo' &&
+      answer.value !== null &&
+      photoRefIsNonDurable(answer.value.localUri)
+    ) {
+      out.add(answer.value.localUri);
+    }
+  }
+  return out;
+}
+
 /**
  * Reads traversal state from `sessionStorage` for the current browser session.
  *
@@ -149,7 +167,13 @@ export function setSymptomPromptSession(
   const runtimeMediaAnswers = extractRuntimeMediaAnswers(state);
   const previousRuntimeMedia = runtimeMediaAnswersByEpisode.get(episodeId);
   if (previousRuntimeMedia) {
-    revokeBlobUris(previousRuntimeMedia);
+    const previousUris = runtimeMediaBlobUris(previousRuntimeMedia);
+    const nextUris = runtimeMediaBlobUris(runtimeMediaAnswers);
+    for (const uri of previousUris) {
+      if (!nextUris.has(uri)) {
+        URL.revokeObjectURL(uri);
+      }
+    }
   }
   if (Object.keys(runtimeMediaAnswers).length === 0) {
     runtimeMediaAnswersByEpisode.delete(episodeId);

--- a/packages/types/src/lib/symptom-prompt-session-sanitize.spec.ts
+++ b/packages/types/src/lib/symptom-prompt-session-sanitize.spec.ts
@@ -30,6 +30,54 @@ describe('symptom-prompt-session-sanitize', () => {
     });
   });
 
+  it('sanitizeSymptomPromptAnswerEntry accepts photo local capture refs', () => {
+    expect(
+      sanitizeSymptomPromptAnswerEntry({
+        type: 'photo',
+        value: {
+          localUri: 'file:///tmp/symptom.jpg',
+          capturedAt: '2026-04-27T12:00:00.000Z',
+        },
+      }),
+    ).toEqual({
+      type: 'photo',
+      value: {
+        localUri: 'file:///tmp/symptom.jpg',
+        capturedAt: '2026-04-27T12:00:00.000Z',
+      },
+    });
+  });
+
+  it('sanitizeSymptomPromptAnswerEntry trims photo localUri and capturedAt', () => {
+    expect(
+      sanitizeSymptomPromptAnswerEntry({
+        type: 'photo',
+        value: {
+          localUri: '  file:///tmp/symptom.jpg  ',
+          capturedAt: '  2026-04-27T12:00:00.000Z  ',
+        },
+      }),
+    ).toEqual({
+      type: 'photo',
+      value: {
+        localUri: 'file:///tmp/symptom.jpg',
+        capturedAt: '2026-04-27T12:00:00.000Z',
+      },
+    });
+  });
+
+  it('sanitizeSymptomPromptAnswerEntry rejects photo refs with invalid capturedAt', () => {
+    expect(
+      sanitizeSymptomPromptAnswerEntry({
+        type: 'photo',
+        value: {
+          localUri: 'file:///tmp/symptom.jpg',
+          capturedAt: 'not-a-date',
+        },
+      }),
+    ).toBeNull();
+  });
+
   it('sanitizeSymptomPromptAnswerEntry accepts video local capture refs', () => {
     expect(
       sanitizeSymptomPromptAnswerEntry({

--- a/packages/types/src/lib/symptom-prompt-session-sanitize.ts
+++ b/packages/types/src/lib/symptom-prompt-session-sanitize.ts
@@ -69,11 +69,36 @@ export function sanitizeSymptomPromptAnswerEntry(
         return { type: 'free_text', value: v };
       }
       return null;
-    case 'photo':
+    case 'photo': {
       if (v === null) {
         return { type: 'photo', value: null };
       }
-      return null;
+      if (typeof v !== 'object' || v === null || Array.isArray(v)) {
+        return null;
+      }
+      const photoRef = v as Record<string, unknown>;
+      if (typeof photoRef.localUri !== 'string') {
+        return null;
+      }
+      const localUri = photoRef.localUri.trim();
+      if (localUri.length === 0) {
+        return null;
+      }
+      if (typeof photoRef.capturedAt !== 'string') {
+        return null;
+      }
+      const capturedAt = photoRef.capturedAt.trim();
+      if (capturedAt.length === 0 || !Number.isFinite(Date.parse(capturedAt))) {
+        return null;
+      }
+      return {
+        type: 'photo',
+        value: {
+          localUri,
+          capturedAt,
+        },
+      };
+    }
     case 'video': {
       if (v === null) {
         return { type: 'video', value: null };

--- a/packages/types/src/lib/symptom-prompt-session.spec.ts
+++ b/packages/types/src/lib/symptom-prompt-session.spec.ts
@@ -73,13 +73,22 @@ describe('symptom-prompt-session', () => {
       ).toBe(true);
     });
 
-    it('photo stays empty and video counts when local capture exists', () => {
+    it('photo and video count when local capture refs are valid', () => {
       expect(symptomPromptAnswerHasValue({ type: 'photo', value: null })).toBe(
         false,
       );
       expect(symptomPromptAnswerHasValue({ type: 'video', value: null })).toBe(
         false,
       );
+      expect(
+        symptomPromptAnswerHasValue({
+          type: 'photo',
+          value: {
+            localUri: 'file:///tmp/capture.jpg',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        }),
+      ).toBe(true);
       expect(
         symptomPromptAnswerHasValue({
           type: 'video',
@@ -90,6 +99,27 @@ describe('symptom-prompt-session', () => {
           },
         }),
       ).toBe(true);
+    });
+
+    it('photo is empty when localUri or capturedAt are invalid', () => {
+      expect(
+        symptomPromptAnswerHasValue({
+          type: 'photo',
+          value: {
+            localUri: '   ',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        }),
+      ).toBe(false);
+      expect(
+        symptomPromptAnswerHasValue({
+          type: 'photo',
+          value: {
+            localUri: 'file:///tmp/capture.jpg',
+            capturedAt: 'not-a-date',
+          },
+        }),
+      ).toBe(false);
     });
 
     it('video is empty when localUri/capturedAt are invalid at runtime', () => {
@@ -177,6 +207,20 @@ describe('symptom-prompt-session', () => {
         [b.id]: { type: 'yes_no', value: false },
       });
       expect(placement).toEqual({ activeIndex: 1, phase: 'complete' });
+    });
+
+    it('treats a photo line as answered when a local capture ref is present', () => {
+      const p = line('p', 0, 'photo');
+      const placement = computeSymptomResumePlacement([p], {
+        [p.id]: {
+          type: 'photo',
+          value: {
+            localUri: 'file:///tmp/s.jpg',
+            capturedAt: '2026-04-27T12:00:00.000Z',
+          },
+        },
+      });
+      expect(placement).toEqual({ activeIndex: 0, phase: 'complete' });
     });
 
     it('returns prompting step zero when no answers exist', () => {

--- a/packages/types/src/lib/symptom-prompt-session.ts
+++ b/packages/types/src/lib/symptom-prompt-session.ts
@@ -4,6 +4,16 @@ import type { PresetSymptomRow, SymptomResponseType, Uuid } from './types.js';
 export const SYMPTOM_PROMPT_VIDEO_MAX_DURATION_MS = 15000;
 
 /**
+ * Temporary local reference to a captured symptom photo (no upload key yet).
+ */
+export interface SymptomPromptPhotoCaptureRef {
+  /** Device/browser-local URI or object URL. */
+  localUri: string;
+  /** ISO timestamp of when capture completed. */
+  capturedAt: string;
+}
+
+/**
  * Temporary local reference to a captured symptom video (no upload key yet).
  */
 export interface SymptomPromptVideoCaptureRef {
@@ -16,14 +26,15 @@ export interface SymptomPromptVideoCaptureRef {
 }
 
 /**
- * One stored answer for a preset symptom line during the Week 5 traversal skeleton.
+ * One stored answer for a preset symptom line during episode symptom traversal.
  * Values are JSON-serializable for session persistence (web `sessionStorage`).
+ * Photo/video may hold temporary local capture metadata until upload exists.
  */
 export type SymptomPromptAnswer =
   | { type: 'yes_no'; value: boolean | null }
   | { type: 'severity_scale'; value: number | null }
   | { type: 'free_text'; value: string }
-  | { type: 'photo'; value: null }
+  | { type: 'photo'; value: SymptomPromptPhotoCaptureRef | null }
   | { type: 'video'; value: SymptomPromptVideoCaptureRef | null };
 
 /**
@@ -97,7 +108,11 @@ export function symptomPromptAnswerHasValue(
     case 'free_text':
       return answer.value.trim().length > 0;
     case 'photo':
-      return false;
+      return (
+        answer.value !== null &&
+        answer.value.localUri.trim().length > 0 &&
+        Number.isFinite(Date.parse(answer.value.capturedAt))
+      );
     case 'video':
       return (
         answer.value !== null &&


### PR DESCRIPTION
Closes #132

## Summary

- Add in-flow `photo` symptom capture to both mobile and web episode prompt response UI, reusing the shared prompt wiring established for media capture.
- Persist temporary local photo capture refs (`localUri`, `capturedAt`) in symptom prompt session state so users can continue the flow after capture.
- Update type/session sanitization and answer-completion logic so photo captures are treated as valid prompt answers and safely restored from session state.
- Improve accessibility for capture controls with large touch targets, explicit labels/hints, and clear status messaging.
- Align mobile photo behavior with the working video camera path (front-facing default + in-app camera modal) and add pinch-to-zoom support in photo capture.

## Scope Notes

- Included: in-flow capture trigger, local prompt-state attachment, mobile/web UI wiring.
- Out of scope (unchanged): preview/re-take UX, storage upload, thumbnails, offline queue.

## Testing

- `pnpm exec nx run @abstrack/types:test`
- `pnpm exec nx test mobile -- --testPathPatterns=SymptomPromptScreen`
- `pnpm exec jest src/components/episode-flow/SymptomPromptResponseField.spec.tsx --no-cache` (from `apps/web`)
- `pnpm exec eslint src/app/components/episode-flow/SymptomPromptResponseField.tsx src/app/screens/SymptomPromptScreen.spec.tsx` (from `apps/mobile`)
- `pnpm exec eslint src/components/episode-flow/SymptomPromptResponseField.tsx` (from `apps/web`)