### PR TITLE
feat(media): signed URL playback in episode management (web + mobile)

### DIFF
--- a/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
+++ b/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
@@ -10,10 +10,15 @@ import {
 } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
-import { formatEpisodeDurationSimple, type EpisodeRow } from '@abstrack/types';
+import {
+  formatEpisodeDurationSimple,
+  isMediaType,
+  type EpisodeRow,
+} from '@abstrack/types';
 import { announce } from '@abstrack/ui/native';
 import {
   cancelActiveEpisodeById,
+  createEpisodeMediaSignedDisplayUrl,
   deleteEpisodeById,
   getActiveEpisodeForUser,
   listEpisodeMediaForEpisode,
@@ -98,10 +103,14 @@ export function EpisodesManagementPanel({
           key: string;
           signedUrl: string | null;
           mediaType: 'video' | 'photo';
+          /** Set when signing fails (permissions, bad path); distinct from expired link retry UX. */
+          loadError: string | null;
         }>;
       }
     >
   >({});
+  /** Prevents overlapping loads per episode (e.g. double tap before `loading` is committed). */
+  const episodeMediaLoadInFlightRef = useRef<Record<string, boolean>>({});
   const loadInitial = useCallback(
     async (cancel?: { cancelled: boolean }) => {
       const generation = ++loadGenRef.current;
@@ -256,6 +265,10 @@ export function EpisodesManagementPanel({
   };
 
   const loadEpisodeMedia = useCallback(async (episodeId: string) => {
+    if (episodeMediaLoadInFlightRef.current[episodeId]) {
+      return;
+    }
+    episodeMediaLoadInFlightRef.current[episodeId] = true;
     setMediaByEpisodeId((prev) => ({
       ...prev,
       [episodeId]: {
@@ -281,14 +294,17 @@ export function EpisodesManagementPanel({
       const items = await Promise.all(
         listed.data.map(async (row) => {
           const key = row.storage_object_key.trim();
-          const signed = await client.storage
-            .from('episode-media')
-            .createSignedUrl(key, 120);
-          const mediaType: 'video' | 'photo' =
-            typeof row.duration_seconds === 'number' && row.duration_seconds > 0
-              ? 'video'
-              : 'photo';
-          return { key, signedUrl: signed.data?.signedUrl ?? null, mediaType };
+          const { signedUrl, errorMessage } =
+            await createEpisodeMediaSignedDisplayUrl(client, key, 120);
+          const mediaType: 'video' | 'photo' = isMediaType(row.media_type)
+            ? row.media_type
+            : 'photo';
+          return {
+            key,
+            signedUrl,
+            mediaType,
+            loadError: signedUrl ? null : errorMessage,
+          };
         }),
       );
       setMediaByEpisodeId((prev) => ({
@@ -304,8 +320,44 @@ export function EpisodesManagementPanel({
           items: [],
         },
       }));
+    } finally {
+      episodeMediaLoadInFlightRef.current[episodeId] = false;
     }
   }, []);
+
+  /**
+   * When a signed URL loads but the asset fails (expired, 403, network), swap to error UI + retry.
+   *
+   * @param episodeId - Episode whose media list should be updated.
+   * @param storageKey - Storage object key (`item.key`) for the failed asset.
+   */
+  const onEpisodeMediaDisplayError = useCallback(
+    (episodeId: string, storageKey: string) => {
+      setMediaByEpisodeId((prev) => {
+        const state = prev[episodeId];
+        if (!state?.items?.length) {
+          return prev;
+        }
+        let changed = false;
+        const items = state.items.map((it) => {
+          if (it.key !== storageKey || !it.signedUrl) {
+            return it;
+          }
+          changed = true;
+          return {
+            ...it,
+            signedUrl: null,
+            loadError: 'Link expired or unavailable.',
+          };
+        });
+        if (!changed) {
+          return prev;
+        }
+        return { ...prev, [episodeId]: { ...state, items } };
+      });
+    },
+    [],
+  );
 
   const onCancelEpisode = useCallback(() => {
     if (!active || cancelingActiveEpisode) {
@@ -637,8 +689,12 @@ export function EpisodesManagementPanel({
                             <Pressable
                               accessibilityRole="button"
                               accessibilityLabel="Retry loading media"
+                              accessibilityState={{
+                                disabled: Boolean(mediaState?.loading),
+                              }}
+                              disabled={Boolean(mediaState?.loading)}
                               onPress={() => void loadEpisodeMedia(ep.id)}
-                              className="mt-2 min-h-[40px] self-start rounded-lg border border-app-border px-3 py-2 dark:border-app-border-dark"
+                              className={`mt-2 min-h-[40px] self-start rounded-lg border border-app-border px-3 py-2 dark:border-app-border-dark ${mediaState?.loading ? 'opacity-50' : ''}`}
                             >
                               <Text
                                 className={`text-xs font-semibold ${nw.textPrimary}`}
@@ -674,11 +730,18 @@ export function EpisodesManagementPanel({
                                       accessibilityIgnoresInvertColors
                                       style={{ width: '100%', height: 220 }}
                                       resizeMode="contain"
+                                      onError={() =>
+                                        onEpisodeMediaDisplayError(
+                                          ep.id,
+                                          item.key,
+                                        )
+                                      }
                                     />
                                   )
                                 ) : (
                                   <Text className="p-3 text-xs text-red-700 dark:text-red-300">
-                                    Link expired or unavailable.
+                                    {item.loadError ??
+                                      'Link expired or unavailable.'}
                                   </Text>
                                 )}
                               </View>
@@ -686,8 +749,12 @@ export function EpisodesManagementPanel({
                             <Pressable
                               accessibilityRole="button"
                               accessibilityLabel="Refresh media links"
+                              accessibilityState={{
+                                disabled: Boolean(mediaState?.loading),
+                              }}
+                              disabled={Boolean(mediaState?.loading)}
                               onPress={() => void loadEpisodeMedia(ep.id)}
-                              className="min-h-[40px] self-start rounded-lg border border-app-border px-3 py-2 dark:border-app-border-dark"
+                              className={`min-h-[40px] self-start rounded-lg border border-app-border px-3 py-2 dark:border-app-border-dark ${mediaState?.loading ? 'opacity-50' : ''}`}
                             >
                               <Text
                                 className={`text-xs font-semibold ${nw.textPrimary}`}

--- a/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
+++ b/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
@@ -1,5 +1,13 @@
 import React, { useCallback, useRef, useState } from 'react';
-import { Alert, Pressable, ScrollView, Text, View } from 'react-native';
+import {
+  ActivityIndicator,
+  Alert,
+  Image,
+  Pressable,
+  ScrollView,
+  Text,
+  View,
+} from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { formatEpisodeDurationSimple, type EpisodeRow } from '@abstrack/types';
@@ -8,8 +16,10 @@ import {
   cancelActiveEpisodeById,
   deleteEpisodeById,
   getActiveEpisodeForUser,
+  listEpisodeMediaForEpisode,
   listCompletedEpisodesForUser,
 } from '@abstrack/supabase';
+import { useVideoPlayer, VideoView } from 'expo-video';
 import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { ScreenShell } from '../components/ScreenShell';
@@ -78,6 +88,20 @@ export function EpisodesManagementPanel({
   const [deletingEpisodeId, setDeletingEpisodeId] = useState<string | null>(
     null,
   );
+  const [mediaByEpisodeId, setMediaByEpisodeId] = useState<
+    Record<
+      string,
+      {
+        loading: boolean;
+        error: string | null;
+        items: Array<{
+          key: string;
+          signedUrl: string | null;
+          mediaType: 'video' | 'photo';
+        }>;
+      }
+    >
+  >({});
   const loadInitial = useCallback(
     async (cancel?: { cancelled: boolean }) => {
       const generation = ++loadGenRef.current;
@@ -231,19 +255,56 @@ export function EpisodesManagementPanel({
     });
   };
 
-  const onViewEpisodeDetails = useCallback((ep: EpisodeRow) => {
-    const body = [
-      `Type: ${ep.episode_type}`,
-      ep.episode_label?.trim() ? `Label: ${ep.episode_label.trim()}` : null,
-      `Started: ${formatInstant(ep.started_at)}`,
-      `Ended: ${ep.ended_at ? formatInstant(ep.ended_at) : '—'}`,
-      `Duration: ${
-        formatEpisodeDurationSimple(ep.started_at, ep.ended_at) ?? '—'
-      }`,
-    ]
-      .filter(Boolean)
-      .join('\n');
-    Alert.alert(episodeSummaryLine(ep), body);
+  const loadEpisodeMedia = useCallback(async (episodeId: string) => {
+    setMediaByEpisodeId((prev) => ({
+      ...prev,
+      [episodeId]: {
+        loading: true,
+        error: null,
+        items: prev[episodeId]?.items ?? [],
+      },
+    }));
+    try {
+      const client = getMobileSupabaseClient();
+      const listed = await listEpisodeMediaForEpisode(client, episodeId);
+      if (!listed.ok) {
+        setMediaByEpisodeId((prev) => ({
+          ...prev,
+          [episodeId]: {
+            loading: false,
+            error: listed.error.message,
+            items: [],
+          },
+        }));
+        return;
+      }
+      const items = await Promise.all(
+        listed.data.map(async (row) => {
+          const key = row.storage_object_key.trim();
+          const signed = await client.storage
+            .from('episode-media')
+            .createSignedUrl(key, 120);
+          const mediaType: 'video' | 'photo' =
+            typeof row.duration_seconds === 'number' && row.duration_seconds > 0
+              ? 'video'
+              : 'photo';
+          return { key, signedUrl: signed.data?.signedUrl ?? null, mediaType };
+        }),
+      );
+      setMediaByEpisodeId((prev) => ({
+        ...prev,
+        [episodeId]: { loading: false, error: null, items },
+      }));
+    } catch {
+      setMediaByEpisodeId((prev) => ({
+        ...prev,
+        [episodeId]: {
+          loading: false,
+          error: 'Unable to load media preview.',
+          items: [],
+        },
+      }));
+    }
   }, []);
 
   const onCancelEpisode = useCallback(() => {
@@ -525,16 +586,121 @@ export function EpisodesManagementPanel({
                   {formatEpisodeDurationSimple(ep.started_at, ep.ended_at) ??
                     '—'}
                 </Text>
-                <Pressable
-                  accessibilityRole="button"
-                  accessibilityLabel={`View details for ${episodeSummaryLine(ep)}`}
-                  onPress={() => onViewEpisodeDetails(ep)}
-                  className="mt-2 min-h-[44px] justify-center rounded-lg border border-app-border px-3 py-2 dark:border-app-border-dark"
-                >
-                  <Text className={`text-sm font-semibold ${nw.textPrimary}`}>
-                    View details
-                  </Text>
-                </Pressable>
+                <View className="mt-2 rounded-lg border border-app-border px-3 py-3 dark:border-app-border-dark">
+                  {(() => {
+                    const mediaState = mediaByEpisodeId[ep.id];
+                    return (
+                      <>
+                        <Text className={`text-sm font-semibold ${nw.textInk}`}>
+                          Details
+                        </Text>
+                        <Text className={`mt-1 text-xs ${nw.textMuted}`}>
+                          Type: {ep.episode_type}
+                        </Text>
+                        {ep.episode_label?.trim() ? (
+                          <Text className={`mt-0.5 text-xs ${nw.textMuted}`}>
+                            Label: {ep.episode_label.trim()}
+                          </Text>
+                        ) : null}
+                        <Text
+                          className={`mt-2 text-xs font-semibold ${nw.textInk}`}
+                        >
+                          Media
+                        </Text>
+                        {!mediaState ? (
+                          <Pressable
+                            accessibilityRole="button"
+                            accessibilityLabel="Load episode media"
+                            onPress={() => void loadEpisodeMedia(ep.id)}
+                            className="mt-2 min-h-[40px] self-start rounded-lg border border-app-border px-3 py-2 dark:border-app-border-dark"
+                          >
+                            <Text
+                              className={`text-xs font-semibold ${nw.textPrimary}`}
+                            >
+                              Load media
+                            </Text>
+                          </Pressable>
+                        ) : null}
+                        {mediaState?.loading ? (
+                          <View className="mt-2 flex-row items-center gap-2">
+                            <ActivityIndicator />
+                            <Text className={`text-xs ${nw.textMuted}`}>
+                              Loading media…
+                            </Text>
+                          </View>
+                        ) : null}
+                        {mediaState?.error ? (
+                          <View className="mt-2">
+                            <Text className={`text-xs ${nw.textError}`}>
+                              {mediaState.error}
+                            </Text>
+                            <Pressable
+                              accessibilityRole="button"
+                              accessibilityLabel="Retry loading media"
+                              onPress={() => void loadEpisodeMedia(ep.id)}
+                              className="mt-2 min-h-[40px] self-start rounded-lg border border-app-border px-3 py-2 dark:border-app-border-dark"
+                            >
+                              <Text
+                                className={`text-xs font-semibold ${nw.textPrimary}`}
+                              >
+                                Retry
+                              </Text>
+                            </Pressable>
+                          </View>
+                        ) : null}
+                        {!mediaState?.loading &&
+                        !mediaState?.error &&
+                        mediaState &&
+                        mediaState.items.length === 0 ? (
+                          <Text className={`mt-2 text-xs ${nw.textMuted}`}>
+                            No photo or video for this episode.
+                          </Text>
+                        ) : null}
+                        {mediaState?.items.length ? (
+                          <View className="mt-2 gap-2">
+                            {mediaState.items.map((item) => (
+                              <View
+                                key={item.key}
+                                className="overflow-hidden rounded-lg border border-app-border/80 bg-black/5 dark:border-app-border-dark/80 dark:bg-black/25"
+                                style={{ minHeight: 180 }}
+                              >
+                                {item.signedUrl ? (
+                                  item.mediaType === 'video' ? (
+                                    <EpisodeMediaVideo uri={item.signedUrl} />
+                                  ) : (
+                                    <Image
+                                      source={{ uri: item.signedUrl }}
+                                      accessibilityLabel="Episode media"
+                                      accessibilityIgnoresInvertColors
+                                      style={{ width: '100%', height: 220 }}
+                                      resizeMode="contain"
+                                    />
+                                  )
+                                ) : (
+                                  <Text className="p-3 text-xs text-red-700 dark:text-red-300">
+                                    Link expired or unavailable.
+                                  </Text>
+                                )}
+                              </View>
+                            ))}
+                            <Pressable
+                              accessibilityRole="button"
+                              accessibilityLabel="Refresh media links"
+                              onPress={() => void loadEpisodeMedia(ep.id)}
+                              className="min-h-[40px] self-start rounded-lg border border-app-border px-3 py-2 dark:border-app-border-dark"
+                            >
+                              <Text
+                                className={`text-xs font-semibold ${nw.textPrimary}`}
+                              >
+                                Refresh media links
+                              </Text>
+                            </Pressable>
+                          </View>
+                        ) : null}
+                      </>
+                    );
+                  })()}
+                </View>
                 <Pressable
                   accessibilityRole="button"
                   accessibilityLabel={`Delete ${episodeSummaryLine(ep)} episode`}
@@ -579,4 +745,17 @@ export function EpisodesManagementPanel({
   }
 
   return <ScreenShell contentAlign="stretch">{body}</ScreenShell>;
+}
+
+function EpisodeMediaVideo({ uri }: { uri: string }) {
+  const player = useVideoPlayer(uri);
+  return (
+    <VideoView
+      player={player}
+      accessibilityLabel="Episode media video"
+      nativeControls
+      contentFit="contain"
+      style={{ width: '100%', height: 220 }}
+    />
+  );
 }

--- a/apps/mobile/src/jest-image-loader-turbo-mock.js
+++ b/apps/mobile/src/jest-image-loader-turbo-mock.js
@@ -12,8 +12,6 @@
  *
  * Loaded from `setupFiles` immediately after `jest-expo` preset setup files.
  */
-'use strict';
-
 const mockNativeModules =
   require('react-native/Libraries/BatchedBridge/NativeModules').default;
 

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.spec.tsx
@@ -461,6 +461,19 @@ function makePhotoLine(symptomName = 'Facial droop'): PresetSymptomRow {
   };
 }
 
+function makeVideoLine(symptomName = 'Dizziness'): PresetSymptomRow {
+  return {
+    id: 'line-video-persisted',
+    preset_id: 'preset-1',
+    sort_order: 0,
+    symptom_name: symptomName,
+    response_type: 'video',
+    prompt_instruction: null,
+    created_at: '2026-01-01T00:00:00.000Z',
+    updated_at: '2026-01-01T00:00:00.000Z',
+  };
+}
+
 describe('SymptomPromptResponseField photo capture', () => {
   let getContextSpy: jest.SpiedFunction<
     typeof HTMLCanvasElement.prototype.getContext
@@ -786,6 +799,17 @@ function makePersistedPhotoAnswer(args: {
   };
 }
 
+function makePersistedVideoAnswer(localUri: string): SymptomPromptAnswer {
+  return {
+    type: 'video',
+    value: {
+      localUri,
+      durationMs: 5000,
+      capturedAt: '2026-01-01T00:00:00.000Z',
+    },
+  };
+}
+
 describe('SymptomPromptResponseField persisted photo preview', () => {
   let resolveEpisodeMediaPreviewUrl: jest.MockedFunction<
     (storageUri: string) => Promise<string | null>
@@ -962,6 +986,114 @@ describe('SymptomPromptResponseField persisted photo preview', () => {
     });
     await waitFor(() => {
       expect(screen.getByAltText('Persisted uploaded preview')).toBeTruthy();
+    });
+  });
+});
+
+describe('SymptomPromptResponseField persisted video preview', () => {
+  let resolveEpisodeMediaPreviewUrl: jest.MockedFunction<
+    (storageUri: string) => Promise<string | null>
+  >;
+  const originalVideoLoad = HTMLVideoElement.prototype.load;
+
+  /**
+   * Persisted video preview sets `src` on an off-DOM `<video>` and waits for `loadeddata`.
+   * jsdom does not emit that event from real media loads; shim `load()` so tests match browser behavior.
+   *
+   * Restore in `afterAll` only: resetting in `afterEach` runs before Testing Library unmount cleanup,
+   * which would call the real jsdom `load` (not implemented) during effect teardown.
+   */
+  beforeAll(() => {
+    HTMLVideoElement.prototype.load = function patchedLoad(
+      this: HTMLVideoElement,
+    ) {
+      queueMicrotask(() => {
+        if (this.src) {
+          this.dispatchEvent(new Event('loadeddata'));
+        }
+      });
+    };
+  });
+
+  afterAll(() => {
+    HTMLVideoElement.prototype.load = originalVideoLoad;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resolveEpisodeMediaPreviewUrl = jest.fn();
+  });
+
+  it('shows preview error and retries when the resolver rejects, then renders uploaded video', async () => {
+    resolveEpisodeMediaPreviewUrl
+      .mockRejectedValueOnce(new Error('network'))
+      .mockResolvedValueOnce('https://cdn.example/signed.webm');
+
+    render(
+      <SymptomPromptResponseField
+        line={makeVideoLine('PersistedVideo')}
+        answer={makePersistedVideoAnswer('storage:user-1/ep-1/video.webm')}
+        onChange={jest.fn()}
+        disabled={false}
+        resolveEpisodeMediaPreviewUrl={resolveEpisodeMediaPreviewUrl}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeTruthy();
+      expect(screen.getByText('Could not load video. Try again.')).toBeTruthy();
+    });
+    expect(resolveEpisodeMediaPreviewUrl).toHaveBeenCalledTimes(1);
+    expect(resolveEpisodeMediaPreviewUrl).toHaveBeenCalledWith(
+      'storage:user-1/ep-1/video.webm',
+    );
+
+    fireEvent.click(
+      screen.getByLabelText('Retry loading PersistedVideo video preview'),
+    );
+
+    await waitFor(() => {
+      expect(resolveEpisodeMediaPreviewUrl).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('PersistedVideo uploaded video'),
+      ).toBeTruthy();
+    });
+  });
+
+  it('shows preview error and retries when the resolver returns null, then renders uploaded video', async () => {
+    resolveEpisodeMediaPreviewUrl
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce('https://cdn.example/signed.webm');
+
+    render(
+      <SymptomPromptResponseField
+        line={makeVideoLine('PersistedVideo')}
+        answer={makePersistedVideoAnswer('storage:user-1/ep-1/video.webm')}
+        onChange={jest.fn()}
+        disabled={false}
+        resolveEpisodeMediaPreviewUrl={resolveEpisodeMediaPreviewUrl}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeTruthy();
+      expect(screen.getByText('Could not load video. Try again.')).toBeTruthy();
+    });
+    expect(resolveEpisodeMediaPreviewUrl).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(
+      screen.getByLabelText('Retry loading PersistedVideo video preview'),
+    );
+
+    await waitFor(() => {
+      expect(resolveEpisodeMediaPreviewUrl).toHaveBeenCalledTimes(2);
+    });
+    await waitFor(() => {
+      expect(
+        screen.getByLabelText('PersistedVideo uploaded video'),
+      ).toBeTruthy();
     });
   });
 });

--- a/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptResponseField.tsx
@@ -960,6 +960,9 @@ function SymptomVideoCaptureField({
   const [committedPreviewError, setCommittedPreviewError] = useState<
     string | null
   >(null);
+  /** Triggers signed URL re-resolution for persisted uploaded videos. */
+  const [videoPreviewRetryGeneration, setVideoPreviewRetryGeneration] =
+    useState(0);
   const [confirmRemoveCommittedOpen, setConfirmRemoveCommittedOpen] =
     useState(false);
   /**
@@ -1051,7 +1054,7 @@ function SymptomVideoCaptureField({
     return () => {
       cancelled = true;
     };
-  }, [captured, resolveEpisodeMediaPreviewUrl]);
+  }, [captured, resolveEpisodeMediaPreviewUrl, videoPreviewRetryGeneration]);
 
   const showVideoPreviewPanel =
     confirmVideoUseTapPending || hasEpisodeVideoMediaAnswer(answer);
@@ -1336,12 +1339,23 @@ function SymptomVideoCaptureField({
           ) : !resolveEpisodeMediaPreviewUrl ? (
             <SymptomEpisodeMediaPreviewLoadingPlaceholder embedded />
           ) : committedPreviewError ? (
-            <p
-              className="p-4 text-sm text-red-700 dark:text-red-300"
-              role="alert"
-            >
-              {committedPreviewError}
-            </p>
+            <div className="flex flex-col gap-3 p-4" role="alert">
+              <p className="text-sm text-red-700 dark:text-red-300">
+                {committedPreviewError}
+              </p>
+              <button
+                type="button"
+                disabled={disabled}
+                aria-label={`Retry loading ${line.symptom_name} video preview`}
+                className="inline-flex min-h-[44px] max-w-xs items-center justify-center self-start rounded-lg border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink hover:bg-app-muted/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-50"
+                onClick={() => {
+                  setCommittedPreviewError(null);
+                  setVideoPreviewRetryGeneration((g) => g + 1);
+                }}
+              >
+                Try again
+              </button>
+            </div>
           ) : !committedPreviewUrl ? (
             <SymptomEpisodeMediaPreviewLoadingPlaceholder embedded />
           ) : !videoReadyDisplaySrc ? (

--- a/apps/web/src/components/episodes/RecentEpisodesList.tsx
+++ b/apps/web/src/components/episodes/RecentEpisodesList.tsx
@@ -2,7 +2,10 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { deleteEpisodeById } from '@abstrack/supabase';
+import {
+  deleteEpisodeById,
+  listEpisodeMediaForEpisode,
+} from '@abstrack/supabase';
 import { formatEpisodeDurationSimple, type EpisodeRow } from '@abstrack/types';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
@@ -40,6 +43,21 @@ export function RecentEpisodesList({
   const [deletingEpisodeId, setDeletingEpisodeId] = useState<string | null>(
     null,
   );
+  const [mediaByEpisodeId, setMediaByEpisodeId] = useState<
+    Record<
+      string,
+      {
+        loading: boolean;
+        error: string | null;
+        items: Array<{
+          key: string;
+          signedUrl: string | null;
+          mediaType: 'video' | 'photo';
+          durationSeconds: number | null;
+        }>;
+      }
+    >
+  >({});
   const pendingEpisode =
     episodes.find((ep) => ep.id === pendingDeleteEpisodeId) ?? null;
   const isDeletingEpisode = deletingEpisodeId !== null;
@@ -71,6 +89,63 @@ export function RecentEpisodesList({
       return;
     } finally {
       setDeletingEpisodeId(null);
+    }
+  };
+
+  const loadEpisodeMedia = async (episodeId: string) => {
+    setMediaByEpisodeId((prev) => ({
+      ...prev,
+      [episodeId]: {
+        loading: true,
+        error: null,
+        items: prev[episodeId]?.items ?? [],
+      },
+    }));
+    try {
+      const supabase = createBrowserClient();
+      const listed = await listEpisodeMediaForEpisode(supabase, episodeId);
+      if (!listed.ok) {
+        setMediaByEpisodeId((prev) => ({
+          ...prev,
+          [episodeId]: {
+            loading: false,
+            error: listed.error.message,
+            items: [],
+          },
+        }));
+        return;
+      }
+      const items = await Promise.all(
+        listed.data.map(async (row) => {
+          const key = row.storage_object_key.trim();
+          const signed = await supabase.storage
+            .from('episode-media')
+            .createSignedUrl(key, 120);
+          const mediaType: 'video' | 'photo' =
+            typeof row.duration_seconds === 'number' && row.duration_seconds > 0
+              ? 'video'
+              : 'photo';
+          return {
+            key,
+            signedUrl: signed.data?.signedUrl ?? null,
+            mediaType,
+            durationSeconds: row.duration_seconds,
+          };
+        }),
+      );
+      setMediaByEpisodeId((prev) => ({
+        ...prev,
+        [episodeId]: { loading: false, error: null, items },
+      }));
+    } catch {
+      setMediaByEpisodeId((prev) => ({
+        ...prev,
+        [episodeId]: {
+          loading: false,
+          error: 'Unable to load media preview.',
+          items: [],
+        },
+      }));
     }
   };
 
@@ -133,6 +208,91 @@ export function RecentEpisodesList({
                       {ep.episode_label.trim()}
                     </p>
                   ) : null}
+                </div>
+                <div className="mt-3">
+                  {(() => {
+                    const mediaState = mediaByEpisodeId[ep.id];
+                    return (
+                      <>
+                        <p className="text-xs font-semibold text-app-ink/90">
+                          Media
+                        </p>
+                        {!mediaState ? (
+                          <button
+                            type="button"
+                            className="mt-2 inline-flex min-h-[40px] items-center rounded-lg border border-app-border px-3 py-2 text-xs font-semibold text-app-primary"
+                            onClick={() => void loadEpisodeMedia(ep.id)}
+                          >
+                            Load media
+                          </button>
+                        ) : null}
+                        {mediaState?.loading ? (
+                          <p className="mt-2 text-xs text-app-muted">
+                            Loading media…
+                          </p>
+                        ) : null}
+                        {mediaState?.error ? (
+                          <div className="mt-2">
+                            <p className="text-xs text-red-700 dark:text-red-300">
+                              {mediaState.error}
+                            </p>
+                            <button
+                              type="button"
+                              className="mt-2 inline-flex min-h-[36px] items-center rounded-lg border border-app-border px-3 py-1.5 text-xs font-semibold text-app-primary"
+                              onClick={() => void loadEpisodeMedia(ep.id)}
+                            >
+                              Retry
+                            </button>
+                          </div>
+                        ) : null}
+                        {!mediaState?.loading &&
+                        !mediaState?.error &&
+                        mediaState &&
+                        mediaState.items.length === 0 ? (
+                          <p className="mt-2 text-xs text-app-muted">
+                            No photo or video for this episode.
+                          </p>
+                        ) : null}
+                        {mediaState?.items.length ? (
+                          <div className="mt-2 space-y-2">
+                            {mediaState.items.map((item) => (
+                              <div
+                                key={item.key}
+                                className="rounded border border-app-border/70 p-2"
+                              >
+                                {item.signedUrl ? (
+                                  item.mediaType === 'video' ? (
+                                    <video
+                                      src={item.signedUrl}
+                                      controls
+                                      className="max-h-56 w-full rounded bg-black object-contain"
+                                    />
+                                  ) : (
+                                    <img
+                                      src={item.signedUrl}
+                                      alt="Episode media"
+                                      className="max-h-56 w-full rounded bg-black/5 object-contain"
+                                    />
+                                  )
+                                ) : (
+                                  <p className="text-xs text-red-700 dark:text-red-300">
+                                    Link expired or unavailable.
+                                  </p>
+                                )}
+                              </div>
+                            ))}
+                            <button
+                              type="button"
+                              className="inline-flex min-h-[36px] items-center rounded-lg border border-app-border px-3 py-1.5 text-xs font-semibold text-app-primary"
+                              onClick={() => void loadEpisodeMedia(ep.id)}
+                            >
+                              Refresh media links
+                            </button>
+                          </div>
+                        ) : null}
+                      </>
+                    );
+                  })()}
                 </div>
               </details>
               <button

--- a/apps/web/src/components/episodes/RecentEpisodesList.tsx
+++ b/apps/web/src/components/episodes/RecentEpisodesList.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import {
+  createEpisodeMediaSignedDisplayUrl,
   deleteEpisodeById,
   listEpisodeMediaForEpisode,
 } from '@abstrack/supabase';
-import { formatEpisodeDurationSimple, type EpisodeRow } from '@abstrack/types';
+import {
+  formatEpisodeDurationSimple,
+  isMediaType,
+  type EpisodeRow,
+} from '@abstrack/types';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { formatEpisodeTypeSummary } from '@/lib/episodes/format-episode-meta';
@@ -54,10 +59,49 @@ export function RecentEpisodesList({
           signedUrl: string | null;
           mediaType: 'video' | 'photo';
           durationSeconds: number | null;
+          loadError: string | null;
         }>;
       }
     >
   >({});
+  /** Prevents overlapping media loads per episode (e.g. double‑tap before `loading` commits). */
+  const episodeMediaLoadInFlightRef = useRef<Record<string, boolean>>({});
+
+  /**
+   * Signed URL existed but the asset failed to load (expired, 403, network). Per-item error UI +
+   * refresh affordance.
+   *
+   * @param episodeId - Episode whose media list should be updated.
+   * @param storageKey - Episode media storage object key (`item.key`).
+   */
+  const onEpisodeMediaDisplayError = useCallback(
+    (episodeId: string, storageKey: string) => {
+      setMediaByEpisodeId((prev) => {
+        const state = prev[episodeId];
+        if (!state?.items?.length) {
+          return prev;
+        }
+        let changed = false;
+        const items = state.items.map((it) => {
+          if (it.key !== storageKey || !it.signedUrl) {
+            return it;
+          }
+          changed = true;
+          return {
+            ...it,
+            signedUrl: null,
+            loadError: 'Link expired or unavailable.',
+          };
+        });
+        if (!changed) {
+          return prev;
+        }
+        return { ...prev, [episodeId]: { ...state, items } };
+      });
+    },
+    [],
+  );
+
   const pendingEpisode =
     episodes.find((ep) => ep.id === pendingDeleteEpisodeId) ?? null;
   const isDeletingEpisode = deletingEpisodeId !== null;
@@ -92,7 +136,11 @@ export function RecentEpisodesList({
     }
   };
 
-  const loadEpisodeMedia = async (episodeId: string) => {
+  const loadEpisodeMedia = useCallback(async (episodeId: string) => {
+    if (episodeMediaLoadInFlightRef.current[episodeId]) {
+      return;
+    }
+    episodeMediaLoadInFlightRef.current[episodeId] = true;
     setMediaByEpisodeId((prev) => ({
       ...prev,
       [episodeId]: {
@@ -115,21 +163,30 @@ export function RecentEpisodesList({
         }));
         return;
       }
+      // Signing uses `createEpisodeMediaSignedDisplayUrl`: checks Storage `signed.error`, tries
+      // normalized legacy key shapes (`storage:`, `episode-media/`, URLs). Per-item `loadError`
+      // carries API/auth messages instead of only implying an expired link.
       const items = await Promise.all(
         listed.data.map(async (row) => {
-          const key = row.storage_object_key.trim();
-          const signed = await supabase.storage
-            .from('episode-media')
-            .createSignedUrl(key, 120);
-          const mediaType: 'video' | 'photo' =
-            typeof row.duration_seconds === 'number' && row.duration_seconds > 0
-              ? 'video'
-              : 'photo';
+          const rawKey = row.storage_object_key ?? '';
+          const { signedUrl, errorMessage } =
+            await createEpisodeMediaSignedDisplayUrl(supabase, rawKey, 120);
+          const key = rawKey.trim();
+          const mediaType: 'video' | 'photo' = isMediaType(row.media_type)
+            ? row.media_type
+            : 'photo';
+          const signingFailure =
+            typeof errorMessage === 'string' ? errorMessage.trim() : '';
           return {
             key,
-            signedUrl: signed.data?.signedUrl ?? null,
+            signedUrl,
             mediaType,
             durationSeconds: row.duration_seconds,
+            loadError: signedUrl
+              ? null
+              : signingFailure !== ''
+                ? signingFailure
+                : 'Could not create media link.',
           };
         }),
       );
@@ -146,8 +203,10 @@ export function RecentEpisodesList({
           items: [],
         },
       }));
+    } finally {
+      episodeMediaLoadInFlightRef.current[episodeId] = false;
     }
-  };
+  }, []);
 
   return (
     <>
@@ -209,7 +268,10 @@ export function RecentEpisodesList({
                     </p>
                   ) : null}
                 </div>
-                <div className="mt-3">
+                <div
+                  className="mt-3"
+                  aria-busy={mediaByEpisodeId[ep.id]?.loading === true}
+                >
                   {(() => {
                     const mediaState = mediaByEpisodeId[ep.id];
                     return (
@@ -238,8 +300,9 @@ export function RecentEpisodesList({
                             </p>
                             <button
                               type="button"
-                              className="mt-2 inline-flex min-h-[36px] items-center rounded-lg border border-app-border px-3 py-1.5 text-xs font-semibold text-app-primary"
+                              className={`mt-2 inline-flex min-h-[36px] items-center rounded-lg border border-app-border px-3 py-1.5 text-xs font-semibold text-app-primary ${mediaState?.loading ? 'cursor-not-allowed opacity-50' : ''}`}
                               onClick={() => void loadEpisodeMedia(ep.id)}
+                              disabled={Boolean(mediaState?.loading)}
                             >
                               Retry
                             </button>
@@ -266,25 +329,39 @@ export function RecentEpisodesList({
                                       src={item.signedUrl}
                                       controls
                                       className="max-h-56 w-full rounded bg-black object-contain"
+                                      onError={() =>
+                                        onEpisodeMediaDisplayError(
+                                          ep.id,
+                                          item.key,
+                                        )
+                                      }
                                     />
                                   ) : (
                                     <img
                                       src={item.signedUrl}
                                       alt="Episode media"
                                       className="max-h-56 w-full rounded bg-black/5 object-contain"
+                                      onError={() =>
+                                        onEpisodeMediaDisplayError(
+                                          ep.id,
+                                          item.key,
+                                        )
+                                      }
                                     />
                                   )
                                 ) : (
                                   <p className="text-xs text-red-700 dark:text-red-300">
-                                    Link expired or unavailable.
+                                    {item.loadError ??
+                                      'Link expired or unavailable.'}
                                   </p>
                                 )}
                               </div>
                             ))}
                             <button
                               type="button"
-                              className="inline-flex min-h-[36px] items-center rounded-lg border border-app-border px-3 py-1.5 text-xs font-semibold text-app-primary"
+                              className={`inline-flex min-h-[36px] items-center rounded-lg border border-app-border px-3 py-1.5 text-xs font-semibold text-app-primary ${mediaState?.loading ? 'cursor-not-allowed opacity-50' : ''}`}
                               onClick={() => void loadEpisodeMedia(ep.id)}
+                              disabled={Boolean(mediaState?.loading)}
                             >
                               Refresh media links
                             </button>

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -105,6 +105,7 @@ export type {
   RemoveEpisodeMediaObjectsFromStorageResult,
 } from './lib/episode-media-data.js';
 export {
+  createEpisodeMediaSignedDisplayUrl,
   createEpisodeMediaObjectKey,
   createEpisodeMediaThumbnailObjectKey,
   listEpisodeMediaForEpisode,

--- a/packages/supabase/src/lib/episode-media-data.spec.ts
+++ b/packages/supabase/src/lib/episode-media-data.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   createEpisodeMediaObjectKey,
+  createEpisodeMediaSignedDisplayUrl,
   createEpisodeMediaThumbnailObjectKey,
   listEpisodeMediaForEpisode,
   normalizedEpisodeMediaBucketKeysFromHints,
@@ -76,6 +77,77 @@ describe('normalizedEpisodeMediaBucketKeysFromHints', () => {
       '11111111-1111-4111-8111-111111111111/ep/v.webm',
       '11111111-1111-4111-8111-111111111111/ep/th.jpg',
     ]);
+  });
+});
+
+describe('createEpisodeMediaSignedDisplayUrl', () => {
+  const uuidPath =
+    '11111111-1111-4111-8111-111111111111/ep/video.webm' as const;
+
+  it('returns Storage API error message when createSignedUrl returns error', async () => {
+    const createSignedUrl = vi.fn(async () => ({
+      data: null as { signedUrl: string } | null,
+      error: { message: 'Object not found' },
+    }));
+    const client = {
+      storage: {
+        from: vi.fn(() => ({ createSignedUrl })),
+      },
+    } as unknown as AbstrackSupabaseClient;
+
+    const r = await createEpisodeMediaSignedDisplayUrl(client, uuidPath, 120);
+    expect(r.signedUrl).toBeNull();
+    expect(r.errorMessage).toBe('Object not found');
+    expect(createSignedUrl).toHaveBeenCalledWith(uuidPath, 120);
+  });
+
+  it('returns signed URL when signing succeeds', async () => {
+    const createSignedUrl = vi.fn(async () => ({
+      data: { signedUrl: 'https://example.test/signed' },
+      error: null,
+    }));
+    const client = {
+      storage: {
+        from: vi.fn(() => ({ createSignedUrl })),
+      },
+    } as unknown as AbstrackSupabaseClient;
+
+    const r = await createEpisodeMediaSignedDisplayUrl(client, uuidPath, 120);
+    expect(r.signedUrl).toBe('https://example.test/signed');
+    expect(r.errorMessage).toBeNull();
+  });
+
+  it('normalizes storage: prefix before signing', async () => {
+    const createSignedUrl = vi.fn(async () => ({
+      data: { signedUrl: 'https://example.test/signed' },
+      error: null,
+    }));
+    const client = {
+      storage: {
+        from: vi.fn(() => ({ createSignedUrl })),
+      },
+    } as unknown as AbstrackSupabaseClient;
+
+    await createEpisodeMediaSignedDisplayUrl(
+      client,
+      `storage:${uuidPath}`,
+      120,
+    );
+    expect(createSignedUrl).toHaveBeenCalledWith(uuidPath, 120);
+  });
+
+  it('returns missing key message for blank storage key', async () => {
+    const createSignedUrl = vi.fn();
+    const client = {
+      storage: {
+        from: vi.fn(() => ({ createSignedUrl })),
+      },
+    } as unknown as AbstrackSupabaseClient;
+
+    const r = await createEpisodeMediaSignedDisplayUrl(client, '   ', 120);
+    expect(r.signedUrl).toBeNull();
+    expect(r.errorMessage).toBe('Missing storage object key.');
+    expect(createSignedUrl).not.toHaveBeenCalled();
   });
 });
 
@@ -1431,7 +1503,7 @@ describe('listEpisodeMediaForEpisode', () => {
 
     expect(result.ok).toBe(true);
     expect(select).toHaveBeenCalledWith(
-      'episode_symptom_id, storage_object_key, thumbnail_storage_key, upload_completed_at, duration_seconds',
+      'episode_symptom_id, storage_object_key, thumbnail_storage_key, media_type, upload_completed_at, duration_seconds',
     );
     expect(orderCalls).toEqual([
       { column: 'created_at', ascending: false },

--- a/packages/supabase/src/lib/episode-media-data.ts
+++ b/packages/supabase/src/lib/episode-media-data.ts
@@ -186,6 +186,69 @@ export function normalizedEpisodeMediaBucketKeysFromHints(
 }
 
 /**
+ * Creates a short-lived signed HTTPS URL for displaying primary episode media in clients (`<video>` /
+ * `<img>`, React Native `Image` / `VideoView`). Uses the same path normalization as deletes ({@link
+ * normalizedEpisodeMediaBucketKeysFromHints}) so legacy `storage:`-prefixed or mis-shaped DB values
+ * still sign when possible. Surfaces Storage API `error` instead of treating failures like an expired
+ * link only.
+ *
+ * @param client - Supabase client (RLS applies to signing).
+ * @param rawStorageObjectKey - `episode_media.storage_object_key` (may include legacy prefixes).
+ * @param expiresIn - Signed URL TTL in seconds (Supabase Storage).
+ * @returns Display URL or an error message suitable for per-item UI.
+ */
+export async function createEpisodeMediaSignedDisplayUrl(
+  client: AbstrackSupabaseClient,
+  rawStorageObjectKey: string,
+  expiresIn: number,
+): Promise<{ signedUrl: string | null; errorMessage: string | null }> {
+  const raw = rawStorageObjectKey.trim();
+  if (!raw) {
+    return { signedUrl: null, errorMessage: 'Missing storage object key.' };
+  }
+
+  let candidates = normalizedEpisodeMediaBucketKeysFromHints([raw]);
+  if (candidates.length === 0) {
+    candidates = normalizedEpisodeMediaBucketKeysFromHints([
+      raw.replace(/^storage:/i, '').trim(),
+    ]);
+  }
+
+  let lastError: string | null = null;
+  for (const key of candidates) {
+    try {
+      const signed = await client.storage
+        .from(EPISODE_MEDIA_BUCKET)
+        .createSignedUrl(key, expiresIn);
+      if (signed.error) {
+        const msg =
+          typeof signed.error.message === 'string'
+            ? signed.error.message.trim()
+            : '';
+        lastError = msg !== '' ? msg : 'Could not create media link.';
+        continue;
+      }
+      const url = signed.data?.signedUrl ?? null;
+      if (url) {
+        return { signedUrl: url, errorMessage: null };
+      }
+      lastError = 'Could not create media link.';
+    } catch {
+      lastError = 'Could not create media link.';
+    }
+  }
+
+  return {
+    signedUrl: null,
+    errorMessage:
+      lastError ??
+      (candidates.length === 0
+        ? 'Invalid storage path for this media.'
+        : 'Could not create media link.'),
+  };
+}
+
+/**
  * RFC 4122 UUID v4 for Storage object keys via Web Crypto `getRandomValues` (cryptographically
  * secure once engines/polyfills expose it — browsers and Node provide `crypto`; React Native needs
  * `react-native-get-random-values` imported first at app startup).
@@ -779,6 +842,7 @@ export type EpisodeMediaListRow = Pick<
   | 'episode_symptom_id'
   | 'storage_object_key'
   | 'thumbnail_storage_key'
+  | 'media_type'
   | 'upload_completed_at'
   | 'duration_seconds'
 >;
@@ -808,7 +872,7 @@ export async function listEpisodeMediaForEpisode(
     let query = client
       .from('episode_media')
       .select(
-        'episode_symptom_id, storage_object_key, thumbnail_storage_key, upload_completed_at, duration_seconds',
+        'episode_symptom_id, storage_object_key, thumbnail_storage_key, media_type, upload_completed_at, duration_seconds',
       )
       .eq('episode_id', episodeId);
 


### PR DESCRIPTION
Closes #136

## Summary

Adds **stored** episode photo/video playback using **short-lived Supabase Storage signed URLs** (private `episode-media` bucket), with **loading**, **error**, and **refresh/retry** paths for expired or failed links.

Also aligns **web** persisted-video preview in the symptom flow with an explicit **Try again** control so signed URLs can be re-requested after failure/expiry.

## Changes

- **Web (`Manage` → recent episodes):** Inside each episode’s **View details**, optional **Load media** loads `episode_media` rows, signs object keys, and renders `<img>` / `<video controls>`. **Retry** / **Refresh media links** re-requests URLs.
- **Mobile (`Manage` → episodes):** Inline **Details** + **Media** on each recent episode card; same signed-URL flow with **`VideoView`** / **`Image`** (`accessibilityIgnoresInvertColors` on images).
- **Web symptom prompt:** Persisted uploaded **video** preview error state now includes **Try again** (re-resolves signed URL).
- **Chore:** Mobile lint — remove unnecessary `'use strict'` from Jest image loader mock.

## Out of scope (unchanged)

- Offline upload queue  
- PowerSync sync rules  

## Test plan

- [ ] Web: `/manage` → Episodes → expand **View details** → **Load media** → photo and video render; **Refresh media links** after TTL still works.
- [ ] Mobile: Manage → Episodes → **Load media** / **Refresh media links** → playback and accessibility smoke (VoiceOver/TalkBack as usual).
- [ ] Web symptom flow: persisted video preview → **Try again** after simulating failure/expiry.