### PR TITLE
feat(db): add practitioner_observation_notes with RLS and PowerSync replication

### DIFF
--- a/apps/mobile/src/lib/powersync/abstrack-app-schema.ts
+++ b/apps/mobile/src/lib/powersync/abstrack-app-schema.ts
@@ -205,6 +205,34 @@ const practitioner_access = new Table(
   },
 );
 
+const practitioner_observation_notes = new Table(
+  {
+    id: column.text,
+    patient_user_id: column.text,
+    episode_id: column.text,
+    practitioner_user_id: column.text,
+    body: column.text,
+    created_at: column.text,
+    updated_at: column.text,
+  },
+  {
+    indexes: {
+      practitioner_observation_notes_patient_created_idx: [
+        'patient_user_id',
+        'created_at',
+      ],
+      practitioner_observation_notes_patient_episode_idx: [
+        'patient_user_id',
+        'episode_id',
+      ],
+      practitioner_observation_notes_practitioner_idx: [
+        'practitioner_user_id',
+        'patient_user_id',
+      ],
+    },
+  },
+);
+
 const caretaker_access = new Table(
   {
     patient_user_id: column.text,
@@ -324,6 +352,7 @@ export const abstrackPowerSyncSchema = new Schema({
   food_diary_entries,
   episode_media,
   practitioner_access,
+  practitioner_observation_notes,
   caretaker_access,
   access_log,
   pending_episode_media_storage_cleanup,

--- a/apps/mobile/src/lib/powersync/powersync-replica-diagnostics.ts
+++ b/apps/mobile/src/lib/powersync/powersync-replica-diagnostics.ts
@@ -29,6 +29,7 @@ const REPLICA_DIAGNOSTICS_TABLES = [
   'food_diary_entries',
   'episode_media',
   'practitioner_access',
+  'practitioner_observation_notes',
   'caretaker_access',
   'access_log',
 ] as const;

--- a/packages/powersync/src/lib/replicated-artifacts-alignment.spec.ts
+++ b/packages/powersync/src/lib/replicated-artifacts-alignment.spec.ts
@@ -1,4 +1,5 @@
-import { readFileSync } from 'node:fs';
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { describe, expect, it } from 'vitest';
@@ -64,6 +65,37 @@ function parseMigrationRequiredTables(sql: string): string[] {
   return [...match[1].matchAll(/'([^']+)'/g)].map((groups) => groups[1]);
 }
 
+/** Tables added after the base PowerSync migration via `ALTER PUBLICATION powersync ADD TABLE`. */
+function parseAlterPublicationAddTables(migrationsDir: string): string[] {
+  const names = new Set<string>();
+  for (const file of readdirSync(migrationsDir).filter((f) =>
+    f.endsWith('.sql'),
+  )) {
+    const sql = readFileSync(join(migrationsDir, file), 'utf8');
+    const re =
+      /\bALTER\s+PUBLICATION\s+powersync\s+ADD\s+TABLE\s+public\.([a-z_][a-z0-9_]*)\b/gi;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(sql)) !== null) {
+      names.add(m[1]);
+    }
+  }
+  return [...names];
+}
+
+function publicationAllowlistFromMigrations(repoRoot: string): string[] {
+  const migrationsDir = join(repoRoot, 'supabase/migrations');
+  const baseSql = readFileSync(
+    join(
+      migrationsDir,
+      '20260430120000_powersync_replication_role_and_publication.sql',
+    ),
+    'utf8',
+  );
+  const base = parseMigrationRequiredTables(baseSql);
+  const added = parseAlterPublicationAddTables(migrationsDir);
+  return [...new Set([...base, ...added])].sort();
+}
+
 describe('Replicated table allowlist alignment', () => {
   const allowlistSorted = [...REPLICATED_PUBLIC_TABLE_NAMES].sort();
 
@@ -74,15 +106,10 @@ describe('Replicated table allowlist alignment', () => {
     expect(referenced).toEqual(allowlistSorted);
   });
 
-  it('matches powersync migration required_tables array', () => {
-    const migrationPath = resolveFromSpec(
-      '../../../../supabase/migrations/20260430120000_powersync_replication_role_and_publication.sql',
-    );
-    const sql = readFileSync(migrationPath, 'utf8');
-    const fromMigration = [
-      ...new Set(parseMigrationRequiredTables(sql)),
-    ].sort();
-    expect(fromMigration).toEqual(allowlistSorted);
+  it('matches powersync publication allowlist (base migration + ADD TABLE in later files)', () => {
+    const repoRoot = resolveFromSpec('../../../../');
+    const fromMigrations = publicationAllowlistFromMigrations(repoRoot);
+    expect(fromMigrations).toEqual(allowlistSorted);
   });
 
   it('matches mobile abstrack-app-schema.ts Schema table keys', () => {

--- a/packages/powersync/src/lib/replicated-public-tables.ts
+++ b/packages/powersync/src/lib/replicated-public-tables.ts
@@ -4,7 +4,8 @@
  * Must stay aligned with:
  * - `packages/powersync/sync-rules.yaml` (`FROM` / `JOIN` references)
  * - `supabase/migrations/20260430120000_powersync_replication_role_and_publication.sql`
- *   (`required_tables` + publication / grants)
+ *   (`required_tables` + publication / grants), plus later migrations that
+ *   `ALTER PUBLICATION powersync ADD TABLE` (see `replicated-artifacts-alignment.spec.ts`)
  * - `apps/mobile/src/lib/powersync/abstrack-app-schema.ts` — replicated tables below **plus**
  *   {@link MOBILE_LOCAL_ONLY_POWER_SYNC_SCHEMA_TABLE_NAMES} (`localOnly` client tables not in Postgres
  *   sync streams).
@@ -25,6 +26,7 @@ export const REPLICATED_PUBLIC_TABLE_NAMES = [
   'preset_health_markers',
   'preset_symptoms',
   'practitioner_access',
+  'practitioner_observation_notes',
   'profiles',
   'symptom_presets',
 ] as const;

--- a/packages/powersync/src/lib/sync-scope-model.ts
+++ b/packages/powersync/src/lib/sync-scope-model.ts
@@ -56,8 +56,9 @@ function activePractitionerPatients(input: SyncScopeModelInput): Set<string> {
 /**
  * Returns distinct patient scope ids for `phi_*` buckets (aligned with YAML parameter queries:
  * `patient_self`, `caretaker_patients`, `practitioner_mfa_patients`). Values match PHI row `user_id`
- * / profile ids and grant-side `patient_user_id`; combines own patient data, caretaker-linked
- * patients, or practitioner-linked patients with MFA (`aal2`).
+ * (and `practitioner_observation_notes.patient_user_id`), profile ids, and grant-side
+ * `patient_user_id`; combines own patient data, caretaker-linked patients, or practitioner-linked
+ * patients with MFA (`aal2`).
  *
  * @param input Modeled auth claims and grant rows (same intent as sync-rule parameter queries).
  * @returns Stable sorted ids for assertions.

--- a/packages/powersync/sync-rules.yaml
+++ b/packages/powersync/sync-rules.yaml
@@ -70,6 +70,7 @@ streams:
       - SELECT * FROM health_markers WHERE user_id IN patient_self
       - SELECT * FROM food_diary_entries WHERE user_id IN patient_self
       - SELECT * FROM episode_media WHERE user_id IN patient_self
+      - SELECT * FROM practitioner_observation_notes WHERE patient_user_id IN patient_self
 
   phi_caretaker_linked_patients:
     auto_subscribe: true
@@ -88,6 +89,8 @@ streams:
       - SELECT * FROM health_markers WHERE user_id IN caretaker_patients
       - SELECT * FROM food_diary_entries WHERE user_id IN caretaker_patients
       - SELECT * FROM episode_media WHERE user_id IN caretaker_patients
+      - >-
+        SELECT * FROM practitioner_observation_notes WHERE patient_user_id IN caretaker_patients
 
   phi_practitioner_linked_patients:
     auto_subscribe: true
@@ -106,3 +109,6 @@ streams:
       - SELECT * FROM health_markers WHERE user_id IN practitioner_mfa_patients
       - SELECT * FROM food_diary_entries WHERE user_id IN practitioner_mfa_patients
       - SELECT * FROM episode_media WHERE user_id IN practitioner_mfa_patients
+      - >-
+        SELECT * FROM practitioner_observation_notes WHERE patient_user_id IN
+        practitioner_mfa_patients

--- a/packages/supabase/src/lib/database.types.ts
+++ b/packages/supabase/src/lib/database.types.ts
@@ -463,6 +463,44 @@ export type Database = {
         }
         Relationships: []
       }
+      practitioner_observation_notes: {
+        Row: {
+          body: string
+          created_at: string
+          episode_id: string | null
+          id: string
+          patient_user_id: string
+          practitioner_user_id: string
+          updated_at: string
+        }
+        Insert: {
+          body: string
+          created_at?: string
+          episode_id?: string | null
+          id?: string
+          patient_user_id: string
+          practitioner_user_id: string
+          updated_at?: string
+        }
+        Update: {
+          body?: string
+          created_at?: string
+          episode_id?: string | null
+          id?: string
+          patient_user_id?: string
+          practitioner_user_id?: string
+          updated_at?: string
+        }
+        Relationships: [
+          {
+            foreignKeyName: "practitioner_observation_notes_episode_owner_fk"
+            columns: ["patient_user_id", "episode_id"]
+            isOneToOne: false
+            referencedRelation: "episodes"
+            referencedColumns: ["user_id", "id"]
+          },
+        ]
+      }
       preset_health_markers: {
         Row: {
           created_at: string

--- a/supabase/migrations/20260509120000_practitioner_observation_notes.sql
+++ b/supabase/migrations/20260509120000_practitioner_observation_notes.sql
@@ -97,9 +97,9 @@ CREATE POLICY practitioner_observation_notes_update ON public.practitioner_obser
 
 -- ---------------------------------------------------------------------------
 -- PowerSync replication (publication + role grant; BYPASSRLS download scope in sync-rules.yaml)
+-- Idempotent: skip when powersync_role is absent (environments without 20260430120000) so GRANT
+-- does not error; ADD TABLE only when publication exists and the table is not already a member.
 -- ---------------------------------------------------------------------------
-GRANT SELECT ON TABLE public.practitioner_observation_notes TO powersync_role;
-
 DO $$
 BEGIN
   IF EXISTS (
@@ -109,6 +109,7 @@ BEGIN
       pg_roles
     WHERE
       rolname = 'powersync_role') THEN
+    GRANT SELECT ON TABLE public.practitioner_observation_notes TO powersync_role;
     IF EXISTS (
       SELECT
         1

--- a/supabase/migrations/20260509120000_practitioner_observation_notes.sql
+++ b/supabase/migrations/20260509120000_practitioner_observation_notes.sql
@@ -1,0 +1,133 @@
+-- PRD §8: practitioner observation notes (episode-scoped and/or patient-level).
+--
+-- Notes are stored in this dedicated table—not as writes to patient-owned PHI rows (`episodes`,
+-- `episode_symptoms`, etc.). Practitioners receive INSERT/UPDATE only here, gated by
+-- public.user_has_practitioner_access(patient_user_id) (active grant + profiles.app_role
+-- practitioner + JWT AAL2 per 20260416120000_practitioner_mfa_assurance_rls.sql).
+--
+-- Read access (SELECT): patient (owner), caretaker with active caretaker_access for that patient,
+-- and practitioners with grant + MFA on the same helper. Product intent (PRD §8): the patient
+-- (and a caretaker acting for the patient, same as other PHI read paths) can read practitioner
+-- notes on their record; practitioners read via the practitioner grant path. No DELETE policy:
+-- practitioners may insert/update own rows only; retention is a future product concern.
+--
+-- PowerSync: PHI-like free text replicates to mobile for offline read paths mirroring other
+-- patient-scoped tables (sync-rules.yaml + publication below).
+
+CREATE TABLE public.practitioner_observation_notes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid (),
+  patient_user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  episode_id uuid,
+  practitioner_user_id uuid NOT NULL REFERENCES auth.users (id) ON DELETE CASCADE,
+  body text NOT NULL
+    CHECK (char_length(body) <= 16000),
+  created_at timestamptz NOT NULL DEFAULT now (),
+  updated_at timestamptz NOT NULL DEFAULT now (),
+  CONSTRAINT practitioner_observation_notes_episode_owner_fk FOREIGN KEY (patient_user_id, episode_id)
+    REFERENCES public.episodes (user_id, id)
+    ON DELETE CASCADE
+);
+
+CREATE INDEX practitioner_observation_notes_patient_created_idx ON public.practitioner_observation_notes (patient_user_id, created_at DESC);
+
+CREATE INDEX practitioner_observation_notes_patient_episode_idx ON public.practitioner_observation_notes (patient_user_id, episode_id);
+
+CREATE INDEX practitioner_observation_notes_practitioner_idx ON public.practitioner_observation_notes (practitioner_user_id, patient_user_id);
+
+COMMENT ON TABLE public.practitioner_observation_notes IS 'PRD §8 practitioner-authored observation notes. Scoped by patient_user_id; optional episode_id (NULL = patient-level note). Writes only for practitioners with grant + MFA; patients/caretakers SELECT only.';
+
+COMMENT ON COLUMN public.practitioner_observation_notes.episode_id IS 'When set, note is tied to a specific episode of patient_user_id; NULL means a patient-record-level note (PRD §8).';
+
+COMMENT ON COLUMN public.practitioner_observation_notes.body IS 'Plaintext clinical free text; RLS + TLS + platform encryption at rest (same PHI posture as other note fields).';
+
+CREATE OR REPLACE FUNCTION public.practitioner_observation_notes_immutable_scope ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  IF TG_OP = 'UPDATE' THEN
+    IF NEW.patient_user_id IS DISTINCT FROM OLD.patient_user_id
+      OR NEW.practitioner_user_id IS DISTINCT FROM OLD.practitioner_user_id
+      OR NEW.episode_id IS DISTINCT FROM OLD.episode_id THEN
+      RAISE EXCEPTION 'practitioner_observation_notes: patient_user_id, practitioner_user_id, and episode_id cannot change';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.practitioner_observation_notes_immutable_scope () IS 'Prevents reassigning a note to another patient, episode, or author after insert.';
+
+REVOKE ALL ON FUNCTION public.practitioner_observation_notes_immutable_scope ()
+  FROM PUBLIC;
+
+CREATE TRIGGER practitioner_observation_notes_immutable_scope
+  BEFORE UPDATE ON public.practitioner_observation_notes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.practitioner_observation_notes_immutable_scope ();
+
+CREATE TRIGGER set_updated_at
+  BEFORE UPDATE ON public.practitioner_observation_notes
+  FOR EACH ROW
+  EXECUTE FUNCTION public.set_updated_at ();
+
+ALTER TABLE public.practitioner_observation_notes
+  ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY practitioner_observation_notes_select ON public.practitioner_observation_notes
+  FOR SELECT
+  TO authenticated
+  USING (patient_user_id = (SELECT auth.uid())
+    OR public.user_is_caretaker_for_patient (patient_user_id)
+    OR public.user_has_practitioner_access (patient_user_id));
+
+CREATE POLICY practitioner_observation_notes_insert ON public.practitioner_observation_notes
+  FOR INSERT
+  TO authenticated
+  WITH CHECK (practitioner_user_id = (SELECT auth.uid())
+  AND public.user_has_practitioner_access (patient_user_id));
+
+CREATE POLICY practitioner_observation_notes_update ON public.practitioner_observation_notes
+  FOR UPDATE
+  TO authenticated
+  USING (practitioner_user_id = (SELECT auth.uid())
+    AND public.user_has_practitioner_access (patient_user_id))
+  WITH CHECK (practitioner_user_id = (SELECT auth.uid())
+    AND public.user_has_practitioner_access (patient_user_id));
+
+-- ---------------------------------------------------------------------------
+-- PowerSync replication (publication + role grant; BYPASSRLS download scope in sync-rules.yaml)
+-- ---------------------------------------------------------------------------
+GRANT SELECT ON TABLE public.practitioner_observation_notes TO powersync_role;
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT
+      1
+    FROM
+      pg_roles
+    WHERE
+      rolname = 'powersync_role') THEN
+    IF EXISTS (
+      SELECT
+        1
+      FROM
+        pg_publication p
+      WHERE
+        p.pubname = 'powersync') THEN
+      IF NOT EXISTS (
+        SELECT
+          1
+        FROM
+          pg_publication_tables pt
+        WHERE
+          pt.pubname = 'powersync'
+          AND pt.schemaname = 'public'
+          AND pt.tablename::text = 'practitioner_observation_notes') THEN
+        ALTER PUBLICATION powersync ADD TABLE public.practitioner_observation_notes;
+      END IF;
+    END IF;
+  END IF;
+END
+$$;


### PR DESCRIPTION
Closes #149

## Summary

Adds PRD §8 **practitioner observation notes** as a dedicated table (episode-scoped and/or patient-level via nullable `episode_id`), with RLS aligned to `user_has_practitioner_access` (grant + AAL2). Patients and caretakers get **SELECT** only; practitioners **INSERT/UPDATE** own rows. No writes on patient-owned PHI tables.

## Changes

- **Migration:** `practitioner_observation_notes`, indexes, comments, immutability trigger, publication `ADD TABLE` + `powersync_role` `SELECT` grant.
- **PowerSync:** `sync-rules.yaml` + `REPLICATED_PUBLIC_TABLE_NAMES`, alignment spec (base publication list ∪ `ALTER PUBLICATION … ADD TABLE`), mobile `abstrack-app-schema.ts` + replica diagnostics table list.
- **Types:** `database.types.ts` updated for CI; regenerate with `gen types --linked` (and Prettier) after `db push` if the snapshot differs.

## Testing

- `pnpm exec nx run @abstrack/powersync:test` / `:build`
- `pnpm exec nx run supabase:lint` / `supabase:build` / `supabase:test`
- UI: none (#156 will consume this API). Validate PowerSync rules with pinned CLI when deploying sync config.