### PR TITLE
feat(episode-flow): add web/mobile capture review step with explicit use/retake actions and harden media prompt a11y/tests

### DIFF
--- a/apps/mobile/app.json
+++ b/apps/mobile/app.json
@@ -42,7 +42,8 @@
           "recordAudioAndroid": true
         }
       ],
-      "@react-native-community/datetimepicker"
+      "@react-native-community/datetimepicker",
+      "expo-video"
     ]
   }
 }

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -28,6 +28,7 @@
     "expo-splash-screen": "*",
     "expo-status-bar": "*",
     "expo-system-ui": "*",
+    "expo-video": "^3.0.16",
     "jest-expo": "*",
     "js-base64": "^3.7.8",
     "metro-config": "*",

--- a/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import {
   type GestureResponderEvent,
+  Image,
   Modal,
   Platform,
   Pressable,
@@ -51,6 +52,10 @@ export function SymptomPromptResponseField({
   const [photoModalOpen, setPhotoModalOpen] = useState(false);
   const [photoCameraReady, setPhotoCameraReady] = useState(false);
   const [photoCapturing, setPhotoCapturing] = useState(false);
+  const [pendingPhotoReview, setPendingPhotoReview] = useState<{
+    localUri: string;
+    capturedAt: string;
+  } | null>(null);
   const [videoBusy, setVideoBusy] = useState(false);
   const [cameraPermission, requestCameraPermission] = useCameraPermissions();
   const [microphonePermission, requestMicrophonePermission] =
@@ -283,6 +288,7 @@ export function SymptomPromptResponseField({
               void (async () => {
                 setPhotoBusy(true);
                 try {
+                  setPendingPhotoReview(null);
                   if (Platform.OS === 'android' || Platform.OS === 'ios') {
                     if (!cameraPermission?.granted) {
                       const granted = await requestCameraPermission();
@@ -349,9 +355,62 @@ export function SymptomPromptResponseField({
             maxFontSizeMultiplier={2}
           >
             {capturedPhoto
-              ? 'Photo saved on this device for this step. Continue when you are ready.'
-              : 'Use a large button to open the camera, take one photo, then return here.'}
+              ? 'Photo selected for this step. Continue when you are ready.'
+              : pendingPhotoReview
+                ? 'Review your photo, then choose Use photo or Take again.'
+                : 'Use a large button to open the camera, take one photo, then return here.'}
           </Text>
+          {pendingPhotoReview ? (
+            <View className="gap-3 rounded-xl border border-app-border bg-white p-3 dark:border-app-border-dark dark:bg-app-bg-dark">
+              <Image
+                source={{ uri: pendingPhotoReview.localUri }}
+                accessibilityLabel={`${line.symptom_name} photo preview`}
+                accessibilityIgnoresInvertColors
+                style={{
+                  width: '100%',
+                  aspectRatio: 3 / 4,
+                  borderRadius: 12,
+                }}
+                resizeMode="contain"
+              />
+              <View className="flex-row gap-3">
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Use ${line.symptom_name} photo`}
+                  onPress={() => {
+                    onChange({
+                      type: 'photo',
+                      value: pendingPhotoReview,
+                    });
+                    setPendingPhotoReview(null);
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="flex-1 items-center justify-center rounded-xl bg-app-primary px-4 py-3 active:opacity-90"
+                >
+                  <Text className="text-[17px] font-semibold text-white">
+                    Use photo
+                  </Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={`Take ${line.symptom_name} photo again`}
+                  onPress={() => {
+                    setPendingPhotoReview(null);
+                    setCameraFacing('front');
+                    setCameraZoom(0);
+                    setPhotoCameraReady(false);
+                    setPhotoModalOpen(true);
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="flex-1 items-center justify-center rounded-xl border border-app-border px-4 py-3 active:opacity-90 dark:border-app-border-dark"
+                >
+                  <Text className={`text-[17px] font-semibold ${nw.textInk}`}>
+                    Take again
+                  </Text>
+                </Pressable>
+              </View>
+            </View>
+          ) : null}
           <Modal
             visible={photoModalOpen}
             animationType="slide"
@@ -456,12 +515,9 @@ export function SymptomPromptResponseField({
                         }
                         setPhotoModalOpen(false);
                         setPhotoCameraReady(false);
-                        onChange({
-                          type: 'photo',
-                          value: {
-                            localUri: result.uri,
-                            capturedAt: new Date().toISOString(),
-                          },
+                        setPendingPhotoReview({
+                          localUri: result.uri,
+                          capturedAt: new Date().toISOString(),
                         });
                       } finally {
                         setPhotoCapturing(false);

--- a/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
@@ -33,11 +33,18 @@ export type SymptomPromptResponseFieldProps = {
   disabled: boolean;
 };
 
-function PendingVideoPreview({ uri }: { uri: string }) {
+function PendingVideoPreview({
+  uri,
+  accessibilityLabel,
+}: {
+  uri: string;
+  accessibilityLabel: string;
+}) {
   const player = useVideoPlayer(uri);
   return (
     <VideoView
       player={player}
+      accessibilityLabel={accessibilityLabel}
       nativeControls
       contentFit="contain"
       style={{ height: '100%', width: '100%' }}
@@ -735,7 +742,10 @@ export function SymptomPromptResponseField({
               ) : (
                 <View className="flex-1 items-center justify-center px-4">
                   <View className="h-[70%] w-full overflow-hidden rounded-2xl bg-black">
-                    <PendingVideoPreview uri={pendingVideoReview.localUri} />
+                    <PendingVideoPreview
+                      uri={pendingVideoReview.localUri}
+                      accessibilityLabel={`${line.symptom_name} captured video preview`}
+                    />
                   </View>
                 </View>
               )}

--- a/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/mobile/src/app/components/episode-flow/SymptomPromptResponseField.tsx
@@ -16,6 +16,7 @@ import {
 } from '@abstrack/types';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import * as ImagePicker from 'expo-image-picker';
+import { useVideoPlayer, VideoView } from 'expo-video';
 import {
   CameraView,
   useCameraPermissions,
@@ -31,6 +32,19 @@ export type SymptomPromptResponseFieldProps = {
   onChange: (next: SymptomPromptAnswer) => void;
   disabled: boolean;
 };
+
+function PendingVideoPreview({ uri }: { uri: string }) {
+  const player = useVideoPlayer(uri);
+  return (
+    <VideoView
+      player={player}
+      nativeControls
+      contentFit="contain"
+      style={{ height: '100%', width: '100%' }}
+    />
+  );
+}
+
 const VIDEO_MAX_DURATION_SECONDS = Math.floor(
   SYMPTOM_PROMPT_VIDEO_MAX_DURATION_MS / 1000,
 );
@@ -63,6 +77,11 @@ export function SymptomPromptResponseField({
   const [videoModalOpen, setVideoModalOpen] = useState(false);
   const [videoRecording, setVideoRecording] = useState(false);
   const [videoPaused, setVideoPaused] = useState(false);
+  const [pendingVideoReview, setPendingVideoReview] = useState<{
+    localUri: string;
+    durationMs: number | null;
+    capturedAt: string;
+  } | null>(null);
   const [cameraFacing, setCameraFacing] = useState<'front' | 'back'>('front');
   const [cameraZoom, setCameraZoom] = useState(0);
   const [canTogglePause, setCanTogglePause] = useState(false);
@@ -143,6 +162,7 @@ export function SymptomPromptResponseField({
     videoStartMsRef.current = null;
     videoPausedStartedAtRef.current = null;
     videoPausedTotalMsRef.current = 0;
+    setPendingVideoReview(null);
     setCameraReady(false);
     setVideoModalOpen(false);
   };
@@ -354,10 +374,10 @@ export function SymptomPromptResponseField({
             className={`text-sm leading-relaxed ${nw.textMuted}`}
             maxFontSizeMultiplier={2}
           >
-            {capturedPhoto
-              ? 'Photo selected for this step. Continue when you are ready.'
-              : pendingPhotoReview
-                ? 'Review your photo, then choose Use photo or Take again.'
+            {pendingPhotoReview
+              ? 'Review your photo, then choose Use photo or Take again.'
+              : capturedPhoto
+                ? 'Photo selected for this step. Continue when you are ready.'
                 : 'Use a large button to open the camera, take one photo, then return here.'}
           </Text>
           {pendingPhotoReview ? (
@@ -568,6 +588,7 @@ export function SymptomPromptResponseField({
               void (async () => {
                 setVideoBusy(true);
                 try {
+                  setPendingVideoReview(null);
                   if (Platform.OS === 'android' || Platform.OS === 'ios') {
                     if (!cameraPermission?.granted) {
                       const granted = await requestCameraPermission();
@@ -605,16 +626,13 @@ export function SymptomPromptResponseField({
                     return;
                   }
                   const asset = result.assets[0];
-                  onChange({
-                    type: 'video',
-                    value: {
-                      localUri: asset.uri,
-                      durationMs:
-                        typeof asset.duration === 'number'
-                          ? Math.round(asset.duration)
-                          : null,
-                      capturedAt: new Date().toISOString(),
-                    },
+                  setPendingVideoReview({
+                    localUri: asset.uri,
+                    durationMs:
+                      typeof asset.duration === 'number'
+                        ? Math.round(asset.duration)
+                        : null,
+                    capturedAt: new Date().toISOString(),
                   });
                 } finally {
                   setVideoBusy(false);
@@ -642,13 +660,19 @@ export function SymptomPromptResponseField({
             className={`text-sm leading-relaxed ${nw.textMuted}`}
             maxFontSizeMultiplier={2}
           >
-            {captured
-              ? `Video captured. Duration ${
-                  captured.durationMs !== null
-                    ? `${Math.round(captured.durationMs / 1000)}s`
+            {pendingVideoReview
+              ? `Video ready to review. Duration ${
+                  pendingVideoReview.durationMs !== null
+                    ? `${Math.round(pendingVideoReview.durationMs / 1000)}s`
                     : 'unknown'
-                }.`
-              : `Stop early in the camera to save a shorter clip. Maximum is ${VIDEO_MAX_DURATION_SECONDS} seconds.`}
+                }. Choose Use video or Record again.`
+              : captured
+                ? `Video captured. Duration ${
+                    captured.durationMs !== null
+                      ? `${Math.round(captured.durationMs / 1000)}s`
+                      : 'unknown'
+                  }.`
+                : `Stop early in the camera to save a shorter clip. Maximum is ${VIDEO_MAX_DURATION_SECONDS} seconds.`}
           </Text>
           <Text
             className={`text-xs leading-relaxed ${nw.textMuted}`}
@@ -663,78 +687,97 @@ export function SymptomPromptResponseField({
             onRequestClose={closeVideoModal}
           >
             <View className="flex-1 bg-black">
-              <View
-                className="flex-1"
-                onTouchStart={(event) => {
-                  const distance = pinchDistance(event);
-                  if (distance === null) {
-                    pinchStartDistanceRef.current = null;
-                    return;
-                  }
-                  pinchStartDistanceRef.current = distance;
-                  pinchStartZoomRef.current = cameraZoom;
-                }}
-                onTouchMove={(event) => {
-                  const startDistance = pinchStartDistanceRef.current;
-                  const distance = pinchDistance(event);
-                  if (startDistance === null || distance === null) {
-                    return;
-                  }
-                  const delta = (distance - startDistance) / 250;
-                  setCameraZoom(clampZoom(pinchStartZoomRef.current + delta));
-                }}
-                onTouchEnd={() => {
-                  pinchStartDistanceRef.current = null;
-                }}
-                onTouchCancel={() => {
-                  pinchStartDistanceRef.current = null;
-                }}
-              >
-                <CameraView
-                  ref={cameraRef}
-                  facing={cameraFacing}
-                  mode="video"
-                  mute={false}
-                  zoom={cameraZoom}
-                  style={{ flex: 1 }}
-                  onCameraReady={() => {
-                    setCameraReady(true);
-                    const supported = cameraRef.current?.getSupportedFeatures();
-                    setCanTogglePause(
-                      Boolean(supported?.toggleRecordingAsyncAvailable),
-                    );
+              {!pendingVideoReview ? (
+                <View
+                  className="flex-1"
+                  onTouchStart={(event) => {
+                    const distance = pinchDistance(event);
+                    if (distance === null) {
+                      pinchStartDistanceRef.current = null;
+                      return;
+                    }
+                    pinchStartDistanceRef.current = distance;
+                    pinchStartZoomRef.current = cameraZoom;
                   }}
-                />
-              </View>
+                  onTouchMove={(event) => {
+                    const startDistance = pinchStartDistanceRef.current;
+                    const distance = pinchDistance(event);
+                    if (startDistance === null || distance === null) {
+                      return;
+                    }
+                    const delta = (distance - startDistance) / 250;
+                    setCameraZoom(clampZoom(pinchStartZoomRef.current + delta));
+                  }}
+                  onTouchEnd={() => {
+                    pinchStartDistanceRef.current = null;
+                  }}
+                  onTouchCancel={() => {
+                    pinchStartDistanceRef.current = null;
+                  }}
+                >
+                  <CameraView
+                    ref={cameraRef}
+                    facing={cameraFacing}
+                    mode="video"
+                    mute={false}
+                    zoom={cameraZoom}
+                    style={{ flex: 1 }}
+                    onCameraReady={() => {
+                      setCameraReady(true);
+                      const supported =
+                        cameraRef.current?.getSupportedFeatures();
+                      setCanTogglePause(
+                        Boolean(supported?.toggleRecordingAsyncAvailable),
+                      );
+                    }}
+                  />
+                </View>
+              ) : (
+                <View className="flex-1 items-center justify-center px-4">
+                  <View className="h-[70%] w-full overflow-hidden rounded-2xl bg-black">
+                    <PendingVideoPreview uri={pendingVideoReview.localUri} />
+                  </View>
+                </View>
+              )}
               <View className="absolute left-0 right-0 top-0 flex-row items-center justify-between px-4 pt-12">
                 <Text
                   accessibilityRole="text"
                   className="rounded-md bg-black/70 px-3 py-2 text-base font-semibold text-white"
                   maxFontSizeMultiplier={2}
                 >
-                  {videoRecording ? `REC ${elapsedLabel}` : 'Ready'}
+                  {pendingVideoReview
+                    ? 'Review'
+                    : videoRecording
+                      ? `REC ${elapsedLabel}`
+                      : 'Ready'}
                 </Text>
                 <View className="flex-row items-center gap-2">
+                  {!pendingVideoReview ? (
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel="Switch camera"
+                      onPress={() => {
+                        setCameraFacing((v) =>
+                          v === 'front' ? 'back' : 'front',
+                        );
+                      }}
+                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                      className="items-center justify-center rounded-md bg-black/70 px-3 py-2"
+                    >
+                      <Ionicons
+                        name="camera-reverse-outline"
+                        size={22}
+                        color="white"
+                      />
+                    </Pressable>
+                  ) : null}
                   <Pressable
                     accessibilityRole="button"
-                    accessibilityLabel="Switch camera"
-                    onPress={() => {
-                      setCameraFacing((v) =>
-                        v === 'front' ? 'back' : 'front',
-                      );
-                    }}
-                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                    className="items-center justify-center rounded-md bg-black/70 px-3 py-2"
-                  >
-                    <Ionicons
-                      name="camera-reverse-outline"
-                      size={22}
-                      color="white"
-                    />
-                  </Pressable>
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel="Close recorder"
+                    accessibilityLabel={
+                      pendingVideoReview
+                        ? 'Close video preview'
+                        : 'Close recorder'
+                    }
                     onPress={closeVideoModal}
                     style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
                     className="items-center justify-center rounded-md bg-black/70 px-4 py-2"
@@ -746,7 +789,46 @@ export function SymptomPromptResponseField({
                 </View>
               </View>
               <View className="absolute bottom-12 left-0 right-0 items-center">
-                {!videoRecording ? (
+                {pendingVideoReview ? (
+                  <View className="w-full flex-row items-center gap-4 px-6">
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel={`Record ${line.symptom_name} video again`}
+                      onPress={() => {
+                        setPendingVideoReview(null);
+                        setElapsedSeconds(0);
+                        setVideoPaused(false);
+                        setCameraFacing('front');
+                        setCameraZoom(0);
+                        setCameraReady(false);
+                      }}
+                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                      className="flex-1 items-center justify-center rounded-xl bg-black/70 px-4 py-3"
+                    >
+                      <Text className="text-base font-semibold text-white">
+                        Record again
+                      </Text>
+                    </Pressable>
+                    <Pressable
+                      accessibilityRole="button"
+                      accessibilityLabel={`Use ${line.symptom_name} video`}
+                      onPress={() => {
+                        onChange({
+                          type: 'video',
+                          value: pendingVideoReview,
+                        });
+                        setPendingVideoReview(null);
+                        setVideoModalOpen(false);
+                      }}
+                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                      className="flex-1 items-center justify-center rounded-xl bg-app-primary px-4 py-3"
+                    >
+                      <Text className="text-base font-semibold text-white">
+                        Use video
+                      </Text>
+                    </Pressable>
+                  </View>
+                ) : !videoRecording ? (
                   <Pressable
                     accessibilityRole="button"
                     accessibilityLabel={`Start ${line.symptom_name} video recording`}
@@ -812,14 +894,10 @@ export function SymptomPromptResponseField({
                         if (!result?.uri) {
                           return;
                         }
-                        setVideoModalOpen(false);
-                        onChange({
-                          type: 'video',
-                          value: {
-                            localUri: result.uri,
-                            durationMs,
-                            capturedAt: new Date().toISOString(),
-                          },
+                        setPendingVideoReview({
+                          localUri: result.uri,
+                          durationMs,
+                          capturedAt: new Date().toISOString(),
                         });
                       })();
                     }}

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -988,185 +988,411 @@ export function HealthMarkerPromptScreen() {
           />
         ) : phase === 'postMarkers' ? (
           <ScrollView
+            className="flex-1"
+            keyboardShouldPersistTaps="handled"
+            showsVerticalScrollIndicator
+            contentContainerStyle={{ paddingBottom: 24 }}
+          >
+            <Text
+              className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
+              maxFontSizeMultiplier={2}
+            >
+              After health markers and food diary, choose ABS or Other; other
+              fields are optional.
+            </Text>
+            <Text
+              accessibilityRole="header"
+              className={`mb-2 text-lg font-semibold ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              Episode type
+            </Text>
+            <View
+              accessibilityRole="radiogroup"
+              accessibilityLabel="Episode type"
+              className="mb-4 gap-3"
+            >
+              <Pressable
+                accessibilityRole="radio"
+                accessibilityLabel="ABS episode type"
+                accessibilityState={{
+                  checked: postEpisodeKind === 'ABS',
+                  disabled: savingPost,
+                }}
+                onPress={() => {
+                  setPostEpisodeKind('ABS');
+                }}
+                disabled={savingPost}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className={`w-full items-center justify-center rounded-xl border-2 px-3 py-4 dark:border-app-border-dark ${
+                  postEpisodeKind === 'ABS'
+                    ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                    : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
+                }`}
+              >
+                <Text
+                  className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  ABS
+                </Text>
+              </Pressable>
+              <Pressable
+                accessibilityRole="radio"
+                accessibilityLabel="Other episode type"
+                accessibilityState={{
+                  checked: postEpisodeKind === 'Other',
+                  disabled: savingPost,
+                }}
+                onPress={() => {
+                  setPostEpisodeKind('Other');
+                }}
+                disabled={savingPost}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className={`w-full items-center justify-center rounded-xl border-2 px-3 py-4 dark:border-app-border-dark ${
+                  postEpisodeKind === 'Other'
+                    ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
+                    : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
+                }`}
+              >
+                <Text
+                  className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  Other
+                </Text>
+              </Pressable>
+            </View>
+            {bacSuggestAbs && postEpisodeKind === 'ABS' ? (
+              <Text
+                className={`mb-4 text-sm ${nw.textMuted}`}
+                accessibilityLiveRegion="polite"
+                maxFontSizeMultiplier={2}
+              >
+                Suggested as ABS because a BAC value above zero was logged. You
+                can change this.
+              </Text>
+            ) : null}
+            <Text
+              accessibilityRole="text"
+              className={`mb-1 text-base font-medium ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              Custom label (optional)
+            </Text>
+            <TextInput
+              editable={!savingPost}
+              accessibilityLabel="Custom episode label"
+              value={postLabel}
+              onChangeText={setPostLabel}
+              placeholder="Label"
+              placeholderTextColor={colors.inputPlaceholder}
+              className={`mb-4 min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            />
+            <Text
+              accessibilityRole="text"
+              className={`mb-1 text-base font-medium ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              Additional symptoms or markers (optional)
+            </Text>
+            <TextInput
+              editable={!savingPost}
+              accessibilityLabel="Additional symptoms or markers"
+              multiline
+              value={postAdditional}
+              onChangeText={setPostAdditional}
+              placeholder="Not in your presets"
+              placeholderTextColor={colors.inputPlaceholder}
+              className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            />
+            <Text
+              accessibilityRole="text"
+              className={`mb-1 text-base font-medium ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            >
+              Episode note (optional)
+            </Text>
+            <TextInput
+              editable={!savingPost}
+              accessibilityLabel="Episode note"
+              multiline
+              value={postNote}
+              onChangeText={setPostNote}
+              placeholder="General note"
+              placeholderTextColor={colors.inputPlaceholder}
+              className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+            />
+            {postFeedback ? (
+              <Text
+                className="mb-2 text-sm text-red-700 dark:text-red-300"
+                accessibilityLiveRegion="assertive"
+                maxFontSizeMultiplier={2}
+              >
+                {postFeedback}
+              </Text>
+            ) : null}
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Back"
+              accessibilityState={{ disabled: savingPost }}
+              disabled={savingPost}
+              onPress={() => {
+                void onBackToFoodDiaryFromPostMarkers();
+              }}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
+            >
+              <Text
+                className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+              >
+                Back
+              </Text>
+            </Pressable>
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel="Save episode details"
+              accessibilityState={{ disabled: savingPost }}
+              disabled={savingPost}
+              onPress={() => {
+                void onSubmitPostMarkers();
+              }}
+              style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+              className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 dark:bg-red-600"
+            >
+              <Text className="text-center text-[17px] font-semibold text-white">
+                {savingPost ? 'Saving…' : 'Save and continue'}
+              </Text>
+            </Pressable>
+            <EpisodeFlowSecondaryActionsSection>
+              <Pressable
+                accessibilityRole="button"
+                accessibilityLabel="Cancel episode"
+                onPress={onCancelEpisodePress}
+                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
+              >
+                <Text
+                  className="text-sm font-medium text-red-700 dark:text-red-300"
+                  maxFontSizeMultiplier={2}
+                >
+                  Cancel episode
+                </Text>
+              </Pressable>
+            </EpisodeFlowSecondaryActionsSection>
+          </ScrollView>
+        ) : (
+          <AsyncScreenContainer
+            status={status}
+            loadingAccessibilityLabel="Loading health marker list"
+            errorTitle="Could not load health markers"
+            errorMessage={errorMessage ?? undefined}
+            onRetry={() => {
+              void load();
+            }}
+          >
+            <ScrollView
               className="flex-1"
               keyboardShouldPersistTaps="handled"
               showsVerticalScrollIndicator
               contentContainerStyle={{ paddingBottom: 24 }}
             >
               <Text
-                className={`mb-4 text-base leading-relaxed ${nw.textMuted}`}
+                accessibilityRole="text"
+                className={`mb-2 text-base font-medium ${nw.textMuted}`}
                 maxFontSizeMultiplier={2}
               >
-                After health markers and food diary, choose ABS or Other; other
-                fields are optional.
+                {lines.length === 0
+                  ? 'Next: episode details (after this screen)'
+                  : `Step ${activeIndex + 1} of ${lines.length}`}
               </Text>
-              <Text
-                accessibilityRole="header"
-                className={`mb-2 text-lg font-semibold ${nw.textInk}`}
-                maxFontSizeMultiplier={2}
-              >
-                Episode type
-              </Text>
-              <View
-                accessibilityRole="radiogroup"
-                accessibilityLabel="Episode type"
-                className="mb-4 gap-3"
-              >
+
+              {lines.length === 0 ? (
+                <Text
+                  className={`text-base leading-relaxed ${nw.textInk}`}
+                  maxFontSizeMultiplier={2}
+                >
+                  This preset has no health marker lines to log—that is normal
+                  for some templates. Use the button below to continue and add
+                  episode type, optional label, and notes.
+                </Text>
+              ) : currentLine ? (
+                <View className="gap-4">
+                  <Text
+                    accessibilityRole="header"
+                    className={`text-xl font-semibold ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {markerLineTitle(currentLine)}
+                  </Text>
+                  {currentLine.custom_unit ? (
+                    <Text
+                      className={`text-base leading-relaxed ${nw.textMuted}`}
+                      maxFontSizeMultiplier={2}
+                    >
+                      Unit: {currentLine.custom_unit}
+                    </Text>
+                  ) : null}
+                  {currentLine.marker_kind === 'blood_pressure' ? (
+                    <View className="gap-3">
+                      <TextInput
+                        editable={!saving}
+                        accessibilityLabel="Systolic value"
+                        keyboardType="decimal-pad"
+                        value={currentDraft.systolic}
+                        onChangeText={(text) => {
+                          onUpdateDraft({ systolic: text });
+                        }}
+                        placeholder="Systolic"
+                        placeholderTextColor={colors.inputPlaceholder}
+                        className={`min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      />
+                      <TextInput
+                        editable={!saving}
+                        accessibilityLabel="Diastolic value"
+                        keyboardType="decimal-pad"
+                        value={currentDraft.diastolic}
+                        onChangeText={(text) => {
+                          onUpdateDraft({ diastolic: text });
+                        }}
+                        placeholder="Diastolic"
+                        placeholderTextColor={colors.inputPlaceholder}
+                        className={`min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+                        maxFontSizeMultiplier={2}
+                      />
+                    </View>
+                  ) : (
+                    <TextInput
+                      editable={!saving}
+                      accessibilityLabel="Marker value"
+                      keyboardType="decimal-pad"
+                      value={currentDraft.value}
+                      onChangeText={(text) => {
+                        onUpdateDraft({ value: text });
+                      }}
+                      placeholder="Enter value"
+                      placeholderTextColor={colors.inputPlaceholder}
+                      className={`min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+                      maxFontSizeMultiplier={2}
+                    />
+                  )}
+                  <TextInput
+                    editable={!saving}
+                    accessibilityLabel="Marker notes"
+                    multiline
+                    value={currentDraft.notes}
+                    onChangeText={(text) => {
+                      onUpdateDraft({ notes: text });
+                    }}
+                    placeholder="Notes (optional)"
+                    placeholderTextColor={colors.inputPlaceholder}
+                    className={`min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  />
+                </View>
+              ) : null}
+
+              <View className="mt-6 gap-3">
                 <Pressable
-                  accessibilityRole="radio"
-                  accessibilityLabel="ABS episode type"
-                  accessibilityState={{
-                    checked: postEpisodeKind === 'ABS',
-                    disabled: savingPost,
-                  }}
+                  accessibilityRole="button"
+                  accessibilityLabel="Back"
                   onPress={() => {
-                    setPostEpisodeKind('ABS');
+                    if (activeIndex > 0) {
+                      goBackStep();
+                      return;
+                    }
+                    void onBackToSymptomsFromHealthMarkers();
                   }}
-                  disabled={savingPost}
+                  disabled={saving}
                   style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                  className={`w-full items-center justify-center rounded-xl border-2 px-3 py-4 dark:border-app-border-dark ${
-                    postEpisodeKind === 'ABS'
-                      ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
-                      : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
-                  }`}
+                  className="w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
                 >
                   <Text
                     className={`text-center text-[17px] font-semibold ${nw.textInk}`}
                     maxFontSizeMultiplier={2}
                   >
-                    ABS
+                    Back
                   </Text>
                 </Pressable>
-                <Pressable
-                  accessibilityRole="radio"
-                  accessibilityLabel="Other episode type"
-                  accessibilityState={{
-                    checked: postEpisodeKind === 'Other',
-                    disabled: savingPost,
-                  }}
-                  onPress={() => {
-                    setPostEpisodeKind('Other');
-                  }}
-                  disabled={savingPost}
-                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                  className={`w-full items-center justify-center rounded-xl border-2 px-3 py-4 dark:border-app-border-dark ${
-                    postEpisodeKind === 'Other'
-                      ? 'border-red-700 bg-red-50 dark:border-red-500 dark:bg-red-950/40'
-                      : 'border-app-border bg-app-bg dark:bg-app-bg-dark'
-                  }`}
-                >
-                  <Text
-                    className={`text-center text-[17px] font-semibold ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
+                {currentLine ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    accessibilityLabel="Skip this marker"
+                    accessibilityState={{ disabled: !canSkip || saving }}
+                    disabled={!canSkip || saving}
+                    onPress={() => {
+                      void skipCurrent();
+                    }}
+                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                    className={`w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 dark:border-app-border-dark dark:bg-app-bg-dark ${
+                      skipPressable ? 'active:opacity-90' : 'opacity-50'
+                    }`}
                   >
-                    Other
+                    <Text
+                      className={`text-center text-[17px] font-semibold ${nw.textInk}`}
+                      maxFontSizeMultiplier={2}
+                    >
+                      Skip
+                    </Text>
+                  </Pressable>
+                ) : null}
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={
+                    continueToFoodDiary
+                      ? 'Continue to food diary'
+                      : 'Next health marker'
+                  }
+                  accessibilityState={{ disabled: saving }}
+                  disabled={saving}
+                  onPress={() => {
+                    void goNext();
+                  }}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
+                  className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 dark:bg-red-600"
+                >
+                  <Text className="text-center text-[17px] font-semibold text-white">
+                    {saving
+                      ? 'Saving…'
+                      : continueToFoodDiary
+                        ? 'Continue to food diary'
+                        : 'Next'}
                   </Text>
                 </Pressable>
               </View>
-              {bacSuggestAbs && postEpisodeKind === 'ABS' ? (
-                <Text
-                  className={`mb-4 text-sm ${nw.textMuted}`}
-                  accessibilityLiveRegion="polite"
-                  maxFontSizeMultiplier={2}
+              {observationTimeline.length > 0 ? (
+                <View
+                  accessibilityLabel="Recent log entries in this episode, oldest first within this slice"
+                  className="mt-6 rounded-xl border border-app-border bg-app-surface p-4 dark:border-app-border-dark dark:bg-app-bg-dark"
                 >
-                  Suggested as ABS because a BAC value above zero was logged.
-                  You can change this.
-                </Text>
+                  <Text
+                    className={`text-sm font-semibold ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Recent log entries in this episode
+                  </Text>
+                  <Text
+                    className={`mb-2 text-xs ${nw.textMuted}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    Showing recent entries only. Oldest first within this slice.
+                  </Text>
+                  {observationTimeline.map((row) => (
+                    <Text
+                      key={`${row.kind}-${row.id}`}
+                      className={`mb-2 text-sm ${nw.textInk}`}
+                      maxFontSizeMultiplier={2}
+                    >
+                      {formatTimelineInstant(row.sortAt)} — {row.label}:{' '}
+                      {row.detail}
+                    </Text>
+                  ))}
+                </View>
               ) : null}
-              <Text
-                accessibilityRole="text"
-                className={`mb-1 text-base font-medium ${nw.textInk}`}
-                maxFontSizeMultiplier={2}
-              >
-                Custom label (optional)
-              </Text>
-              <TextInput
-                editable={!savingPost}
-                accessibilityLabel="Custom episode label"
-                value={postLabel}
-                onChangeText={setPostLabel}
-                placeholder="Label"
-                placeholderTextColor={colors.inputPlaceholder}
-                className={`mb-4 min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-                maxFontSizeMultiplier={2}
-              />
-              <Text
-                accessibilityRole="text"
-                className={`mb-1 text-base font-medium ${nw.textInk}`}
-                maxFontSizeMultiplier={2}
-              >
-                Additional symptoms or markers (optional)
-              </Text>
-              <TextInput
-                editable={!savingPost}
-                accessibilityLabel="Additional symptoms or markers"
-                multiline
-                value={postAdditional}
-                onChangeText={setPostAdditional}
-                placeholder="Not in your presets"
-                placeholderTextColor={colors.inputPlaceholder}
-                className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-                maxFontSizeMultiplier={2}
-              />
-              <Text
-                accessibilityRole="text"
-                className={`mb-1 text-base font-medium ${nw.textInk}`}
-                maxFontSizeMultiplier={2}
-              >
-                Episode note (optional)
-              </Text>
-              <TextInput
-                editable={!savingPost}
-                accessibilityLabel="Episode note"
-                multiline
-                value={postNote}
-                onChangeText={setPostNote}
-                placeholder="General note"
-                placeholderTextColor={colors.inputPlaceholder}
-                className={`mb-4 min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-                maxFontSizeMultiplier={2}
-              />
-              {postFeedback ? (
-                <Text
-                  className="mb-2 text-sm text-red-700 dark:text-red-300"
-                  accessibilityLiveRegion="assertive"
-                  maxFontSizeMultiplier={2}
-                >
-                  {postFeedback}
-                </Text>
-              ) : null}
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Back"
-                accessibilityState={{ disabled: savingPost }}
-                disabled={savingPost}
-                onPress={() => {
-                  void onBackToFoodDiaryFromPostMarkers();
-                }}
-                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                className="w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
-              >
-                <Text
-                  className={`text-center text-[17px] font-semibold ${nw.textInk}`}
-                >
-                  Back
-                </Text>
-              </Pressable>
-              <Pressable
-                accessibilityRole="button"
-                accessibilityLabel="Save episode details"
-                accessibilityState={{ disabled: savingPost }}
-                disabled={savingPost}
-                onPress={() => {
-                  void onSubmitPostMarkers();
-                }}
-                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 dark:bg-red-600"
-              >
-                <Text className="text-center text-[17px] font-semibold text-white">
-                  {savingPost ? 'Saving…' : 'Save and continue'}
-                </Text>
-              </Pressable>
               <EpisodeFlowSecondaryActionsSection>
                 <Pressable
                   accessibilityRole="button"
@@ -1184,234 +1410,7 @@ export function HealthMarkerPromptScreen() {
                 </Pressable>
               </EpisodeFlowSecondaryActionsSection>
             </ScrollView>
-        ) : (
-          <AsyncScreenContainer
-              status={status}
-              loadingAccessibilityLabel="Loading health marker list"
-              errorTitle="Could not load health markers"
-              errorMessage={errorMessage ?? undefined}
-              onRetry={() => {
-                void load();
-              }}
-            >
-              <ScrollView
-                className="flex-1"
-                keyboardShouldPersistTaps="handled"
-                showsVerticalScrollIndicator
-                contentContainerStyle={{ paddingBottom: 24 }}
-              >
-                <Text
-                  accessibilityRole="text"
-                  className={`mb-2 text-base font-medium ${nw.textMuted}`}
-                  maxFontSizeMultiplier={2}
-                >
-                  {lines.length === 0
-                    ? 'Next: episode details (after this screen)'
-                    : `Step ${activeIndex + 1} of ${lines.length}`}
-                </Text>
-
-                {lines.length === 0 ? (
-                  <Text
-                    className={`text-base leading-relaxed ${nw.textInk}`}
-                    maxFontSizeMultiplier={2}
-                  >
-                    This preset has no health marker lines to log—that is normal
-                    for some templates. Use the button below to continue and add
-                    episode type, optional label, and notes.
-                  </Text>
-                ) : currentLine ? (
-                  <View className="gap-4">
-                    <Text
-                      accessibilityRole="header"
-                      className={`text-xl font-semibold ${nw.textInk}`}
-                      maxFontSizeMultiplier={2}
-                    >
-                      {markerLineTitle(currentLine)}
-                    </Text>
-                    {currentLine.custom_unit ? (
-                      <Text
-                        className={`text-base leading-relaxed ${nw.textMuted}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        Unit: {currentLine.custom_unit}
-                      </Text>
-                    ) : null}
-                    {currentLine.marker_kind === 'blood_pressure' ? (
-                      <View className="gap-3">
-                        <TextInput
-                          editable={!saving}
-                          accessibilityLabel="Systolic value"
-                          keyboardType="decimal-pad"
-                          value={currentDraft.systolic}
-                          onChangeText={(text) => {
-                            onUpdateDraft({ systolic: text });
-                          }}
-                          placeholder="Systolic"
-                          placeholderTextColor={colors.inputPlaceholder}
-                          className={`min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-                          maxFontSizeMultiplier={2}
-                        />
-                        <TextInput
-                          editable={!saving}
-                          accessibilityLabel="Diastolic value"
-                          keyboardType="decimal-pad"
-                          value={currentDraft.diastolic}
-                          onChangeText={(text) => {
-                            onUpdateDraft({ diastolic: text });
-                          }}
-                          placeholder="Diastolic"
-                          placeholderTextColor={colors.inputPlaceholder}
-                          className={`min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-                          maxFontSizeMultiplier={2}
-                        />
-                      </View>
-                    ) : (
-                      <TextInput
-                        editable={!saving}
-                        accessibilityLabel="Marker value"
-                        keyboardType="decimal-pad"
-                        value={currentDraft.value}
-                        onChangeText={(text) => {
-                          onUpdateDraft({ value: text });
-                        }}
-                        placeholder="Enter value"
-                        placeholderTextColor={colors.inputPlaceholder}
-                        className={`min-h-[52px] rounded-xl border border-app-border bg-white px-4 py-3 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-                        maxFontSizeMultiplier={2}
-                      />
-                    )}
-                    <TextInput
-                      editable={!saving}
-                      accessibilityLabel="Marker notes"
-                      multiline
-                      value={currentDraft.notes}
-                      onChangeText={(text) => {
-                        onUpdateDraft({ notes: text });
-                      }}
-                      placeholder="Notes (optional)"
-                      placeholderTextColor={colors.inputPlaceholder}
-                      className={`min-h-[120px] rounded-xl border border-app-border bg-white p-4 text-[17px] text-app-ink dark:border-app-border-dark dark:bg-app-bg-dark ${nw.textInk}`}
-                      maxFontSizeMultiplier={2}
-                    />
-                  </View>
-                ) : null}
-
-                <View className="mt-6 gap-3">
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel="Back"
-                    onPress={() => {
-                      if (activeIndex > 0) {
-                        goBackStep();
-                        return;
-                      }
-                      void onBackToSymptomsFromHealthMarkers();
-                    }}
-                    disabled={saving}
-                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                    className="w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 active:opacity-90 dark:border-app-border-dark dark:bg-app-bg-dark"
-                  >
-                    <Text
-                      className={`text-center text-[17px] font-semibold ${nw.textInk}`}
-                      maxFontSizeMultiplier={2}
-                    >
-                      Back
-                    </Text>
-                  </Pressable>
-                  {currentLine ? (
-                    <Pressable
-                      accessibilityRole="button"
-                      accessibilityLabel="Skip this marker"
-                      accessibilityState={{ disabled: !canSkip || saving }}
-                      disabled={!canSkip || saving}
-                      onPress={() => {
-                        void skipCurrent();
-                      }}
-                      style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                      className={`w-full items-center justify-center rounded-xl border-2 border-app-border bg-app-bg px-3 py-4 dark:border-app-border-dark dark:bg-app-bg-dark ${
-                        skipPressable ? 'active:opacity-90' : 'opacity-50'
-                      }`}
-                    >
-                      <Text
-                        className={`text-center text-[17px] font-semibold ${nw.textInk}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        Skip
-                      </Text>
-                    </Pressable>
-                  ) : null}
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel={
-                      continueToFoodDiary
-                        ? 'Continue to food diary'
-                        : 'Next health marker'
-                    }
-                    accessibilityState={{ disabled: saving }}
-                    disabled={saving}
-                    onPress={() => {
-                      void goNext();
-                    }}
-                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                    className="w-full items-center justify-center rounded-xl bg-red-700 px-3 py-4 active:opacity-90 dark:bg-red-600"
-                  >
-                    <Text className="text-center text-[17px] font-semibold text-white">
-                      {saving
-                        ? 'Saving…'
-                        : continueToFoodDiary
-                          ? 'Continue to food diary'
-                          : 'Next'}
-                    </Text>
-                  </Pressable>
-                </View>
-                {observationTimeline.length > 0 ? (
-                  <View
-                    accessibilityLabel="Recent log entries in this episode, oldest first within this slice"
-                    className="mt-6 rounded-xl border border-app-border bg-app-surface p-4 dark:border-app-border-dark dark:bg-app-bg-dark"
-                  >
-                    <Text
-                      className={`text-sm font-semibold ${nw.textInk}`}
-                      maxFontSizeMultiplier={2}
-                    >
-                      Recent log entries in this episode
-                    </Text>
-                    <Text
-                      className={`mb-2 text-xs ${nw.textMuted}`}
-                      maxFontSizeMultiplier={2}
-                    >
-                      Showing recent entries only. Oldest first within this
-                      slice.
-                    </Text>
-                    {observationTimeline.map((row) => (
-                      <Text
-                        key={`${row.kind}-${row.id}`}
-                        className={`mb-2 text-sm ${nw.textInk}`}
-                        maxFontSizeMultiplier={2}
-                      >
-                        {formatTimelineInstant(row.sortAt)} — {row.label}:{' '}
-                        {row.detail}
-                      </Text>
-                    ))}
-                  </View>
-                ) : null}
-                <EpisodeFlowSecondaryActionsSection>
-                  <Pressable
-                    accessibilityRole="button"
-                    accessibilityLabel="Cancel episode"
-                    onPress={onCancelEpisodePress}
-                    style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP }}
-                    className="w-full items-center justify-center rounded-lg px-3 py-3 active:opacity-80"
-                  >
-                    <Text
-                      className="text-sm font-medium text-red-700 dark:text-red-300"
-                      maxFontSizeMultiplier={2}
-                    >
-                      Cancel episode
-                    </Text>
-                  </Pressable>
-                </EpisodeFlowSecondaryActionsSection>
-              </ScrollView>
-            </AsyncScreenContainer>
+          </AsyncScreenContainer>
         )}
       </View>
     </ScreenShell>

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -627,7 +627,7 @@ export function HealthMarkerPromptScreen() {
       symptomPresetId: presetId,
       resume: true,
     });
-  }, [announce, episodeId, episodeRow?.symptom_preset_id, navigation]);
+  }, [episodeId, episodeRow?.symptom_preset_id, navigation]);
 
   const onBackToSymptomsFromHealthMarkers = useCallback(async () => {
     const symptomPresetId = episodeRow?.symptom_preset_id;
@@ -987,8 +987,7 @@ export function HealthMarkerPromptScreen() {
             onCancelEpisodePress={onCancelEpisodePress}
           />
         ) : phase === 'postMarkers' ? (
-          <>
-            <ScrollView
+          <ScrollView
               className="flex-1"
               keyboardShouldPersistTaps="handled"
               showsVerticalScrollIndicator
@@ -1185,10 +1184,8 @@ export function HealthMarkerPromptScreen() {
                 </Pressable>
               </EpisodeFlowSecondaryActionsSection>
             </ScrollView>
-          </>
         ) : (
-          <>
-            <AsyncScreenContainer
+          <AsyncScreenContainer
               status={status}
               loadingAccessibilityLabel="Loading health marker list"
               errorTitle="Could not load health markers"
@@ -1415,7 +1412,6 @@ export function HealthMarkerPromptScreen() {
                 </EpisodeFlowSecondaryActionsSection>
               </ScrollView>
             </AsyncScreenContainer>
-          </>
         )}
       </View>
     </ScreenShell>

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -88,19 +88,6 @@ jest.mock('expo-image-picker', () => ({
   launchCameraAsync: jest.fn(),
 }));
 
-jest.mock('expo-video', () => {
-  const React = require('react');
-  const { View } = require('react-native');
-  return {
-    VideoView: (props: { accessibilityLabel?: string }) => (
-      <View
-        accessibilityLabel={props.accessibilityLabel ?? 'Mock video view'}
-      />
-    ),
-    useVideoPlayer: jest.fn(() => ({})),
-  };
-});
-
 jest.mock('expo-camera', () => {
   const React = require('react');
   const { View } = require('react-native');

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -88,6 +88,19 @@ jest.mock('expo-image-picker', () => ({
   launchCameraAsync: jest.fn(),
 }));
 
+jest.mock('expo-video', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  return {
+    VideoView: (props: { accessibilityLabel?: string }) => (
+      <View
+        accessibilityLabel={props.accessibilityLabel ?? 'Mock video view'}
+      />
+    ),
+    useVideoPlayer: jest.fn(() => ({})),
+  };
+});
+
 jest.mock('expo-camera', () => {
   const React = require('react');
   const { View } = require('react-native');
@@ -703,6 +716,16 @@ describe('SymptomPromptScreen', () => {
     await waitFor(() => {
       expect(mockRecordAsync).toHaveBeenCalledTimes(1);
     });
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Use Dizziness video')).toBeTruthy();
+      expect(
+        screen.getByLabelText('Next symptom').props.accessibilityState,
+      ).toEqual({
+        disabled: true,
+      });
+    });
+    fireEvent.press(screen.getByLabelText('Use Dizziness video'));
 
     await waitFor(() => {
       expect(

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ForwardedRef } from 'react';
 import { Alert } from 'react-native';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import { CommonActions, DefaultTheme } from '@react-navigation/native';
@@ -91,7 +91,10 @@ jest.mock('expo-image-picker', () => ({
 jest.mock('expo-camera', () => {
   const React = require('react');
   const { View } = require('react-native');
-  const CameraView = React.forwardRef((props: any, ref: any) => {
+  const CameraView = React.forwardRef(function MockCameraView(
+    props: { onCameraReady?: () => void },
+    ref: ForwardedRef<unknown>,
+  ) {
     React.useImperativeHandle(ref, () => ({
       recordAsync: mockRecordAsync,
       stopRecording: mockStopRecording,
@@ -751,6 +754,10 @@ describe('SymptomPromptScreen', () => {
       expect(screen.getByLabelText('Capture Facial droop photo')).toBeTruthy();
     });
     fireEvent.press(screen.getByLabelText('Capture Facial droop photo'));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Use Facial droop photo')).toBeTruthy();
+    });
+    fireEvent.press(screen.getByLabelText('Use Facial droop photo'));
 
     await waitFor(() => {
       expect(

--- a/apps/mobile/src/test-setup.ts
+++ b/apps/mobile/src/test-setup.ts
@@ -50,6 +50,16 @@ jest.mock('react-native-safe-area-context', () => {
   };
 });
 
+jest.mock('expo-video', () => {
+  return {
+    VideoView: (props: { accessibilityLabel?: string }) =>
+      require('react').createElement(require('react-native').View, {
+        accessibilityLabel: props.accessibilityLabel ?? 'Mock video view',
+      }),
+    useVideoPlayer: jest.fn(() => ({})),
+  };
+});
+
 configure({ asyncUtilTimeout: 5000 });
 
 if (typeof global.structuredClone === 'undefined') {

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
@@ -264,7 +264,7 @@ describe('SymptomPromptResponseField video capture', () => {
     }
   });
 
-  it('revokes prior object URL when recording again', async () => {
+  it('keeps confirmed video object URLs when recording and confirming again', async () => {
     createObjectUrlMock
       .mockReturnValueOnce('blob:first-video')
       .mockReturnValueOnce('blob:second-video');

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
@@ -80,6 +80,8 @@ describe('SymptomPromptResponseField video capture', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    createObjectUrlMock.mockReset();
+    revokeObjectUrlMock.mockReset();
     getUserMediaMock.mockResolvedValue(mockStream);
     createObjectUrlMock.mockReturnValue('blob:local-video');
     Object.defineProperty(globalThis, 'navigator', {
@@ -179,6 +181,14 @@ describe('SymptomPromptResponseField video capture', () => {
     fireEvent.click(screen.getByLabelText('Stop Dizziness video recording'));
 
     await waitFor(() => {
+      expect(
+        screen.getByLabelText('Dizziness captured video preview'),
+      ).toBeTruthy();
+      expect(onChange).toHaveBeenCalledTimes(0);
+    });
+    fireEvent.click(screen.getByLabelText('Use Dizziness video'));
+
+    await waitFor(() => {
       expect(onChange).toHaveBeenCalledTimes(1);
     });
 
@@ -239,6 +249,14 @@ describe('SymptomPromptResponseField video capture', () => {
       });
 
       await waitFor(() => {
+        expect(
+          screen.getByLabelText('Nausea captured video preview'),
+        ).toBeTruthy();
+        expect(onChange).toHaveBeenCalledTimes(0);
+      });
+      fireEvent.click(screen.getByLabelText('Use Nausea video'));
+
+      await waitFor(() => {
         expect(onChange).toHaveBeenCalledTimes(1);
       });
     } finally {
@@ -276,6 +294,13 @@ describe('SymptomPromptResponseField video capture', () => {
     });
     fireEvent.click(screen.getByLabelText('Stop Headache video recording'));
     await waitFor(() => {
+      expect(
+        screen.getByLabelText('Headache captured video preview'),
+      ).toBeTruthy();
+      expect(onChange).toHaveBeenCalledTimes(0);
+    });
+    fireEvent.click(screen.getByLabelText('Use Headache video'));
+    await waitFor(() => {
       expect(onChange).toHaveBeenCalledTimes(1);
     });
     expect(revokeObjectUrlMock).not.toHaveBeenCalled();
@@ -295,11 +320,18 @@ describe('SymptomPromptResponseField video capture', () => {
       ).toBeTruthy();
     });
     fireEvent.click(screen.getByLabelText('Stop Headache video recording'));
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Headache captured video preview'),
+      ).toBeTruthy();
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+    fireEvent.click(screen.getByLabelText('Use Headache video'));
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledTimes(2);
     });
-    expect(revokeObjectUrlMock).toHaveBeenCalledWith('blob:first-video');
+    expect(revokeObjectUrlMock).not.toHaveBeenCalled();
   });
 
   it('disables close button while recording to avoid implicit save', async () => {
@@ -410,6 +442,8 @@ describe('SymptomPromptResponseField photo capture', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    createObjectUrlMock.mockReset();
+    revokeObjectUrlMock.mockReset();
     getUserMediaMock.mockResolvedValue(mockStream);
     createObjectUrlMock.mockReturnValue('blob:local-photo');
     Object.defineProperty(globalThis, 'navigator', {
@@ -505,14 +539,18 @@ describe('SymptomPromptResponseField photo capture', () => {
     await waitFor(() => {
       expect(
         screen
-          .getByLabelText('Save Facial droop photo and return')
+          .getByLabelText('Capture Facial droop photo')
           .hasAttribute('disabled'),
       ).toBe(false);
     });
 
-    fireEvent.click(
-      screen.getByLabelText('Save Facial droop photo and return'),
-    );
+    fireEvent.click(screen.getByLabelText('Capture Facial droop photo'));
+
+    await waitFor(() => {
+      expect(screen.getByAltText('Facial droop photo preview')).toBeTruthy();
+      expect(onChange).toHaveBeenCalledTimes(0);
+    });
+    fireEvent.click(screen.getByLabelText('Use Facial droop photo'));
 
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledTimes(1);
@@ -558,13 +596,88 @@ describe('SymptomPromptResponseField photo capture', () => {
     });
     fireEvent.loadedMetadata(video!);
 
-    fireEvent.click(screen.getByLabelText('Save Ptosis photo and return'));
+    fireEvent.click(screen.getByLabelText('Capture Ptosis photo'));
+    await waitFor(() => {
+      expect(screen.getByAltText('Ptosis photo preview')).toBeTruthy();
+      expect(onChange).toHaveBeenCalledTimes(0);
+    });
+    fireEvent.click(screen.getByLabelText('Use Ptosis photo'));
     await waitFor(() => {
       expect(onChange).toHaveBeenCalledTimes(1);
     });
 
     unmount();
     expect(revokeObjectUrlMock).not.toHaveBeenCalled();
+  });
+
+  it('replaces preview photo when taking again before confirming', async () => {
+    createObjectUrlMock
+      .mockReturnValueOnce('blob:first-photo')
+      .mockReturnValueOnce('blob:second-photo');
+    const onChange = jest.fn();
+    render(
+      <SymptomPromptResponseField
+        line={makePhotoLine('Jaw')}
+        answer={undefined}
+        onChange={onChange}
+        disabled={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Take Jaw photo'));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Jaw photo camera')).toBeTruthy();
+    });
+    const video = document.querySelector('video');
+    expect(video).toBeTruthy();
+    Object.defineProperty(video!, 'videoWidth', {
+      configurable: true,
+      value: 640,
+    });
+    Object.defineProperty(video!, 'videoHeight', {
+      configurable: true,
+      value: 480,
+    });
+    fireEvent.loadedMetadata(video!);
+
+    fireEvent.click(screen.getByLabelText('Capture Jaw photo'));
+    await waitFor(() => {
+      expect(screen.getByAltText('Jaw photo preview')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByLabelText('Take Jaw photo again'));
+    expect(revokeObjectUrlMock).toHaveBeenCalledWith('blob:first-photo');
+    expect(onChange).not.toHaveBeenCalled();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText('Capture Jaw photo')).toBeTruthy();
+    });
+    const videoAgain = document.querySelector('video');
+    expect(videoAgain).toBeTruthy();
+    Object.defineProperty(videoAgain!, 'videoWidth', {
+      configurable: true,
+      value: 640,
+    });
+    Object.defineProperty(videoAgain!, 'videoHeight', {
+      configurable: true,
+      value: 480,
+    });
+    fireEvent.loadedMetadata(videoAgain!);
+    fireEvent.click(screen.getByLabelText('Capture Jaw photo'));
+    await waitFor(() => {
+      expect(screen.getByAltText('Jaw photo preview')).toBeTruthy();
+    });
+    fireEvent.click(screen.getByLabelText('Use Jaw photo'));
+
+    await waitFor(() => {
+      expect(onChange).toHaveBeenCalledTimes(1);
+    });
+    expect(onChange).toHaveBeenCalledWith({
+      type: 'photo',
+      value: expect.objectContaining({
+        localUri: 'blob:second-photo',
+        capturedAt: expect.any(String),
+      }),
+    });
   });
 
   it('renders capture failure errors inside the open photo dialog', async () => {
@@ -597,7 +710,7 @@ describe('SymptomPromptResponseField photo capture', () => {
     });
     fireEvent.loadedMetadata(video!);
 
-    fireEvent.click(screen.getByLabelText('Save Smile photo and return'));
+    fireEvent.click(screen.getByLabelText('Capture Smile photo'));
 
     await waitFor(() => {
       expect(

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
@@ -334,6 +334,54 @@ describe('SymptomPromptResponseField video capture', () => {
     expect(revokeObjectUrlMock).not.toHaveBeenCalled();
   });
 
+  it('record again from captured preview discards draft and returns recorder UI', async () => {
+    createObjectUrlMock.mockReturnValueOnce('blob:draft-video');
+    const onChange = jest.fn();
+    render(
+      <SymptomPromptResponseField
+        line={makeLine('Balance')}
+        answer={undefined}
+        onChange={onChange}
+        disabled={false}
+      />,
+    );
+
+    fireEvent.click(screen.getByLabelText('Record Balance video'));
+    await waitFor(() => {
+      expect(
+        screen
+          .getByLabelText('Start Balance video recording')
+          .hasAttribute('disabled'),
+      ).toBe(false);
+    });
+    fireEvent.click(screen.getByLabelText('Start Balance video recording'));
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Stop Balance video recording'),
+      ).toBeTruthy();
+    });
+    fireEvent.click(screen.getByLabelText('Stop Balance video recording'));
+
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('Balance captured video preview'),
+      ).toBeTruthy();
+      expect(onChange).toHaveBeenCalledTimes(0);
+    });
+    fireEvent.click(screen.getByLabelText('Record Balance video again'));
+
+    expect(onChange).toHaveBeenCalledTimes(0);
+    expect(revokeObjectUrlMock).toHaveBeenCalledWith('blob:draft-video');
+    await waitFor(() => {
+      expect(
+        screen.queryByLabelText('Balance captured video preview'),
+      ).toBeNull();
+      expect(
+        screen.getByLabelText('Start Balance video recording'),
+      ).toBeTruthy();
+    });
+  });
+
   it('disables close button while recording to avoid implicit save', async () => {
     const onChange = jest.fn();
     render(

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -331,7 +331,7 @@ function SymptomPhotoCaptureField({
     }
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     previewingCaptureRef.current = previewingCapture;
   }, [previewingCapture]);
 
@@ -701,7 +701,7 @@ function SymptomVideoCaptureField({
     }
   };
 
-  useEffect(() => {
+  useLayoutEffect(() => {
     previewingCaptureRef.current = previewingCapture;
   }, [previewingCapture]);
 

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -29,6 +29,12 @@ export type SymptomPromptResponseFieldProps = {
 };
 
 type YesNoValue = boolean | null;
+type CapturedPhotoValue = NonNullable<
+  Extract<SymptomPromptAnswer, { type: 'photo' }>['value']
+>;
+type CapturedVideoValue = NonNullable<
+  Extract<SymptomPromptAnswer, { type: 'video' }>['value']
+>;
 
 function SymptomYesNoRadiogroup({
   line,
@@ -293,25 +299,20 @@ function SymptomPhotoCaptureField({
 }) {
   const streamRef = useRef<MediaStream | null>(null);
   const previewRef = useRef<HTMLVideoElement | null>(null);
-  const createdObjectUrlRef = useRef<string | null>(null);
   const isUnmountedRef = useRef(false);
+  const previewingCaptureRef = useRef<CapturedPhotoValue | null>(null);
   const [pickerOpen, setPickerOpen] = useState(false);
   const [starting, setStarting] = useState(false);
   const [cameraReady, setCameraReady] = useState(false);
   const [capturing, setCapturing] = useState(false);
+  const [previewingCapture, setPreviewingCapture] =
+    useState<CapturedPhotoValue | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [previewAspectRatio, setPreviewAspectRatio] = useState<number>(16 / 9);
   const modalErrorId = `symptom-photo-error-${line.id}`;
 
   const captured = answer.type === 'photo' ? answer.value : null;
-
-  const revokeCreatedObjectUrl = () => {
-    if (!createdObjectUrlRef.current) {
-      return;
-    }
-    URL.revokeObjectURL(createdObjectUrlRef.current);
-    createdObjectUrlRef.current = null;
-  };
+  const previewing = previewingCapture !== null;
 
   const stopAllTracks = () => {
     const stream = streamRef.current;
@@ -331,15 +332,22 @@ function SymptomPhotoCaptureField({
   };
 
   useEffect(() => {
+    previewingCaptureRef.current = previewingCapture;
+  }, [previewingCapture]);
+
+  useEffect(() => {
     isUnmountedRef.current = false;
     return () => {
       isUnmountedRef.current = true;
+      if (previewingCaptureRef.current) {
+        URL.revokeObjectURL(previewingCaptureRef.current.localUri);
+      }
       stopAllTracks();
     };
   }, []);
 
   useEffect(() => {
-    if (!pickerOpen) {
+    if (!pickerOpen || previewing) {
       stopAllTracks();
       return;
     }
@@ -398,7 +406,15 @@ function SymptomPhotoCaptureField({
     return () => {
       cancelled = true;
     };
-  }, [pickerOpen]);
+  }, [pickerOpen, previewing]);
+
+  const discardPreviewCapture = () => {
+    if (!previewingCapture) {
+      return;
+    }
+    URL.revokeObjectURL(previewingCapture.localUri);
+    setPreviewingCapture(null);
+  };
 
   const takePhotoFromPreview = async () => {
     const video = previewRef.current;
@@ -425,18 +441,13 @@ function SymptomPhotoCaptureField({
         setError('Photo capture failed. Please try again.');
         return;
       }
-      revokeCreatedObjectUrl();
       const localUri = URL.createObjectURL(blob);
-      createdObjectUrlRef.current = localUri;
-      onChange({
-        type: 'photo',
-        value: {
-          localUri,
-          capturedAt: new Date().toISOString(),
-        },
+      discardPreviewCapture();
+      setPreviewingCapture({
+        localUri,
+        capturedAt: new Date().toISOString(),
       });
       stopAllTracks();
-      setPickerOpen(false);
     } finally {
       setCapturing(false);
     }
@@ -488,61 +499,108 @@ function SymptomPhotoCaptureField({
                   if (capturing) {
                     return;
                   }
+                  discardPreviewCapture();
                   setPickerOpen(false);
                 }}
               >
                 Close
               </button>
             </div>
-            <div className="rounded-xl border border-app-border/90 bg-app-bg p-2">
-              <div
-                className="w-full overflow-hidden rounded-lg bg-black"
-                style={{ aspectRatio: previewAspectRatio }}
-              >
-                <video
-                  ref={previewRef}
-                  aria-label={`${line.symptom_name} live camera preview`}
-                  className="h-full w-full bg-black object-contain"
-                  autoPlay
-                  muted
-                  playsInline
-                  onLoadedMetadata={(event) => {
-                    const v = event.currentTarget;
-                    if (v.videoWidth > 0 && v.videoHeight > 0) {
-                      setPreviewAspectRatio(v.videoWidth / v.videoHeight);
-                      setCameraReady(true);
-                    } else {
-                      setCameraReady(false);
-                    }
-                  }}
-                  onEmptied={() => {
-                    setCameraReady(false);
-                  }}
-                />
-              </div>
-            </div>
-            <div className="mt-4 flex items-center justify-center">
-              <button
-                type="button"
-                aria-disabled={starting || !cameraReady || capturing}
-                aria-label={`Save ${line.symptom_name} photo and return`}
-                className={`inline-flex min-h-[56px] min-w-[200px] items-center justify-center rounded-full px-6 text-base font-semibold text-white ${
-                  starting || !cameraReady || capturing
-                    ? 'cursor-not-allowed bg-slate-400 dark:bg-slate-600'
-                    : 'bg-app-primary hover:opacity-95'
-                }`}
-                disabled={starting || !cameraReady || capturing}
-                onClick={() => {
-                  void takePhotoFromPreview();
-                }}
-              >
-                {starting
-                  ? 'Starting camera…'
-                  : capturing
-                    ? 'Saving photo…'
-                    : 'Save photo'}
-              </button>
-            </div>
+            {!previewingCapture ? (
+              <>
+                <div className="rounded-xl border border-app-border/90 bg-app-bg p-2">
+                  <div
+                    className="w-full overflow-hidden rounded-lg bg-black"
+                    style={{ aspectRatio: previewAspectRatio }}
+                  >
+                    <video
+                      ref={previewRef}
+                      aria-label={`${line.symptom_name} live camera preview`}
+                      className="h-full w-full bg-black object-contain"
+                      autoPlay
+                      muted
+                      playsInline
+                      onLoadedMetadata={(event) => {
+                        const v = event.currentTarget;
+                        if (v.videoWidth > 0 && v.videoHeight > 0) {
+                          setPreviewAspectRatio(v.videoWidth / v.videoHeight);
+                          setCameraReady(true);
+                        } else {
+                          setCameraReady(false);
+                        }
+                      }}
+                      onEmptied={() => {
+                        setCameraReady(false);
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="mt-4 flex items-center justify-center">
+                  <button
+                    type="button"
+                    aria-disabled={starting || !cameraReady || capturing}
+                    aria-label={`Capture ${line.symptom_name} photo`}
+                    className={`inline-flex min-h-[56px] min-w-[200px] items-center justify-center rounded-full px-6 text-base font-semibold text-white ${
+                      starting || !cameraReady || capturing
+                        ? 'cursor-not-allowed bg-slate-400 dark:bg-slate-600'
+                        : 'bg-app-primary hover:opacity-95'
+                    }`}
+                    disabled={starting || !cameraReady || capturing}
+                    onClick={() => {
+                      void takePhotoFromPreview();
+                    }}
+                  >
+                    {starting
+                      ? 'Starting camera…'
+                      : capturing
+                        ? 'Capturing photo…'
+                        : 'Capture photo'}
+                  </button>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="rounded-xl border border-app-border/90 bg-app-bg p-2">
+                  <div
+                    className="w-full overflow-hidden rounded-lg bg-black"
+                    style={{ aspectRatio: previewAspectRatio }}
+                  >
+                    <img
+                      src={previewingCapture.localUri}
+                      alt={`${line.symptom_name} photo preview`}
+                      className="h-full w-full object-contain"
+                    />
+                  </div>
+                </div>
+                <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+                  <button
+                    type="button"
+                    aria-label={`Use ${line.symptom_name} photo`}
+                    className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl bg-app-primary px-4 text-base font-semibold text-white hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                    onClick={() => {
+                      onChange({
+                        type: 'photo',
+                        value: previewingCapture,
+                      });
+                      setPreviewingCapture(null);
+                      setPickerOpen(false);
+                    }}
+                  >
+                    Use photo
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Take ${line.symptom_name} photo again`}
+                    className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                    onClick={() => {
+                      discardPreviewCapture();
+                    }}
+                  >
+                    Take again
+                  </button>
+                </div>
+              </>
+            )}
             {error ? (
               <p
                 id={modalErrorId}
@@ -557,7 +615,7 @@ function SymptomPhotoCaptureField({
       ) : null}
       <p className="text-sm text-app-muted" role="status">
         {captured
-          ? 'Photo saved on this device for this step. You can go to the next symptom when you are ready.'
+          ? 'Photo selected for this step. You can use Take photo again to replace it.'
           : 'Opens your camera so you can take one photo for this symptom. Large buttons are for easier tapping.'}
       </p>
       {!pickerOpen && error ? (
@@ -589,8 +647,8 @@ function SymptomVideoCaptureField({
   const chunksRef = useRef<Blob[]>([]);
   const startMsRef = useRef(0);
   const autoStopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const createdObjectUrlRef = useRef<string | null>(null);
   const isUnmountedRef = useRef(false);
+  const previewingCaptureRef = useRef<CapturedVideoValue | null>(null);
   const [recording, setRecording] = useState(false);
   const [starting, setStarting] = useState(false);
   const [recorderOpen, setRecorderOpen] = useState(false);
@@ -598,22 +656,17 @@ function SymptomVideoCaptureField({
   const [error, setError] = useState<string | null>(null);
   const [previewAspectRatio, setPreviewAspectRatio] = useState<number>(16 / 9);
   const [elapsedMs, setElapsedMs] = useState(0);
+  const [previewingCapture, setPreviewingCapture] =
+    useState<CapturedVideoValue | null>(null);
 
   const captured = answer.type === 'video' ? answer.value : null;
+  const previewing = previewingCapture !== null;
 
   const clearAutoStop = () => {
     if (autoStopTimerRef.current !== null) {
       clearTimeout(autoStopTimerRef.current);
       autoStopTimerRef.current = null;
     }
-  };
-
-  const revokeCreatedObjectUrl = () => {
-    if (!createdObjectUrlRef.current) {
-      return;
-    }
-    URL.revokeObjectURL(createdObjectUrlRef.current);
-    createdObjectUrlRef.current = null;
   };
 
   const stopAllTracks = () => {
@@ -649,9 +702,16 @@ function SymptomVideoCaptureField({
   };
 
   useEffect(() => {
+    previewingCaptureRef.current = previewingCapture;
+  }, [previewingCapture]);
+
+  useEffect(() => {
     isUnmountedRef.current = false;
     return () => {
       isUnmountedRef.current = true;
+      if (previewingCaptureRef.current) {
+        URL.revokeObjectURL(previewingCaptureRef.current.localUri);
+      }
       stopRecording();
       stopAllTracks();
       recorderRef.current = null;
@@ -659,7 +719,7 @@ function SymptomVideoCaptureField({
   }, []);
 
   useEffect(() => {
-    if (!recorderOpen) {
+    if (!recorderOpen || previewing) {
       stopRecording();
       stopAllTracks();
       setElapsedMs(0);
@@ -725,7 +785,15 @@ function SymptomVideoCaptureField({
     return () => {
       cancelled = true;
     };
-  }, [recorderOpen]);
+  }, [previewing, recorderOpen]);
+
+  const discardPreviewCapture = () => {
+    if (!previewingCapture) {
+      return;
+    }
+    URL.revokeObjectURL(previewingCapture.localUri);
+    setPreviewingCapture(null);
+  };
 
   useEffect(() => {
     if (!recording) {
@@ -803,21 +871,16 @@ function SymptomVideoCaptureField({
         type: recorder.mimeType || 'video/webm',
       });
       if (blob.size > 0) {
-        revokeCreatedObjectUrl();
+        discardPreviewCapture();
         const localUri = URL.createObjectURL(blob);
-        createdObjectUrlRef.current = localUri;
-        onChange({
-          type: 'video',
-          value: {
-            localUri,
-            durationMs,
-            capturedAt: new Date().toISOString(),
-          },
+        setPreviewingCapture({
+          localUri,
+          durationMs,
+          capturedAt: new Date().toISOString(),
         });
       }
       setRecording(false);
       stopAllTracks();
-      setRecorderOpen(false);
     };
     try {
       recorder.start();
@@ -899,66 +962,114 @@ function SymptomVideoCaptureField({
                   if (recording) {
                     return;
                   }
+                  discardPreviewCapture();
                   setRecorderOpen(false);
                 }}
               >
                 Close
               </button>
             </div>
-            <div className="rounded-xl border border-app-border/90 bg-app-bg p-2">
-              <div
-                className="w-full overflow-hidden rounded-lg bg-black"
-                style={{ aspectRatio: previewAspectRatio }}
-              >
-                <video
-                  ref={previewRef}
-                  aria-label={`${line.symptom_name} live camera preview`}
-                  className="h-full w-full bg-black object-contain"
-                  autoPlay
-                  muted
-                  playsInline
-                  onLoadedMetadata={(event) => {
-                    const video = event.currentTarget;
-                    if (video.videoWidth > 0 && video.videoHeight > 0) {
-                      setPreviewAspectRatio(
-                        video.videoWidth / video.videoHeight,
-                      );
-                    }
-                  }}
-                />
-              </div>
-            </div>
-            <div className="mt-4 flex items-center justify-center gap-3">
-              {!recording ? (
-                <button
-                  type="button"
-                  aria-disabled={starting || !cameraReady}
-                  aria-label={`Start ${line.symptom_name} video recording`}
-                  className={`inline-flex min-h-[56px] min-w-[180px] items-center justify-center gap-3 rounded-full px-6 text-base font-semibold text-white ${
-                    starting || !cameraReady
-                      ? 'cursor-not-allowed bg-red-400'
-                      : 'bg-red-700 hover:bg-red-800'
-                  }`}
-                  disabled={starting || !cameraReady}
-                  onClick={beginRecording}
-                >
-                  <span
-                    aria-hidden="true"
-                    className="h-4 w-4 rounded-full bg-white"
-                  />
-                  {starting ? 'Starting camera…' : 'Start recording'}
-                </button>
-              ) : (
-                <button
-                  type="button"
-                  aria-label={`Stop ${line.symptom_name} video recording`}
-                  className="inline-flex min-h-[56px] min-w-[180px] items-center justify-center rounded-full bg-red-700 px-6 text-base font-semibold text-white hover:bg-red-800"
-                  onClick={stopRecording}
-                >
-                  Stop recording
-                </button>
-              )}
-            </div>
+            {!previewingCapture ? (
+              <>
+                <div className="rounded-xl border border-app-border/90 bg-app-bg p-2">
+                  <div
+                    className="w-full overflow-hidden rounded-lg bg-black"
+                    style={{ aspectRatio: previewAspectRatio }}
+                  >
+                    <video
+                      ref={previewRef}
+                      aria-label={`${line.symptom_name} live camera preview`}
+                      className="h-full w-full bg-black object-contain"
+                      autoPlay
+                      muted
+                      playsInline
+                      onLoadedMetadata={(event) => {
+                        const video = event.currentTarget;
+                        if (video.videoWidth > 0 && video.videoHeight > 0) {
+                          setPreviewAspectRatio(
+                            video.videoWidth / video.videoHeight,
+                          );
+                        }
+                      }}
+                    />
+                  </div>
+                </div>
+                <div className="mt-4 flex items-center justify-center gap-3">
+                  {!recording ? (
+                    <button
+                      type="button"
+                      aria-disabled={starting || !cameraReady}
+                      aria-label={`Start ${line.symptom_name} video recording`}
+                      className={`inline-flex min-h-[56px] min-w-[180px] items-center justify-center gap-3 rounded-full px-6 text-base font-semibold text-white ${
+                        starting || !cameraReady
+                          ? 'cursor-not-allowed bg-red-400'
+                          : 'bg-red-700 hover:bg-red-800'
+                      }`}
+                      disabled={starting || !cameraReady}
+                      onClick={beginRecording}
+                    >
+                      <span
+                        aria-hidden="true"
+                        className="h-4 w-4 rounded-full bg-white"
+                      />
+                      {starting ? 'Starting camera…' : 'Start recording'}
+                    </button>
+                  ) : (
+                    <button
+                      type="button"
+                      aria-label={`Stop ${line.symptom_name} video recording`}
+                      className="inline-flex min-h-[56px] min-w-[180px] items-center justify-center rounded-full bg-red-700 px-6 text-base font-semibold text-white hover:bg-red-800"
+                      onClick={stopRecording}
+                    >
+                      Stop recording
+                    </button>
+                  )}
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="rounded-xl border border-app-border/90 bg-app-bg p-2">
+                  <div
+                    className="w-full overflow-hidden rounded-lg bg-black"
+                    style={{ aspectRatio: previewAspectRatio }}
+                  >
+                    <video
+                      aria-label={`${line.symptom_name} captured video preview`}
+                      className="h-full w-full bg-black object-contain"
+                      src={previewingCapture.localUri}
+                      controls
+                    />
+                  </div>
+                </div>
+                <div className="mt-4 flex flex-col gap-3 sm:flex-row">
+                  <button
+                    type="button"
+                    aria-label={`Use ${line.symptom_name} video`}
+                    className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl bg-app-primary px-4 text-base font-semibold text-white hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                    onClick={() => {
+                      onChange({
+                        type: 'video',
+                        value: previewingCapture,
+                      });
+                      setPreviewingCapture(null);
+                      setRecorderOpen(false);
+                    }}
+                  >
+                    Use video
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={`Record ${line.symptom_name} video again`}
+                    className="inline-flex min-h-[56px] flex-1 items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                    onClick={() => {
+                      discardPreviewCapture();
+                    }}
+                  >
+                    Record again
+                  </button>
+                </div>
+              </>
+            )}
           </div>
         </div>
       ) : null}
@@ -966,11 +1077,11 @@ function SymptomVideoCaptureField({
         {recording
           ? `Recording in progress. It stops automatically at ${SYMPTOM_PROMPT_VIDEO_MAX_SECONDS} seconds, or you can stop now.`
           : captured
-            ? `Video captured. Duration ${
+            ? `Video selected. Duration ${
                 captured.durationMs !== null
                   ? `${Math.round(captured.durationMs / 1000)}s`
                   : 'unknown'
-              }.`
+              }. Use Record again to replace it.`
             : `Use camera capture for up to ${SYMPTOM_PROMPT_VIDEO_MAX_SECONDS} seconds. Stop any time to finish early.`}
       </p>
       {error ? (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -297,6 +297,9 @@ importers:
       expo-system-ui:
         specifier: '*'
         version: 6.0.9(expo@54.0.34)(react-native-web@0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))
+      expo-video:
+        specifier: ^3.0.16
+        version: 3.0.16(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       jest-expo:
         specifier: '*'
         version: 54.0.17(@babel/core@7.29.0)(expo@54.0.34)(jest@30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)))(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -9189,6 +9192,16 @@ packages:
     peerDependenciesMeta:
       react-native-web:
         optional: true
+
+  expo-video@3.0.16:
+    resolution:
+      {
+        integrity: sha512-H1HlxcHGomZItqisGfW3YL/G9BHtNBfVSimDJcLuyxyU87wFnV8loO9tCjuhufkfh/aTa2sW5BYAjLjg9DvnBQ==,
+      }
+    peerDependencies:
+      expo: '*'
+      react: '*'
+      react-native: '*'
 
   expo@54.0.34:
     resolution:
@@ -23954,6 +23967,12 @@ snapshots:
       react-native-web: 0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
+
+  expo-video@3.0.16(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      expo: 54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0)
 
   expo@54.0.34(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)(typescript@5.9.3):
     dependencies:


### PR DESCRIPTION
Closes #133

## Summary

- Added explicit capture confirmation flows in episode symptom prompts so captured media is staged before finalization.
- Implemented `Use photo` / `Take again` confirmation for mobile photo capture.
- Implemented `Use video` / `Record again` confirmation for mobile video capture (previously finalized immediately).
- Kept web media capture/preview behavior aligned with branch changes and updated associated media capture tests.
- Addressed related mobile lint/a11y/test-quality findings (image invert-colors accessibility prop, spec typing cleanup, and minor lint fixes).

## Why

- Matches Issue #133 acceptance criteria that capture actions should land in a review step before finalizing.
- Prevents accidental media finalization and gives users an explicit retry path.
- Fixes the reported mobile behavior where capture closed without a usable review/confirm step.

## Test Plan

- [x] Unit tests (web):
  - `pnpm exec nx test @abstrack/web -- --runTestsByPath src/components/episode-flow/SymptomPromptResponseField.spec.tsx`
- [x] Unit tests (mobile):
  - `pnpm exec nx test @abstrack/mobile -- --runTestsByPath src/app/screens/SymptomPromptScreen.spec.tsx`
- [x] Lint (mobile):
  - `pnpm exec nx run @abstrack/mobile:lint`
- [x] Manual QA (mobile photo):
  - Capture photo → verify staged review appears (`Use photo` / `Take again`)
  - Verify `Take again` replaces prior temporary capture
  - Verify only `Use photo` finalizes answer
- [x] Manual QA (mobile video):
  - Record video → verify staged review appears (`Use video` / `Record again`)
  - Verify `Record again` replaces prior temporary capture
  - Verify only `Use video` finalizes answer
- [x] Manual QA (web):
  - Capture/record media and verify confirm/retry behavior before progression
- [x] Accessibility smoke checks:
  - Keyboard/screen-reader paths for confirm/retry actions (where applicable)