### PR TITLE
feat(mobile,web): caretaker PHI scope via caretaker_access and shared subject resolver

### DIFF
--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -626,6 +626,20 @@ describe('mobile auth state sync', () => {
             })),
           };
         }
+        if (table === 'profiles') {
+          return {
+            select: jest.fn(() => ({
+              eq: jest.fn(() => ({
+                maybeSingle: jest.fn(() =>
+                  Promise.resolve({
+                    data: { app_role: 'patient' },
+                    error: null,
+                  }),
+                ),
+              })),
+            })),
+          };
+        }
         return {
           select: jest.fn(() => ({
             order: jest.fn(() => ({

--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -109,6 +109,16 @@ describe('mobile auth state sync', () => {
   const invalidOrExpiredMessage =
     'This reset link is invalid or expired. Request a new one.';
 
+  beforeEach(() => {
+    // Cases that need a custom graph override `fetch` in the same test. Default stays a fast,
+    // resolved online snapshot so `App` bootstrap / `fetchMobileDeviceIsConnected` never stall CI.
+    jest.mocked(NetInfo.fetch).mockResolvedValue({
+      type: 'wifi',
+      isConnected: true,
+      isInternetReachable: true,
+    } as unknown as NetInfoState);
+  });
+
   /**
    * Supabase registers multiple `onAuthStateChange` listeners (e.g. App). Tests must
    * broadcast to every subscriber; a single stored callback misses App when Home overwrites it.
@@ -681,13 +691,29 @@ describe('mobile auth state sync', () => {
           },
         })),
       },
-      from: jest.fn(() => ({
-        select: jest.fn(() => ({
-          order: jest.fn(() => ({
-            order: jest.fn(() => Promise.resolve({ data: [], error: null })),
+      from: jest.fn((table: string) => {
+        if (table === 'profiles') {
+          return {
+            select: jest.fn(() => ({
+              eq: jest.fn(() => ({
+                maybeSingle: jest.fn(() =>
+                  Promise.resolve({
+                    data: { app_role: 'patient' },
+                    error: null,
+                  }),
+                ),
+              })),
+            })),
+          };
+        }
+        return {
+          select: jest.fn(() => ({
+            order: jest.fn(() => ({
+              order: jest.fn(() => Promise.resolve({ data: [], error: null })),
+            })),
           })),
-        })),
-      })),
+        };
+      }),
     } as unknown as AbstrackSupabaseClient;
 
     jest.mocked(SecureStore.getItemAsync).mockResolvedValue('false');
@@ -698,15 +724,25 @@ describe('mobile auth state sync', () => {
       .spyOn(Linking, 'getInitialURL')
       .mockResolvedValue(null);
     try {
-      const { findByLabelText, findByTestId } = render(<App />);
+      const { getByLabelText, getByTestId } = render(<App />);
 
-      expect(await findByTestId('episode-start-home-cta')).toBeTruthy();
-      fireEvent.press(await findByLabelText("I'm having an episode"));
-      expect(await findByTestId('episode-start-screen-title')).toBeTruthy();
+      await waitFor(
+        () => {
+          expect(getByTestId('episode-start-home-cta')).toBeTruthy();
+        },
+        { timeout: 15_000, interval: 50 },
+      );
+      fireEvent.press(getByLabelText("I'm having an episode"));
+      await waitFor(
+        () => {
+          expect(getByTestId('episode-start-screen-title')).toBeTruthy();
+        },
+        { timeout: 15_000, interval: 50 },
+      );
     } finally {
       getInitialUrlSpy.mockRestore();
     }
-  });
+  }, 20_000);
 
   test('exposes the re-authentication toggle in settings', async () => {
     const signedInSession = {

--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -629,18 +629,28 @@ describe('mobile auth state sync', () => {
     jest.mocked(SecureStore.getItemAsync).mockResolvedValue('false');
     jest.mocked(getMobileSupabaseClient).mockReturnValue(mockClient);
 
-    const { findByText, findByLabelText, findByTestId } = render(<App />);
+    /** `App` bootstrap awaits `Linking.getInitialURL()`; an unmocked native impl can hang past CI’s async test budget. */
+    const getInitialUrlSpy = jest
+      .spyOn(Linking, 'getInitialURL')
+      .mockResolvedValue(null);
+    try {
+      const { findByText, findByLabelText, findByTestId } = render(<App />);
 
-    expect(await findByText('Welcome to ABStrack')).toBeTruthy();
+      expect(await findByText('Welcome to ABStrack')).toBeTruthy();
 
-    fireEvent.press(await findByLabelText('Symptom presets'));
-    expect(await findByTestId('symptom-preset-list-screen')).toBeTruthy();
+      fireEvent.press(await findByLabelText('Symptom presets'));
+      expect(await findByTestId('symptom-preset-list-screen')).toBeTruthy();
 
-    fireEvent.press(await findByLabelText('Health marker presets'));
-    expect(await findByTestId('health-marker-preset-list-screen')).toBeTruthy();
+      fireEvent.press(await findByLabelText('Health marker presets'));
+      expect(
+        await findByTestId('health-marker-preset-list-screen'),
+      ).toBeTruthy();
 
-    fireEvent.press(await findByLabelText('Episode templates'));
-    expect(await findByTestId('episode-template-list-screen')).toBeTruthy();
+      fireEvent.press(await findByLabelText('Episode templates'));
+      expect(await findByTestId('episode-template-list-screen')).toBeTruthy();
+    } finally {
+      getInitialUrlSpy.mockRestore();
+    }
   });
 
   test('opens episode start shell from home episode CTA', async () => {
@@ -683,11 +693,19 @@ describe('mobile auth state sync', () => {
     jest.mocked(SecureStore.getItemAsync).mockResolvedValue('false');
     jest.mocked(getMobileSupabaseClient).mockReturnValue(mockClient);
 
-    const { findByLabelText, findByTestId } = render(<App />);
+    /** Same as tab navigation test: cold `App` bootstrap must not await an unresolved `getInitialURL()`. */
+    const getInitialUrlSpy = jest
+      .spyOn(Linking, 'getInitialURL')
+      .mockResolvedValue(null);
+    try {
+      const { findByLabelText, findByTestId } = render(<App />);
 
-    expect(await findByTestId('episode-start-home-cta')).toBeTruthy();
-    fireEvent.press(await findByLabelText("I'm having an episode"));
-    expect(await findByTestId('episode-start-screen-title')).toBeTruthy();
+      expect(await findByTestId('episode-start-home-cta')).toBeTruthy();
+      fireEvent.press(await findByLabelText("I'm having an episode"));
+      expect(await findByTestId('episode-start-screen-title')).toBeTruthy();
+    } finally {
+      getInitialUrlSpy.mockRestore();
+    }
   });
 
   test('exposes the re-authentication toggle in settings', async () => {

--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -724,25 +724,16 @@ describe('mobile auth state sync', () => {
       .spyOn(Linking, 'getInitialURL')
       .mockResolvedValue(null);
     try {
-      const { getByLabelText, getByTestId } = render(<App />);
+      const { findByLabelText, findByTestId } = render(<App />);
 
-      await waitFor(
-        () => {
-          expect(getByTestId('episode-start-home-cta')).toBeTruthy();
-        },
-        { timeout: 15_000, interval: 50 },
-      );
-      fireEvent.press(getByLabelText("I'm having an episode"));
-      await waitFor(
-        () => {
-          expect(getByTestId('episode-start-screen-title')).toBeTruthy();
-        },
-        { timeout: 15_000, interval: 50 },
-      );
+      // `episode-start-home-cta` is mounted while the active-episode probe runs; wait for the
+      // primary action that only appears after PHI + resume checks finish (see HomeScreen CTA).
+      fireEvent.press(await findByLabelText("I'm having an episode"));
+      expect(await findByTestId('episode-start-screen-title')).toBeTruthy();
     } finally {
       getInitialUrlSpy.mockRestore();
     }
-  }, 20_000);
+  });
 
   test('exposes the re-authentication toggle in settings', async () => {
     const signedInSession = {

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -242,6 +242,7 @@ export function EpisodeStartScreen() {
             replicationReady:
               powerSyncOfflineReplicaReadsEnabled(bridgeForTemplates),
           },
+          scopeUserId: phiSubjectUserId,
         });
         if (stale()) {
           return;

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -14,11 +14,9 @@ import type {
 } from '@abstrack/types';
 import { getActiveEpisodeForUser, PresetDataError } from '@abstrack/supabase';
 import { announce } from '@abstrack/ui/native';
-import { useMobileAuthUserId } from '../../lib/auth/use-mobile-auth-user-id';
-import {
-  fetchEpisodeTemplates,
-  getCurrentUserId,
-} from '../../lib/episode-templates/episode-template-service';
+import { useMobilePhiSubjectUserContext } from '../../lib/auth/use-mobile-phi-subject-user-context';
+import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
+import { fetchEpisodeTemplates } from '../../lib/episode-templates/episode-template-service';
 import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { endEpisodeIfStillActiveOfflineFirst } from '../../lib/episodes/mobile-offline-first-gateway';
@@ -60,7 +58,7 @@ type EpisodeStartNav = NativeStackNavigationProp<
  */
 export function EpisodeStartScreen() {
   const navigation = useNavigation<EpisodeStartNav>();
-  const viewerUserId = useMobileAuthUserId();
+  const { authUserId: viewerUserId } = useMobilePhiSubjectUserContext();
   /** Invalidates in-flight {@link load} when the screen blurs, retry runs, or a load watchdog fires. */
   const loadGenerationRef = useRef(0);
   /** Cleared on blur / completion so {@link EPISODE_START_LOAD_TIMEOUT_MS} cannot fire late. */
@@ -121,23 +119,6 @@ export function EpisodeStartScreen() {
         setErrorMessage(null);
         setEpisodeStartError(null);
         setBlockingActiveEpisode(null);
-        const authResult = await getCurrentUserId();
-        if (stale()) {
-          return;
-        }
-        if (!authResult.ok) {
-          setErrorMessage(authResult.error.message);
-          setStatus('error');
-          return;
-        }
-        if (authResult.data === null) {
-          setErrorMessage('You need to be signed in to start an episode.');
-          setStatus('error');
-          return;
-        }
-        const userId = authResult.data;
-
-        let activeEpisodeRow: EpisodeRow | null = null;
         const bridgeForActiveRead = psBridgeRef.current;
         const trustedReplicaDb = powerSyncOfflineReplicaReadsEnabled(
           bridgeForActiveRead,
@@ -152,6 +133,26 @@ export function EpisodeStartScreen() {
         /** Prefer trusted mirror for reads; fall back to init-only SQLite after Supabase network errors. */
         const replicaDbForNetworkFallback =
           trustedReplicaDb ?? sqliteReadyReplicaDb;
+
+        const phiRes = await resolveMobilePhiSubjectUserContext({
+          powerSyncDatabase: replicaDbForNetworkFallback,
+        });
+        if (stale()) {
+          return;
+        }
+        if (!phiRes.ok) {
+          setErrorMessage(phiRes.error.message);
+          setStatus('error');
+          return;
+        }
+        if (phiRes.data == null) {
+          setErrorMessage('You need to be signed in to start an episode.');
+          setStatus('error');
+          return;
+        }
+        const phiSubjectUserId = phiRes.data.phiSubjectUserId;
+
+        let activeEpisodeRow: EpisodeRow | null = null;
         let shouldQuerySupabaseForActive = true;
         if (trustedReplicaDb) {
           const connected = await fetchMobileDeviceIsConnected();
@@ -163,7 +164,7 @@ export function EpisodeStartScreen() {
             try {
               activeEpisodeRow = await getActiveEpisodeRowFromPowerSyncDb(
                 trustedReplicaDb,
-                userId,
+                phiSubjectUserId,
               );
             } catch (caught) {
               if (!stale()) {
@@ -182,7 +183,10 @@ export function EpisodeStartScreen() {
 
         if (!activeEpisodeRow && shouldQuerySupabaseForActive) {
           const supabase = getMobileSupabaseClient();
-          const activeResult = await getActiveEpisodeForUser(supabase, userId);
+          const activeResult = await getActiveEpisodeForUser(
+            supabase,
+            phiSubjectUserId,
+          );
           if (stale()) {
             return;
           }
@@ -197,7 +201,7 @@ export function EpisodeStartScreen() {
               try {
                 activeEpisodeRow = await getActiveEpisodeRowFromPowerSyncDb(
                   replicaDbForNetworkFallback,
-                  userId,
+                  phiSubjectUserId,
                 );
               } catch (caught) {
                 if (!stale()) {
@@ -263,7 +267,7 @@ export function EpisodeStartScreen() {
           let didNavigateToSymptomPrompt = false;
           try {
             const saveResult = await saveEpisodeWithTemplatePresets({
-              userId,
+              userId: phiSubjectUserId,
               symptomPresetId: template.symptom_preset_id,
               healthMarkerPresetId: template.health_marker_preset_id,
               powerSyncDatabase: powerSyncReplicaSqliteReady(
@@ -446,20 +450,24 @@ export function EpisodeStartScreen() {
     setSubmitting(true);
     let didNavigateToSymptomPrompt = false;
     try {
-      const authResult = await getCurrentUserId();
-      if (!authResult.ok) {
-        setEpisodeStartError(authResult.error.message);
-        announce(authResult.error.message);
+      const phiRes = await resolveMobilePhiSubjectUserContext({
+        powerSyncDatabase: powerSyncReplicaSqliteReady(psBridgeRef.current)
+          ? psBridgeRef.current.database
+          : null,
+      });
+      if (!phiRes.ok) {
+        setEpisodeStartError(phiRes.error.message);
+        announce(phiRes.error.message);
         return;
       }
-      if (authResult.data === null) {
+      if (phiRes.data == null) {
         const message = 'You need to be signed in to start an episode.';
         setEpisodeStartError(message);
         announce(message);
         return;
       }
       const result = await saveEpisodeWithTemplatePresets({
-        userId: authResult.data,
+        userId: phiRes.data.phiSubjectUserId,
         symptomPresetId: template.symptom_preset_id,
         healthMarkerPresetId: template.health_marker_preset_id,
         powerSyncDatabase: powerSyncReplicaSqliteReady(psBridgeRef.current)

--- a/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
@@ -16,6 +16,7 @@ import {
   validateEpisodeTemplatePresetPair,
 } from '@abstrack/types';
 import { useMobileAuthUserId } from '../../lib/auth/use-mobile-auth-user-id';
+import { useMobilePhiSubjectUserContext } from '../../lib/auth/use-mobile-phi-subject-user-context';
 import {
   powerSyncOfflineReplicaReadsEnabled,
   powerSyncReplicaSqliteReady,
@@ -49,6 +50,24 @@ export function EpisodeTemplateCreateScreen() {
   const navigation = useNavigation<CreateNav>();
   const { colors } = useAppTheme();
   const viewerUserId = useMobileAuthUserId();
+  const viewerUserIdRef = useRef(viewerUserId);
+  viewerUserIdRef.current = viewerUserId;
+
+  const {
+    phiSubjectUserId,
+    loading: phiSubjectContextLoading,
+    errorMessage: phiSubjectContextError,
+  } = useMobilePhiSubjectUserContext();
+  const phiSubjectUserIdRef = useRef<string | null>(null);
+  const phiLoadingRef = useRef(false);
+  const phiErrorRef = useRef<string | null>(null);
+  phiSubjectUserIdRef.current = phiSubjectUserId;
+  phiLoadingRef.current = phiSubjectContextLoading;
+  phiErrorRef.current = phiSubjectContextError;
+
+  /** Dedupes preset-list loads when only `listsLoading` / `listsError` churn after a successful fetch. */
+  const lastPresetFetchKeyRef = useRef<string | null>(null);
+
   const psBridge = usePowerSyncBridgeState();
   const replicaMirrorReads = powerSyncOfflineReplicaReadsEnabled(psBridge);
 
@@ -95,8 +114,14 @@ export function EpisodeTemplateCreateScreen() {
     setListsError(null);
     const offlineRead = offlineReadRef.current;
     const [sRes, mRes] = await Promise.all([
-      fetchSymptomPresets({ powerSyncOfflineRead: offlineRead }),
-      fetchHealthMarkerPresets({ powerSyncOfflineRead: offlineRead }),
+      fetchSymptomPresets({
+        powerSyncOfflineRead: offlineRead,
+        scopeUserId: phiSubjectUserIdRef.current,
+      }),
+      fetchHealthMarkerPresets({
+        powerSyncOfflineRead: offlineRead,
+        scopeUserId: phiSubjectUserIdRef.current,
+      }),
     ]);
     if (signal?.aborted) {
       return;
@@ -130,6 +155,7 @@ export function EpisodeTemplateCreateScreen() {
       symptomId: initSymptom,
       markerId: initMarker,
     });
+    lastPresetFetchKeyRef.current = `${viewerUserIdRef.current ?? ''}|${phiSubjectUserIdRef.current ?? ''}|${phiLoadingRef.current ? 'L' : '-'}|${phiErrorRef.current ?? ''}`;
     setListsLoading(false);
   }, []);
 
@@ -137,9 +163,10 @@ export function EpisodeTemplateCreateScreen() {
   loadPresetListsRef.current = loadPresetLists;
 
   /**
-   * Loads preset picklists when the signed-in user id changes — not only on mount — so an account
-   * switch cannot leave the previous user's symptom/marker names visible. Still intentionally
-   * independent of `replicaMirrorReads` (see retry effect below).
+   * Loads preset picklists when the signed-in user id **or PHI scope** changes — not only on mount
+   * — so an account switch cannot leave the previous user's symptom/marker names visible, and a
+   * caretaker gets patient-scoped replica lists once {@link useMobilePhiSubjectUserContext} resolves.
+   * Still intentionally independent of `replicaMirrorReads` (see retry effect below).
    *
    * `useMobileAuthUserId` starts as `null` and resolves asynchronously; `null → userId` is
    * hydration, not a switch — do not clear the form or refetch when preset lists already loaded
@@ -149,7 +176,14 @@ export function EpisodeTemplateCreateScreen() {
     const next = viewerUserId;
     const prev = prevViewerUserIdRef.current;
 
-    if (prev !== undefined && prev === next) {
+    const presetFetchKey = `${next ?? ''}|${phiSubjectUserId ?? ''}|${phiSubjectContextLoading ? 'L' : '-'}|${phiSubjectContextError ?? ''}`;
+
+    if (
+      prev !== undefined &&
+      prev === next &&
+      lastPresetFetchKeyRef.current != null &&
+      lastPresetFetchKeyRef.current === presetFetchKey
+    ) {
       return;
     }
 
@@ -158,6 +192,7 @@ export function EpisodeTemplateCreateScreen() {
 
     if (isAuthHydration && !listsLoading && listsError == null) {
       prevViewerUserIdRef.current = next;
+      lastPresetFetchKeyRef.current = presetFetchKey;
       return;
     }
 
@@ -167,6 +202,7 @@ export function EpisodeTemplateCreateScreen() {
     prevViewerUserIdRef.current = next;
 
     if (switchedAccount) {
+      lastPresetFetchKeyRef.current = null;
       setName('');
       setSymptomId(null);
       setMarkerId(null);
@@ -188,7 +224,14 @@ export function EpisodeTemplateCreateScreen() {
     return () => {
       ac.abort();
     };
-  }, [viewerUserId, listsLoading, listsError]);
+  }, [
+    viewerUserId,
+    listsLoading,
+    listsError,
+    phiSubjectUserId,
+    phiSubjectContextLoading,
+    phiSubjectContextError,
+  ]);
 
   useEffect(() => {
     if (!listsError) {

--- a/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
@@ -112,15 +112,22 @@ export function EpisodeTemplateCreateScreen() {
   const loadPresetLists = useCallback(async (signal?: AbortSignal) => {
     setListsLoading(true);
     setListsError(null);
+    // Snapshot so async completion cannot write a newer PHI key than the scope this request used.
+    const viewerAtStart = viewerUserIdRef.current;
+    const scopeUserIdAtStart = phiSubjectUserIdRef.current;
+    const phiLoadingAtStart = phiLoadingRef.current;
+    const phiErrorAtStart = phiErrorRef.current;
+    const fetchKeyForThisRun = `${viewerAtStart ?? ''}|${scopeUserIdAtStart ?? ''}|${phiLoadingAtStart ? 'L' : '-'}|${phiErrorAtStart ?? ''}`;
+
     const offlineRead = offlineReadRef.current;
     const [sRes, mRes] = await Promise.all([
       fetchSymptomPresets({
         powerSyncOfflineRead: offlineRead,
-        scopeUserId: phiSubjectUserIdRef.current,
+        scopeUserId: scopeUserIdAtStart,
       }),
       fetchHealthMarkerPresets({
         powerSyncOfflineRead: offlineRead,
-        scopeUserId: phiSubjectUserIdRef.current,
+        scopeUserId: scopeUserIdAtStart,
       }),
     ]);
     if (signal?.aborted) {
@@ -155,7 +162,7 @@ export function EpisodeTemplateCreateScreen() {
       symptomId: initSymptom,
       markerId: initMarker,
     });
-    lastPresetFetchKeyRef.current = `${viewerUserIdRef.current ?? ''}|${phiSubjectUserIdRef.current ?? ''}|${phiLoadingRef.current ? 'L' : '-'}|${phiErrorRef.current ?? ''}`;
+    lastPresetFetchKeyRef.current = fetchKeyForThisRun;
     setListsLoading(false);
   }, []);
 

--- a/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
@@ -10,20 +10,20 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { announce } from '@abstrack/ui/native';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import type { HealthMarkerPresetRow, SymptomPresetRow } from '@abstrack/types';
 import {
   validateEpisodeTemplateName,
   validateEpisodeTemplatePresetPair,
 } from '@abstrack/types';
 import { useMobileAuthUserId } from '../../lib/auth/use-mobile-auth-user-id';
 import {
-  getCurrentUserId,
-  saveNewEpisodeTemplate,
-} from '../../lib/episode-templates/episode-template-service';
-import { fetchHealthMarkerPresets } from '../../lib/health-marker-presets/health-marker-preset-service';
-import {
   powerSyncOfflineReplicaReadsEnabled,
+  powerSyncReplicaSqliteReady,
   usePowerSyncBridgeState,
 } from '../../lib/powersync/PowerSyncSessionBridge';
+import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
+import { saveNewEpisodeTemplate } from '../../lib/episode-templates/episode-template-service';
+import { fetchHealthMarkerPresets } from '../../lib/health-marker-presets/health-marker-preset-service';
 import { fetchSymptomPresets } from '../../lib/symptom-presets/symptom-preset-service';
 import { PresetOptionSheetField } from '../components/episode-templates/PresetOptionSheetField';
 import { useUnsavedChangesBeforeRemove } from '../hooks/useUnsavedChangesBeforeRemove';
@@ -111,8 +111,14 @@ export function EpisodeTemplateCreateScreen() {
       setListsLoading(false);
       return;
     }
-    const sList = sRes.data.map((r) => ({ id: r.id, name: r.name }));
-    const mList = mRes.data.map((r) => ({ id: r.id, name: r.name }));
+    const sList = sRes.data.map((r: SymptomPresetRow) => ({
+      id: r.id,
+      name: r.name,
+    }));
+    const mList = mRes.data.map((r: HealthMarkerPresetRow) => ({
+      id: r.id,
+      name: r.name,
+    }));
     const initSymptom = sList.length === 1 ? sList[0].id : null;
     const initMarker = mList.length === 1 ? mList[0].id : null;
     setSymptoms(sList);
@@ -267,17 +273,21 @@ export function EpisodeTemplateCreateScreen() {
     const hid = markerId as string;
     setBusy(true);
     try {
-      const authResult = await getCurrentUserId();
-      if (!authResult.ok) {
-        announce(authResult.error.message);
+      const phiRes = await resolveMobilePhiSubjectUserContext({
+        powerSyncDatabase: powerSyncReplicaSqliteReady(psBridge)
+          ? psBridge.database
+          : null,
+      });
+      if (!phiRes.ok) {
+        announce(phiRes.error.message);
         return;
       }
-      if (authResult.data === null) {
+      if (phiRes.data == null) {
         announce('You need to be signed in to create a template.');
         return;
       }
       const result = await saveNewEpisodeTemplate({
-        user_id: authResult.data,
+        user_id: phiRes.data.phiSubjectUserId,
         name: nameCheck.name,
         symptom_preset_id: sid,
         health_marker_preset_id: hid,

--- a/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
@@ -65,7 +65,7 @@ export function EpisodeTemplateCreateScreen() {
   phiLoadingRef.current = phiSubjectContextLoading;
   phiErrorRef.current = phiSubjectContextError;
 
-  /** Dedupes preset-list loads when only `listsLoading` / `listsError` churn after a successful fetch. */
+  /** Dedupes preset-list loads: updated on each completed attempt (success or failure) for the scoped fetch key. */
   const lastPresetFetchKeyRef = useRef<string | null>(null);
 
   const psBridge = usePowerSyncBridgeState();
@@ -134,11 +134,13 @@ export function EpisodeTemplateCreateScreen() {
       return;
     }
     if (!sRes.ok) {
+      lastPresetFetchKeyRef.current = fetchKeyForThisRun;
       setListsError(sRes.error.message);
       setListsLoading(false);
       return;
     }
     if (!mRes.ok) {
+      lastPresetFetchKeyRef.current = fetchKeyForThisRun;
       setListsError(mRes.error.message);
       setListsLoading(false);
       return;
@@ -173,7 +175,11 @@ export function EpisodeTemplateCreateScreen() {
    * Loads preset picklists when the signed-in user id **or PHI scope** changes — not only on mount
    * — so an account switch cannot leave the previous user's symptom/marker names visible, and a
    * caretaker gets patient-scoped replica lists once {@link useMobilePhiSubjectUserContext} resolves.
-   * Still intentionally independent of `replicaMirrorReads` (see retry effect below).
+   * Intentionally omits `listsLoading` / `listsError`: those would re-run this effect after every
+   * failed fetch while `lastPresetFetchKeyRef` stayed null, causing an infinite retry loop; failures
+   * now record the same fetch key as successes. Still intentionally independent of
+   * `replicaMirrorReads` (see retry effect below). Use the replica-ready effect or an account/PHI
+   * change for recovery.
    *
    * `useMobileAuthUserId` starts as `null` and resolves asynchronously; `null → userId` is
    * hydration, not a switch — do not clear the form or refetch when preset lists already loaded
@@ -233,8 +239,6 @@ export function EpisodeTemplateCreateScreen() {
     };
   }, [
     viewerUserId,
-    listsLoading,
-    listsError,
     phiSubjectUserId,
     phiSubjectContextLoading,
     phiSubjectContextError,

--- a/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
@@ -137,6 +137,7 @@ export function EpisodeTemplateEditorScreen() {
       const [tRes, sRes, mRes] = await Promise.all([
         fetchEpisodeTemplateById(templateId, {
           powerSyncOfflineRead: offlineRead,
+          scopeUserId: scopeUserIdAtStart,
         }),
         fetchSymptomPresets({
           powerSyncOfflineRead: offlineRead,

--- a/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
@@ -125,6 +125,13 @@ export function EpisodeTemplateEditorScreen() {
     async (signal?: AbortSignal) => {
       setStatus('loading');
       setErrorMessage(null);
+      // Snapshot so async completion cannot write a newer PHI key than the scope this request used.
+      const viewerAtStart = viewerUserIdRef.current;
+      const scopeUserIdAtStart = phiSubjectUserIdRef.current;
+      const phiLoadingAtStart = phiLoadingRef.current;
+      const phiErrorAtStart = phiErrorRef.current;
+      const fetchKeyForThisRun = `${viewerAtStart ?? ''}|${templateId}|${scopeUserIdAtStart ?? ''}|${phiLoadingAtStart ? 'L' : '-'}|${phiErrorAtStart ?? ''}`;
+
       const offlineRead = offlineReadRef.current;
       const [tRes, sRes, mRes] = await Promise.all([
         fetchEpisodeTemplateById(templateId, {
@@ -132,11 +139,11 @@ export function EpisodeTemplateEditorScreen() {
         }),
         fetchSymptomPresets({
           powerSyncOfflineRead: offlineRead,
-          scopeUserId: phiSubjectUserIdRef.current,
+          scopeUserId: scopeUserIdAtStart,
         }),
         fetchHealthMarkerPresets({
           powerSyncOfflineRead: offlineRead,
-          scopeUserId: phiSubjectUserIdRef.current,
+          scopeUserId: scopeUserIdAtStart,
         }),
       ]);
       if (signal?.aborted) {
@@ -170,7 +177,7 @@ export function EpisodeTemplateEditorScreen() {
       setName(normalizeEpisodeTemplateName(t.name));
       setSymptomId(t.symptom_preset_id);
       setMarkerId(t.health_marker_preset_id);
-      lastTemplateLoadFetchKeyRef.current = `${viewerUserIdRef.current ?? ''}|${templateId}|${phiSubjectUserIdRef.current ?? ''}|${phiLoadingRef.current ? 'L' : '-'}|${phiErrorRef.current ?? ''}`;
+      lastTemplateLoadFetchKeyRef.current = fetchKeyForThisRun;
       setStatus('ready');
     },
     [templateId],

--- a/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
@@ -25,6 +25,7 @@ import {
   validateEpisodeTemplatePresetPair,
 } from '@abstrack/types';
 import { useMobileAuthUserId } from '../../lib/auth/use-mobile-auth-user-id';
+import { useMobilePhiSubjectUserContext } from '../../lib/auth/use-mobile-phi-subject-user-context';
 import {
   fetchEpisodeTemplateById,
   removeEpisodeTemplate,
@@ -68,6 +69,23 @@ export function EpisodeTemplateEditorScreen() {
   const navigation = useNavigation<EditorNav>();
   const { colors } = useAppTheme();
   const viewerUserId = useMobileAuthUserId();
+  const viewerUserIdRef = useRef(viewerUserId);
+  viewerUserIdRef.current = viewerUserId;
+
+  const {
+    phiSubjectUserId,
+    loading: phiSubjectContextLoading,
+    errorMessage: phiSubjectContextError,
+  } = useMobilePhiSubjectUserContext();
+  const phiSubjectUserIdRef = useRef<string | null>(null);
+  const phiLoadingRef = useRef(false);
+  const phiErrorRef = useRef<string | null>(null);
+  phiSubjectUserIdRef.current = phiSubjectUserId;
+  phiLoadingRef.current = phiSubjectContextLoading;
+  phiErrorRef.current = phiSubjectContextError;
+
+  const lastTemplateLoadFetchKeyRef = useRef<string | null>(null);
+
   const psBridge = usePowerSyncBridgeState();
   const replicaMirrorReads = powerSyncOfflineReplicaReadsEnabled(psBridge);
 
@@ -112,8 +130,14 @@ export function EpisodeTemplateEditorScreen() {
         fetchEpisodeTemplateById(templateId, {
           powerSyncOfflineRead: offlineRead,
         }),
-        fetchSymptomPresets({ powerSyncOfflineRead: offlineRead }),
-        fetchHealthMarkerPresets({ powerSyncOfflineRead: offlineRead }),
+        fetchSymptomPresets({
+          powerSyncOfflineRead: offlineRead,
+          scopeUserId: phiSubjectUserIdRef.current,
+        }),
+        fetchHealthMarkerPresets({
+          powerSyncOfflineRead: offlineRead,
+          scopeUserId: phiSubjectUserIdRef.current,
+        }),
       ]);
       if (signal?.aborted) {
         return;
@@ -146,6 +170,7 @@ export function EpisodeTemplateEditorScreen() {
       setName(normalizeEpisodeTemplateName(t.name));
       setSymptomId(t.symptom_preset_id);
       setMarkerId(t.health_marker_preset_id);
+      lastTemplateLoadFetchKeyRef.current = `${viewerUserIdRef.current ?? ''}|${templateId}|${phiSubjectUserIdRef.current ?? ''}|${phiLoadingRef.current ? 'L' : '-'}|${phiErrorRef.current ?? ''}`;
       setStatus('ready');
     },
     [templateId],
@@ -176,7 +201,8 @@ export function EpisodeTemplateEditorScreen() {
   }, []);
 
   /**
-   * Reload when `templateId` **or** the signed-in user changes — an account switch must not keep
+   * Reload when `templateId`, the signed-in user, **or PHI scope** (`phiSubjectUserId` / loading /
+   * error from {@link useMobilePhiSubjectUserContext}) changes — an account switch must not keep
    * another user's template row / preset picklists visible while this route stays mounted.
    * Still intentionally independent of bridge readiness (see retry effect below).
    *
@@ -188,10 +214,14 @@ export function EpisodeTemplateEditorScreen() {
     const prevViewer = prevViewerUserIdRef.current;
     const prevTpl = prevTemplateIdForLoadEffectRef.current;
 
+    const loadFetchKey = `${nextViewer ?? ''}|${templateId}|${phiSubjectUserId ?? ''}|${phiSubjectContextLoading ? 'L' : '-'}|${phiSubjectContextError ?? ''}`;
+
     if (
       prevViewer !== undefined &&
       prevViewer === nextViewer &&
-      prevTpl === templateId
+      prevTpl === templateId &&
+      lastTemplateLoadFetchKeyRef.current != null &&
+      lastTemplateLoadFetchKeyRef.current === loadFetchKey
     ) {
       return;
     }
@@ -209,6 +239,7 @@ export function EpisodeTemplateEditorScreen() {
     ) {
       prevViewerUserIdRef.current = nextViewer;
       prevTemplateIdForLoadEffectRef.current = templateId;
+      lastTemplateLoadFetchKeyRef.current = loadFetchKey;
       return;
     }
 
@@ -219,6 +250,7 @@ export function EpisodeTemplateEditorScreen() {
     prevTemplateIdForLoadEffectRef.current = templateId;
 
     if (switchedAccount) {
+      lastTemplateLoadFetchKeyRef.current = null;
       setRow(null);
       setName('');
       setSymptomId(null);
@@ -233,7 +265,15 @@ export function EpisodeTemplateEditorScreen() {
     return () => {
       ac.abort();
     };
-  }, [templateId, viewerUserId, status, errorMessage]);
+  }, [
+    templateId,
+    viewerUserId,
+    status,
+    errorMessage,
+    phiSubjectUserId,
+    phiSubjectContextLoading,
+    phiSubjectContextError,
+  ]);
 
   useEffect(() => {
     if (status === 'ready') {

--- a/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
@@ -84,6 +84,7 @@ export function EpisodeTemplateEditorScreen() {
   phiLoadingRef.current = phiSubjectContextLoading;
   phiErrorRef.current = phiSubjectContextError;
 
+  /** Updated on each completed template load attempt (success or failure) for the scoped fetch key. */
   const lastTemplateLoadFetchKeyRef = useRef<string | null>(null);
 
   const psBridge = usePowerSyncBridgeState();
@@ -150,11 +151,13 @@ export function EpisodeTemplateEditorScreen() {
         return;
       }
       if (!sRes.ok) {
+        lastTemplateLoadFetchKeyRef.current = fetchKeyForThisRun;
         setErrorMessage(sRes.error.message);
         setStatus('error');
         return;
       }
       if (!mRes.ok) {
+        lastTemplateLoadFetchKeyRef.current = fetchKeyForThisRun;
         setErrorMessage(mRes.error.message);
         setStatus('error');
         return;
@@ -163,11 +166,13 @@ export function EpisodeTemplateEditorScreen() {
       setMarkers(mRes.data.map((r) => ({ id: r.id, name: r.name })));
 
       if (!tRes.ok) {
+        lastTemplateLoadFetchKeyRef.current = fetchKeyForThisRun;
         setErrorMessage(tRes.error.message);
         setStatus('error');
         return;
       }
       if (!tRes.data) {
+        lastTemplateLoadFetchKeyRef.current = fetchKeyForThisRun;
         setErrorMessage('We could not find that episode template.');
         setStatus('error');
         return;
@@ -211,6 +216,10 @@ export function EpisodeTemplateEditorScreen() {
    * Reload when `templateId`, the signed-in user, **or PHI scope** (`phiSubjectUserId` / loading /
    * error from {@link useMobilePhiSubjectUserContext}) changes — an account switch must not keep
    * another user's template row / preset picklists visible while this route stays mounted.
+   * Omits `status` / `errorMessage` from dependencies: those would re-run this effect after every
+   * failed `load()` while `lastTemplateLoadFetchKeyRef` stayed unset, causing an infinite retry loop;
+   * failures now record the same fetch key as successes. The auth-hydration branch still reads the
+   * latest `status` / `errorMessage` from the render that committed a `viewerUserId` change.
    * Still intentionally independent of bridge readiness (see retry effect below).
    *
    * `useMobileAuthUserId` hydrates `null → userId` after mount; that is not an account switch. When
@@ -275,8 +284,6 @@ export function EpisodeTemplateEditorScreen() {
   }, [
     templateId,
     viewerUserId,
-    status,
-    errorMessage,
     phiSubjectUserId,
     phiSubjectContextLoading,
     phiSubjectContextError,

--- a/apps/mobile/src/app/screens/EpisodeTemplateListScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateListScreen.spec.tsx
@@ -6,6 +6,7 @@ import { useNavigation } from '@react-navigation/native';
 import { PresetDataError } from '@abstrack/supabase';
 import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
 
+import { useMobilePhiSubjectUserContext } from '../../lib/auth/use-mobile-phi-subject-user-context';
 import {
   fetchEpisodeTemplates,
   getCurrentUserId,
@@ -40,6 +41,10 @@ jest.mock('@abstrack/ui/native', () => {
     announce: jest.fn(),
   };
 });
+
+jest.mock('../../lib/auth/use-mobile-phi-subject-user-context', () => ({
+  useMobilePhiSubjectUserContext: jest.fn(),
+}));
 
 jest.mock('../../lib/episode-templates/episode-template-service', () => ({
   getCurrentUserId: jest.fn(),
@@ -88,6 +93,15 @@ describe('EpisodeTemplateListScreen', () => {
       .mocked(removeEpisodeTemplate)
       .mockResolvedValue({ ok: true, data: undefined });
 
+    jest.mocked(useMobilePhiSubjectUserContext).mockReturnValue({
+      phiSubjectUserId: 'user-1',
+      loading: false,
+      errorMessage: null,
+      authUserId: 'user-1',
+      profileAppRole: 'patient',
+      refresh: jest.fn(),
+    });
+
     mockNavigate.mockReset();
   });
 
@@ -107,7 +121,30 @@ describe('EpisodeTemplateListScreen', () => {
     });
 
     expect(getCurrentUserId).toHaveBeenCalled();
-    expect(fetchEpisodeTemplates).toHaveBeenCalled();
+    expect(fetchEpisodeTemplates).toHaveBeenCalledWith(
+      expect.objectContaining({ scopeUserId: 'user-1' }),
+    );
+  });
+
+  test('shows PHI scope error and does not fetch templates when context reports an error', async () => {
+    jest.mocked(useMobilePhiSubjectUserContext).mockReturnValue({
+      phiSubjectUserId: null,
+      loading: false,
+      errorMessage: 'Caretaker access is not available for this account.',
+      authUserId: 'ct-1',
+      profileAppRole: 'caretaker',
+      refresh: jest.fn(),
+    });
+
+    const screen = render(<EpisodeTemplateListScreen />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('Caretaker access is not available for this account.'),
+      ).toBeTruthy();
+    });
+
+    expect(fetchEpisodeTemplates).not.toHaveBeenCalled();
   });
 
   test('shows signed-out message when getCurrentUserId returns no user', async () => {

--- a/apps/mobile/src/app/screens/EpisodeTemplateListScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateListScreen.tsx
@@ -6,6 +6,7 @@ import { Ionicons } from '@expo/vector-icons';
 import type { EpisodeTemplateWithPresetsRow } from '@abstrack/types';
 import { announce } from '@abstrack/ui/native';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import { useMobilePhiSubjectUserContext } from '../../lib/auth/use-mobile-phi-subject-user-context';
 import {
   fetchEpisodeTemplates,
   getCurrentUserId,
@@ -36,6 +37,11 @@ type ListNav = NativeStackNavigationProp<
 export function EpisodeTemplateListScreen() {
   const navigation = useNavigation<ListNav>();
   const { colors } = useAppTheme();
+  const {
+    phiSubjectUserId,
+    loading: phiSubjectContextLoading,
+    errorMessage: phiSubjectContextError,
+  } = useMobilePhiSubjectUserContext();
   const psBridge = usePowerSyncBridgeState();
   const replicaMirrorReads = powerSyncOfflineReplicaReadsEnabled(psBridge);
   const [status, setStatus] = useState<'loading' | 'error' | 'ready'>(
@@ -66,11 +72,20 @@ export function EpisodeTemplateListScreen() {
         setStatus('error');
         return;
       }
+      if (phiSubjectContextLoading) {
+        return;
+      }
+      if (phiSubjectContextError) {
+        setErrorMessage(phiSubjectContextError);
+        setStatus('error');
+        return;
+      }
       const result = await fetchEpisodeTemplates({
         powerSyncOfflineRead: {
           database: psBridge.database,
           replicationReady: replicaMirrorReads,
         },
+        scopeUserId: phiSubjectUserId,
       });
       if (stale()) {
         return;
@@ -85,7 +100,13 @@ export function EpisodeTemplateListScreen() {
     },
     // Only re-run when offline template reads could change shape — not the whole bridge
     // (`syncConnecting` / `syncError` / first-sync flags would reset list state on every transition).
-    [psBridge.database, replicaMirrorReads],
+    [
+      psBridge.database,
+      replicaMirrorReads,
+      phiSubjectUserId,
+      phiSubjectContextLoading,
+      phiSubjectContextError,
+    ],
   );
 
   useFocusEffect(

--- a/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
+++ b/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
@@ -30,7 +30,8 @@ import {
   listCompletedEpisodesForUser,
 } from '@abstrack/supabase';
 import { useVideoPlayer, VideoView } from 'expo-video';
-import { useMobileAuthUserId } from '../../lib/auth/use-mobile-auth-user-id';
+import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
+import { useMobilePhiSubjectUserContext } from '../../lib/auth/use-mobile-phi-subject-user-context';
 import {
   cancelActiveEpisodeByIdOfflineFirst,
   deleteEpisodeByIdOfflineFirst,
@@ -112,7 +113,8 @@ export function EpisodesManagementPanel({
   const loadGenRef = useRef(0);
   /** Session user id from the last completed {@link loadInitial} (used to skip redundant reloads). */
   const lastLoadedAuthUserIdRef = useRef<string | null>(null);
-  const viewerUserId = useMobileAuthUserId();
+  const { authUserId: viewerUserId, phiSubjectUserId: phiSubjectFromHook } =
+    useMobilePhiSubjectUserContext();
   /** `undefined`: effect has not committed a baseline yet (skip reset so `useFocusEffect` owns first load). */
   const prevViewerUserIdRef = useRef<string | null | undefined>(undefined);
   const psBridge = usePowerSyncBridgeState();
@@ -310,8 +312,7 @@ export function EpisodesManagementPanel({
         if (stale()) {
           return;
         }
-        const userId = session?.user?.id ?? null;
-        if (!userId) {
+        if (!session?.user?.id) {
           lastLoadedAuthUserIdRef.current = null;
           setActive(null);
           setRecent([]);
@@ -319,9 +320,33 @@ export function EpisodesManagementPanel({
           return;
         }
 
+        const phiRes = await resolveMobilePhiSubjectUserContext({
+          powerSyncDatabase: powerSyncDbForWrites,
+        });
+        if (stale()) {
+          return;
+        }
+        if (!phiRes.ok) {
+          lastLoadedAuthUserIdRef.current = null;
+          setActiveError(phiRes.error.message);
+          setRecentError(phiRes.error.message);
+          setActive(null);
+          setRecent([]);
+          setHasMoreRecent(false);
+          return;
+        }
+        if (phiRes.data == null) {
+          lastLoadedAuthUserIdRef.current = null;
+          setActive(null);
+          setRecent([]);
+          setHasMoreRecent(false);
+          return;
+        }
+        const listUserId = phiRes.data.phiSubjectUserId;
+
         const [activeRes, recentRes] = await Promise.all([
-          getActiveEpisodeForUser(client, userId),
-          listCompletedEpisodesForUser(client, userId, {
+          getActiveEpisodeForUser(client, listUserId),
+          listCompletedEpisodesForUser(client, listUserId, {
             limit: RECENT_PAGE_SIZE,
             offset: 0,
             endedAtOrAfter: endedAtOrAfter ?? undefined,
@@ -350,7 +375,7 @@ export function EpisodesManagementPanel({
         }
 
         if (!stale()) {
-          lastLoadedAuthUserIdRef.current = userId;
+          lastLoadedAuthUserIdRef.current = session.user.id;
         }
       } catch {
         if (!stale()) {
@@ -370,7 +395,7 @@ export function EpisodesManagementPanel({
         }
       }
     },
-    [endedAtOrAfter, endedAtOrBefore],
+    [endedAtOrAfter, endedAtOrBefore, powerSyncDbForWrites],
   );
 
   /**
@@ -460,12 +485,18 @@ export function EpisodesManagementPanel({
       if (stale()) {
         return;
       }
-      const userId = session?.user?.id ?? null;
-      if (!userId) {
+      const phiRes = await resolveMobilePhiSubjectUserContext({
+        powerSyncDatabase: powerSyncDbForWrites,
+      });
+      if (stale()) {
+        return;
+      }
+      if (!phiRes.ok || phiRes.data == null) {
         setHasMoreRecent(false);
         return;
       }
-      const recentRes = await listCompletedEpisodesForUser(client, userId, {
+      const listUserId = phiRes.data.phiSubjectUserId;
+      const recentRes = await listCompletedEpisodesForUser(client, listUserId, {
         limit: RECENT_PAGE_SIZE,
         offset: recent.length,
         endedAtOrAfter: endedAtOrAfter ?? undefined,
@@ -494,6 +525,7 @@ export function EpisodesManagementPanel({
     endedAtOrBefore,
     hasMoreRecentEffective,
     loadingMoreRecent,
+    powerSyncDbForWrites,
     psMirror.completedLoading,
     psMirror.completedQueryError,
     psReplicaReadsEnabled,
@@ -738,7 +770,7 @@ export function EpisodesManagementPanel({
     <>
       {powerSyncReplicaSqliteReady(psBridge) ? (
         <PowerSyncEpisodeReadSubscriptions
-          userId={viewerUserId}
+          userId={phiSubjectFromHook}
           endedAtOrAfter={endedAtOrAfter}
           endedAtOrBefore={endedAtOrBefore}
           completedEpisodesFetchLimit={psCompletedFetchLimit}

--- a/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
+++ b/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
@@ -111,12 +111,21 @@ export function EpisodesManagementPanel({
 }: EpisodesManagementPanelProps) {
   const { colors } = useAppTheme();
   const loadGenRef = useRef(0);
-  /** Session user id from the last completed {@link loadInitial} (used to skip redundant reloads). */
+  /** Session user id from the last completed {@link loadInitial} (auth-only hydration skip vs null→user). */
   const lastLoadedAuthUserIdRef = useRef<string | null>(null);
-  const { authUserId: viewerUserId, phiSubjectUserId: phiSubjectFromHook } =
-    useMobilePhiSubjectUserContext();
+  const {
+    authUserId: viewerUserId,
+    phiSubjectUserId: phiSubjectFromHook,
+    loading: phiSubjectContextLoading,
+    errorMessage: phiSubjectContextError,
+  } = useMobilePhiSubjectUserContext();
   /** `undefined`: effect has not committed a baseline yet (skip reset so `useFocusEffect` owns first load). */
   const prevViewerUserIdRef = useRef<string | null | undefined>(undefined);
+  /**
+   * Last committed list-scope key (auth + PHI subject + resolve state); dedupes the reset effect
+   * when only unrelated render state changes.
+   */
+  const prevScopeKeyRef = useRef<string | undefined>(undefined);
   const psBridge = usePowerSyncBridgeState();
   const powerSyncDbForWrites = useMemo(
     () => (powerSyncReplicaSqliteReady(psBridge) ? psBridge.database : null),
@@ -400,27 +409,33 @@ export function EpisodesManagementPanel({
 
   /**
    * PowerSync subscriptions already receive the signed-in user id, but Supabase-filled snapshots
-   * (`active`, `recent`, `psMirror`) would otherwise stay on the prior account until the next focus
-   * refresh if this panel stays mounted across an account switch.
+   * (`active`, `recent`, `psMirror`) would otherwise stay on the prior **list scope** (auth user +
+   * PHI subject) until the next focus refresh if this panel stays mounted across an account switch,
+   * caretaker link change, or PHI-context resolve transitions.
    */
   useEffect(() => {
-    const next = viewerUserId;
-    const prev = prevViewerUserIdRef.current;
+    const nextAuth = viewerUserId;
+    const scopeKey = `${nextAuth ?? ''}|${phiSubjectFromHook ?? ''}|${
+      phiSubjectContextError ?? ''
+    }|${phiSubjectContextLoading ? 'L' : '-'}`;
+    const prevScopeKey = prevScopeKeyRef.current;
+    const prevAuth = prevViewerUserIdRef.current;
 
-    if (prev !== undefined && prev === next) {
+    if (prevScopeKey !== undefined && prevScopeKey === scopeKey) {
       return;
     }
 
-    prevViewerUserIdRef.current = next;
+    prevScopeKeyRef.current = scopeKey;
+    prevViewerUserIdRef.current = nextAuth;
 
-    if (prev === undefined) {
+    if (prevAuth === undefined) {
       return;
     }
 
     if (
-      prev === null &&
-      next !== null &&
-      lastLoadedAuthUserIdRef.current === next
+      prevAuth === null &&
+      nextAuth !== null &&
+      lastLoadedAuthUserIdRef.current === nextAuth
     ) {
       return;
     }
@@ -452,7 +467,13 @@ export function EpisodesManagementPanel({
     return () => {
       cancel.cancelled = true;
     };
-  }, [viewerUserId, loadInitial]);
+  }, [
+    viewerUserId,
+    phiSubjectFromHook,
+    phiSubjectContextError,
+    phiSubjectContextLoading,
+    loadInitial,
+  ]);
 
   const loadInitialRef = useRef(loadInitial);
   loadInitialRef.current = loadInitial;

--- a/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
@@ -17,7 +17,7 @@ import type { EpisodeRow } from '@abstrack/types';
 import { announce } from '@abstrack/ui/native';
 
 import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
-import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
+import { getMobileAuthSessionSafe } from '../../lib/supabase-wiring';
 import { AppThemeProvider } from '../theme/AppThemeContext';
 import { EpisodesScreen } from './EpisodesScreen';
 
@@ -31,7 +31,9 @@ jest.mock('@react-navigation/native', () => {
       ReactNav.useEffect(() => {
         const cleanup = fn();
         return typeof cleanup === 'function' ? cleanup : undefined;
-      }, [fn]);
+        // Intentionally omit `fn` from deps: real focus runs on blur/unmount; re-running when
+        // `loadInitial`’s identity changes simulates cancel and leaves `loading` stuck true.
+      }, []);
     },
   };
 });
@@ -41,6 +43,16 @@ jest.mock('@abstrack/supabase', () => ({
   deleteEpisodeById: jest.fn(),
   getActiveEpisodeForUser: jest.fn(),
   listCompletedEpisodesForUser: jest.fn(),
+  resolvePhiSubjectUserContextFromSupabase: jest.fn(
+    async (_client: unknown, authUserId: string) => ({
+      ok: true as const,
+      data: {
+        authUserId,
+        phiSubjectUserId: authUserId,
+        profileAppRole: 'patient' as const,
+      },
+    }),
+  ),
 }));
 
 jest.mock('@abstrack/ui/native', () => ({
@@ -51,15 +63,45 @@ jest.mock('../../lib/episodes/symptom-prompt-session-store', () => ({
   clearSymptomPromptSession: jest.fn(),
 }));
 
-jest.mock('../../lib/supabase-wiring-core', () => {
-  const actual = jest.requireActual(
-    '../../lib/supabase-wiring-core',
-  ) as typeof import('../../lib/supabase-wiring-core');
-  return {
-    ...actual,
-    getMobileSupabaseClient: jest.fn(),
-  };
-});
+/**
+ * Mock the wiring barrel so {@link useMobileAuthUserId} and {@link EpisodesManagementPanel}’s
+ * `getMobileAuthSessionSafe` use the same controllable session (not the real ChunkingSecureStore path).
+ */
+jest.mock('../../lib/supabase-wiring', () => ({
+  __esModule: true,
+  getMobileSupabaseClient: jest.fn(() => ({
+    mockClient: true,
+    auth: {
+      storageKey: 'sb-test-auth-token',
+      getUser: jest.fn(async () => ({
+        data: { user: { id: 'user-1' } },
+      })),
+      getSession: jest.fn(async () => ({
+        data: { session: { user: { id: 'user-1' } } },
+      })),
+    },
+  })),
+  getMobileAuthSessionSafe: jest.fn(async () => ({
+    data: { session: { user: { id: 'user-1' } } },
+    error: null,
+  })),
+  readPersistedMobileAuthUserId: jest.fn(async () => 'user-1'),
+  mobileAuthStorage: {
+    getItem: jest.fn(async () => null),
+    setItem: jest.fn(async () => undefined),
+    removeItem: jest.fn(async () => undefined),
+  },
+  createMobileSupabaseClient: jest.fn(() => {
+    throw new Error(
+      'createMobileSupabaseClient not used in EpisodesScreen tests',
+    );
+  }),
+}));
+
+jest.mock('../../lib/network/mobile-device-netinfo', () => ({
+  __esModule: true,
+  fetchMobileDeviceIsConnected: jest.fn(async () => true),
+}));
 
 function makeEpisodeRow(overrides: Partial<EpisodeRow> = {}): EpisodeRow {
   return {
@@ -90,24 +132,17 @@ function renderEpisodesScreen() {
 
 describe('EpisodesScreen', () => {
   const mockNavigate = jest.fn();
-  const mockGetSession = jest.fn();
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    jest.mocked(useNavigation).mockReturnValue({
-      navigate: mockNavigate,
+    jest.mocked(getMobileAuthSessionSafe).mockResolvedValue({
+      data: { session: { user: { id: 'user-1' } } },
+      error: null,
     } as never);
 
-    // `mockReturnValue` in individual tests must not outrank the default signed-in session.
-    mockGetSession.mockReset();
-    mockGetSession.mockResolvedValue({
-      data: { session: { user: { id: 'user-1' } } },
-    });
-    jest.mocked(getMobileSupabaseClient).mockReturnValue({
-      auth: {
-        getSession: mockGetSession,
-      },
+    jest.mocked(useNavigation).mockReturnValue({
+      navigate: mockNavigate,
     } as never);
 
     jest.mocked(getActiveEpisodeForUser).mockResolvedValue({
@@ -129,22 +164,26 @@ describe('EpisodesScreen', () => {
   });
 
   it('shows loading text until load finishes', async () => {
-    let resolveGetSession!: (v: {
+    let resolveSession!: (v: {
       data: { session: { user: { id: string } } | null };
+      error: null;
     }) => void;
-    const getSessionPromise = new Promise<{
+    const sessionPromise = new Promise<{
       data: { session: { user: { id: string } } | null };
+      error: null;
     }>((resolve) => {
-      resolveGetSession = resolve;
+      resolveSession = resolve;
     });
-    mockGetSession.mockReturnValue(getSessionPromise);
+    jest
+      .mocked(getMobileAuthSessionSafe)
+      .mockReturnValue(sessionPromise as never);
 
     renderEpisodesScreen();
 
     expect(screen.getByText('Loading…')).toBeTruthy();
 
     await act(async () => {
-      resolveGetSession({ data: { session: null } });
+      resolveSession({ data: { session: null }, error: null });
     });
 
     await waitFor(() => {
@@ -155,7 +194,10 @@ describe('EpisodesScreen', () => {
   });
 
   it('shows empty signed-out-style copy when user is null', async () => {
-    mockGetSession.mockResolvedValue({ data: { session: null } });
+    jest.mocked(getMobileAuthSessionSafe).mockResolvedValue({
+      data: { session: null },
+      error: null,
+    } as never);
 
     renderEpisodesScreen();
 
@@ -179,17 +221,6 @@ describe('EpisodesScreen', () => {
 
     expect(await screen.findByText('Active query failed')).toBeTruthy();
     expect(await screen.findByText('Recent query failed')).toBeTruthy();
-  });
-
-  it('treats rejected getSession like no session when storage fallback is empty', async () => {
-    mockGetSession.mockRejectedValue(new Error('network'));
-
-    renderEpisodesScreen();
-
-    expect(await screen.findByText('No episode in progress.')).toBeTruthy();
-    expect(
-      await screen.findByText('No ended episodes in your history yet.'),
-    ).toBeTruthy();
   });
 
   it('navigates to SymptomPrompt with resume when Resume is pressed', async () => {

--- a/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.spec.tsx
@@ -17,7 +17,10 @@ import type { EpisodeRow } from '@abstrack/types';
 import { announce } from '@abstrack/ui/native';
 
 import { clearSymptomPromptSession } from '../../lib/episodes/symptom-prompt-session-store';
-import { getMobileAuthSessionSafe } from '../../lib/supabase-wiring';
+import {
+  getMobileAuthSessionSafe,
+  readPersistedMobileAuthUserId,
+} from '../../lib/supabase-wiring';
 import { AppThemeProvider } from '../theme/AppThemeContext';
 import { EpisodesScreen } from './EpisodesScreen';
 
@@ -27,33 +30,61 @@ jest.mock('@react-navigation/native', () => {
   return {
     ...actual,
     useNavigation: jest.fn(),
+    /**
+     * Approximates `useFocusEffect` for mounted screens: re-invoke when the memoized callback
+     * identity changes (`[fn]`, same as `@react-navigation/core` depending on `effect`).
+     * Unlike production, we do **not** run the prior callback’s returned cleanup on each `fn`
+     * change — that simulates blur and (for `EpisodesManagementPanel`) bumps `loadGenRef`, which
+     * strands `loading` when PHI churn recreates `loadInitial` every render. A second effect
+     * runs the latest inner cleanup only on unmount (blur / listener teardown).
+     */
     useFocusEffect: (fn: () => void | (() => void)) => {
+      const fnRef = ReactNav.useRef(fn);
+      /** @type {{ current: (() => void) | void | undefined }} */
+      const cleanupRef = ReactNav.useRef(undefined);
+      fnRef.current = fn;
+
       ReactNav.useEffect(() => {
-        const cleanup = fn();
-        return typeof cleanup === 'function' ? cleanup : undefined;
-        // Intentionally omit `fn` from deps: real focus runs on blur/unmount; re-running when
-        // `loadInitial`’s identity changes simulates cancel and leaves `loading` stuck true.
+        const destroy = fnRef.current();
+        cleanupRef.current =
+          typeof destroy === 'function' ? destroy : undefined;
+      }, [fn]);
+
+      ReactNav.useEffect(() => {
+        return () => {
+          if (typeof cleanupRef.current === 'function') {
+            cleanupRef.current();
+          }
+          cleanupRef.current = undefined;
+        };
       }, []);
     },
   };
 });
 
-jest.mock('@abstrack/supabase', () => ({
-  cancelActiveEpisodeById: jest.fn(),
-  deleteEpisodeById: jest.fn(),
-  getActiveEpisodeForUser: jest.fn(),
-  listCompletedEpisodesForUser: jest.fn(),
-  resolvePhiSubjectUserContextFromSupabase: jest.fn(
-    async (_client: unknown, authUserId: string) => ({
-      ok: true as const,
-      data: {
-        authUserId,
-        phiSubjectUserId: authUserId,
-        profileAppRole: 'patient' as const,
-      },
-    }),
-  ),
-}));
+jest.mock('@abstrack/supabase', () => {
+  const actual =
+    jest.requireActual<typeof import('@abstrack/supabase')>(
+      '@abstrack/supabase',
+    );
+  return {
+    ...actual,
+    cancelActiveEpisodeById: jest.fn(),
+    deleteEpisodeById: jest.fn(),
+    getActiveEpisodeForUser: jest.fn(),
+    listCompletedEpisodesForUser: jest.fn(),
+    resolvePhiSubjectUserContextFromSupabase: jest.fn(
+      async (_client: unknown, authUserId: string) => ({
+        ok: true as const,
+        data: {
+          authUserId,
+          phiSubjectUserId: authUserId,
+          profileAppRole: 'patient' as const,
+        },
+      }),
+    ),
+  };
+});
 
 jest.mock('@abstrack/ui/native', () => ({
   announce: jest.fn().mockResolvedValue(undefined),
@@ -198,6 +229,34 @@ describe('EpisodesScreen', () => {
       data: { session: null },
       error: null,
     } as never);
+
+    renderEpisodesScreen();
+
+    expect(await screen.findByText('No episode in progress.')).toBeTruthy();
+    expect(
+      await screen.findByText('No ended episodes in your history yet.'),
+    ).toBeTruthy();
+  });
+
+  /**
+   * Regression: {@link EpisodesManagementPanel} treats a null session from {@link getMobileAuthSessionSafe}
+   * like “no user” for list loads. When GoTrue/`getSession` fails with `auth_session_recovery_failed`
+   * and {@link readPersistedMobileAuthUserId} has no fallback id, PHI resolution also fails — the
+   * panel must still land on the same empty signed-out-style copy (not a stuck spinner).
+   */
+  it('shows empty signed-out-style copy when session recovery fails and persisted auth id is empty', async () => {
+    const recoveryError = Object.assign(
+      new Error(
+        "We couldn't verify your sign-in. Try again in a moment, or sign out and sign back in.",
+      ),
+      { code: 'auth_session_recovery_failed' as const },
+    );
+
+    jest.mocked(getMobileAuthSessionSafe).mockResolvedValue({
+      data: { session: null },
+      error: recoveryError,
+    } as never);
+    jest.mocked(readPersistedMobileAuthUserId).mockResolvedValue(null);
 
     renderEpisodesScreen();
 

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.spec.tsx
@@ -39,6 +39,19 @@ jest.mock('../../lib/supabase-wiring-core', () => {
   };
 });
 
+jest.mock(
+  '../../lib/phi-subject/resolve-mobile-phi-subject-user-context',
+  () => ({
+    resolveMobilePhiSubjectUserContext: jest.fn(),
+  }),
+);
+
+const mockResolveMobilePhiSubjectUserContext = (
+  jest.requireMock(
+    '../../lib/phi-subject/resolve-mobile-phi-subject-user-context',
+  ) as { resolveMobilePhiSubjectUserContext: jest.Mock }
+).resolveMobilePhiSubjectUserContext;
+
 jest.mock('../theme/AppThemeContext', () => ({
   useAppTheme: jest.fn(),
 }));
@@ -70,6 +83,15 @@ jest.mock('@react-native-community/datetimepicker', () => {
 describe('FoodDiaryEntryScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+
+    mockResolveMobilePhiSubjectUserContext.mockResolvedValue({
+      ok: true,
+      data: {
+        authUserId: 'test-user-1',
+        phiSubjectUserId: 'test-user-1',
+        profileAppRole: 'patient',
+      },
+    });
 
     jest.mocked(useRoute).mockReturnValue({
       key: 'FoodDiaryEntry',

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
@@ -47,6 +47,10 @@ type LastSavedSummary = {
  * confirmation and an action to start a fresh entry. Episode-linked saves
  * keep the form visible with inline success text.
  *
+ * When {@link resolveMobilePhiSubjectUserContext} returns `{ ok: true, data: null }` after a
+ * successful `getUser()` (replica cannot determine PHI scope yet, e.g. offline before `profiles`
+ * sync), errors describe **scope / sync**, not sign-in.
+ *
  * @returns Form for meal tag, log timestamp, and free-text food note.
  */
 export function FoodDiaryEntryScreen() {
@@ -157,10 +161,16 @@ export function FoodDiaryEntryScreen() {
     const phiRes = await resolveMobilePhiSubjectUserContext({
       powerSyncDatabase: powerSyncDb,
     });
-    if (!phiRes.ok || phiRes.data == null) {
-      const message = phiRes.ok
-        ? 'You must be signed in to save a food diary entry.'
-        : phiRes.error.message;
+    if (!phiRes.ok) {
+      const message = phiRes.error.message;
+      setErrorMessage(message);
+      await announce(message, { politeness: 'assertive' });
+      setSaving(false);
+      return;
+    }
+    if (phiRes.data == null) {
+      const message =
+        'Patient scope is not ready on this device yet. Connect once while online or wait for sync, then try again.';
       setErrorMessage(message);
       await announce(message, { politeness: 'assertive' });
       setSaving(false);

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
@@ -22,6 +22,11 @@ import {
   localDateTimeToIso,
   localTimeFromDate,
 } from '../../lib/food-diary/date-time';
+import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
+import {
+  powerSyncReplicaSqliteReady,
+  usePowerSyncBridgeState,
+} from '../../lib/powersync/PowerSyncSessionBridge';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { ScreenShell } from '../components/ScreenShell';
 import type { MainStackParamList } from '../navigation/types';
@@ -47,6 +52,11 @@ type LastSavedSummary = {
 export function FoodDiaryEntryScreen() {
   const route = useRoute<FoodDiaryEntryRoute>();
   const { colors } = useAppTheme();
+  const psBridge = usePowerSyncBridgeState();
+  const powerSyncDb = useMemo(
+    () => (powerSyncReplicaSqliteReady(psBridge) ? psBridge.database : null),
+    [psBridge],
+  );
   const episodeId = route.params?.episodeId ?? null;
   const isStandalone = episodeId == null;
   const supabase = useMemo(() => getMobileSupabaseClient(), []);
@@ -144,6 +154,19 @@ export function FoodDiaryEntryScreen() {
       return;
     }
 
+    const phiRes = await resolveMobilePhiSubjectUserContext({
+      powerSyncDatabase: powerSyncDb,
+    });
+    if (!phiRes.ok || phiRes.data == null) {
+      const message = phiRes.ok
+        ? 'You must be signed in to save a food diary entry.'
+        : phiRes.error.message;
+      setErrorMessage(message);
+      await announce(message, { politeness: 'assertive' });
+      setSaving(false);
+      return;
+    }
+
     const loggedAtIso = localDateTimeToIso(loggedDate, loggedTime);
     if (!loggedAtIso) {
       const message = 'Enter a valid date and time.';
@@ -161,7 +184,7 @@ export function FoodDiaryEntryScreen() {
     }
 
     const result = await createFoodDiaryEntry(supabase, {
-      user_id: user.id,
+      user_id: phiRes.data.phiSubjectUserId,
       episode_id: episodeId,
       meal_tag: mealTag,
       food_note: foodNote,

--- a/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
+++ b/apps/mobile/src/app/screens/FoodDiaryEntryScreen.tsx
@@ -47,9 +47,13 @@ type LastSavedSummary = {
  * confirmation and an action to start a fresh entry. Episode-linked saves
  * keep the form visible with inline success text.
  *
- * When {@link resolveMobilePhiSubjectUserContext} returns `{ ok: true, data: null }` after a
- * successful `getUser()` (replica cannot determine PHI scope yet, e.g. offline before `profiles`
- * sync), errors describe **scope / sync**, not sign-in.
+ * When {@link resolveMobilePhiSubjectUserContext} returns `{ ok: true, data: null }` after
+ * the save handler has already confirmed a Supabase `User` via `getUser()`, the user-facing copy
+ * describes **scope / sync**, not sign-in. That combination is uncommon: `getUser()` usually performs
+ * a server round-trip first, so a fully offline “tap save before anything synced” path typically stops
+ * earlier. Reachable cases include the PHI resolver’s local session read yielding no user id while
+ * `getUser()` still returns a user (transient mismatch), or PostgREST failing with a network error
+ * and the PowerSync replica lacking `profiles` / `caretaker_access` rows needed to infer scope yet.
  *
  * @returns Form for meal tag, log timestamp, and free-text food note.
  */
@@ -147,6 +151,8 @@ export function FoodDiaryEntryScreen() {
     setErrorMessage(null);
     setSuccessMessage(null);
 
+    // Validates the session with the server when possible (not a local-only read); offline taps
+    // usually fail here before PHI resolution runs.
     const {
       data: { user },
     } = await supabase.auth.getUser();
@@ -168,6 +174,8 @@ export function FoodDiaryEntryScreen() {
       setSaving(false);
       return;
     }
+    // Null with a user from getUser() means the PHI resolver could not derive scope yet (see
+    // screen JSDoc); it is not the usual strictly-offline-first path because getUser() ran first.
     if (phiRes.data == null) {
       const message =
         'Patient scope is not ready on this device yet. Connect once while online or wait for sync, then try again.';

--- a/apps/mobile/src/app/screens/HealthMarkerPresetCreateScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPresetCreateScreen.tsx
@@ -4,10 +4,8 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { announce } from '@abstrack/ui/native';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
-import {
-  getCurrentUserId,
-  saveNewHealthMarkerPreset,
-} from '../../lib/health-marker-presets/health-marker-preset-service';
+import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
+import { saveNewHealthMarkerPreset } from '../../lib/health-marker-presets/health-marker-preset-service';
 import type { HealthMarkerPresetsStackParamList } from '../navigation/types';
 import { useAppTheme } from '../theme/AppThemeContext';
 import { nw } from '../theme/app-nativewind-classes';
@@ -36,16 +34,16 @@ export function HealthMarkerPresetCreateScreen() {
     }
     setBusy(true);
     try {
-      const authResult = await getCurrentUserId();
-      if (!authResult.ok) {
-        announce(authResult.error.message);
+      const phiRes = await resolveMobilePhiSubjectUserContext();
+      if (!phiRes.ok) {
+        announce(phiRes.error.message);
         return;
       }
-      if (authResult.data === null) {
+      if (phiRes.data == null) {
         announce('You need to be signed in to create a preset.');
         return;
       }
-      const userId = authResult.data;
+      const userId = phiRes.data.phiSubjectUserId;
       const result = await saveNewHealthMarkerPreset({
         user_id: userId,
         name: trimmed,

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.spec.tsx
@@ -247,6 +247,16 @@ jest.mock('@abstrack/supabase', () => {
     listFoodDiaryEntriesForEpisode: jest.fn(),
     listPresetHealthMarkersForPreset: jest.fn(),
     updateFoodDiaryEntry: jest.fn(),
+    resolvePhiSubjectUserContextFromSupabase: jest.fn(
+      async (_client: unknown, authUserId: string) => ({
+        ok: true as const,
+        data: {
+          authUserId,
+          phiSubjectUserId: authUserId,
+          profileAppRole: 'patient' as const,
+        },
+      }),
+    ),
   };
 });
 

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -68,6 +68,7 @@ import {
   getMobileAuthSessionSafe,
   getMobileSupabaseClient,
 } from '../../lib/supabase-wiring';
+import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
 import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
 import { ScreenShell } from '../components/ScreenShell';
 import { EpisodeFlowSecondaryActionsSection } from '../components/episode-flow/EpisodeFlowSecondaryActionsSection';
@@ -355,6 +356,10 @@ export function HealthMarkerPromptScreen() {
     setObservationTimeline([]);
 
     let sessionUserId: string | null = null;
+    const psDb =
+      powerSyncReplicaSqliteReady(psBridge) && psBridge.database != null
+        ? psBridge.database
+        : getPowerSyncDatabaseForOfflineReads();
     const {
       data: { session },
       error: sessionError,
@@ -378,12 +383,23 @@ export function HealthMarkerPromptScreen() {
       setStatus('error');
       return;
     }
-    setUserId(sessionUserId);
+    const phiRes = await resolveMobilePhiSubjectUserContext({
+      powerSyncDatabase: psDb,
+    });
+    if (stale()) {
+      return;
+    }
+    if (!phiRes.ok || phiRes.data == null) {
+      setErrorMessage(
+        phiRes.ok
+          ? 'You must be signed in to save health marker answers. Try signing in again.'
+          : phiRes.error.message,
+      );
+      setStatus('error');
+      return;
+    }
+    setUserId(phiRes.data.phiSubjectUserId);
 
-    const psDb =
-      powerSyncReplicaSqliteReady(psBridge) && psBridge.database != null
-        ? psBridge.database
-        : getPowerSyncDatabaseForOfflineReads();
     let usedPowerSyncReplicaReads = false;
 
     const episodeRemote = await getEpisodeById(supabase, episodeId);

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -64,10 +64,7 @@ import {
   powerSyncReplicaSqliteReady,
   usePowerSyncBridgeState,
 } from '../../lib/powersync/PowerSyncSessionBridge';
-import {
-  getMobileAuthSessionSafe,
-  getMobileSupabaseClient,
-} from '../../lib/supabase-wiring';
+import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
 import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
 import { ScreenShell } from '../components/ScreenShell';
@@ -355,34 +352,13 @@ export function HealthMarkerPromptScreen() {
     setEndedSummary(null);
     setObservationTimeline([]);
 
-    let sessionUserId: string | null = null;
     const psDb =
       powerSyncReplicaSqliteReady(psBridge) && psBridge.database != null
         ? psBridge.database
         : getPowerSyncDatabaseForOfflineReads();
-    const {
-      data: { session },
-      error: sessionError,
-    } = await getMobileAuthSessionSafe();
-    if (sessionError) {
-      if (stale()) {
-        return;
-      }
-      setErrorMessage(sessionError.message);
-      setStatus('error');
-      return;
-    }
-    sessionUserId = session?.user?.id ?? null;
-    if (stale()) {
-      return;
-    }
-    if (!sessionUserId) {
-      setErrorMessage(
-        'You must be signed in to save health marker answers. Try signing in again.',
-      );
-      setStatus('error');
-      return;
-    }
+    // Signed-in + PHI scope: use resolveMobilePhiSubjectUserContext only; it calls
+    // getMobileAuthSessionSafe (with persisted-id fallback). A prior session pre-check aborted on any
+    // session error and blocked that recovery path while duplicating session reads.
     const phiRes = await resolveMobilePhiSubjectUserContext({
       powerSyncDatabase: psDb,
     });

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -19,7 +19,7 @@ import {
   healthCheckProfilesLimit1,
   signOut,
 } from '@abstrack/supabase';
-import { useMobileAuthUserId } from '../../lib/auth/use-mobile-auth-user-id';
+import { useMobilePhiSubjectUserContext } from '../../lib/auth/use-mobile-phi-subject-user-context';
 import { PowerSyncActiveEpisodeSubscription } from '../../lib/powersync/PowerSyncActiveEpisodeSubscription';
 import {
   powerSyncOfflineReplicaReadsEnabled,
@@ -87,7 +87,13 @@ export function HomeScreen({
   const [networkResumeSkippedOffline, setNetworkResumeSkippedOffline] =
     useState(false);
 
-  const userId = useMobileAuthUserId();
+  const {
+    authUserId,
+    phiSubjectUserId,
+    loading: phiSubjectLoading,
+    errorMessage: phiSubjectError,
+    refresh: refreshPhiSubject,
+  } = useMobilePhiSubjectUserContext();
   const { isConnected: deviceNetConnected } = useMobileDeviceNetworkConnected();
   const psBridge = usePowerSyncBridgeState();
   const replicaMirrorHomeReads = useMemo(
@@ -114,7 +120,7 @@ export function HomeScreen({
     setNetworkResumeEpisode(null);
     setNetworkResumeLoading(false);
     setNetworkResumeSkippedOffline(false);
-  }, [userId]);
+  }, [phiSubjectUserId]);
 
   useEffect(() => {
     if (replicaMirrorHomeReads) {
@@ -130,7 +136,7 @@ export function HomeScreen({
       options?: { bypassReplicaMirrorGate?: boolean },
     ) => {
       const stale = () => cancel?.cancelled === true;
-      if (!userId) {
+      if (!phiSubjectUserId) {
         if (!stale()) {
           setNetworkResumeLoading(false);
           setNetworkResumeSkippedOffline(false);
@@ -171,7 +177,7 @@ export function HomeScreen({
         }
         const result = await getActiveEpisodeForUser(
           mobileSupabase,
-          session.user.id,
+          phiSubjectUserId,
         );
         if (stale()) {
           return;
@@ -193,12 +199,12 @@ export function HomeScreen({
         }
       }
     },
-    [userId, replicaMirrorHomeReads],
+    [phiSubjectUserId, replicaMirrorHomeReads],
   );
 
   /** When the watched SQLite query fails, fetch Supabase resume as a fallback (same user, online). */
   useEffect(() => {
-    if (!userId || !replicaMirrorHomeReads || !psEpisodeSnap.error) {
+    if (!phiSubjectUserId || !replicaMirrorHomeReads || !psEpisodeSnap.error) {
       return;
     }
     const cancel = { cancelled: false };
@@ -207,7 +213,7 @@ export function HomeScreen({
       cancel.cancelled = true;
     };
   }, [
-    userId,
+    phiSubjectUserId,
     replicaMirrorHomeReads,
     psEpisodeSnap.error,
     loadNetworkResumeEpisode,
@@ -237,6 +243,7 @@ export function HomeScreen({
         bypassReplicaMirrorGate: Boolean(psEpisodeQueryErrorRef.current),
       });
       void runDevHealthCheckRef.current();
+      refreshPhiSubject();
     });
 
   useFocusEffect(
@@ -244,7 +251,7 @@ export function HomeScreen({
       if (showHealthCheck) {
         void runDevHealthCheckRef.current();
       }
-      if (!userId) {
+      if (!authUserId) {
         return;
       }
       const bypass = replicaMirrorHomeReads && Boolean(psEpisodeSnap.error);
@@ -263,7 +270,7 @@ export function HomeScreen({
       showHealthCheck,
       loadNetworkResumeEpisode,
       replicaMirrorHomeReads,
-      userId,
+      authUserId,
       psEpisodeSnap.error,
     ]),
   );
@@ -305,8 +312,14 @@ export function HomeScreen({
    * init without helping resume accuracy.
    */
   const activeEpisodeLoading = useMemo(() => {
-    if (!userId) {
+    if (!authUserId) {
       return false;
+    }
+    if (phiSubjectError) {
+      return false;
+    }
+    if (phiSubjectLoading || !phiSubjectUserId) {
+      return true;
     }
     if (psBridge.powerSyncUrlConfigured) {
       const maybeStillOpeningSqlite =
@@ -333,7 +346,10 @@ export function HomeScreen({
     }
     return networkResumeLoading;
   }, [
-    userId,
+    authUserId,
+    phiSubjectUserId,
+    phiSubjectLoading,
+    phiSubjectError,
     psBridge.database,
     psBridge.powerSyncUrlConfigured,
     psBridge.firstSyncCompleted,
@@ -347,7 +363,7 @@ export function HomeScreen({
   ]);
 
   const homeActiveEpisode = useMemo((): ActiveEpisodeHomeSummary | null => {
-    if (!userId) {
+    if (!phiSubjectUserId || phiSubjectError) {
       return null;
     }
     if (replicaMirrorHomeReads) {
@@ -370,7 +386,8 @@ export function HomeScreen({
     }
     return networkResumeEpisode;
   }, [
-    userId,
+    phiSubjectUserId,
+    phiSubjectError,
     replicaMirrorHomeReads,
     psEpisodeSnap.episode,
     psEpisodeSnap.error,
@@ -494,7 +511,7 @@ export function HomeScreen({
     <AppNavigationShell title="Home">
       {powerSyncReplicaSqliteReady(psBridge) ? (
         <PowerSyncActiveEpisodeSubscription
-          userId={userId}
+          userId={phiSubjectError ? null : phiSubjectUserId}
           onChange={setPsEpisodeSnap}
         />
       ) : null}
@@ -516,6 +533,19 @@ export function HomeScreen({
           />
         }
       >
+        {phiSubjectError ? (
+          <View
+            className={`mb-3 rounded-xl border border-app-border bg-app-surface p-4 dark:border-app-border-dark dark:bg-app-surface-dark`}
+            accessibilityRole="alert"
+          >
+            <Text className={`text-base font-semibold ${nw.textInk}`}>
+              Caretaker access
+            </Text>
+            <Text className={`mt-2 text-sm ${nw.textMuted}`}>
+              {phiSubjectError}
+            </Text>
+          </View>
+        ) : null}
         <EpisodeStartHomeCta
           onStartEpisode={onStartEpisode}
           onResumeEpisode={onResumeEpisode}

--- a/apps/mobile/src/app/screens/ManageScreen.tsx
+++ b/apps/mobile/src/app/screens/ManageScreen.tsx
@@ -6,6 +6,7 @@ import React, {
   useState,
 } from 'react';
 import {
+  ActivityIndicator,
   Alert,
   FlatList,
   Pressable,
@@ -37,6 +38,7 @@ import {
   type UsePullToResyncPowerSyncOptions,
 } from '../../lib/powersync/use-pull-to-resync-powersync';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
+import { useMobilePhiSubjectUserContext } from '../../lib/auth/use-mobile-phi-subject-user-context';
 import { ScreenShell } from '../components/ScreenShell';
 import type { MainStackParamList, MainTabParamList } from '../navigation/types';
 import { useAppTheme } from '../theme/AppThemeContext';
@@ -128,6 +130,13 @@ export function ManageScreen() {
   }
   const route = useRoute<RouteProp<MainTabParamList, 'Manage'>>();
   const initialSegment = route.params?.initialSegment;
+  const { colors } = useAppTheme();
+
+  const {
+    phiSubjectUserId,
+    errorMessage: phiScopeError,
+    loading: phiScopeLoading,
+  } = useMobilePhiSubjectUserContext();
 
   const [segment, setSegment] = useState<ManageTabSegment>('episodes');
   const [filterDay, setFilterDay] = useState<Date | null>(null);
@@ -308,16 +317,42 @@ export function ManageScreen() {
             />
           ) : null}
           {segment === 'health' ? (
-            <StandaloneHealthMarkersManageList
-              recordedAtOrAfter={markerDateBounds.recordedAtOrAfter}
-              recordedAtOrBefore={markerDateBounds.recordedAtOrBefore}
-            />
+            phiScopeError ? (
+              <Text
+                className={`text-sm ${nw.textError}`}
+                accessibilityRole="alert"
+                maxFontSizeMultiplier={2}
+              >
+                {phiScopeError}
+              </Text>
+            ) : phiScopeLoading || !phiSubjectUserId ? (
+              <ActivityIndicator size="large" color={colors.primary} />
+            ) : (
+              <StandaloneHealthMarkersManageList
+                scopeUserId={phiSubjectUserId}
+                recordedAtOrAfter={markerDateBounds.recordedAtOrAfter}
+                recordedAtOrBefore={markerDateBounds.recordedAtOrBefore}
+              />
+            )
           ) : null}
           {segment === 'food' ? (
-            <StandaloneFoodDiaryManageList
-              loggedAtOrAfter={foodDateBounds.loggedAtOrAfter}
-              loggedAtOrBefore={foodDateBounds.loggedAtOrBefore}
-            />
+            phiScopeError ? (
+              <Text
+                className={`text-sm ${nw.textError}`}
+                accessibilityRole="alert"
+                maxFontSizeMultiplier={2}
+              >
+                {phiScopeError}
+              </Text>
+            ) : phiScopeLoading || !phiSubjectUserId ? (
+              <ActivityIndicator size="large" color={colors.primary} />
+            ) : (
+              <StandaloneFoodDiaryManageList
+                scopeUserId={phiSubjectUserId}
+                loggedAtOrAfter={foodDateBounds.loggedAtOrAfter}
+                loggedAtOrBefore={foodDateBounds.loggedAtOrBefore}
+              />
+            )
           ) : null}
         </View>
       </View>
@@ -326,11 +361,14 @@ export function ManageScreen() {
 }
 
 type StandaloneHealthMarkersManageListProps = {
+  /** Patient id for PHI list queries (includes caretaker acting for a linked patient). */
+  scopeUserId: string;
   recordedAtOrAfter: string | null;
   recordedAtOrBefore: string | null;
 };
 
 function StandaloneHealthMarkersManageList({
+  scopeUserId,
   recordedAtOrAfter,
   recordedAtOrBefore,
 }: StandaloneHealthMarkersManageListProps) {
@@ -357,23 +395,19 @@ function StandaloneHealthMarkersManageList({
       setError(null);
       try {
         const client = getMobileSupabaseClient();
-        const {
-          data: { user },
-        } = await client.auth.getUser();
         if (stale()) {
           return 'stale';
         }
-        if (!user) {
-          setRows([]);
-          setHasMore(false);
-          return 'no-user';
-        }
-        const res = await listStandaloneHealthMarkersForUser(client, user.id, {
-          limit: PAGE_SIZE,
-          offset: 0,
-          recordedAtOrAfter: recordedAtOrAfter ?? undefined,
-          recordedAtOrBefore: recordedAtOrBefore ?? undefined,
-        });
+        const res = await listStandaloneHealthMarkersForUser(
+          client,
+          scopeUserId,
+          {
+            limit: PAGE_SIZE,
+            offset: 0,
+            recordedAtOrAfter: recordedAtOrAfter ?? undefined,
+            recordedAtOrBefore: recordedAtOrBefore ?? undefined,
+          },
+        );
         if (stale()) {
           return 'stale';
         }
@@ -400,7 +434,7 @@ function StandaloneHealthMarkersManageList({
         }
       }
     },
-    [recordedAtOrAfter, recordedAtOrBefore],
+    [recordedAtOrAfter, recordedAtOrBefore, scopeUserId],
   );
 
   const loadInitialRef = useRef(loadInitial);
@@ -455,22 +489,19 @@ function StandaloneHealthMarkersManageList({
     setLoadingMore(true);
     try {
       const client = getMobileSupabaseClient();
-      const {
-        data: { user },
-      } = await client.auth.getUser();
       if (stale()) {
         return;
       }
-      if (!user) {
-        setHasMore(false);
-        return;
-      }
-      const res = await listStandaloneHealthMarkersForUser(client, user.id, {
-        limit: PAGE_SIZE,
-        offset: rows.length,
-        recordedAtOrAfter: recordedAtOrAfter ?? undefined,
-        recordedAtOrBefore: recordedAtOrBefore ?? undefined,
-      });
+      const res = await listStandaloneHealthMarkersForUser(
+        client,
+        scopeUserId,
+        {
+          limit: PAGE_SIZE,
+          offset: rows.length,
+          recordedAtOrAfter: recordedAtOrAfter ?? undefined,
+          recordedAtOrBefore: recordedAtOrBefore ?? undefined,
+        },
+      );
       if (stale()) {
         return;
       }
@@ -495,6 +526,7 @@ function StandaloneHealthMarkersManageList({
     recordedAtOrAfter,
     recordedAtOrBefore,
     rows.length,
+    scopeUserId,
   ]);
 
   const onDelete = useCallback(
@@ -663,11 +695,13 @@ function StandaloneHealthMarkersManageList({
 }
 
 type StandaloneFoodDiaryManageListProps = {
+  scopeUserId: string;
   loggedAtOrAfter: string | null;
   loggedAtOrBefore: string | null;
 };
 
 function StandaloneFoodDiaryManageList({
+  scopeUserId,
   loggedAtOrAfter,
   loggedAtOrBefore,
 }: StandaloneFoodDiaryManageListProps) {
@@ -694,18 +728,10 @@ function StandaloneFoodDiaryManageList({
       setError(null);
       try {
         const client = getMobileSupabaseClient();
-        const {
-          data: { user },
-        } = await client.auth.getUser();
         if (stale()) {
           return 'stale';
         }
-        if (!user) {
-          setRows([]);
-          setHasMore(false);
-          return 'no-user';
-        }
-        const res = await listFoodDiaryEntriesForUser(client, user.id, {
+        const res = await listFoodDiaryEntriesForUser(client, scopeUserId, {
           limit: PAGE_SIZE,
           offset: 0,
           standaloneOnly: true,
@@ -738,7 +764,7 @@ function StandaloneFoodDiaryManageList({
         }
       }
     },
-    [loggedAtOrAfter, loggedAtOrBefore],
+    [loggedAtOrAfter, loggedAtOrBefore, scopeUserId],
   );
 
   const loadInitialRef = useRef(loadInitial);
@@ -791,17 +817,10 @@ function StandaloneFoodDiaryManageList({
     setLoadingMore(true);
     try {
       const client = getMobileSupabaseClient();
-      const {
-        data: { user },
-      } = await client.auth.getUser();
       if (stale()) {
         return;
       }
-      if (!user) {
-        setHasMore(false);
-        return;
-      }
-      const res = await listFoodDiaryEntriesForUser(client, user.id, {
+      const res = await listFoodDiaryEntriesForUser(client, scopeUserId, {
         limit: PAGE_SIZE,
         offset: rows.length,
         standaloneOnly: true,
@@ -826,7 +845,14 @@ function StandaloneFoodDiaryManageList({
     } finally {
       setLoadingMore(false);
     }
-  }, [hasMore, loadingMore, loggedAtOrAfter, loggedAtOrBefore, rows.length]);
+  }, [
+    hasMore,
+    loadingMore,
+    loggedAtOrAfter,
+    loggedAtOrBefore,
+    rows.length,
+    scopeUserId,
+  ]);
 
   const onDelete = useCallback(
     (row: FoodDiaryEntryRow) => {

--- a/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
+++ b/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
@@ -84,7 +84,11 @@ export function StandaloneHealthMarkersScreen() {
   /** Lines successfully persisted via Next/Finish in the current preset session. */
   const [linesSavedCount, setLinesSavedCount] = useState(0);
   const [presetRefetchTick, setPresetRefetchTick] = useState(0);
-  const lastPresetUserIdRef = useRef<string | null>(null);
+  /**
+   * Last scope key `authUserId|phiSubjectUserId` for preset loads. When either changes (caretaker
+   * patient link, first sync, etc.), we reset pick-preset / line UI so lists match the active PHI subject.
+   */
+  const lastPresetScopeKeyRef = useRef<string | null>(null);
   const authSnapshotGenerationRef = useRef(0);
 
   useEffect(() => {
@@ -136,7 +140,7 @@ export function StandaloneHealthMarkersScreen() {
 
     const userId = authUserId;
     if (phiScopeError || !userId) {
-      lastPresetUserIdRef.current = null;
+      lastPresetScopeKeyRef.current = null;
       setPresets([]);
       setLoadError(null);
       setLoadingPresets(false);
@@ -150,12 +154,13 @@ export function StandaloneHealthMarkersScreen() {
       return;
     }
 
-    const switchedAccount =
-      lastPresetUserIdRef.current !== null &&
-      lastPresetUserIdRef.current !== userId;
-    lastPresetUserIdRef.current = userId;
+    const scopeKey = `${userId}|${phiSubjectUserId ?? ''}`;
+    const switchedScope =
+      lastPresetScopeKeyRef.current !== null &&
+      lastPresetScopeKeyRef.current !== scopeKey;
+    lastPresetScopeKeyRef.current = scopeKey;
 
-    if (switchedAccount) {
+    if (switchedScope) {
       setPhase('pickPreset');
       setLines([]);
       setDrafts({});
@@ -191,6 +196,7 @@ export function StandaloneHealthMarkersScreen() {
     phiScopeLoading,
     phiScopeError,
     authUserId,
+    phiSubjectUserId,
     supabase,
     presetRefetchTick,
   ]);

--- a/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
+++ b/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
@@ -36,6 +36,7 @@ import {
   getMobileAuthSessionSafe,
   getMobileSupabaseClient,
 } from '../../lib/supabase-wiring';
+import { useMobilePhiSubjectUserContext } from '../../lib/auth/use-mobile-phi-subject-user-context';
 import { ScreenShell } from '../components/ScreenShell';
 import type { MainStackParamList } from '../navigation/types';
 import { nw } from '../theme/app-nativewind-classes';
@@ -53,6 +54,11 @@ type StandaloneHealthMarkersNav = NativeStackNavigationProp<
 export function StandaloneHealthMarkersScreen() {
   const navigation = useNavigation<StandaloneHealthMarkersNav>();
   const supabase = useMemo(() => getMobileSupabaseClient(), []);
+  const {
+    phiSubjectUserId,
+    loading: phiScopeLoading,
+    errorMessage: phiScopeError,
+  } = useMobilePhiSubjectUserContext();
 
   const [authLoading, setAuthLoading] = useState(true);
   const [authUserId, setAuthUserId] = useState<string | null>(null);
@@ -124,7 +130,7 @@ export function StandaloneHealthMarkersScreen() {
   }, [supabase, authRetryTick]);
 
   useEffect(() => {
-    if (authLoading) {
+    if (authLoading || phiScopeLoading) {
       return;
     }
 
@@ -180,7 +186,7 @@ export function StandaloneHealthMarkersScreen() {
     return () => {
       cancelled = true;
     };
-  }, [authLoading, authUserId, supabase, presetRefetchTick]);
+  }, [authLoading, phiScopeLoading, authUserId, supabase, presetRefetchTick]);
 
   useEffect(() => {
     setFeedback(null);
@@ -263,7 +269,7 @@ export function StandaloneHealthMarkersScreen() {
   };
 
   const saveCurrentLine = async (): Promise<boolean> => {
-    if (!currentLine || !authUserId) {
+    if (!currentLine || !phiSubjectUserId) {
       return false;
     }
     const customValidation = validatePresetHealthMarkerCustomFields(
@@ -285,7 +291,7 @@ export function StandaloneHealthMarkersScreen() {
     setSaving(true);
     setFeedback(null);
     const result = await createStandaloneHealthMarkerForLine(supabase, {
-      userId: authUserId,
+      userId: phiSubjectUserId,
       line: currentLine,
       valueNumeric: parsed.valueNumeric,
       systolicNumeric: parsed.systolicNumeric,
@@ -333,7 +339,7 @@ export function StandaloneHealthMarkersScreen() {
   const secondaryBtn =
     'min-h-[56px] items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 dark:border-app-border-dark dark:bg-app-surface-dark';
 
-  if (authLoading) {
+  if (authLoading || phiScopeLoading) {
     return (
       <ScreenShell>
         <View className="min-h-[120px] items-center justify-center py-8">
@@ -377,6 +383,38 @@ export function StandaloneHealthMarkersScreen() {
             Try again
           </Text>
         </Pressable>
+      </ScreenShell>
+    );
+  }
+
+  if (phiScopeError) {
+    return (
+      <ScreenShell>
+        <Text
+          className={`text-xl font-semibold ${nw.textInk}`}
+          maxFontSizeMultiplier={2}
+        >
+          Log health markers
+        </Text>
+        <Text
+          className={`mt-2 text-sm ${nw.textMuted}`}
+          accessibilityRole="alert"
+        >
+          {phiScopeError}
+        </Text>
+      </ScreenShell>
+    );
+  }
+
+  if (!phiSubjectUserId) {
+    return (
+      <ScreenShell>
+        <View className="min-h-[120px] items-center justify-center py-8">
+          <ActivityIndicator size="large" />
+          <Text className={`mt-3 text-center text-sm ${nw.textMuted}`}>
+            Preparing your account…
+          </Text>
+        </View>
       </ScreenShell>
     );
   }

--- a/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
+++ b/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
@@ -406,7 +406,7 @@ export function StandaloneHealthMarkersScreen() {
     );
   }
 
-  if (!phiSubjectUserId) {
+  if (authUserId && !phiSubjectUserId) {
     return (
       <ScreenShell>
         <View className="min-h-[120px] items-center justify-center py-8">

--- a/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
+++ b/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
@@ -135,7 +135,7 @@ export function StandaloneHealthMarkersScreen() {
     }
 
     const userId = authUserId;
-    if (!userId) {
+    if (phiScopeError || !userId) {
       lastPresetUserIdRef.current = null;
       setPresets([]);
       setLoadError(null);
@@ -186,7 +186,14 @@ export function StandaloneHealthMarkersScreen() {
     return () => {
       cancelled = true;
     };
-  }, [authLoading, phiScopeLoading, authUserId, supabase, presetRefetchTick]);
+  }, [
+    authLoading,
+    phiScopeLoading,
+    phiScopeError,
+    authUserId,
+    supabase,
+    presetRefetchTick,
+  ]);
 
   useEffect(() => {
     setFeedback(null);

--- a/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
+++ b/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
@@ -48,6 +48,8 @@ type StandaloneHealthMarkersNav = NativeStackNavigationProp<
 
 /**
  * Standalone health-marker logging (no episode), matching web `/health-markers/new`.
+ * Preset and line loads wait for {@link useMobilePhiSubjectUserContext} `phiSubjectUserId` and pass
+ * it into scoped list helpers so caretakers never pick presets for the wrong patient.
  *
  * @returns Preset picker, line-by-line prompts, and completion UI.
  */
@@ -154,7 +156,23 @@ export function StandaloneHealthMarkersScreen() {
       return;
     }
 
-    const scopeKey = `${userId}|${phiSubjectUserId ?? ''}`;
+    /** Do not list presets until PHI subject is known — RLS alone can expose the wrong rows for caretakers. */
+    if (!phiSubjectUserId?.trim()) {
+      lastPresetScopeKeyRef.current = null;
+      setPresets([]);
+      setLoadError(null);
+      setLoadingPresets(false);
+      setPhase('pickPreset');
+      setLines([]);
+      setDrafts({});
+      setActiveIndex(0);
+      setSelectedPresetId(null);
+      setFeedback(null);
+      setLinesSavedCount(0);
+      return;
+    }
+
+    const scopeKey = `${userId}|${phiSubjectUserId}`;
     const switchedScope =
       lastPresetScopeKeyRef.current !== null &&
       lastPresetScopeKeyRef.current !== scopeKey;
@@ -175,7 +193,9 @@ export function StandaloneHealthMarkersScreen() {
     setLoadError(null);
 
     void (async () => {
-      const result = await listHealthMarkerPresets(supabase);
+      const result = await listHealthMarkerPresets(supabase, {
+        scopeUserId: phiSubjectUserId,
+      });
       if (cancelled) {
         return;
       }
@@ -247,7 +267,7 @@ export function StandaloneHealthMarkersScreen() {
   );
 
   const startPresetFlow = async () => {
-    if (!selectedPresetId || saving) {
+    if (!selectedPresetId || saving || !phiSubjectUserId?.trim()) {
       return;
     }
     setSaving(true);
@@ -255,6 +275,7 @@ export function StandaloneHealthMarkersScreen() {
     const result = await listPresetHealthMarkersForPreset(
       supabase,
       selectedPresetId,
+      { scopeUserId: phiSubjectUserId },
     );
     setSaving(false);
     if (!result.ok) {

--- a/apps/mobile/src/app/screens/SymptomPresetCreateScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPresetCreateScreen.tsx
@@ -4,10 +4,8 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { announce } from '@abstrack/ui/native';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
-import {
-  getCurrentUserId,
-  saveNewSymptomPreset,
-} from '../../lib/symptom-presets/symptom-preset-service';
+import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
+import { saveNewSymptomPreset } from '../../lib/symptom-presets/symptom-preset-service';
 import type { SymptomPresetsStackParamList } from '../navigation/types';
 import { useAppTheme } from '../theme/AppThemeContext';
 import { nw } from '../theme/app-nativewind-classes';
@@ -36,16 +34,16 @@ export function SymptomPresetCreateScreen() {
     }
     setBusy(true);
     try {
-      const authResult = await getCurrentUserId();
-      if (!authResult.ok) {
-        announce(authResult.error.message);
+      const phiRes = await resolveMobilePhiSubjectUserContext();
+      if (!phiRes.ok) {
+        announce(phiRes.error.message);
         return;
       }
-      if (authResult.data === null) {
+      if (phiRes.data == null) {
         announce('You need to be signed in to create a preset.');
         return;
       }
-      const userId = authResult.data;
+      const userId = phiRes.data.phiSubjectUserId;
       const result = await saveNewSymptomPreset({
         user_id: userId,
         name: trimmed,

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.spec.tsx
@@ -52,6 +52,16 @@ jest.mock('@abstrack/supabase', () => ({
   listEpisodeSymptomsForEpisode: jest.fn(),
   insertEpisodeSymptomAnswer: jest.fn(),
   uploadConfirmedEpisodeMedia: jest.fn(),
+  resolvePhiSubjectUserContextFromSupabase: jest.fn(
+    async (_client: unknown, authUserId: string) => ({
+      ok: true as const,
+      data: {
+        authUserId,
+        phiSubjectUserId: authUserId,
+        profileAppRole: 'patient' as const,
+      },
+    }),
+  ),
 }));
 
 /**
@@ -89,6 +99,11 @@ jest.mock('../../lib/supabase-wiring', () => ({
       'createMobileSupabaseClient not used in SymptomPromptScreen tests',
     );
   }),
+}));
+
+jest.mock('../../lib/network/mobile-device-netinfo', () => ({
+  __esModule: true,
+  fetchMobileDeviceIsConnected: jest.fn(async () => true),
 }));
 
 jest.mock('../../lib/episodes/symptom-prompt-session-store', () => ({

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -78,6 +78,7 @@ import {
   getMobileAuthSessionSafe,
   getMobileSupabaseClient,
 } from '../../lib/supabase-wiring';
+import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
 import {
   clearSymptomPromptSession,
   getSymptomPromptSession,
@@ -433,20 +434,18 @@ export function SymptomPromptScreen() {
   );
 
   /**
-   * Reads the signed-in user id from {@link getMobileAuthSessionSafe} on every call (no ref cache).
-   * Queued symptom writes can flush after sign-out / during replica teardown; a stale cached id
-   * could otherwise insert PHI into a DB being cleared.
+   * Resolves the PHI `user_id` for queued writes (patient id when acting as caretaker).
+   * Uses {@link resolveMobilePhiSubjectUserContext} so queued writes stay aligned with RLS.
    */
   const resolveSessionUserId = useCallback(async (): Promise<string | null> => {
-    try {
-      const {
-        data: { session },
-      } = await getMobileAuthSessionSafe();
-      return session?.user?.id ?? null;
-    } catch {
+    const res = await resolveMobilePhiSubjectUserContext({
+      powerSyncDatabase: powerSyncDbForWrites,
+    });
+    if (!res.ok || res.data == null) {
       return null;
     }
-  }, []);
+    return res.data.phiSubjectUserId;
+  }, [powerSyncDbForWrites]);
 
   useLayoutEffect(() => {
     answersRef.current = answers;

--- a/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
+++ b/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
@@ -12,7 +12,6 @@ import {
   listFoodDiaryEntriesForEpisodeOfflineFirst,
   updateFoodDiaryEntryOfflineFirst,
 } from '../../lib/episodes/mobile-offline-first-gateway';
-import { getMobileAuthSessionSafe } from '../../lib/get-mobile-auth-session-safe';
 import {
   currentLocalDate,
   currentLocalTime,
@@ -347,19 +346,6 @@ export function useHealthMarkerFoodDiary({
         },
       );
     } else {
-      const {
-        data: { session },
-        error: sessionError,
-      } = await getMobileAuthSessionSafe();
-      if (session?.user?.id == null || session.user.id === '') {
-        const message =
-          sessionError?.message ??
-          'Your session could not be verified. Try signing in again.';
-        setSavingFoodDiary(false);
-        setFoodDiaryFeedback(message);
-        await announce(message, { politeness: 'assertive' });
-        return;
-      }
       const phiRes = await resolveMobilePhiSubjectUserContext({
         powerSyncDatabase,
       });

--- a/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
+++ b/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
@@ -12,11 +12,7 @@ import {
   listFoodDiaryEntriesForEpisodeOfflineFirst,
   updateFoodDiaryEntryOfflineFirst,
 } from '../../lib/episodes/mobile-offline-first-gateway';
-import {
-  getMobileAuthSessionSafe,
-  isAuthSessionRecoveryFailure,
-  readPersistedMobileAuthUserId,
-} from '../../lib/get-mobile-auth-session-safe';
+import { getMobileAuthSessionSafe } from '../../lib/get-mobile-auth-session-safe';
 import {
   currentLocalDate,
   currentLocalTime,
@@ -26,6 +22,7 @@ import {
   localDateTimeToIso,
   localTimeFromDate,
 } from '../../lib/food-diary/date-time';
+import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
 
 /** Same ordering as `listFoodDiaryEntriesForEpisode` (newest first). */
 function compareFoodDiaryEntriesDesc(
@@ -127,11 +124,10 @@ export type HealthMarkerFoodDiaryHookResult = {
 /**
  * Food diary list / add / edit / delete for the in-episode health marker flow (mobile).
  *
- * **Creates:** {@link onSaveFoodDiary} resolves {@link getMobileAuthSessionSafe} for **new** entries
- * and passes that `user_id` into offline-first creates — queued SQLite writes have no RLS, so a
+ * **Creates:** {@link onSaveFoodDiary} resolves {@link resolveMobilePhiSubjectUserContext} for **new**
+ * entries and passes that patient-scope `user_id` into offline-first creates — queued SQLite writes have no RLS, so a
  * caller-supplied id from mount would be unsafe across sign-out / account switches (same pattern as
- * symptom persists on {@link SymptomPromptScreen}). On `auth_session_recovery_failed`, falls back to
- * {@link readPersistedMobileAuthUserId} so transient secure-store hiccups do not block offline creates.
+ * symptom persists on {@link SymptomPromptScreen}).
  * **Edits** skip that session check and call
  * {@link updateFoodDiaryEntryOfflineFirst} by row id only so local updates still apply when persisted-session
  * recovery fails after sync.
@@ -355,18 +351,7 @@ export function useHealthMarkerFoodDiary({
         data: { session },
         error: sessionError,
       } = await getMobileAuthSessionSafe();
-      let userId: string | null =
-        session?.user?.id != null && session.user.id !== ''
-          ? session.user.id
-          : null;
-      if (
-        userId == null &&
-        sessionError != null &&
-        isAuthSessionRecoveryFailure(sessionError)
-      ) {
-        userId = await readPersistedMobileAuthUserId();
-      }
-      if (userId == null || userId === '') {
+      if (session?.user?.id == null || session.user.id === '') {
         const message =
           sessionError?.message ??
           'Your session could not be verified. Try signing in again.';
@@ -375,6 +360,19 @@ export function useHealthMarkerFoodDiary({
         await announce(message, { politeness: 'assertive' });
         return;
       }
+      const phiRes = await resolveMobilePhiSubjectUserContext({
+        powerSyncDatabase,
+      });
+      if (!phiRes.ok || phiRes.data == null) {
+        const message = phiRes.ok
+          ? 'Your session could not be verified. Try signing in again.'
+          : phiRes.error.message;
+        setSavingFoodDiary(false);
+        setFoodDiaryFeedback(message);
+        await announce(message, { politeness: 'assertive' });
+        return;
+      }
+      const userId = phiRes.data.phiSubjectUserId;
       result = await createFoodDiaryEntryOfflineFirst(
         supabase,
         powerSyncDatabase,

--- a/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
+++ b/apps/mobile/src/app/screens/use-health-marker-food-diary.ts
@@ -22,6 +22,7 @@ import {
   localTimeFromDate,
 } from '../../lib/food-diary/date-time';
 import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
+import { getMobileAuthSessionSafe } from '../../lib/supabase-wiring';
 
 /** Same ordering as `listFoodDiaryEntriesForEpisode` (newest first). */
 function compareFoodDiaryEntriesDesc(
@@ -126,7 +127,9 @@ export type HealthMarkerFoodDiaryHookResult = {
  * **Creates:** {@link onSaveFoodDiary} resolves {@link resolveMobilePhiSubjectUserContext} for **new**
  * entries and passes that patient-scope `user_id` into offline-first creates — queued SQLite writes have no RLS, so a
  * caller-supplied id from mount would be unsafe across sign-out / account switches (same pattern as
- * symptom persists on {@link SymptomPromptScreen}).
+ * symptom persists on {@link SymptomPromptScreen}). When resolve returns `{ ok: true, data: null }`
+ * (replica cannot determine PHI scope yet, e.g. offline before `profiles` / `caretaker_access` sync),
+ * signed-in users see a **scope / sync** message, not a sign-in error.
  * **Edits** skip that session check and call
  * {@link updateFoodDiaryEntryOfflineFirst} by row id only so local updates still apply when persisted-session
  * recovery fails after sync.
@@ -349,10 +352,21 @@ export function useHealthMarkerFoodDiary({
       const phiRes = await resolveMobilePhiSubjectUserContext({
         powerSyncDatabase,
       });
-      if (!phiRes.ok || phiRes.data == null) {
-        const message = phiRes.ok
-          ? 'Your session could not be verified. Try signing in again.'
-          : phiRes.error.message;
+      if (!phiRes.ok) {
+        const message = phiRes.error.message;
+        setSavingFoodDiary(false);
+        setFoodDiaryFeedback(message);
+        await announce(message, { politeness: 'assertive' });
+        return;
+      }
+      if (phiRes.data == null) {
+        const {
+          data: { session },
+        } = await getMobileAuthSessionSafe();
+        const message =
+          session?.user?.id != null
+            ? 'Patient scope is not ready on this device yet. Connect once while online or wait for sync, then try again.'
+            : 'Your session could not be verified. Try signing in again.';
         setSavingFoodDiary(false);
         setFoodDiaryFeedback(message);
         await announce(message, { politeness: 'assertive' });

--- a/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
@@ -1,12 +1,9 @@
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import type { AppRole } from '@abstrack/types';
 
 import { useMobileAuthUserId } from './use-mobile-auth-user-id';
-import {
-  powerSyncReplicaSqliteReady,
-  usePowerSyncBridgeState,
-} from '../powersync/PowerSyncSessionBridge';
+import { usePowerSyncBridgeState } from '../powersync/PowerSyncSessionBridge';
 import { resolveMobilePhiSubjectUserContext } from '../phi-subject/resolve-mobile-phi-subject-user-context';
 
 export type MobilePhiSubjectUserContextState = {
@@ -28,14 +25,22 @@ export type MobilePhiSubjectUserContextState = {
  * signed-in auth id (`authUserId`). Caretakers use the linked patient from active `caretaker_access`.
  *
  * In-flight {@link resolveMobilePhiSubjectUserContext} results are ignored after unmount or when
- * `authUserId` / PowerSync bridge inputs change, by bumping a generation counter so async completion
- * does not call `setState` on an unmounted consumer.
+ * `authUserId` / replica readiness (`database` + `localSqliteInitialized`) / first-sync completion
+ * change, by bumping a generation counter so async completion does not call `setState` on an
+ * unmounted consumer. Bridge fields such as `syncConnecting` are intentionally excluded from the
+ * resolve callback deps so unrelated PowerSync UI state does not re-trigger network resolution.
  *
  * @returns Loading and error state plus ids for Home, Manage, and episode flows.
  */
 export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextState {
   const authUserId = useMobileAuthUserId();
   const psBridge = usePowerSyncBridgeState();
+  const firstSyncCompleted = psBridge.firstSyncCompleted;
+  const dbForPhi = useMemo(() => {
+    return psBridge.database != null && psBridge.localSqliteInitialized
+      ? psBridge.database
+      : null;
+  }, [psBridge.database, psBridge.localSqliteInitialized]);
   const [loading, setLoading] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [phiSubjectUserId, setPhiSubjectUserId] = useState<string | null>(null);
@@ -53,9 +58,8 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
     }
     setLoading(true);
     setErrorMessage(null);
-    const db = powerSyncReplicaSqliteReady(psBridge) ? psBridge.database : null;
     const result = await resolveMobilePhiSubjectUserContext({
-      powerSyncDatabase: db,
+      powerSyncDatabase: dbForPhi,
     });
     if (gen !== genRef.current) {
       return;
@@ -76,7 +80,7 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
     setPhiSubjectUserId(result.data.phiSubjectUserId);
     setProfileAppRole(result.data.profileAppRole);
     setErrorMessage(null);
-  }, [authUserId, psBridge]);
+  }, [authUserId, dbForPhi]);
 
   useEffect(() => {
     void runResolve();
@@ -87,7 +91,7 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
 
   const firstSyncHandledRef = useRef(false);
   useEffect(() => {
-    if (!psBridge.firstSyncCompleted) {
+    if (!firstSyncCompleted) {
       firstSyncHandledRef.current = false;
     } else if (!firstSyncHandledRef.current) {
       firstSyncHandledRef.current = true;
@@ -96,7 +100,7 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
     return () => {
       genRef.current += 1;
     };
-  }, [psBridge.firstSyncCompleted, runResolve]);
+  }, [firstSyncCompleted, runResolve]);
 
   const refresh = useCallback(() => {
     void runResolve();

--- a/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
@@ -30,7 +30,9 @@ export type MobilePhiSubjectUserContextState = {
  * In-flight {@link resolveMobilePhiSubjectUserContext} results are ignored after unmount or when
  * `authUserId` / replica readiness (`database` + `localSqliteInitialized`) / first-sync completion
  * change, by bumping a generation counter so async completion does not call `setState` on an
- * unmounted consumer. Resolution still runs when `authUserId` is null: on cold starts where
+ * unmounted consumer. Each new resolve clears `phiSubjectUserId` and `profileAppRole` before
+ * awaiting the resolver so consumers that do not gate every read on `loading` cannot briefly use a
+ * stale PHI subject after an account switch or replica re-scope. Resolution still runs when `authUserId` is null: on cold starts where
  * {@link useMobileAuthUserId} has not recovered yet, {@link resolveMobilePhiSubjectUserContext}
  * may still read a persisted auth id (the same path as inside that resolver), so those sessions are
  * not treated as signed-out for PHI scope. Bridge fields such as `syncConnecting` are intentionally
@@ -58,6 +60,8 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
     const gen = ++genRef.current;
     setLoading(true);
     setErrorMessage(null);
+    setPhiSubjectUserId(null);
+    setProfileAppRole(null);
     const result = await resolveMobilePhiSubjectUserContext({
       powerSyncDatabase: dbForPhi,
     });

--- a/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
@@ -7,11 +7,14 @@ import { usePowerSyncBridgeState } from '../powersync/PowerSyncSessionBridge';
 import { resolveMobilePhiSubjectUserContext } from '../phi-subject/resolve-mobile-phi-subject-user-context';
 
 export type MobilePhiSubjectUserContextState = {
-  /** Same as {@link useMobileAuthUserId} while resolving. */
+  /** True while resolving PHI scope (includes awaiting {@link resolveMobilePhiSubjectUserContext}). */
   loading: boolean;
   /** User-facing resolve failure (e.g. caretaker not linked). */
   errorMessage: string | null;
-  /** Supabase auth user id. */
+  /**
+   * Same as {@link useMobileAuthUserId}; may remain null briefly on cold start while PHI scope
+   * still resolves via persisted session recovery inside {@link resolveMobilePhiSubjectUserContext}.
+   */
   authUserId: string | null;
   /** Patient id for PHI rows (same as `authUserId` for patients). */
   phiSubjectUserId: string | null;
@@ -27,8 +30,12 @@ export type MobilePhiSubjectUserContextState = {
  * In-flight {@link resolveMobilePhiSubjectUserContext} results are ignored after unmount or when
  * `authUserId` / replica readiness (`database` + `localSqliteInitialized`) / first-sync completion
  * change, by bumping a generation counter so async completion does not call `setState` on an
- * unmounted consumer. Bridge fields such as `syncConnecting` are intentionally excluded from the
- * resolve callback deps so unrelated PowerSync UI state does not re-trigger network resolution.
+ * unmounted consumer. Resolution still runs when `authUserId` is null: on cold starts where
+ * {@link useMobileAuthUserId} has not recovered yet, {@link resolveMobilePhiSubjectUserContext}
+ * may still read a persisted auth id (the same path as inside that resolver), so those sessions are
+ * not treated as signed-out for PHI scope. Bridge fields such as `syncConnecting` are intentionally
+ * excluded from the resolve callback deps so unrelated PowerSync UI state does not re-trigger
+ * network resolution.
  *
  * @returns Loading and error state plus ids for Home, Manage, and episode flows.
  */
@@ -49,13 +56,6 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
 
   const runResolve = useCallback(async () => {
     const gen = ++genRef.current;
-    if (authUserId == null || authUserId.trim() === '') {
-      setLoading(false);
-      setErrorMessage(null);
-      setPhiSubjectUserId(null);
-      setProfileAppRole(null);
-      return;
-    }
     setLoading(true);
     setErrorMessage(null);
     const result = await resolveMobilePhiSubjectUserContext({

--- a/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
@@ -27,6 +27,10 @@ export type MobilePhiSubjectUserContextState = {
  * Resolves the patient user id used for episode / marker / food PHI (`phiSubjectUserId`) vs the
  * signed-in auth id (`authUserId`). Caretakers use the linked patient from active `caretaker_access`.
  *
+ * In-flight {@link resolveMobilePhiSubjectUserContext} results are ignored after unmount or when
+ * `authUserId` / PowerSync bridge inputs change, by bumping a generation counter so async completion
+ * does not call `setState` on an unmounted consumer.
+ *
  * @returns Loading and error state plus ids for Home, Manage, and episode flows.
  */
 export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextState {
@@ -76,18 +80,22 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
 
   useEffect(() => {
     void runResolve();
+    return () => {
+      genRef.current += 1;
+    };
   }, [runResolve]);
 
   const firstSyncHandledRef = useRef(false);
   useEffect(() => {
     if (!psBridge.firstSyncCompleted) {
       firstSyncHandledRef.current = false;
-      return;
-    }
-    if (!firstSyncHandledRef.current) {
+    } else if (!firstSyncHandledRef.current) {
       firstSyncHandledRef.current = true;
       void runResolve();
     }
+    return () => {
+      genRef.current += 1;
+    };
   }, [psBridge.firstSyncCompleted, runResolve]);
 
   const refresh = useCallback(() => {

--- a/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
@@ -1,0 +1,105 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import type { AppRole } from '@abstrack/types';
+
+import { useMobileAuthUserId } from './use-mobile-auth-user-id';
+import {
+  powerSyncReplicaSqliteReady,
+  usePowerSyncBridgeState,
+} from '../powersync/PowerSyncSessionBridge';
+import { resolveMobilePhiSubjectUserContext } from '../phi-subject/resolve-mobile-phi-subject-user-context';
+
+export type MobilePhiSubjectUserContextState = {
+  /** Same as {@link useMobileAuthUserId} while resolving. */
+  loading: boolean;
+  /** User-facing resolve failure (e.g. caretaker not linked). */
+  errorMessage: string | null;
+  /** Supabase auth user id. */
+  authUserId: string | null;
+  /** Patient id for PHI rows (same as `authUserId` for patients). */
+  phiSubjectUserId: string | null;
+  profileAppRole: AppRole | null;
+  /** Re-runs resolution (e.g. after first PowerSync sync lands `caretaker_access`). */
+  refresh: () => void;
+};
+
+/**
+ * Resolves the patient user id used for episode / marker / food PHI (`phiSubjectUserId`) vs the
+ * signed-in auth id (`authUserId`). Caretakers use the linked patient from active `caretaker_access`.
+ *
+ * @returns Loading and error state plus ids for Home, Manage, and episode flows.
+ */
+export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextState {
+  const authUserId = useMobileAuthUserId();
+  const psBridge = usePowerSyncBridgeState();
+  const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [phiSubjectUserId, setPhiSubjectUserId] = useState<string | null>(null);
+  const [profileAppRole, setProfileAppRole] = useState<AppRole | null>(null);
+  const genRef = useRef(0);
+
+  const runResolve = useCallback(async () => {
+    const gen = ++genRef.current;
+    if (authUserId == null || authUserId.trim() === '') {
+      setLoading(false);
+      setErrorMessage(null);
+      setPhiSubjectUserId(null);
+      setProfileAppRole(null);
+      return;
+    }
+    setLoading(true);
+    setErrorMessage(null);
+    const db = powerSyncReplicaSqliteReady(psBridge) ? psBridge.database : null;
+    const result = await resolveMobilePhiSubjectUserContext({
+      powerSyncDatabase: db,
+    });
+    if (gen !== genRef.current) {
+      return;
+    }
+    setLoading(false);
+    if (!result.ok) {
+      setPhiSubjectUserId(null);
+      setProfileAppRole(null);
+      setErrorMessage(result.error.message);
+      return;
+    }
+    if (result.data == null) {
+      setPhiSubjectUserId(null);
+      setProfileAppRole(null);
+      setErrorMessage(null);
+      return;
+    }
+    setPhiSubjectUserId(result.data.phiSubjectUserId);
+    setProfileAppRole(result.data.profileAppRole);
+    setErrorMessage(null);
+  }, [authUserId, psBridge]);
+
+  useEffect(() => {
+    void runResolve();
+  }, [runResolve]);
+
+  const firstSyncHandledRef = useRef(false);
+  useEffect(() => {
+    if (!psBridge.firstSyncCompleted) {
+      firstSyncHandledRef.current = false;
+      return;
+    }
+    if (!firstSyncHandledRef.current) {
+      firstSyncHandledRef.current = true;
+      void runResolve();
+    }
+  }, [psBridge.firstSyncCompleted, runResolve]);
+
+  const refresh = useCallback(() => {
+    void runResolve();
+  }, [runResolve]);
+
+  return {
+    loading,
+    errorMessage,
+    authUserId,
+    phiSubjectUserId,
+    profileAppRole,
+    refresh,
+  };
+}

--- a/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
@@ -27,10 +27,12 @@ export type MobilePhiSubjectUserContextState = {
  * Resolves the patient user id used for episode / marker / food PHI (`phiSubjectUserId`) vs the
  * signed-in auth id (`authUserId`). Caretakers use the linked patient from active `caretaker_access`.
  *
- * In-flight {@link resolveMobilePhiSubjectUserContext} results are ignored after unmount or when
- * `authUserId` / replica readiness (`database` + `localSqliteInitialized`) / first-sync completion
- * change, by bumping a generation counter so async completion does not call `setState` on an
- * unmounted consumer. Each new resolve clears `phiSubjectUserId` and `profileAppRole` before
+ * In-flight {@link resolveMobilePhiSubjectUserContext} results are ignored when a **new** resolve
+ * starts (each `runResolve` call increments a generation counter first) or when the hook
+ * **unmounts** (a final increment drops any still-pending completion). Replica readiness
+ * (`database` + `localSqliteInitialized`) and `authUserId` changes recreate `runResolve` and
+ * re-run the primary effect, which invokes it again; the first-sync effect may invoke it once when
+ * `firstSyncCompleted` becomes true. Each new resolve clears `phiSubjectUserId` and `profileAppRole` before
  * awaiting the resolver so consumers that do not gate every read on `loading` cannot briefly use a
  * stale PHI subject after an account switch or replica re-scope. Resolution still runs when `authUserId` is null: on cold starts where
  * {@link useMobileAuthUserId} has not recovered yet, {@link resolveMobilePhiSubjectUserContext}
@@ -86,11 +88,20 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
     setErrorMessage(null);
   }, [authUserId, dbForPhi]);
 
+  /**
+   * Invalidate in-flight resolves only on real unmount. Do not bump `genRef` from other effect
+   * cleanups when `runResolve` identity changes: `runResolve` already increments the generation at
+   * the start of each call, so the previous async completion is dropped without an extra cleanup
+   * bump (which would also have raced the first-sync effect's overlapping resolve).
+   */
   useEffect(() => {
-    void runResolve();
     return () => {
       genRef.current += 1;
     };
+  }, []);
+
+  useEffect(() => {
+    void runResolve();
   }, [runResolve]);
 
   const firstSyncHandledRef = useRef(false);
@@ -101,9 +112,6 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
       firstSyncHandledRef.current = true;
       void runResolve();
     }
-    return () => {
-      genRef.current += 1;
-    };
   }, [firstSyncCompleted, runResolve]);
 
   const refresh = useCallback(() => {

--- a/apps/mobile/src/lib/episode-templates/episode-template-service.ts
+++ b/apps/mobile/src/lib/episode-templates/episode-template-service.ts
@@ -2,7 +2,9 @@
  * Mobile episode template operations: persistence only through `@abstrack/supabase` helpers.
  *
  * {@link getCurrentUserId} is re-exported from the shared preset offline auth helper (same
- * implementation as symptom / health-marker preset services).
+ * implementation as symptom / health-marker preset services). PowerSync SQLite reads use
+ * {@link resolveOfflinePresetListScopeUserId} so `episode_templates.user_id` (PHI subject) matches
+ * caretaker sessions; pass {@link EpisodeTemplateFetchOptions.scopeUserId} from UI when known.
  */
 import type {
   EpisodeTemplateInsert,
@@ -30,11 +32,24 @@ import {
   resolvePowerSyncDatabaseForOfflineRead,
   type PowerSyncOfflineReadContext,
 } from '../powersync/powersync-offline-read-bridge-snapshot';
-import { getMobileAuthUserIdForPresetListOffline } from '../phi-subject/resolve-offline-preset-list-scope-user-id';
+import {
+  getMobileAuthUserIdForPresetListOffline,
+  resolveOfflinePresetListScopeUserId,
+} from '../phi-subject/resolve-offline-preset-list-scope-user-id';
 import { getMobileSupabaseClient } from '../supabase-wiring';
 
 /** @see {@link getMobileAuthUserIdForPresetListOffline} */
 export const getCurrentUserId = getMobileAuthUserIdForPresetListOffline;
+
+type EpisodeTemplateFetchOptions = {
+  powerSyncOfflineRead?: PowerSyncOfflineReadContext | null;
+  /**
+   * Optional PHI row owner (`episode_templates.user_id`) for replica SQL. When omitted but a
+   * replica handle is used, {@link resolveOfflinePresetListScopeUserId} supplies the subject
+   * (caretaker → linked patient).
+   */
+  scopeUserId?: string | null;
+};
 
 /**
  * Lists episode templates with nested preset names, falling back to the PowerSync replica when
@@ -54,11 +69,12 @@ export const getCurrentUserId = getMobileAuthUserIdForPresetListOffline;
  * already known offline, the mapped local error is returned (not a masked Supabase network result).
  *
  * @param options.powerSyncOfflineRead - From `usePowerSyncBridgeState()` when calling from UI.
+ * @param options.scopeUserId - See {@link EpisodeTemplateFetchOptions.scopeUserId}.
  * @returns {@link PresetDataResult} of template rows or an error.
  */
-export async function fetchEpisodeTemplates(options?: {
-  powerSyncOfflineRead?: PowerSyncOfflineReadContext | null;
-}): Promise<PresetDataResult<EpisodeTemplateWithPresetsRow[]>> {
+export async function fetchEpisodeTemplates(
+  options?: EpisodeTemplateFetchOptions,
+): Promise<PresetDataResult<EpisodeTemplateWithPresetsRow[]>> {
   const client = getMobileSupabaseClient();
   const db = resolvePowerSyncDatabaseForOfflineRead(
     options?.powerSyncOfflineRead ?? null,
@@ -67,17 +83,20 @@ export async function fetchEpisodeTemplates(options?: {
   if (db) {
     const connected = await fetchMobileDeviceIsConnected();
     if (connected === false) {
-      const auth = await getCurrentUserId();
-      if (!auth.ok) {
-        return auth;
+      const scope = await resolveOfflinePresetListScopeUserId(
+        options?.scopeUserId ?? null,
+        db,
+      );
+      if (!scope.ok) {
+        return scope;
       }
-      if (auth.data == null) {
+      if (scope.data == null) {
         return listEpisodeTemplates(client);
       }
       try {
         const data = await listEpisodeTemplatesWithPresetsFromPowerSyncDb(
           db,
-          auth.data,
+          scope.data,
         );
         return { ok: true, data };
       } catch (caught) {
@@ -92,11 +111,14 @@ export async function fetchEpisodeTemplates(options?: {
     return remote;
   }
 
-  const auth = await getCurrentUserId();
-  if (!auth.ok || auth.data == null) {
+  const scope = await resolveOfflinePresetListScopeUserId(
+    options?.scopeUserId ?? null,
+    db,
+  );
+  if (!scope.ok || scope.data == null) {
     return remote;
   }
-  const userId = auth.data;
+  const userId = scope.data;
 
   if (!remote.ok && isPresetDataNetworkError(remote.error)) {
     if (!db) {
@@ -162,10 +184,11 @@ export async function fetchEpisodeTemplates(options?: {
  *
  * @param id - Template row id.
  * @param options.powerSyncOfflineRead - From `usePowerSyncBridgeState()` when calling from UI.
+ * @param options.scopeUserId - See {@link EpisodeTemplateFetchOptions.scopeUserId}.
  */
 export async function fetchEpisodeTemplateById(
   id: string,
-  options?: { powerSyncOfflineRead?: PowerSyncOfflineReadContext | null },
+  options?: EpisodeTemplateFetchOptions,
 ): Promise<PresetDataResult<EpisodeTemplateWithPresetsRow | null>> {
   const client = getMobileSupabaseClient();
   const db = resolvePowerSyncDatabaseForOfflineRead(
@@ -173,9 +196,12 @@ export async function fetchEpisodeTemplateById(
   );
   let userId: string | null = null;
   if (db) {
-    const auth = await getCurrentUserId();
-    if (auth.ok && auth.data != null) {
-      userId = auth.data;
+    const scope = await resolveOfflinePresetListScopeUserId(
+      options?.scopeUserId ?? null,
+      db,
+    );
+    if (scope.ok && scope.data != null) {
+      userId = scope.data;
       const connected = await fetchMobileDeviceIsConnected();
       if (connected === false) {
         try {
@@ -202,11 +228,14 @@ export async function fetchEpisodeTemplateById(
   }
 
   if (userId == null) {
-    const auth = await getCurrentUserId();
-    if (!auth.ok || auth.data == null) {
+    const scope = await resolveOfflinePresetListScopeUserId(
+      options?.scopeUserId ?? null,
+      db,
+    );
+    if (!scope.ok || scope.data == null) {
       return remote;
     }
-    userId = auth.data;
+    userId = scope.data;
   }
 
   if (!remote.ok && isPresetDataNetworkError(remote.error)) {

--- a/apps/mobile/src/lib/episode-templates/episode-template-service.ts
+++ b/apps/mobile/src/lib/episode-templates/episode-template-service.ts
@@ -1,5 +1,8 @@
 /**
  * Mobile episode template operations: persistence only through `@abstrack/supabase` helpers.
+ *
+ * {@link getCurrentUserId} is re-exported from the shared preset offline auth helper (same
+ * implementation as symptom / health-marker preset services).
  */
 import type {
   EpisodeTemplateInsert,
@@ -27,44 +30,11 @@ import {
   resolvePowerSyncDatabaseForOfflineRead,
   type PowerSyncOfflineReadContext,
 } from '../powersync/powersync-offline-read-bridge-snapshot';
-import {
-  getMobileAuthSessionSafe,
-  getMobileSupabaseClient,
-  isAuthSessionRecoveryFailure,
-  readPersistedMobileAuthUserId,
-} from '../supabase-wiring';
+import { getMobileAuthUserIdForPresetListOffline } from '../phi-subject/resolve-offline-preset-list-scope-user-id';
+import { getMobileSupabaseClient } from '../supabase-wiring';
 
-/**
- * Resolves the signed-in user id for template saves (same pattern as symptom preset service).
- * Uses {@link getMobileAuthSessionSafe} (local persisted session) rather than `getUser()` so airplane mode
- * does not fail: `auth.getUser()` validates with the server and throws `Network request failed`.
- * On `auth_session_recovery_failed`, falls back to {@link readPersistedMobileAuthUserId} (see symptom presets).
- *
- * @returns User id, null when signed out, or an error when the session read fails.
- */
-export async function getCurrentUserId(): Promise<
-  PresetDataResult<string | null>
-> {
-  try {
-    const {
-      data: { session },
-      error,
-    } = await getMobileAuthSessionSafe();
-    if (!error) {
-      return { ok: true, data: session?.user?.id ?? null };
-    }
-    if (!isAuthSessionRecoveryFailure(error)) {
-      return { ok: false, error: toPresetDataError(error) };
-    }
-    const persistedId = await readPersistedMobileAuthUserId();
-    if (persistedId != null) {
-      return { ok: true, data: persistedId };
-    }
-    return { ok: false, error: toPresetDataError(error) };
-  } catch (caught) {
-    return { ok: false, error: toPresetDataError(caught) };
-  }
-}
+/** @see {@link getMobileAuthUserIdForPresetListOffline} */
+export const getCurrentUserId = getMobileAuthUserIdForPresetListOffline;
 
 /**
  * Lists episode templates with nested preset names, falling back to the PowerSync replica when

--- a/apps/mobile/src/lib/health-marker-presets/health-marker-preset-service.ts
+++ b/apps/mobile/src/lib/health-marker-presets/health-marker-preset-service.ts
@@ -71,6 +71,18 @@ export async function getCurrentUserId(): Promise<
   }
 }
 
+async function resolveOfflinePresetListScopeUserId(
+  explicitScopeUserId?: string | null,
+): Promise<PresetDataResult<string | null>> {
+  if (explicitScopeUserId != null) {
+    const trimmed = explicitScopeUserId.trim();
+    if (trimmed !== '') {
+      return { ok: true, data: trimmed };
+    }
+  }
+  return getCurrentUserId();
+}
+
 /**
  * Lists the signed-in user’s health marker presets, falling back to the PowerSync replica when
  * Supabase is unreachable and {@link resolvePowerSyncDatabaseForOfflineRead} returns a database
@@ -87,9 +99,12 @@ export async function getCurrentUserId(): Promise<
  * network result).
  *
  * @param options.powerSyncOfflineRead - From `usePowerSyncBridgeState()` when calling from UI.
+ * @param options.scopeUserId - Optional PHI row owner for replica SQL (caretaker’s linked patient).
+ *   When omitted, {@link getCurrentUserId} is used.
  */
 export async function fetchHealthMarkerPresets(options?: {
   powerSyncOfflineRead?: PowerSyncOfflineReadContext | null;
+  scopeUserId?: string | null;
 }): Promise<PresetDataResult<HealthMarkerPresetRow[]>> {
   const client = getMobileSupabaseClient();
   const db = resolvePowerSyncDatabaseForOfflineRead(
@@ -99,7 +114,9 @@ export async function fetchHealthMarkerPresets(options?: {
   if (db) {
     const connected = await fetchMobileDeviceIsConnected();
     if (connected === false) {
-      const auth = await getCurrentUserId();
+      const auth = await resolveOfflinePresetListScopeUserId(
+        options?.scopeUserId,
+      );
       if (!auth.ok) {
         return auth;
       }
@@ -130,7 +147,7 @@ export async function fetchHealthMarkerPresets(options?: {
     const alt = clarifyNetworkErrorWhenReplicaUnavailable(remote.error);
     return alt ? { ok: false, error: alt } : remote;
   }
-  const auth = await getCurrentUserId();
+  const auth = await resolveOfflinePresetListScopeUserId(options?.scopeUserId);
   if (!auth.ok || auth.data == null) {
     return remote;
   }

--- a/apps/mobile/src/lib/health-marker-presets/health-marker-preset-service.ts
+++ b/apps/mobile/src/lib/health-marker-presets/health-marker-preset-service.ts
@@ -23,9 +23,8 @@ import {
   updateHealthMarkerPreset,
   updatePresetHealthMarker,
 } from '@abstrack/supabase';
-import type { PowerSyncDatabase } from '@powersync/react-native';
 import { fetchMobileDeviceIsConnected } from '../network/mobile-device-netinfo';
-import { resolveMobilePhiSubjectUserContext } from '../phi-subject/resolve-mobile-phi-subject-user-context';
+import { resolveOfflinePresetListScopeUserId } from '../phi-subject/resolve-offline-preset-list-scope-user-id';
 import { listHealthMarkerPresetsForUserFromPowerSyncDb } from '../powersync/powersync-episode-flow-reads';
 import {
   clarifyNetworkErrorWhenReplicaUnavailable,
@@ -33,83 +32,9 @@ import {
   resolvePowerSyncDatabaseForOfflineRead,
   type PowerSyncOfflineReadContext,
 } from '../powersync/powersync-offline-read-bridge-snapshot';
-import {
-  getMobileAuthSessionSafe,
-  getMobileSupabaseClient,
-  isAuthSessionRecoveryFailure,
-  readPersistedMobileAuthUserId,
-} from '../supabase-wiring';
+import { getMobileSupabaseClient } from '../supabase-wiring';
 
-/**
- * Resolves the signed-in user id from the persisted session (offline-safe).
- * When {@link getMobileAuthSessionSafe} returns `auth_session_recovery_failed`, falls back to
- * {@link readPersistedMobileAuthUserId} (same as symptom presets) so offline replica reads survive
- * transient secure-store / recovery failures.
- *
- * @returns `{ ok: true, data: id }` when signed in; `{ ok: true, data: null }` when signed out with
- * no auth error; `{ ok: false, error }` when the session read failed.
- */
-export async function getCurrentUserId(): Promise<
-  PresetDataResult<string | null>
-> {
-  try {
-    const {
-      data: { session },
-      error,
-    } = await getMobileAuthSessionSafe();
-    if (!error) {
-      return { ok: true, data: session?.user?.id ?? null };
-    }
-    if (!isAuthSessionRecoveryFailure(error)) {
-      return { ok: false, error: toPresetDataError(error) };
-    }
-    const persistedId = await readPersistedMobileAuthUserId();
-    if (persistedId != null) {
-      return { ok: true, data: persistedId };
-    }
-    return { ok: false, error: toPresetDataError(error) };
-  } catch (caught) {
-    return { ok: false, error: toPresetDataError(caught) };
-  }
-}
-
-/**
- * Resolves which `user_id` to filter on for offline replica preset lists.
- *
- * When `explicitScopeUserId` is a non-empty string, returns it. Otherwise, when `replicaDb` is set,
- * uses {@link resolveMobilePhiSubjectUserContext} so caretaker sessions query the linked patient’s
- * rows. Falls back to {@link getCurrentUserId} when no replica is available or PHI scope is unavailable.
- *
- * @param explicitScopeUserId - Optional PHI row owner from the caller (skips resolver when set).
- * @param replicaDb - Open PowerSync database when reading SQLite; enables PHI resolution when scope is omitted.
- */
-async function resolveOfflinePresetListScopeUserId(
-  explicitScopeUserId: string | null | undefined,
-  replicaDb: PowerSyncDatabase | null,
-): Promise<PresetDataResult<string | null>> {
-  if (explicitScopeUserId != null) {
-    const trimmed = explicitScopeUserId.trim();
-    if (trimmed !== '') {
-      return { ok: true, data: trimmed };
-    }
-  }
-  if (replicaDb) {
-    const phi = await resolveMobilePhiSubjectUserContext({
-      powerSyncDatabase: replicaDb,
-    });
-    if (!phi.ok) {
-      return phi;
-    }
-    const subject =
-      phi.data?.phiSubjectUserId != null
-        ? phi.data.phiSubjectUserId.trim()
-        : '';
-    if (subject !== '') {
-      return { ok: true, data: subject };
-    }
-  }
-  return getCurrentUserId();
-}
+export { getMobileAuthUserIdForPresetListOffline as getCurrentUserId } from '../phi-subject/resolve-offline-preset-list-scope-user-id';
 
 /**
  * Lists the signed-in user’s health marker presets, falling back to the PowerSync replica when
@@ -128,7 +53,7 @@ async function resolveOfflinePresetListScopeUserId(
  *
  * @param options.powerSyncOfflineRead - From `usePowerSyncBridgeState()` when calling from UI.
  * @param options.scopeUserId - Optional PHI row owner for replica SQL. When omitted but a replica
- *   handle is used, {@link resolveMobilePhiSubjectUserContext} supplies the subject. Otherwise
+ *   handle is used, {@link resolveOfflinePresetListScopeUserId} supplies the subject. Otherwise
  *   {@link getCurrentUserId} is used.
  */
 export async function fetchHealthMarkerPresets(options?: {

--- a/apps/mobile/src/lib/health-marker-presets/health-marker-preset-service.ts
+++ b/apps/mobile/src/lib/health-marker-presets/health-marker-preset-service.ts
@@ -23,7 +23,9 @@ import {
   updateHealthMarkerPreset,
   updatePresetHealthMarker,
 } from '@abstrack/supabase';
+import type { PowerSyncDatabase } from '@powersync/react-native';
 import { fetchMobileDeviceIsConnected } from '../network/mobile-device-netinfo';
+import { resolveMobilePhiSubjectUserContext } from '../phi-subject/resolve-mobile-phi-subject-user-context';
 import { listHealthMarkerPresetsForUserFromPowerSyncDb } from '../powersync/powersync-episode-flow-reads';
 import {
   clarifyNetworkErrorWhenReplicaUnavailable,
@@ -71,13 +73,39 @@ export async function getCurrentUserId(): Promise<
   }
 }
 
+/**
+ * Resolves which `user_id` to filter on for offline replica preset lists.
+ *
+ * When `explicitScopeUserId` is a non-empty string, returns it. Otherwise, when `replicaDb` is set,
+ * uses {@link resolveMobilePhiSubjectUserContext} so caretaker sessions query the linked patient’s
+ * rows. Falls back to {@link getCurrentUserId} when no replica is available or PHI scope is unavailable.
+ *
+ * @param explicitScopeUserId - Optional PHI row owner from the caller (skips resolver when set).
+ * @param replicaDb - Open PowerSync database when reading SQLite; enables PHI resolution when scope is omitted.
+ */
 async function resolveOfflinePresetListScopeUserId(
-  explicitScopeUserId?: string | null,
+  explicitScopeUserId: string | null | undefined,
+  replicaDb: PowerSyncDatabase | null,
 ): Promise<PresetDataResult<string | null>> {
   if (explicitScopeUserId != null) {
     const trimmed = explicitScopeUserId.trim();
     if (trimmed !== '') {
       return { ok: true, data: trimmed };
+    }
+  }
+  if (replicaDb) {
+    const phi = await resolveMobilePhiSubjectUserContext({
+      powerSyncDatabase: replicaDb,
+    });
+    if (!phi.ok) {
+      return phi;
+    }
+    const subject =
+      phi.data?.phiSubjectUserId != null
+        ? phi.data.phiSubjectUserId.trim()
+        : '';
+    if (subject !== '') {
+      return { ok: true, data: subject };
     }
   }
   return getCurrentUserId();
@@ -99,8 +127,9 @@ async function resolveOfflinePresetListScopeUserId(
  * network result).
  *
  * @param options.powerSyncOfflineRead - From `usePowerSyncBridgeState()` when calling from UI.
- * @param options.scopeUserId - Optional PHI row owner for replica SQL (caretaker’s linked patient).
- *   When omitted, {@link getCurrentUserId} is used.
+ * @param options.scopeUserId - Optional PHI row owner for replica SQL. When omitted but a replica
+ *   handle is used, {@link resolveMobilePhiSubjectUserContext} supplies the subject. Otherwise
+ *   {@link getCurrentUserId} is used.
  */
 export async function fetchHealthMarkerPresets(options?: {
   powerSyncOfflineRead?: PowerSyncOfflineReadContext | null;
@@ -116,6 +145,7 @@ export async function fetchHealthMarkerPresets(options?: {
     if (connected === false) {
       const auth = await resolveOfflinePresetListScopeUserId(
         options?.scopeUserId,
+        db,
       );
       if (!auth.ok) {
         return auth;
@@ -147,7 +177,10 @@ export async function fetchHealthMarkerPresets(options?: {
     const alt = clarifyNetworkErrorWhenReplicaUnavailable(remote.error);
     return alt ? { ok: false, error: alt } : remote;
   }
-  const auth = await resolveOfflinePresetListScopeUserId(options?.scopeUserId);
+  const auth = await resolveOfflinePresetListScopeUserId(
+    options?.scopeUserId,
+    db,
+  );
   if (!auth.ok || auth.data == null) {
     return remote;
   }

--- a/apps/mobile/src/lib/media/pending-episode-media-upload.spec.ts
+++ b/apps/mobile/src/lib/media/pending-episode-media-upload.spec.ts
@@ -21,6 +21,17 @@ jest.mock('@abstrack/supabase', () => ({
     '@abstrack/supabase',
   ),
   uploadConfirmedEpisodeMedia: jest.fn(),
+  /** Worker resolves PHI before selecting queue rows; the test Supabase stub cannot load profiles. */
+  resolvePhiSubjectUserContextFromSupabase: jest.fn(
+    async (_client: unknown, authUserId: string) => ({
+      ok: true as const,
+      data: {
+        authUserId,
+        phiSubjectUserId: authUserId,
+        profileAppRole: 'patient' as const,
+      },
+    }),
+  ),
 }));
 
 jest.mock('../supabase-wiring', () => ({

--- a/apps/mobile/src/lib/media/pending-episode-media-upload.spec.ts
+++ b/apps/mobile/src/lib/media/pending-episode-media-upload.spec.ts
@@ -6,6 +6,7 @@ import {
 import type { PowerSyncDatabase } from '@powersync/react-native';
 
 import { fetchMobileDeviceIsConnected } from '../network/mobile-device-netinfo';
+import * as mobilePhiSubjectUserContext from '../phi-subject/resolve-mobile-phi-subject-user-context';
 import { getMobileAuthSessionSafe } from '../supabase-wiring';
 import * as pendingCrypto from './device-pending-media-crypto';
 import {
@@ -301,6 +302,58 @@ describe('runPendingEpisodeMediaUploadWorker', () => {
     const out = await runPendingEpisodeMediaUploadWorker(db, {});
     expect(out).toEqual({ processed: 0, failures: 0 });
     expect(mockUploadConfirmedEpisodeMedia).not.toHaveBeenCalled();
+  });
+
+  it('treats PHI scope resolution error as a failed worker run (warn + failures count)', async () => {
+    const phiSpy = jest
+      .spyOn(mobilePhiSubjectUserContext, 'resolveMobilePhiSubjectUserContext')
+      .mockResolvedValue({
+        ok: false,
+        error: new PresetDataError(
+          'validation_error',
+          'Your caretaker account is not linked to a patient yet.',
+        ),
+      });
+    const warnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    try {
+      const row = createQueueRow();
+      const db = createWorkerDbMock([row]) as unknown as PowerSyncDatabase;
+      const out = await runPendingEpisodeMediaUploadWorker(db, {});
+      expect(out).toEqual({ processed: 0, failures: 1 });
+      expect(mockUploadConfirmedEpisodeMedia).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        '[PendingEpisodeMediaUploadWorker] PHI scope resolution failed; pending episode media drain skipped.',
+        expect.objectContaining({
+          code: 'validation_error',
+          message: 'Your caretaker account is not linked to a patient yet.',
+        }),
+      );
+    } finally {
+      phiSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
+  });
+
+  it('returns idle counts when PHI scope is ok but unauthenticated (data null)', async () => {
+    const phiSpy = jest
+      .spyOn(mobilePhiSubjectUserContext, 'resolveMobilePhiSubjectUserContext')
+      .mockResolvedValue({ ok: true, data: null });
+    const warnSpy = jest
+      .spyOn(console, 'warn')
+      .mockImplementation(() => undefined);
+    try {
+      const row = createQueueRow();
+      const db = createWorkerDbMock([row]) as unknown as PowerSyncDatabase;
+      const out = await runPendingEpisodeMediaUploadWorker(db, {});
+      expect(out).toEqual({ processed: 0, failures: 0 });
+      expect(mockUploadConfirmedEpisodeMedia).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      phiSpy.mockRestore();
+      warnSpy.mockRestore();
+    }
   });
 
   it('skips rows still inside exponential backoff window', async () => {

--- a/apps/mobile/src/lib/media/pending-episode-media-upload.ts
+++ b/apps/mobile/src/lib/media/pending-episode-media-upload.ts
@@ -389,6 +389,10 @@ export type RunPendingEpisodeMediaUploadWorkerOptions = {
 
 /**
  * Implementation for {@link runPendingEpisodeMediaUploadWorker} (runs after mutex acquisition).
+ *
+ * @returns `processed` / `failures` for row-level upload attempts; `failures` is incremented by one
+ *   when {@link resolveMobilePhiSubjectUserContext} returns an error (misconfigured caretaker, offline
+ *   scope, etc.) so telemetry differs from the no-session / idle path (`processed: 0`, `failures: 0`).
  */
 async function runPendingEpisodeMediaUploadWorkerImpl(
   db: PowerSyncDatabase,
@@ -418,7 +422,17 @@ async function runPendingEpisodeMediaUploadWorkerImpl(
   const phiRes = await resolveMobilePhiSubjectUserContext({
     powerSyncDatabase: db,
   });
-  if (!phiRes.ok || phiRes.data == null) {
+  if (!phiRes.ok) {
+    console.warn(
+      '[PendingEpisodeMediaUploadWorker] PHI scope resolution failed; pending episode media drain skipped.',
+      {
+        code: phiRes.error.code,
+        message: phiRes.error.message,
+      },
+    );
+    return { processed: 0, failures: 1 };
+  }
+  if (phiRes.data == null) {
     return { processed: 0, failures: 0 };
   }
   const uid = phiRes.data.phiSubjectUserId;
@@ -604,6 +618,8 @@ async function runPendingEpisodeMediaUploadWorkerImpl(
  *
  * @param db - Open PowerSync DB, or `null` to no-op.
  * @param options - {@link RunPendingEpisodeMediaUploadWorkerOptions}
+ * @returns Row-level `processed` / `failures`, plus one aggregate `failures` increment when PHI scope
+ *   resolution errors before any row is attempted (see {@link runPendingEpisodeMediaUploadWorkerImpl}).
  */
 export function runPendingEpisodeMediaUploadWorker(
   db: PowerSyncDatabase | null | undefined,

--- a/apps/mobile/src/lib/media/pending-episode-media-upload.ts
+++ b/apps/mobile/src/lib/media/pending-episode-media-upload.ts
@@ -26,10 +26,8 @@ import {
 } from './device-pending-media-crypto';
 import { getOrCreateDeviceSqlcipherKey } from '../powersync/powersync-sqlcipher-key';
 import { newRandomUuidV4 } from '../random-uuid';
-import {
-  getMobileAuthSessionSafe,
-  getMobileSupabaseClient,
-} from '../supabase-wiring';
+import { getMobileSupabaseClient } from '../supabase-wiring';
+import { resolveMobilePhiSubjectUserContext } from '../phi-subject/resolve-mobile-phi-subject-user-context';
 import { fetchMobileDeviceIsConnected } from '../network/mobile-device-netinfo';
 
 function newQueueId(): string {
@@ -417,13 +415,13 @@ async function runPendingEpisodeMediaUploadWorkerImpl(
     return { processed: 0, failures: 0 };
   }
 
-  const {
-    data: { session },
-  } = await getMobileAuthSessionSafe();
-  const uid = session?.user?.id;
-  if (!uid) {
+  const phiRes = await resolveMobilePhiSubjectUserContext({
+    powerSyncDatabase: db,
+  });
+  if (!phiRes.ok || phiRes.data == null) {
     return { processed: 0, failures: 0 };
   }
+  const uid = phiRes.data.phiSubjectUserId;
 
   if (pendingMediaUploadSignalRequestedStop(signal)) {
     return { processed: 0, failures: 0 };

--- a/apps/mobile/src/lib/phi-subject/resolve-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/phi-subject/resolve-mobile-phi-subject-user-context.ts
@@ -25,11 +25,44 @@ function normalizeAppRole(raw: unknown): AppRole | null {
 }
 
 /**
+ * Active `caretaker_access.patient_user_id` for this caretaker in the local replica, if any.
+ *
+ * @param db - Open PowerSync database.
+ * @param caretakerUserId - `caretaker_access.caretaker_user_id`.
+ * @returns Non-empty patient id, or `null` when no active grant row exists locally.
+ */
+async function readActiveCaretakerPatientIdFromReplicaDb(
+  db: PowerSyncDatabase,
+  caretakerUserId: string,
+): Promise<string | null> {
+  const grantRow = await db.getOptional<{ patient_user_id: unknown }>(
+    `SELECT patient_user_id FROM caretaker_access
+     WHERE caretaker_user_id = ?
+       AND (revoked_at IS NULL OR revoked_at = '')
+     ORDER BY created_at DESC
+     LIMIT 1`,
+    [caretakerUserId],
+  );
+  const patientId =
+    grantRow?.patient_user_id != null
+      ? String(grantRow.patient_user_id).trim()
+      : '';
+  return patientId === '' ? null : patientId;
+}
+
+/**
  * Reads {@link PhiSubjectUserContext} from replicated SQLite when the network path is unavailable.
+ *
+ * When the **`profiles` row is missing** (e.g. before that table has replicated), we must not assume
+ * the subject is a patient: an offline caretaker would otherwise get `phiSubjectUserId === authUserId`
+ * and write PHI under the wrong user. If an active **`caretaker_access`** row is already present,
+ * we still resolve the linked patient; otherwise we return `{ ok: true, data: null }` until replica
+ * data is ready (callers should treat like “scope not yet available”, not signed-out).
  *
  * @param db - Open PowerSync database.
  * @param authUserId - Signed-in auth user id.
- * @returns Context or an error; `null` only when role data is missing (treat as unknown offline).
+ * @returns Context or an error; `null` when replica cannot determine scope yet (missing profile and
+ *   no local caretaker grant), or blank `authUserId`.
  */
 async function resolvePhiSubjectUserContextFromPowerSyncDb(
   db: PowerSyncDatabase,
@@ -44,7 +77,24 @@ async function resolvePhiSubjectUserContextFromPowerSyncDb(
       `SELECT app_role FROM profiles WHERE id = ?`,
       [trimmed],
     );
-    const profileAppRole = normalizeAppRole(profileRow?.app_role);
+
+    if (profileRow == null) {
+      const patientIdIfCaretakerGrant =
+        await readActiveCaretakerPatientIdFromReplicaDb(db, trimmed);
+      if (patientIdIfCaretakerGrant != null) {
+        return {
+          ok: true,
+          data: {
+            authUserId: trimmed,
+            phiSubjectUserId: patientIdIfCaretakerGrant,
+            profileAppRole: 'caretaker',
+          },
+        };
+      }
+      return { ok: true, data: null };
+    }
+
+    const profileAppRole = normalizeAppRole(profileRow.app_role);
 
     if (profileAppRole !== 'caretaker') {
       return {
@@ -57,19 +107,11 @@ async function resolvePhiSubjectUserContextFromPowerSyncDb(
       };
     }
 
-    const grantRow = await db.getOptional<{ patient_user_id: unknown }>(
-      `SELECT patient_user_id FROM caretaker_access
-       WHERE caretaker_user_id = ?
-         AND (revoked_at IS NULL OR revoked_at = '')
-       ORDER BY created_at DESC
-       LIMIT 1`,
-      [trimmed],
+    const patientId = await readActiveCaretakerPatientIdFromReplicaDb(
+      db,
+      trimmed,
     );
-    const patientId =
-      grantRow?.patient_user_id != null
-        ? String(grantRow.patient_user_id).trim()
-        : '';
-    if (patientId === '') {
+    if (patientId == null) {
       return {
         ok: false,
         error: new PresetDataError(

--- a/apps/mobile/src/lib/phi-subject/resolve-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/phi-subject/resolve-mobile-phi-subject-user-context.ts
@@ -195,7 +195,8 @@ export type ResolveMobilePhiSubjectUserContextOptions = {
  *
  * @param options - Optional PowerSync DB for caretaker/patient offline fallback.
  * @returns Same contract as {@link resolvePhiSubjectUserContextFromSupabase}; `data: null` when
- *   there is no auth user id.
+ *   there is no auth user id. When NetInfo reports **definitively offline** and no replica `db` is
+ *   passed, returns `{ ok: false, network_error }` immediately (no Supabase round-trip timeout).
  */
 export async function resolveMobilePhiSubjectUserContext(
   options?: ResolveMobilePhiSubjectUserContextOptions,
@@ -208,32 +209,33 @@ export async function resolveMobilePhiSubjectUserContext(
     return { ok: true, data: null };
   }
 
-  const client = getMobileSupabaseClient();
   const connected = await fetchMobileDeviceIsConnected();
+  const db = options?.powerSyncDatabase ?? null;
 
-  if (connected !== false) {
-    const remote = await resolvePhiSubjectUserContextFromSupabase(
-      client,
-      auth.data,
-    );
-    if (remote.ok || remote.error.code !== 'network_error') {
-      return remote;
-    }
-    const db = options?.powerSyncDatabase ?? null;
+  if (connected === false) {
     if (db) {
       return resolvePhiSubjectUserContextFromPowerSyncDb(db, auth.data);
     }
-    return remote;
+    return {
+      ok: false,
+      error: new PresetDataError(
+        'network_error',
+        'Could not verify your account scope while offline. Connect once while online so this device can sync, then try again.',
+        new TypeError('Network request failed'),
+      ),
+    };
   }
 
-  const db = options?.powerSyncDatabase ?? null;
-  if (db) {
-    return resolvePhiSubjectUserContextFromPowerSyncDb(db, auth.data);
-  }
-
+  const client = getMobileSupabaseClient();
   const remote = await resolvePhiSubjectUserContextFromSupabase(
     client,
     auth.data,
   );
+  if (remote.ok || remote.error.code !== 'network_error') {
+    return remote;
+  }
+  if (db) {
+    return resolvePhiSubjectUserContextFromPowerSyncDb(db, auth.data);
+  }
   return remote;
 }

--- a/apps/mobile/src/lib/phi-subject/resolve-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/phi-subject/resolve-mobile-phi-subject-user-context.ts
@@ -188,12 +188,20 @@ export type ResolveMobilePhiSubjectUserContextOptions = {
    * to read `profiles` / `caretaker_access` from the replica.
    */
   powerSyncDatabase?: PowerSyncDatabase | null;
+  /**
+   * When `true` together with a non-null {@link powerSyncDatabase}, resolves PHI from SQLite only
+   * (no NetInfo read, no PostgREST). Use when the caller is already offline-first (e.g. preset list
+   * scope after a remote failure) so a misleading “online” NetInfo snapshot does not trigger a
+   * redundant network timeout before replica fallback.
+   */
+  replicaOnly?: boolean;
 };
 
 /**
  * Resolves {@link PhiSubjectUserContext} for the current mobile session (patient or caretaker).
  *
  * @param options - Optional PowerSync DB for caretaker/patient offline fallback.
+ * @param options.replicaOnly - With {@link options.powerSyncDatabase}, SQLite-only PHI resolution.
  * @returns Same contract as {@link resolvePhiSubjectUserContextFromSupabase}; `data: null` when
  *   there is no auth user id. When NetInfo reports **definitively offline** and no replica `db` is
  *   passed, returns `{ ok: false, network_error }` immediately (no Supabase round-trip timeout).
@@ -209,8 +217,12 @@ export async function resolveMobilePhiSubjectUserContext(
     return { ok: true, data: null };
   }
 
-  const connected = await fetchMobileDeviceIsConnected();
   const db = options?.powerSyncDatabase ?? null;
+  if (options?.replicaOnly === true && db != null) {
+    return resolvePhiSubjectUserContextFromPowerSyncDb(db, auth.data);
+  }
+
+  const connected = await fetchMobileDeviceIsConnected();
 
   if (connected === false) {
     if (db) {

--- a/apps/mobile/src/lib/phi-subject/resolve-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/phi-subject/resolve-mobile-phi-subject-user-context.ts
@@ -5,6 +5,7 @@
 import { isAppRole, type AppRole } from '@abstrack/types';
 import type { PresetDataResult } from '@abstrack/supabase';
 import {
+  CARETAKER_MULTIPLE_ACTIVE_PATIENTS_MESSAGE,
   PresetDataError,
   resolvePhiSubjectUserContextFromSupabase,
   toPresetDataError,
@@ -25,29 +26,48 @@ function normalizeAppRole(raw: unknown): AppRole | null {
 }
 
 /**
- * Active `caretaker_access.patient_user_id` for this caretaker in the local replica, if any.
+ * Distinct active `caretaker_access.patient_user_id` values for this caretaker in the local replica.
+ *
+ * Matches {@link resolvePhiSubjectUserContextFromSupabase}: multiple active patients return a
+ * validation error instead of picking an arbitrary row.
  *
  * @param db - Open PowerSync database.
  * @param caretakerUserId - `caretaker_access.caretaker_user_id`.
- * @returns Non-empty patient id, or `null` when no active grant row exists locally.
+ * @returns Single patient id, `null` when no active grant exists, or a validation error when
+ *   multiple distinct active patients are linked.
  */
 async function readActiveCaretakerPatientIdFromReplicaDb(
   db: PowerSyncDatabase,
   caretakerUserId: string,
-): Promise<string | null> {
-  const grantRow = await db.getOptional<{ patient_user_id: unknown }>(
+): Promise<PresetDataResult<string | null>> {
+  const rows = await db.getAll<{ patient_user_id: unknown }>(
     `SELECT patient_user_id FROM caretaker_access
      WHERE caretaker_user_id = ?
-       AND (revoked_at IS NULL OR revoked_at = '')
-     ORDER BY created_at DESC
-     LIMIT 1`,
+       AND (revoked_at IS NULL OR revoked_at = '')`,
     [caretakerUserId],
   );
-  const patientId =
-    grantRow?.patient_user_id != null
-      ? String(grantRow.patient_user_id).trim()
-      : '';
-  return patientId === '' ? null : patientId;
+  const patientIds = new Set<string>();
+  for (const row of rows) {
+    const id =
+      row.patient_user_id != null ? String(row.patient_user_id).trim() : '';
+    if (id !== '') {
+      patientIds.add(id);
+    }
+  }
+  if (patientIds.size === 0) {
+    return { ok: true, data: null };
+  }
+  if (patientIds.size > 1) {
+    return {
+      ok: false,
+      error: new PresetDataError(
+        'validation_error',
+        CARETAKER_MULTIPLE_ACTIVE_PATIENTS_MESSAGE,
+      ),
+    };
+  }
+  const [onlyPatientId] = patientIds;
+  return { ok: true, data: onlyPatientId };
 }
 
 /**
@@ -79,14 +99,19 @@ async function resolvePhiSubjectUserContextFromPowerSyncDb(
     );
 
     if (profileRow == null) {
-      const patientIdIfCaretakerGrant =
-        await readActiveCaretakerPatientIdFromReplicaDb(db, trimmed);
-      if (patientIdIfCaretakerGrant != null) {
+      const grant = await readActiveCaretakerPatientIdFromReplicaDb(
+        db,
+        trimmed,
+      );
+      if (!grant.ok) {
+        return grant;
+      }
+      if (grant.data != null) {
         return {
           ok: true,
           data: {
             authUserId: trimmed,
-            phiSubjectUserId: patientIdIfCaretakerGrant,
+            phiSubjectUserId: grant.data,
             profileAppRole: 'caretaker',
           },
         };
@@ -107,11 +132,11 @@ async function resolvePhiSubjectUserContextFromPowerSyncDb(
       };
     }
 
-    const patientId = await readActiveCaretakerPatientIdFromReplicaDb(
-      db,
-      trimmed,
-    );
-    if (patientId == null) {
+    const grant = await readActiveCaretakerPatientIdFromReplicaDb(db, trimmed);
+    if (!grant.ok) {
+      return grant;
+    }
+    if (grant.data == null) {
       return {
         ok: false,
         error: new PresetDataError(
@@ -124,7 +149,7 @@ async function resolvePhiSubjectUserContextFromPowerSyncDb(
       ok: true,
       data: {
         authUserId: trimmed,
-        phiSubjectUserId: patientId,
+        phiSubjectUserId: grant.data,
         profileAppRole: 'caretaker',
       },
     };

--- a/apps/mobile/src/lib/phi-subject/resolve-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/phi-subject/resolve-mobile-phi-subject-user-context.ts
@@ -1,0 +1,172 @@
+/**
+ * PHI subject resolution for the Expo app: online via PostgREST, optional PowerSync SQLite fallback
+ * when the device is explicitly offline and the replica has synced `profiles` / `caretaker_access`.
+ */
+import { isAppRole, type AppRole } from '@abstrack/types';
+import type { PresetDataResult } from '@abstrack/supabase';
+import {
+  PresetDataError,
+  resolvePhiSubjectUserContextFromSupabase,
+  toPresetDataError,
+  type PhiSubjectUserContext,
+} from '@abstrack/supabase';
+import type { PowerSyncDatabase } from '@powersync/react-native';
+
+import { fetchMobileDeviceIsConnected } from '../network/mobile-device-netinfo';
+import {
+  getMobileAuthSessionSafe,
+  getMobileSupabaseClient,
+  isAuthSessionRecoveryFailure,
+  readPersistedMobileAuthUserId,
+} from '../supabase-wiring';
+
+function normalizeAppRole(raw: unknown): AppRole | null {
+  return isAppRole(raw) ? raw : null;
+}
+
+/**
+ * Reads {@link PhiSubjectUserContext} from replicated SQLite when the network path is unavailable.
+ *
+ * @param db - Open PowerSync database.
+ * @param authUserId - Signed-in auth user id.
+ * @returns Context or an error; `null` only when role data is missing (treat as unknown offline).
+ */
+async function resolvePhiSubjectUserContextFromPowerSyncDb(
+  db: PowerSyncDatabase,
+  authUserId: string,
+): Promise<PresetDataResult<PhiSubjectUserContext | null>> {
+  const trimmed = authUserId.trim();
+  if (trimmed === '') {
+    return { ok: true, data: null };
+  }
+  try {
+    const profileRow = await db.getOptional<{ app_role: unknown }>(
+      `SELECT app_role FROM profiles WHERE id = ?`,
+      [trimmed],
+    );
+    const profileAppRole = normalizeAppRole(profileRow?.app_role);
+
+    if (profileAppRole !== 'caretaker') {
+      return {
+        ok: true,
+        data: {
+          authUserId: trimmed,
+          phiSubjectUserId: trimmed,
+          profileAppRole,
+        },
+      };
+    }
+
+    const grantRow = await db.getOptional<{ patient_user_id: unknown }>(
+      `SELECT patient_user_id FROM caretaker_access
+       WHERE caretaker_user_id = ?
+         AND (revoked_at IS NULL OR revoked_at = '')
+       ORDER BY created_at DESC
+       LIMIT 1`,
+      [trimmed],
+    );
+    const patientId =
+      grantRow?.patient_user_id != null
+        ? String(grantRow.patient_user_id).trim()
+        : '';
+    if (patientId === '') {
+      return {
+        ok: false,
+        error: new PresetDataError(
+          'validation_error',
+          'Your caretaker account is not linked to a patient yet. Connect online once after the patient invites you, or ask them to send a new invite.',
+        ),
+      };
+    }
+    return {
+      ok: true,
+      data: {
+        authUserId: trimmed,
+        phiSubjectUserId: patientId,
+        profileAppRole: 'caretaker',
+      },
+    };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
+}
+
+async function resolveAuthUserIdForPhi(): Promise<
+  PresetDataResult<string | null>
+> {
+  try {
+    const {
+      data: { session },
+      error,
+    } = await getMobileAuthSessionSafe();
+    if (!error) {
+      return { ok: true, data: session?.user?.id ?? null };
+    }
+    if (!isAuthSessionRecoveryFailure(error)) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+    const persistedId = await readPersistedMobileAuthUserId();
+    if (persistedId != null) {
+      return { ok: true, data: persistedId };
+    }
+    return { ok: false, error: toPresetDataError(error) };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
+}
+
+export type ResolveMobilePhiSubjectUserContextOptions = {
+  /**
+   * When set and the device is explicitly offline after a failed or skipped network resolve, used
+   * to read `profiles` / `caretaker_access` from the replica.
+   */
+  powerSyncDatabase?: PowerSyncDatabase | null;
+};
+
+/**
+ * Resolves {@link PhiSubjectUserContext} for the current mobile session (patient or caretaker).
+ *
+ * @param options - Optional PowerSync DB for caretaker/patient offline fallback.
+ * @returns Same contract as {@link resolvePhiSubjectUserContextFromSupabase}; `data: null` when
+ *   there is no auth user id.
+ */
+export async function resolveMobilePhiSubjectUserContext(
+  options?: ResolveMobilePhiSubjectUserContextOptions,
+): Promise<PresetDataResult<PhiSubjectUserContext | null>> {
+  const auth = await resolveAuthUserIdForPhi();
+  if (!auth.ok) {
+    return auth;
+  }
+  if (auth.data == null || auth.data.trim() === '') {
+    return { ok: true, data: null };
+  }
+
+  const client = getMobileSupabaseClient();
+  const connected = await fetchMobileDeviceIsConnected();
+
+  if (connected !== false) {
+    const remote = await resolvePhiSubjectUserContextFromSupabase(
+      client,
+      auth.data,
+    );
+    if (remote.ok || remote.error.code !== 'network_error') {
+      return remote;
+    }
+    const db = options?.powerSyncDatabase ?? null;
+    if (db) {
+      return resolvePhiSubjectUserContextFromPowerSyncDb(db, auth.data);
+    }
+    return remote;
+  }
+
+  const db = options?.powerSyncDatabase ?? null;
+  if (db) {
+    return resolvePhiSubjectUserContextFromPowerSyncDb(db, auth.data);
+  }
+
+  const remote = await resolvePhiSubjectUserContextFromSupabase(
+    client,
+    auth.data,
+  );
+  return remote;
+}

--- a/apps/mobile/src/lib/phi-subject/resolve-offline-preset-list-scope-user-id.ts
+++ b/apps/mobile/src/lib/phi-subject/resolve-offline-preset-list-scope-user-id.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared offline / replica preset list scope: explicit PHI owner id vs
+ * {@link resolveMobilePhiSubjectUserContext} vs persisted auth fallback.
+ *
+ * Symptom and health-marker preset services must stay aligned here — do not fork this logic per
+ * feature.
+ */
+import type { PresetDataResult } from '@abstrack/supabase';
+import { toPresetDataError } from '@abstrack/supabase';
+import type { PowerSyncDatabase } from '@powersync/react-native';
+
+import {
+  getMobileAuthSessionSafe,
+  isAuthSessionRecoveryFailure,
+  readPersistedMobileAuthUserId,
+} from '../supabase-wiring';
+import { resolveMobilePhiSubjectUserContext } from './resolve-mobile-phi-subject-user-context';
+
+/**
+ * Resolves the signed-in user id from the persisted session (offline-safe).
+ * Uses {@link getMobileAuthSessionSafe} rather than `getUser()` so airplane mode does not fail the
+ * auth lookup. When that helper returns `auth_session_recovery_failed`, falls back to
+ * {@link readPersistedMobileAuthUserId} so transient secure-store / recovery hiccups do not block
+ * offline PowerSync preset lists.
+ *
+ * @returns `{ ok: true, data: id }` when signed in; `{ ok: true, data: null }` when signed out
+ *   with no auth error; `{ ok: false, error }` when the session read failed.
+ */
+export async function getMobileAuthUserIdForPresetListOffline(): Promise<
+  PresetDataResult<string | null>
+> {
+  try {
+    const {
+      data: { session },
+      error,
+    } = await getMobileAuthSessionSafe();
+    if (!error) {
+      return { ok: true, data: session?.user?.id ?? null };
+    }
+    if (!isAuthSessionRecoveryFailure(error)) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+    const persistedId = await readPersistedMobileAuthUserId();
+    if (persistedId != null) {
+      return { ok: true, data: persistedId };
+    }
+    return { ok: false, error: toPresetDataError(error) };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
+}
+
+/**
+ * Resolves which `user_id` to filter on for offline replica preset lists (symptom and health
+ * marker presets).
+ *
+ * When `explicitScopeUserId` is a non-empty string, returns it. Otherwise, when `replicaDb` is
+ * set, uses {@link resolveMobilePhiSubjectUserContext} so caretaker sessions query the linked
+ * patient’s rows instead of the caretaker auth uid. Falls back to
+ * {@link getMobileAuthUserIdForPresetListOffline} when no replica is available or PHI scope is
+ * unavailable.
+ *
+ * @param explicitScopeUserId - Optional PHI row owner from the caller (skips resolver when set).
+ * @param replicaDb - Open PowerSync database when reading SQLite; enables PHI resolution when scope is omitted.
+ * @returns Trimmed scope user id, null when signed out, or an error.
+ */
+export async function resolveOfflinePresetListScopeUserId(
+  explicitScopeUserId: string | null | undefined,
+  replicaDb: PowerSyncDatabase | null,
+): Promise<PresetDataResult<string | null>> {
+  if (explicitScopeUserId != null) {
+    const trimmed = explicitScopeUserId.trim();
+    if (trimmed !== '') {
+      return { ok: true, data: trimmed };
+    }
+  }
+  if (replicaDb) {
+    const phi = await resolveMobilePhiSubjectUserContext({
+      powerSyncDatabase: replicaDb,
+    });
+    if (!phi.ok) {
+      return phi;
+    }
+    const subject =
+      phi.data?.phiSubjectUserId != null
+        ? phi.data.phiSubjectUserId.trim()
+        : '';
+    if (subject !== '') {
+      return { ok: true, data: subject };
+    }
+  }
+  return getMobileAuthUserIdForPresetListOffline();
+}

--- a/apps/mobile/src/lib/phi-subject/resolve-offline-preset-list-scope-user-id.ts
+++ b/apps/mobile/src/lib/phi-subject/resolve-offline-preset-list-scope-user-id.ts
@@ -1,6 +1,6 @@
 /**
  * Shared offline / replica preset list scope: explicit PHI owner id vs
- * {@link resolveMobilePhiSubjectUserContext} vs persisted auth fallback.
+ * {@link resolveMobilePhiSubjectUserContext} (`replicaOnly` + replica DB) vs persisted auth fallback.
  *
  * Symptom and health-marker preset services must stay aligned here — do not fork this logic per
  * feature.
@@ -55,10 +55,10 @@ export async function getMobileAuthUserIdForPresetListOffline(): Promise<
  * marker presets).
  *
  * When `explicitScopeUserId` is a non-empty string, returns it. Otherwise, when `replicaDb` is
- * set, uses {@link resolveMobilePhiSubjectUserContext} so caretaker sessions query the linked
- * patient’s rows instead of the caretaker auth uid. Falls back to
- * {@link getMobileAuthUserIdForPresetListOffline} when no replica is available or PHI scope is
- * unavailable.
+ * set, uses {@link resolveMobilePhiSubjectUserContext} with `replicaOnly: true` so PHI scope is
+ * read from SQLite only (no redundant PostgREST round-trip when NetInfo still reports connected
+ * after a remote failure). Falls back to {@link getMobileAuthUserIdForPresetListOffline} when no
+ * replica is available or PHI scope is unavailable from the replica.
  *
  * @param explicitScopeUserId - Optional PHI row owner from the caller (skips resolver when set).
  * @param replicaDb - Open PowerSync database when reading SQLite; enables PHI resolution when scope is omitted.
@@ -77,6 +77,7 @@ export async function resolveOfflinePresetListScopeUserId(
   if (replicaDb) {
     const phi = await resolveMobilePhiSubjectUserContext({
       powerSyncDatabase: replicaDb,
+      replicaOnly: true,
     });
     if (!phi.ok) {
       return phi;

--- a/apps/mobile/src/lib/symptom-presets/symptom-preset-service.ts
+++ b/apps/mobile/src/lib/symptom-presets/symptom-preset-service.ts
@@ -23,7 +23,9 @@ import {
   updatePresetSymptom,
   updateSymptomPreset,
 } from '@abstrack/supabase';
+import type { PowerSyncDatabase } from '@powersync/react-native';
 import { fetchMobileDeviceIsConnected } from '../network/mobile-device-netinfo';
+import { resolveMobilePhiSubjectUserContext } from '../phi-subject/resolve-mobile-phi-subject-user-context';
 import { listSymptomPresetsForUserFromPowerSyncDb } from '../powersync/powersync-episode-flow-reads';
 import {
   clarifyNetworkErrorWhenReplicaUnavailable,
@@ -71,13 +73,40 @@ export async function getCurrentUserId(): Promise<
   }
 }
 
+/**
+ * Resolves which `user_id` to filter on for offline replica preset lists.
+ *
+ * When `explicitScopeUserId` is a non-empty string, returns it. Otherwise, when `replicaDb` is
+ * set, uses {@link resolveMobilePhiSubjectUserContext} so caretaker sessions query the linked
+ * patient’s rows instead of the caretaker auth uid. Falls back to {@link getCurrentUserId} when no
+ * replica is available or PHI scope is unavailable.
+ *
+ * @param explicitScopeUserId - Optional PHI row owner from the caller (skips resolver when set).
+ * @param replicaDb - Open PowerSync database when reading SQLite; enables PHI resolution when scope is omitted.
+ */
 async function resolveOfflinePresetListScopeUserId(
-  explicitScopeUserId?: string | null,
+  explicitScopeUserId: string | null | undefined,
+  replicaDb: PowerSyncDatabase | null,
 ): Promise<PresetDataResult<string | null>> {
   if (explicitScopeUserId != null) {
     const trimmed = explicitScopeUserId.trim();
     if (trimmed !== '') {
       return { ok: true, data: trimmed };
+    }
+  }
+  if (replicaDb) {
+    const phi = await resolveMobilePhiSubjectUserContext({
+      powerSyncDatabase: replicaDb,
+    });
+    if (!phi.ok) {
+      return phi;
+    }
+    const subject =
+      phi.data?.phiSubjectUserId != null
+        ? phi.data.phiSubjectUserId.trim()
+        : '';
+    if (subject !== '') {
+      return { ok: true, data: subject };
     }
   }
   return getCurrentUserId();
@@ -96,9 +125,9 @@ async function resolveOfflinePresetListScopeUserId(
  *
  * @param options.powerSyncOfflineRead - Prefer passing `usePowerSyncBridgeState()` fields from the
  *   screen so reads use the same DB instance as `PowerSyncContext` (PowerSync SDK lifecycle).
- * @param options.scopeUserId - Optional PHI row owner (`user_id`) for replica SQL. Pass the
- *   resolved patient id for caretakers so offline SQLite lists match PostgREST; when omitted,
- *   {@link getCurrentUserId} is used (patient / self).
+ * @param options.scopeUserId - Optional PHI row owner (`user_id`) for replica SQL. When omitted but
+ *   a replica handle is used, {@link resolveMobilePhiSubjectUserContext} supplies the subject
+ *   (caretaker → linked patient). Otherwise {@link getCurrentUserId} is used.
  * @returns {@link PresetDataResult} of preset rows or an error.
  */
 export async function fetchSymptomPresets(options?: {
@@ -115,6 +144,7 @@ export async function fetchSymptomPresets(options?: {
     if (connected === false) {
       const auth = await resolveOfflinePresetListScopeUserId(
         options?.scopeUserId,
+        db,
       );
       if (!auth.ok) {
         return auth;
@@ -145,7 +175,10 @@ export async function fetchSymptomPresets(options?: {
     const alt = clarifyNetworkErrorWhenReplicaUnavailable(remote.error);
     return alt ? { ok: false, error: alt } : remote;
   }
-  const auth = await resolveOfflinePresetListScopeUserId(options?.scopeUserId);
+  const auth = await resolveOfflinePresetListScopeUserId(
+    options?.scopeUserId,
+    db,
+  );
   if (!auth.ok || auth.data == null) {
     return remote;
   }

--- a/apps/mobile/src/lib/symptom-presets/symptom-preset-service.ts
+++ b/apps/mobile/src/lib/symptom-presets/symptom-preset-service.ts
@@ -71,6 +71,18 @@ export async function getCurrentUserId(): Promise<
   }
 }
 
+async function resolveOfflinePresetListScopeUserId(
+  explicitScopeUserId?: string | null,
+): Promise<PresetDataResult<string | null>> {
+  if (explicitScopeUserId != null) {
+    const trimmed = explicitScopeUserId.trim();
+    if (trimmed !== '') {
+      return { ok: true, data: trimmed };
+    }
+  }
+  return getCurrentUserId();
+}
+
 /**
  * Lists the signed-in user’s symptom presets, falling back to the PowerSync replica when Supabase
  * is unreachable and the bridge reports the replica is ready for server-mirror reads (first sync
@@ -84,10 +96,14 @@ export async function getCurrentUserId(): Promise<
  *
  * @param options.powerSyncOfflineRead - Prefer passing `usePowerSyncBridgeState()` fields from the
  *   screen so reads use the same DB instance as `PowerSyncContext` (PowerSync SDK lifecycle).
+ * @param options.scopeUserId - Optional PHI row owner (`user_id`) for replica SQL. Pass the
+ *   resolved patient id for caretakers so offline SQLite lists match PostgREST; when omitted,
+ *   {@link getCurrentUserId} is used (patient / self).
  * @returns {@link PresetDataResult} of preset rows or an error.
  */
 export async function fetchSymptomPresets(options?: {
   powerSyncOfflineRead?: PowerSyncOfflineReadContext | null;
+  scopeUserId?: string | null;
 }): Promise<PresetDataResult<SymptomPresetRow[]>> {
   const client = getMobileSupabaseClient();
   const db = resolvePowerSyncDatabaseForOfflineRead(
@@ -97,7 +113,9 @@ export async function fetchSymptomPresets(options?: {
   if (db) {
     const connected = await fetchMobileDeviceIsConnected();
     if (connected === false) {
-      const auth = await getCurrentUserId();
+      const auth = await resolveOfflinePresetListScopeUserId(
+        options?.scopeUserId,
+      );
       if (!auth.ok) {
         return auth;
       }
@@ -127,7 +145,7 @@ export async function fetchSymptomPresets(options?: {
     const alt = clarifyNetworkErrorWhenReplicaUnavailable(remote.error);
     return alt ? { ok: false, error: alt } : remote;
   }
-  const auth = await getCurrentUserId();
+  const auth = await resolveOfflinePresetListScopeUserId(options?.scopeUserId);
   if (!auth.ok || auth.data == null) {
     return remote;
   }

--- a/apps/mobile/src/lib/symptom-presets/symptom-preset-service.ts
+++ b/apps/mobile/src/lib/symptom-presets/symptom-preset-service.ts
@@ -23,9 +23,8 @@ import {
   updatePresetSymptom,
   updateSymptomPreset,
 } from '@abstrack/supabase';
-import type { PowerSyncDatabase } from '@powersync/react-native';
 import { fetchMobileDeviceIsConnected } from '../network/mobile-device-netinfo';
-import { resolveMobilePhiSubjectUserContext } from '../phi-subject/resolve-mobile-phi-subject-user-context';
+import { resolveOfflinePresetListScopeUserId } from '../phi-subject/resolve-offline-preset-list-scope-user-id';
 import { listSymptomPresetsForUserFromPowerSyncDb } from '../powersync/powersync-episode-flow-reads';
 import {
   clarifyNetworkErrorWhenReplicaUnavailable,
@@ -33,84 +32,9 @@ import {
   resolvePowerSyncDatabaseForOfflineRead,
   type PowerSyncOfflineReadContext,
 } from '../powersync/powersync-offline-read-bridge-snapshot';
-import {
-  getMobileAuthSessionSafe,
-  getMobileSupabaseClient,
-  isAuthSessionRecoveryFailure,
-  readPersistedMobileAuthUserId,
-} from '../supabase-wiring';
+import { getMobileSupabaseClient } from '../supabase-wiring';
 
-/**
- * Resolves the signed-in user id from the persisted session (same pattern as episode templates).
- * Uses {@link getMobileAuthSessionSafe} rather than `getUser()` so airplane mode does not fail the auth lookup.
- * When that helper returns `auth_session_recovery_failed`, falls back to {@link readPersistedMobileAuthUserId}
- * so transient secure-store / recovery hiccups do not block offline PowerSync preset lists.
- *
- * @returns `{ ok: true, data: id }` when signed in; `{ ok: true, data: null }` when signed out with
- * no auth error; `{ ok: false, error }` when the session read failed.
- */
-export async function getCurrentUserId(): Promise<
-  PresetDataResult<string | null>
-> {
-  try {
-    const {
-      data: { session },
-      error,
-    } = await getMobileAuthSessionSafe();
-    if (!error) {
-      return { ok: true, data: session?.user?.id ?? null };
-    }
-    if (!isAuthSessionRecoveryFailure(error)) {
-      return { ok: false, error: toPresetDataError(error) };
-    }
-    const persistedId = await readPersistedMobileAuthUserId();
-    if (persistedId != null) {
-      return { ok: true, data: persistedId };
-    }
-    return { ok: false, error: toPresetDataError(error) };
-  } catch (caught) {
-    return { ok: false, error: toPresetDataError(caught) };
-  }
-}
-
-/**
- * Resolves which `user_id` to filter on for offline replica preset lists.
- *
- * When `explicitScopeUserId` is a non-empty string, returns it. Otherwise, when `replicaDb` is
- * set, uses {@link resolveMobilePhiSubjectUserContext} so caretaker sessions query the linked
- * patient’s rows instead of the caretaker auth uid. Falls back to {@link getCurrentUserId} when no
- * replica is available or PHI scope is unavailable.
- *
- * @param explicitScopeUserId - Optional PHI row owner from the caller (skips resolver when set).
- * @param replicaDb - Open PowerSync database when reading SQLite; enables PHI resolution when scope is omitted.
- */
-async function resolveOfflinePresetListScopeUserId(
-  explicitScopeUserId: string | null | undefined,
-  replicaDb: PowerSyncDatabase | null,
-): Promise<PresetDataResult<string | null>> {
-  if (explicitScopeUserId != null) {
-    const trimmed = explicitScopeUserId.trim();
-    if (trimmed !== '') {
-      return { ok: true, data: trimmed };
-    }
-  }
-  if (replicaDb) {
-    const phi = await resolveMobilePhiSubjectUserContext({
-      powerSyncDatabase: replicaDb,
-    });
-    if (!phi.ok) {
-      return phi;
-    }
-    const subject =
-      phi.data?.phiSubjectUserId != null
-        ? phi.data.phiSubjectUserId.trim()
-        : '';
-    if (subject !== '') {
-      return { ok: true, data: subject };
-    }
-  }
-  return getCurrentUserId();
-}
+export { getMobileAuthUserIdForPresetListOffline as getCurrentUserId } from '../phi-subject/resolve-offline-preset-list-scope-user-id';
 
 /**
  * Lists the signed-in user’s symptom presets, falling back to the PowerSync replica when Supabase
@@ -126,7 +50,7 @@ async function resolveOfflinePresetListScopeUserId(
  * @param options.powerSyncOfflineRead - Prefer passing `usePowerSyncBridgeState()` fields from the
  *   screen so reads use the same DB instance as `PowerSyncContext` (PowerSync SDK lifecycle).
  * @param options.scopeUserId - Optional PHI row owner (`user_id`) for replica SQL. When omitted but
- *   a replica handle is used, {@link resolveMobilePhiSubjectUserContext} supplies the subject
+ *   a replica handle is used, {@link resolveOfflinePresetListScopeUserId} supplies the subject
  *   (caretaker → linked patient). Otherwise {@link getCurrentUserId} is used.
  * @returns {@link PresetDataResult} of preset rows or an error.
  */

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -66,6 +66,9 @@ export type AuthenticatedShellProps = {
 /**
  * Authenticated app chrome: skip link, {@link NavigationShell} with primary nav, sign-out, and a
  * centered main column. Surfaces use CSS variables so light/dark tracks the theme toggle.
+ * Primary nav omits the patient-only Caretaker settings link until the web PHI subject context
+ * hook finishes resolving (or reports an error): `profileAppRole` is null while resolving, so we
+ * default to the stricter caretaker-visible set to avoid a brief incorrect link for caretakers.
  *
  * @param props - Props.
  * @returns Shell layout wrapping page content.
@@ -75,13 +78,21 @@ export function AuthenticatedShell({
   email,
 }: AuthenticatedShellProps) {
   const pathname = usePathname() ?? '/';
-  const { profileAppRole } = useWebPhiSubjectUserContext();
+  const {
+    profileAppRole,
+    loading: phiSubjectContextLoading,
+    errorMessage: phiSubjectContextError,
+  } = useWebPhiSubjectUserContext();
   const navItems = useMemo(() => {
-    if (profileAppRole === 'caretaker') {
+    const roleUnknownOrCaretaker =
+      phiSubjectContextLoading ||
+      phiSubjectContextError != null ||
+      profileAppRole === 'caretaker';
+    if (roleUnknownOrCaretaker) {
       return NAV_ITEMS.filter((item) => item.href !== '/settings/caretaker');
     }
     return NAV_ITEMS;
-  }, [profileAppRole]);
+  }, [profileAppRole, phiSubjectContextLoading, phiSubjectContextError]);
 
   return (
     <div className="flex min-h-screen flex-col">

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -3,7 +3,10 @@
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { ReactNode } from 'react';
+import { useMemo } from 'react';
 import { NavigationShell } from '@abstrack/ui';
+
+import { useWebPhiSubjectUserContext } from '@/lib/patient/use-web-phi-subject-user-context';
 
 const NAV_ITEMS: {
   href: string;
@@ -72,6 +75,13 @@ export function AuthenticatedShell({
   email,
 }: AuthenticatedShellProps) {
   const pathname = usePathname() ?? '/';
+  const { profileAppRole } = useWebPhiSubjectUserContext();
+  const navItems = useMemo(() => {
+    if (profileAppRole === 'caretaker') {
+      return NAV_ITEMS.filter((item) => item.href !== '/settings/caretaker');
+    }
+    return NAV_ITEMS;
+  }, [profileAppRole]);
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -110,7 +120,7 @@ export function AuthenticatedShell({
                 aria-label="Primary"
                 className="flex flex-1 flex-wrap items-center justify-center gap-1.5 sm:justify-start lg:justify-center"
               >
-                {NAV_ITEMS.map(({ href, label, match }) => {
+                {navItems.map(({ href, label, match }) => {
                   const active = isNavActive(pathname, match);
                   return (
                     <Link

--- a/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartFlow.tsx
@@ -18,6 +18,7 @@ import { buildResumeEpisodeHref } from '@/lib/episode-flow/resume-episode-href';
 import { clearSymptomPromptSession } from '@/lib/episode-flow/symptom-prompt-session-store';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { useAuth } from '@/lib/auth-provider';
+import { useWebPhiSubjectUserContext } from '@/lib/patient/use-web-phi-subject-user-context';
 import { PageLoading } from '@/components/page-states/PageLoading';
 
 /**
@@ -30,6 +31,11 @@ import { PageLoading } from '@/components/page-states/PageLoading';
 export function EpisodeStartFlow() {
   const router = useRouter();
   const { session, loading: authLoading } = useAuth();
+  const {
+    phiSubjectUserId,
+    loading: phiLoading,
+    errorMessage: phiScopeError,
+  } = useWebPhiSubjectUserContext();
   const { announce } = useAnnounce();
   const groupLegendId = useId();
   /** Prevents concurrent or repeated `createEpisode` on the single-template auto-start path when `refresh` runs more than once before navigation. */
@@ -50,7 +56,7 @@ export function EpisodeStartFlow() {
   const [resolvingActiveBlock, setResolvingActiveBlock] = useState(false);
 
   const refresh = useCallback(async (): Promise<void> => {
-    const userId = session?.user?.id;
+    const userId = phiSubjectUserId;
     if (!userId) {
       return;
     }
@@ -131,17 +137,37 @@ export function EpisodeStartFlow() {
       }
       return null;
     });
-  }, [announce, router, session?.user?.id]);
+  }, [announce, phiSubjectUserId, router, session?.user?.id]);
 
   useEffect(() => {
-    if (authLoading || !session?.user?.id) {
+    if (authLoading || phiLoading || !session?.user?.id) {
+      return;
+    }
+    if (phiScopeError) {
+      setLoadState('error');
+      setLoadError(phiScopeError);
+      return;
+    }
+    if (!phiSubjectUserId) {
       return;
     }
     void refresh();
-  }, [authLoading, session?.user?.id, refresh]);
+  }, [
+    authLoading,
+    phiLoading,
+    phiScopeError,
+    phiSubjectUserId,
+    refresh,
+    session?.user?.id,
+  ]);
 
   const onEndActiveEpisodeAndStartNew = useCallback(async (): Promise<void> => {
-    if (!session?.user?.id || !blockingActiveEpisode || resolvingActiveBlock) {
+    if (
+      !session?.user?.id ||
+      !phiSubjectUserId ||
+      !blockingActiveEpisode ||
+      resolvingActiveBlock
+    ) {
       return;
     }
     setResolvingActiveBlock(true);
@@ -164,7 +190,10 @@ export function EpisodeStartFlow() {
       if (!end.data.didEnd) {
         return;
       }
-      const verify = await getActiveEpisodeForUser(supabase, session.user.id);
+      const verify = await getActiveEpisodeForUser(
+        supabase,
+        blockingActiveEpisode.user_id,
+      );
       if (!verify.ok) {
         setSubmitError(verify.error.message);
         return;
@@ -184,13 +213,19 @@ export function EpisodeStartFlow() {
   }, [
     announce,
     blockingActiveEpisode,
+    phiSubjectUserId,
     refresh,
     resolvingActiveBlock,
     session?.user?.id,
   ]);
 
   const onSubmit = async (): Promise<void> => {
-    if (!session?.user?.id || selectedId === null || submitting) {
+    if (
+      !session?.user?.id ||
+      !phiSubjectUserId ||
+      selectedId === null ||
+      submitting
+    ) {
       return;
     }
     const template = rows.find((r) => r.id === selectedId);
@@ -203,7 +238,7 @@ export function EpisodeStartFlow() {
     try {
       const supabase = createBrowserClient();
       const result = await createEpisode(supabase, {
-        user_id: session.user.id,
+        user_id: phiSubjectUserId,
         started_at: new Date().toISOString(),
         symptom_preset_id: template.symptom_preset_id,
         health_marker_preset_id: template.health_marker_preset_id,
@@ -225,7 +260,7 @@ export function EpisodeStartFlow() {
     }
   };
 
-  if (authLoading) {
+  if (authLoading || phiLoading) {
     return <PageLoading title="Start an episode" />;
   }
 

--- a/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
+++ b/apps/web/src/components/episode-flow/EpisodeStartHomeCta.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useEffect, useId, useState } from 'react';
 import { getActiveEpisodeForUser } from '@abstrack/supabase';
 import { buildResumeEpisodeHref } from '@/lib/episode-flow/resume-episode-href';
+import { useWebPhiSubjectUserContext } from '@/lib/patient/use-web-phi-subject-user-context';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { useAuth } from '@/lib/auth-provider';
 
@@ -32,6 +33,11 @@ export function EpisodeStartHomeCta({
   const statusId = `episode-start-home-cta-status${instanceId}`;
 
   const { session, loading: authLoading } = useAuth();
+  const {
+    phiSubjectUserId,
+    loading: phiLoading,
+    errorMessage: phiError,
+  } = useWebPhiSubjectUserContext();
 
   const [ctaMode, setCtaMode] = useState<CtaMode>('loading');
   const [resumeHref, setResumeHref] = useState<string | null>(null);
@@ -43,7 +49,24 @@ export function EpisodeStartHomeCta({
     if (authLoading) {
       return;
     }
-    const userId = session?.user?.id;
+    if (!session?.user?.id) {
+      setCtaMode('start');
+      setResumeHref(null);
+      setResumeToHub(false);
+      setResumeSupportsAnotherCheckIn(false);
+      return;
+    }
+    if (phiLoading) {
+      return;
+    }
+    if (phiError) {
+      setCtaMode('start');
+      setResumeHref(null);
+      setResumeToHub(false);
+      setResumeSupportsAnotherCheckIn(false);
+      return;
+    }
+    const userId = phiSubjectUserId;
     if (!userId) {
       setCtaMode('start');
       setResumeHref(null);
@@ -98,7 +121,7 @@ export function EpisodeStartHomeCta({
     return () => {
       cancelled = true;
     };
-  }, [authLoading, session?.user?.id]);
+  }, [authLoading, phiLoading, phiSubjectUserId, phiError, session?.user?.id]);
 
   const primaryLinkClass =
     'inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-red-700 px-5 py-4 text-center text-base font-semibold leading-snug text-white shadow-md outline-none ring-2 ring-transparent transition hover:bg-red-800 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-red-50 dark:bg-red-600 dark:hover:bg-red-500 dark:focus-visible:ring-offset-red-950';

--- a/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/HealthMarkerPromptFlow.tsx
@@ -29,6 +29,7 @@ import {
   listEpisodeHealthMarkersForEpisode,
   listEpisodeObservationTimeline,
   listPresetHealthMarkersForPreset,
+  resolvePhiSubjectUserContextFromSupabase,
   type EpisodeTimelineItem,
   upsertEpisodeTimelineItem,
 } from '@abstrack/supabase';
@@ -198,7 +199,23 @@ export function HealthMarkerPromptFlow({
       setStatus('error');
       return;
     }
-    setUserId(user.id);
+    const phiRes = await resolvePhiSubjectUserContextFromSupabase(
+      supabase,
+      user.id,
+    );
+    if (isStale()) {
+      return;
+    }
+    if (!phiRes.ok || phiRes.data == null) {
+      setErrorMessage(
+        phiRes.ok
+          ? 'You must be signed in to save health marker answers. Try signing in again.'
+          : phiRes.error.message,
+      );
+      setStatus('error');
+      return;
+    }
+    setUserId(phiRes.data.phiSubjectUserId);
 
     const episode = await getEpisodeById(supabase, episodeId);
     if (isStale()) {

--- a/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
+++ b/apps/web/src/components/episode-flow/SymptomPromptFlow.tsx
@@ -40,6 +40,7 @@ import {
   listEpisodeMediaForEpisode,
   listEpisodeSymptomsForEpisode,
   listPresetSymptomsForPreset,
+  resolvePhiSubjectUserContextFromSupabase,
   uploadConfirmedEpisodeMedia,
 } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
@@ -77,6 +78,10 @@ const VIDEO_MAX_DURATION_SECONDS = Math.floor(
 
 /** Long edge for JPEG symptom-media thumbnails (episode-media bucket; matches mobile scaling). */
 const SYMPTOM_MEDIA_THUMB_MAX_EDGE_PX = 480;
+
+type PhiSubjectWriteResolution =
+  | { ok: true; userId: string }
+  | { ok: false; message: string };
 
 async function blobToJpegThumbnailBlob(
   blob: Blob,
@@ -388,7 +393,7 @@ export function SymptomPromptFlow({
    * order within an episode only — not across `episodeId` changes while mounted.
    */
   const lineWriteQueueRef = useRef<Map<string, Promise<void>>>(new Map());
-  const userIdRef = useRef<string | null>(null);
+  const phiSubjectUserIdRef = useRef<string | null>(null);
   /** Bumps on each `load()` start and on effect cleanup so in-flight loads ignore stale results after unmount, retry, or param change. */
   const loadGenRef = useRef(0);
   /**
@@ -437,22 +442,41 @@ export function SymptomPromptFlow({
   const supabase = useMemo(() => createBrowserClient(), []);
 
   /**
-   * Resolves the signed-in user id for RLS writes, caching on {@link userIdRef}.
-   * Used by `load()` (before inputs enable) and as a fallback in {@link executeServerPersist}.
+   * Resolves the PHI subject user id for RLS writes (patient or linked caretaker subject), caching on
+   * {@link phiSubjectUserIdRef}.
+   * Used by `load()` (before inputs enable) and by {@link executeServerPersist}.
    */
-  const resolveSessionUserId = useCallback(
+  const resolvePhiSubjectUserIdForWrites = useCallback(
     async (
       supabase: ReturnType<typeof createBrowserClient>,
-    ): Promise<string | null> => {
-      if (userIdRef.current) {
-        return userIdRef.current;
+    ): Promise<PhiSubjectWriteResolution> => {
+      if (phiSubjectUserIdRef.current) {
+        return { ok: true, userId: phiSubjectUserIdRef.current };
       }
       const {
         data: { user },
       } = await supabase.auth.getUser();
-      const id = user?.id ?? null;
-      userIdRef.current = id;
-      return id;
+      if (!user?.id) {
+        return {
+          ok: false,
+          message:
+            'You must be signed in to save symptom answers. Try signing in again.',
+        };
+      }
+      const phiRes = await resolvePhiSubjectUserContextFromSupabase(
+        supabase,
+        user.id,
+      );
+      if (!phiRes.ok || phiRes.data == null) {
+        return {
+          ok: false,
+          message: phiRes.ok
+            ? 'You must be signed in to save symptom answers. Try signing in again.'
+            : phiRes.error.message,
+        };
+      }
+      phiSubjectUserIdRef.current = phiRes.data.phiSubjectUserId;
+      return { ok: true, userId: phiRes.data.phiSubjectUserId };
     },
     [],
   );
@@ -490,20 +514,19 @@ export function SymptomPromptFlow({
         })
         .then(async () => {
           const targetEpisodeId = enqueueEpisodeId;
-          const uid = await resolveSessionUserId(supabase);
-          if (!uid) {
+          const resolved = await resolvePhiSubjectUserIdForWrites(supabase);
+          if (!resolved.ok) {
             if (
               isMountedRef.current &&
               episodeIdRef.current === enqueueEpisodeId &&
               enqueueEpoch === serverPersistEpochRef.current &&
               attemptId === persistUiAttemptRef.current
             ) {
-              setPersistError(
-                'Your session could not be verified. Try signing in again.',
-              );
+              setPersistError(resolved.message);
             }
             return;
           }
+          const uid = resolved.userId;
           const r = await insertEpisodeSymptomAnswer(supabase, {
             userId: uid,
             episodeId: targetEpisodeId,
@@ -631,7 +654,7 @@ export function SymptomPromptFlow({
         }
       });
     },
-    [resolveSessionUserId, supabase],
+    [resolvePhiSubjectUserIdForWrites, supabase],
   );
 
   const executeServerDelete = useCallback(
@@ -653,17 +676,15 @@ export function SymptomPromptFlow({
         })
         .then(async () => {
           const targetEpisodeId = enqueueEpisodeId;
-          const uid = await resolveSessionUserId(supabase);
-          if (!uid) {
+          const resolved = await resolvePhiSubjectUserIdForWrites(supabase);
+          if (!resolved.ok) {
             if (
               isMountedRef.current &&
               episodeIdRef.current === enqueueEpisodeId &&
               enqueueEpoch === serverPersistEpochRef.current &&
               attemptId === persistUiAttemptRef.current
             ) {
-              setPersistError(
-                'Your session could not be verified. Try signing in again.',
-              );
+              setPersistError(resolved.message);
             }
             return;
           }
@@ -695,7 +716,7 @@ export function SymptomPromptFlow({
         }
       });
     },
-    [resolveSessionUserId, supabase],
+    [resolvePhiSubjectUserIdForWrites, supabase],
   );
 
   /**
@@ -857,14 +878,13 @@ export function SymptomPromptFlow({
     setStatus('loading');
     setErrorMessage(null);
     setPersistError(null);
-    const uid = await resolveSessionUserId(supabase);
+    phiSubjectUserIdRef.current = null;
+    const resolved = await resolvePhiSubjectUserIdForWrites(supabase);
     if (stale()) {
       return;
     }
-    if (!uid) {
-      setErrorMessage(
-        'You must be signed in to save symptom answers. Try signing in again.',
-      );
+    if (!resolved.ok) {
+      setErrorMessage(resolved.message);
       setStatus('error');
       return;
     }
@@ -1019,7 +1039,7 @@ export function SymptomPromptFlow({
       setPersistError(mediaRows.error.message);
     }
     setStatus('ready');
-  }, [episodeId, symptomPresetId, resolveSessionUserId, supabase]);
+  }, [episodeId, symptomPresetId, resolvePhiSubjectUserIdForWrites, supabase]);
 
   useEffect(() => {
     void load();

--- a/apps/web/src/components/episode-templates/EpisodeTemplateCreateForm.tsx
+++ b/apps/web/src/components/episode-templates/EpisodeTemplateCreateForm.tsx
@@ -24,6 +24,10 @@ import { ConfirmDialog } from '../symptom-presets/ConfirmDialog';
 /**
  * Form to create an episode template: display name plus paired symptom and health marker presets.
  *
+ * Preset picklists load after {@link resolvePhiSubjectUserContextFromSupabase}; health marker options
+ * call {@link listHealthMarkerPresets} with `scopeUserId` so the dropdown matches the PHI subject
+ * used when saving the template.
+ *
  * @returns Create episode template page content.
  */
 export function EpisodeTemplateCreateForm() {
@@ -120,9 +124,26 @@ export function EpisodeTemplateCreateForm() {
       setListsLoading(true);
       setListsError(null);
       const supabase = createBrowserClient();
+      const phiRes = await resolvePhiSubjectUserContextFromSupabase(
+        supabase,
+        session.user.id,
+      );
+      if (cancelled) {
+        return;
+      }
+      if (!phiRes.ok || phiRes.data == null) {
+        setListsError(
+          phiRes.ok
+            ? 'You must be signed in to load presets for this account.'
+            : phiRes.error.message,
+        );
+        setListsLoading(false);
+        return;
+      }
+      const scopeUserId = phiRes.data.phiSubjectUserId;
       const [symRes, hmRes] = await Promise.all([
         listSymptomPresets(supabase),
-        listHealthMarkerPresets(supabase),
+        listHealthMarkerPresets(supabase, { scopeUserId }),
       ]);
       if (cancelled) {
         return;

--- a/apps/web/src/components/episode-templates/EpisodeTemplateCreateForm.tsx
+++ b/apps/web/src/components/episode-templates/EpisodeTemplateCreateForm.tsx
@@ -10,6 +10,7 @@ import {
   createEpisodeTemplate,
   listHealthMarkerPresets,
   listSymptomPresets,
+  resolvePhiSubjectUserContextFromSupabase,
 } from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
@@ -169,8 +170,21 @@ export function EpisodeTemplateCreateForm() {
     setSaving(true);
     setError(null);
     const supabase = createBrowserClient();
+    const phiRes = await resolvePhiSubjectUserContextFromSupabase(
+      supabase,
+      session.user.id,
+    );
+    if (!phiRes.ok || phiRes.data == null) {
+      setSaving(false);
+      const msg = phiRes.ok
+        ? 'You must be signed in to save an episode template.'
+        : phiRes.error.message;
+      setError(msg);
+      announce(msg, { politeness: 'assertive' });
+      return;
+    }
     const result = await createEpisodeTemplate(supabase, {
-      user_id: session.user.id,
+      user_id: phiRes.data.phiSubjectUserId,
       name: nameCheck.name,
       symptom_preset_id: symptomPresetId,
       health_marker_preset_id: healthMarkerPresetId,

--- a/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
+++ b/apps/web/src/components/food-diary/FoodDiaryEntryForm.tsx
@@ -3,7 +3,10 @@
 import { useMemo, useState } from 'react';
 import type { MealTag } from '@abstrack/types';
 import { MEAL_TAGS } from '@abstrack/types';
-import { createFoodDiaryEntry } from '@abstrack/supabase';
+import {
+  createFoodDiaryEntry,
+  resolvePhiSubjectUserContextFromSupabase,
+} from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import {
@@ -88,6 +91,20 @@ export function FoodDiaryEntryForm({
       return;
     }
 
+    const phiRes = await resolvePhiSubjectUserContextFromSupabase(
+      supabase,
+      user.id,
+    );
+    if (!phiRes.ok || phiRes.data == null) {
+      const message = phiRes.ok
+        ? 'You must be signed in to save a food diary entry.'
+        : phiRes.error.message;
+      setErrorMessage(message);
+      announce(message, { politeness: 'assertive' });
+      setSaving(false);
+      return;
+    }
+
     const loggedAtIso = localInputValueToIso(loggedAtLocal);
     if (!mealTag) {
       const message = 'Choose a meal tag.';
@@ -105,7 +122,7 @@ export function FoodDiaryEntryForm({
     }
 
     const result = await createFoodDiaryEntry(supabase, {
-      user_id: user.id,
+      user_id: phiRes.data.phiSubjectUserId,
       episode_id: episodeId,
       meal_tag: mealTag,
       food_note: foodNote,

--- a/apps/web/src/components/health-marker-presets/HealthMarkerPresetCreateForm.tsx
+++ b/apps/web/src/components/health-marker-presets/HealthMarkerPresetCreateForm.tsx
@@ -3,7 +3,10 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { createHealthMarkerPreset } from '@abstrack/supabase';
+import {
+  createHealthMarkerPreset,
+  resolvePhiSubjectUserContextFromSupabase,
+} from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { useAuth } from '@/lib/auth-provider';
@@ -35,8 +38,21 @@ export function HealthMarkerPresetCreateForm() {
     setSaving(true);
     setError(null);
     const supabase = createBrowserClient();
+    const phiRes = await resolvePhiSubjectUserContextFromSupabase(
+      supabase,
+      session.user.id,
+    );
+    if (!phiRes.ok || phiRes.data == null) {
+      setSaving(false);
+      const msg = phiRes.ok
+        ? 'You must be signed in to create a preset.'
+        : phiRes.error.message;
+      setError(msg);
+      announce(msg, { politeness: 'assertive' });
+      return;
+    }
     const result = await createHealthMarkerPreset(supabase, {
-      user_id: session.user.id,
+      user_id: phiRes.data.phiSubjectUserId,
       name: trimmed,
     });
     setSaving(false);

--- a/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
+++ b/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
@@ -7,6 +7,7 @@ import {
   createStandaloneHealthMarkerForLine,
   listHealthMarkerPresets,
   listPresetHealthMarkersForPreset,
+  resolvePhiSubjectUserContextFromSupabase,
 } from '@abstrack/supabase';
 import type {
   HealthMarkerPresetRow,
@@ -208,8 +209,21 @@ export function StandaloneHealthMarkerFlow() {
     }
     setSaving(true);
     setFeedback(null);
+    const phiRes = await resolvePhiSubjectUserContextFromSupabase(
+      supabase,
+      session.user.id,
+    );
+    if (!phiRes.ok || phiRes.data == null) {
+      setSaving(false);
+      const msg = phiRes.ok
+        ? 'You must be signed in to save health markers.'
+        : phiRes.error.message;
+      setFeedback(msg);
+      announce(msg, { politeness: 'assertive' });
+      return false;
+    }
     const result = await createStandaloneHealthMarkerForLine(supabase, {
-      userId: session.user.id,
+      userId: phiRes.data.phiSubjectUserId,
       line: currentLine,
       valueNumeric: parsed.valueNumeric,
       systolicNumeric: parsed.systolicNumeric,

--- a/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
+++ b/apps/web/src/components/health-markers/StandaloneHealthMarkerFlow.tsx
@@ -7,7 +7,6 @@ import {
   createStandaloneHealthMarkerForLine,
   listHealthMarkerPresets,
   listPresetHealthMarkersForPreset,
-  resolvePhiSubjectUserContextFromSupabase,
 } from '@abstrack/supabase';
 import type {
   HealthMarkerPresetRow,
@@ -23,10 +22,14 @@ import {
 } from '@abstrack/types';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { useAuth } from '@/lib/auth-provider';
+import { useWebPhiSubjectUserContext } from '@/lib/patient/use-web-phi-subject-user-context';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { PageLoading } from '@/components/page-states/PageLoading';
 /**
  * Standalone, non-episode health-marker prompt flow.
+ *
+ * Preset and line reads use {@link useWebPhiSubjectUserContext} `phiSubjectUserId` so caretakers
+ * only see and log markers for the linked patient, matching {@link createStandaloneHealthMarkerForLine}.
  *
  * Presets with no marker lines stay on preset selection with guidance, or show
  * recovery actions if prompting ever has an empty line list.
@@ -37,6 +40,12 @@ export function StandaloneHealthMarkerFlow() {
   const router = useRouter();
   const { announce } = useAnnounce();
   const { session, loading: authLoading } = useAuth();
+  const {
+    phiSubjectUserId,
+    loading: phiScopeLoading,
+    errorMessage: phiScopeError,
+    refresh: refreshPhiScope,
+  } = useWebPhiSubjectUserContext();
   const supabase = useMemo(() => createBrowserClient(), []);
 
   const [phase, setPhase] = useState<'pickPreset' | 'prompting' | 'complete'>(
@@ -54,16 +63,18 @@ export function StandaloneHealthMarkerFlow() {
   /** Successful `createStandaloneHealthMarkerForLine` calls in the current preset session. */
   const [linesSavedCount, setLinesSavedCount] = useState(0);
   const [presetRefetchTick, setPresetRefetchTick] = useState(0);
-  const lastPresetUserIdRef = useRef<string | null>(null);
+  const lastPresetScopeKeyRef = useRef<string | null>(null);
+
+  const scopeLoading = authLoading || phiScopeLoading;
 
   useEffect(() => {
-    if (authLoading) {
+    if (scopeLoading) {
       return;
     }
 
     const userId = session?.user?.id ?? null;
     if (!userId) {
-      lastPresetUserIdRef.current = null;
+      lastPresetScopeKeyRef.current = null;
       setPresets([]);
       setLoadError(null);
       setLoadingPresets(false);
@@ -77,12 +88,43 @@ export function StandaloneHealthMarkerFlow() {
       return;
     }
 
-    const switchedAccount =
-      lastPresetUserIdRef.current !== null &&
-      lastPresetUserIdRef.current !== userId;
-    lastPresetUserIdRef.current = userId;
+    if (phiScopeError) {
+      lastPresetScopeKeyRef.current = null;
+      setPresets([]);
+      setLoadError(phiScopeError);
+      setLoadingPresets(false);
+      setPhase('pickPreset');
+      setLines([]);
+      setDrafts({});
+      setActiveIndex(0);
+      setSelectedPresetId(null);
+      setFeedback(null);
+      setLinesSavedCount(0);
+      return;
+    }
 
-    if (switchedAccount) {
+    if (!phiSubjectUserId) {
+      lastPresetScopeKeyRef.current = null;
+      setPresets([]);
+      setLoadError(null);
+      setLoadingPresets(false);
+      setPhase('pickPreset');
+      setLines([]);
+      setDrafts({});
+      setActiveIndex(0);
+      setSelectedPresetId(null);
+      setFeedback(null);
+      setLinesSavedCount(0);
+      return;
+    }
+
+    const scopeKey = `${userId}|${phiSubjectUserId}`;
+    const switchedScope =
+      lastPresetScopeKeyRef.current !== null &&
+      lastPresetScopeKeyRef.current !== scopeKey;
+    lastPresetScopeKeyRef.current = scopeKey;
+
+    if (switchedScope) {
       setPhase('pickPreset');
       setLines([]);
       setDrafts({});
@@ -97,7 +139,9 @@ export function StandaloneHealthMarkerFlow() {
     setLoadError(null);
 
     void (async () => {
-      const result = await listHealthMarkerPresets(supabase);
+      const result = await listHealthMarkerPresets(supabase, {
+        scopeUserId: phiSubjectUserId,
+      });
       if (cancelled) {
         return;
       }
@@ -113,7 +157,14 @@ export function StandaloneHealthMarkerFlow() {
     return () => {
       cancelled = true;
     };
-  }, [authLoading, session?.user?.id, supabase, presetRefetchTick]);
+  }, [
+    phiScopeError,
+    phiSubjectUserId,
+    presetRefetchTick,
+    scopeLoading,
+    session?.user?.id,
+    supabase,
+  ]);
 
   useEffect(() => {
     setFeedback(null);
@@ -153,7 +204,7 @@ export function StandaloneHealthMarkerFlow() {
   );
 
   const startPresetFlow = async () => {
-    if (!selectedPresetId || saving) {
+    if (!selectedPresetId || saving || !phiSubjectUserId) {
       return;
     }
     setSaving(true);
@@ -161,6 +212,7 @@ export function StandaloneHealthMarkerFlow() {
     const result = await listPresetHealthMarkersForPreset(
       supabase,
       selectedPresetId,
+      { scopeUserId: phiSubjectUserId },
     );
     setSaving(false);
     if (!result.ok) {
@@ -188,7 +240,7 @@ export function StandaloneHealthMarkerFlow() {
   };
 
   const saveCurrentLine = async (): Promise<boolean> => {
-    if (!currentLine || !session?.user?.id) {
+    if (!currentLine || !session?.user?.id || !phiSubjectUserId) {
       return false;
     }
     const customValidation = validatePresetHealthMarkerCustomFields(
@@ -209,21 +261,8 @@ export function StandaloneHealthMarkerFlow() {
     }
     setSaving(true);
     setFeedback(null);
-    const phiRes = await resolvePhiSubjectUserContextFromSupabase(
-      supabase,
-      session.user.id,
-    );
-    if (!phiRes.ok || phiRes.data == null) {
-      setSaving(false);
-      const msg = phiRes.ok
-        ? 'You must be signed in to save health markers.'
-        : phiRes.error.message;
-      setFeedback(msg);
-      announce(msg, { politeness: 'assertive' });
-      return false;
-    }
     const result = await createStandaloneHealthMarkerForLine(supabase, {
-      userId: phiRes.data.phiSubjectUserId,
+      userId: phiSubjectUserId,
       line: currentLine,
       valueNumeric: parsed.valueNumeric,
       systolicNumeric: parsed.systolicNumeric,
@@ -265,7 +304,7 @@ export function StandaloneHealthMarkerFlow() {
     setActiveIndex((prev) => prev + 1);
   };
 
-  if (authLoading) {
+  if (scopeLoading) {
     return <PageLoading title="Log health markers" />;
   }
 
@@ -282,6 +321,51 @@ export function StandaloneHealthMarkerFlow() {
         >
           Sign in
         </Link>
+      </div>
+    );
+  }
+
+  if (phiScopeError) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Log health markers
+        </h1>
+        <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+          {phiScopeError}
+        </p>
+        <button
+          type="button"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          onClick={() => {
+            void refreshPhiScope();
+          }}
+        >
+          Try again
+        </button>
+      </div>
+    );
+  }
+
+  if (!phiSubjectUserId) {
+    return (
+      <div className="space-y-4">
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Log health markers
+        </h1>
+        <p className="text-sm text-app-muted" role="status">
+          Your account could not be scoped for health markers yet. Try
+          refreshing the page, or sign out and sign back in.
+        </p>
+        <button
+          type="button"
+          className="inline-flex min-h-[44px] items-center justify-center rounded-xl border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          onClick={() => {
+            void refreshPhiScope();
+          }}
+        >
+          Retry
+        </button>
       </div>
     );
   }

--- a/apps/web/src/components/manage/ManageRecordsPage.tsx
+++ b/apps/web/src/components/manage/ManageRecordsPage.tsx
@@ -29,6 +29,7 @@ import { ActiveEpisodeCard } from '@/components/episodes/ActiveEpisodeCard';
 import { EpisodeLocaleInstant } from '@/components/episodes/EpisodeLocaleInstant';
 import { RecentEpisodesList } from '@/components/episodes/RecentEpisodesList';
 import { ConfirmDialog } from '@/components/symptom-presets/ConfirmDialog';
+import { useWebPhiSubjectUserContext } from '@/lib/patient/use-web-phi-subject-user-context';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 
 const PAGE = 25;
@@ -81,6 +82,11 @@ export function ManageRecordsPage() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const { announce } = useAnnounce();
+  const {
+    phiSubjectUserId,
+    loading: phiScopeLoading,
+    errorMessage: phiScopeError,
+  } = useWebPhiSubjectUserContext();
   const segmentParam = searchParams.get('segment');
   const segment: ManageSegment =
     segmentParam === 'health' || segmentParam === 'food'
@@ -181,21 +187,23 @@ export function ManageRecordsPage() {
     setRecentError(null);
     try {
       const supabase = createBrowserClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (stale()) {
+      if (phiScopeError) {
+        setActiveEpisodeError(phiScopeError);
+        setRecentError(phiScopeError);
+        setActiveEpisode(null);
+        setRecentEpisodes([]);
+        setHasMoreEpisodes(false);
         return;
       }
-      if (!user) {
+      if (!phiSubjectUserId) {
         setActiveEpisode(null);
         setRecentEpisodes([]);
         setHasMoreEpisodes(false);
         return;
       }
       const [activeRes, recentRes] = await Promise.all([
-        getActiveEpisodeForUser(supabase, user.id),
-        listCompletedEpisodesForUser(supabase, user.id, {
+        getActiveEpisodeForUser(supabase, phiSubjectUserId),
+        listCompletedEpisodesForUser(supabase, phiSubjectUserId, {
           limit: PAGE,
           offset: 0,
           endedAtOrAfter: episodeBounds.endedAtOrAfter,
@@ -230,13 +238,18 @@ export function ManageRecordsPage() {
         setEpisodesLoading(false);
       }
     }
-  }, [episodeBounds.endedAtOrAfter, episodeBounds.endedAtOrBefore]);
+  }, [
+    episodeBounds.endedAtOrAfter,
+    episodeBounds.endedAtOrBefore,
+    phiScopeError,
+    phiSubjectUserId,
+  ]);
 
   useEffect(() => {
-    if (segment === 'episodes') {
+    if (segment === 'episodes' && !phiScopeLoading) {
       void loadEpisodesInitial();
     }
-  }, [segment, loadEpisodesInitial]);
+  }, [segment, loadEpisodesInitial, phiScopeLoading]);
 
   const loadMoreEpisodes = useCallback(async () => {
     if (loadingMoreEpisodes || !hasMoreEpisodes) {
@@ -247,22 +260,20 @@ export function ManageRecordsPage() {
     setLoadingMoreEpisodes(true);
     try {
       const supabase = createBrowserClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (stale()) {
-        return;
-      }
-      if (!user) {
+      if (!phiSubjectUserId) {
         setHasMoreEpisodes(false);
         return;
       }
-      const recentRes = await listCompletedEpisodesForUser(supabase, user.id, {
-        limit: PAGE,
-        offset: recentEpisodes.length,
-        endedAtOrAfter: episodeBounds.endedAtOrAfter,
-        endedAtOrBefore: episodeBounds.endedAtOrBefore,
-      });
+      const recentRes = await listCompletedEpisodesForUser(
+        supabase,
+        phiSubjectUserId,
+        {
+          limit: PAGE,
+          offset: recentEpisodes.length,
+          endedAtOrAfter: episodeBounds.endedAtOrAfter,
+          endedAtOrBefore: episodeBounds.endedAtOrBefore,
+        },
+      );
       if (stale()) {
         return;
       }
@@ -285,6 +296,7 @@ export function ManageRecordsPage() {
     episodeBounds.endedAtOrBefore,
     hasMoreEpisodes,
     loadingMoreEpisodes,
+    phiSubjectUserId,
     recentEpisodes.length,
   ]);
 
@@ -311,23 +323,27 @@ export function ManageRecordsPage() {
     setMarkersError(null);
     try {
       const supabase = createBrowserClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (stale()) {
-        return;
-      }
-      if (!user) {
+      if (phiScopeError) {
+        setMarkersError(phiScopeError);
         setMarkers([]);
         setHasMoreMarkers(false);
         return;
       }
-      const res = await listStandaloneHealthMarkersForUser(supabase, user.id, {
-        limit: PAGE,
-        offset: 0,
-        recordedAtOrAfter: markerBounds.recordedAtOrAfter,
-        recordedAtOrBefore: markerBounds.recordedAtOrBefore,
-      });
+      if (!phiSubjectUserId) {
+        setMarkers([]);
+        setHasMoreMarkers(false);
+        return;
+      }
+      const res = await listStandaloneHealthMarkersForUser(
+        supabase,
+        phiSubjectUserId,
+        {
+          limit: PAGE,
+          offset: 0,
+          recordedAtOrAfter: markerBounds.recordedAtOrAfter,
+          recordedAtOrBefore: markerBounds.recordedAtOrBefore,
+        },
+      );
       if (stale()) {
         return;
       }
@@ -348,13 +364,18 @@ export function ManageRecordsPage() {
         setMarkersLoading(false);
       }
     }
-  }, [markerBounds.recordedAtOrAfter, markerBounds.recordedAtOrBefore]);
+  }, [
+    markerBounds.recordedAtOrAfter,
+    markerBounds.recordedAtOrBefore,
+    phiScopeError,
+    phiSubjectUserId,
+  ]);
 
   useEffect(() => {
-    if (segment === 'health') {
+    if (segment === 'health' && !phiScopeLoading) {
       void loadMarkersInitial();
     }
-  }, [segment, loadMarkersInitial]);
+  }, [segment, loadMarkersInitial, phiScopeLoading]);
 
   const loadMoreMarkers = useCallback(async () => {
     if (loadingMoreMarkers || !hasMoreMarkers) {
@@ -365,22 +386,20 @@ export function ManageRecordsPage() {
     setLoadingMoreMarkers(true);
     try {
       const supabase = createBrowserClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (stale()) {
-        return;
-      }
-      if (!user) {
+      if (!phiSubjectUserId) {
         setHasMoreMarkers(false);
         return;
       }
-      const res = await listStandaloneHealthMarkersForUser(supabase, user.id, {
-        limit: PAGE,
-        offset: markers.length,
-        recordedAtOrAfter: markerBounds.recordedAtOrAfter,
-        recordedAtOrBefore: markerBounds.recordedAtOrBefore,
-      });
+      const res = await listStandaloneHealthMarkersForUser(
+        supabase,
+        phiSubjectUserId,
+        {
+          limit: PAGE,
+          offset: markers.length,
+          recordedAtOrAfter: markerBounds.recordedAtOrAfter,
+          recordedAtOrBefore: markerBounds.recordedAtOrBefore,
+        },
+      );
       if (stale()) {
         return;
       }
@@ -406,6 +425,7 @@ export function ManageRecordsPage() {
     markerBounds.recordedAtOrAfter,
     markerBounds.recordedAtOrBefore,
     markers.length,
+    phiSubjectUserId,
   ]);
 
   const confirmDeleteMarker = useCallback(async (): Promise<void | false> => {
@@ -471,24 +491,28 @@ export function ManageRecordsPage() {
     setFoodError(null);
     try {
       const supabase = createBrowserClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (stale()) {
-        return;
-      }
-      if (!user) {
+      if (phiScopeError) {
+        setFoodError(phiScopeError);
         setFoodRows([]);
         setHasMoreFood(false);
         return;
       }
-      const res = await listFoodDiaryEntriesForUser(supabase, user.id, {
-        limit: PAGE,
-        offset: 0,
-        standaloneOnly: true,
-        loggedAtOrAfter: foodBounds.loggedAtOrAfter,
-        loggedAtOrBefore: foodBounds.loggedAtOrBefore,
-      });
+      if (!phiSubjectUserId) {
+        setFoodRows([]);
+        setHasMoreFood(false);
+        return;
+      }
+      const res = await listFoodDiaryEntriesForUser(
+        supabase,
+        phiSubjectUserId,
+        {
+          limit: PAGE,
+          offset: 0,
+          standaloneOnly: true,
+          loggedAtOrAfter: foodBounds.loggedAtOrAfter,
+          loggedAtOrBefore: foodBounds.loggedAtOrBefore,
+        },
+      );
       if (stale()) {
         return;
       }
@@ -509,13 +533,18 @@ export function ManageRecordsPage() {
         setFoodLoading(false);
       }
     }
-  }, [foodBounds.loggedAtOrAfter, foodBounds.loggedAtOrBefore]);
+  }, [
+    foodBounds.loggedAtOrAfter,
+    foodBounds.loggedAtOrBefore,
+    phiScopeError,
+    phiSubjectUserId,
+  ]);
 
   useEffect(() => {
-    if (segment === 'food') {
+    if (segment === 'food' && !phiScopeLoading) {
       void loadFoodInitial();
     }
-  }, [segment, loadFoodInitial]);
+  }, [segment, loadFoodInitial, phiScopeLoading]);
 
   const loadMoreFood = useCallback(async () => {
     if (loadingMoreFood || !hasMoreFood) {
@@ -526,23 +555,21 @@ export function ManageRecordsPage() {
     setLoadingMoreFood(true);
     try {
       const supabase = createBrowserClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (stale()) {
-        return;
-      }
-      if (!user) {
+      if (!phiSubjectUserId) {
         setHasMoreFood(false);
         return;
       }
-      const res = await listFoodDiaryEntriesForUser(supabase, user.id, {
-        limit: PAGE,
-        offset: foodRows.length,
-        standaloneOnly: true,
-        loggedAtOrAfter: foodBounds.loggedAtOrAfter,
-        loggedAtOrBefore: foodBounds.loggedAtOrBefore,
-      });
+      const res = await listFoodDiaryEntriesForUser(
+        supabase,
+        phiSubjectUserId,
+        {
+          limit: PAGE,
+          offset: foodRows.length,
+          standaloneOnly: true,
+          loggedAtOrAfter: foodBounds.loggedAtOrAfter,
+          loggedAtOrBefore: foodBounds.loggedAtOrBefore,
+        },
+      );
       if (stale()) {
         return;
       }
@@ -568,6 +595,7 @@ export function ManageRecordsPage() {
     foodRows.length,
     hasMoreFood,
     loadingMoreFood,
+    phiSubjectUserId,
   ]);
 
   const confirmDeleteFood = useCallback(async (): Promise<void | false> => {

--- a/apps/web/src/components/symptom-presets/SymptomPresetCreateForm.tsx
+++ b/apps/web/src/components/symptom-presets/SymptomPresetCreateForm.tsx
@@ -3,7 +3,10 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useState } from 'react';
-import { createSymptomPreset } from '@abstrack/supabase';
+import {
+  createSymptomPreset,
+  resolvePhiSubjectUserContextFromSupabase,
+} from '@abstrack/supabase';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { useAuth } from '@/lib/auth-provider';
@@ -35,8 +38,21 @@ export function SymptomPresetCreateForm() {
     setSaving(true);
     setError(null);
     const supabase = createBrowserClient();
+    const phiRes = await resolvePhiSubjectUserContextFromSupabase(
+      supabase,
+      session.user.id,
+    );
+    if (!phiRes.ok || phiRes.data == null) {
+      setSaving(false);
+      const msg = phiRes.ok
+        ? 'You must be signed in to create a preset.'
+        : phiRes.error.message;
+      setError(msg);
+      announce(msg, { politeness: 'assertive' });
+      return;
+    }
     const result = await createSymptomPreset(supabase, {
-      user_id: session.user.id,
+      user_id: phiRes.data.phiSubjectUserId,
       name: trimmed,
     });
     setSaving(false);

--- a/apps/web/src/lib/patient/use-web-phi-subject-user-context.ts
+++ b/apps/web/src/lib/patient/use-web-phi-subject-user-context.ts
@@ -22,7 +22,9 @@ export type WebPhiSubjectUserContextState = {
  *
  * In-flight resolves are dropped after unmount or when `authUserId` / auth loading changes by
  * bumping an internal generation counter so async completion does not call `setState` on an
- * unmounted consumer.
+ * unmounted consumer. When starting a resolve for a non-null `authUserId`, `phiSubjectUserId` and
+ * `profileAppRole` state are cleared first so consumers that do not gate every read on `loading`
+ * cannot briefly use a prior account’s PHI scope.
  *
  * @returns Async-resolved ids plus loading and error state for episode, manage, and preset flows.
  */
@@ -47,8 +49,10 @@ export function useWebPhiSubjectUserContext(): WebPhiSubjectUserContextState {
       setResolving(false);
       return;
     }
-    setResolving(true);
+    setPhiSubjectUserId(null);
+    setProfileAppRole(null);
     setErrorMessage(null);
+    setResolving(true);
     const supabase = createBrowserClient();
     const result = await resolvePhiSubjectUserContextFromSupabase(
       supabase,

--- a/apps/web/src/lib/patient/use-web-phi-subject-user-context.ts
+++ b/apps/web/src/lib/patient/use-web-phi-subject-user-context.ts
@@ -20,6 +20,10 @@ export type WebPhiSubjectUserContextState = {
  * Resolves the patient id used for PHI reads/writes on user web (`phiSubjectUserId`) vs the
  * signed-in auth id. Caretakers use the linked patient from active `caretaker_access`.
  *
+ * In-flight resolves are dropped after unmount or when `authUserId` / auth loading changes by
+ * bumping an internal generation counter so async completion does not call `setState` on an
+ * unmounted consumer.
+ *
  * @returns Async-resolved ids plus loading and error state for episode, manage, and preset flows.
  */
 export function useWebPhiSubjectUserContext(): WebPhiSubjectUserContextState {
@@ -72,10 +76,12 @@ export function useWebPhiSubjectUserContext(): WebPhiSubjectUserContextState {
   }, [authUserId]);
 
   useEffect(() => {
-    if (authLoading) {
-      return;
+    if (!authLoading) {
+      void run();
     }
-    void run();
+    return () => {
+      genRef.current += 1;
+    };
   }, [authLoading, run]);
 
   const refresh = useCallback(() => {

--- a/apps/web/src/lib/patient/use-web-phi-subject-user-context.ts
+++ b/apps/web/src/lib/patient/use-web-phi-subject-user-context.ts
@@ -1,0 +1,93 @@
+'use client';
+
+import type { AppRole } from '@abstrack/types';
+import { resolvePhiSubjectUserContextFromSupabase } from '@abstrack/supabase';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useAuth } from '@/lib/auth-provider';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+
+export type WebPhiSubjectUserContextState = {
+  authUserId: string | null;
+  phiSubjectUserId: string | null;
+  profileAppRole: AppRole | null;
+  loading: boolean;
+  errorMessage: string | null;
+  refresh: () => void;
+};
+
+/**
+ * Resolves the patient id used for PHI reads/writes on user web (`phiSubjectUserId`) vs the
+ * signed-in auth id. Caretakers use the linked patient from active `caretaker_access`.
+ *
+ * @returns Async-resolved ids plus loading and error state for episode, manage, and preset flows.
+ */
+export function useWebPhiSubjectUserContext(): WebPhiSubjectUserContextState {
+  const { session, loading: authLoading } = useAuth();
+  const authUserId =
+    session?.user?.id != null && session.user.id !== ''
+      ? session.user.id
+      : null;
+  const [phiSubjectUserId, setPhiSubjectUserId] = useState<string | null>(null);
+  const [profileAppRole, setProfileAppRole] = useState<AppRole | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [resolving, setResolving] = useState(false);
+  const genRef = useRef(0);
+
+  const run = useCallback(async () => {
+    const gen = ++genRef.current;
+    if (authUserId == null) {
+      setPhiSubjectUserId(null);
+      setProfileAppRole(null);
+      setErrorMessage(null);
+      setResolving(false);
+      return;
+    }
+    setResolving(true);
+    setErrorMessage(null);
+    const supabase = createBrowserClient();
+    const result = await resolvePhiSubjectUserContextFromSupabase(
+      supabase,
+      authUserId,
+    );
+    if (gen !== genRef.current) {
+      return;
+    }
+    setResolving(false);
+    if (!result.ok) {
+      setPhiSubjectUserId(null);
+      setProfileAppRole(null);
+      setErrorMessage(result.error.message);
+      return;
+    }
+    if (result.data == null) {
+      setPhiSubjectUserId(null);
+      setProfileAppRole(null);
+      setErrorMessage(null);
+      return;
+    }
+    setPhiSubjectUserId(result.data.phiSubjectUserId);
+    setProfileAppRole(result.data.profileAppRole);
+    setErrorMessage(null);
+  }, [authUserId]);
+
+  useEffect(() => {
+    if (authLoading) {
+      return;
+    }
+    void run();
+  }, [authLoading, run]);
+
+  const refresh = useCallback(() => {
+    void run();
+  }, [run]);
+
+  return {
+    authUserId,
+    phiSubjectUserId,
+    profileAppRole,
+    loading: authLoading || resolving,
+    errorMessage,
+    refresh,
+  };
+}

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -49,6 +49,8 @@ export {
   toPresetDataError,
 } from './lib/preset-data-error.js';
 export type { PresetDataResult } from './lib/preset-data.js';
+export type { PhiSubjectUserContext } from './lib/phi-subject-user-id.js';
+export { resolvePhiSubjectUserContextFromSupabase } from './lib/phi-subject-user-id.js';
 export {
   createHealthMarkerPreset,
   createPresetHealthMarker,

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -50,7 +50,10 @@ export {
 } from './lib/preset-data-error.js';
 export type { PresetDataResult } from './lib/preset-data.js';
 export type { PhiSubjectUserContext } from './lib/phi-subject-user-id.js';
-export { resolvePhiSubjectUserContextFromSupabase } from './lib/phi-subject-user-id.js';
+export {
+  CARETAKER_MULTIPLE_ACTIVE_PATIENTS_MESSAGE,
+  resolvePhiSubjectUserContextFromSupabase,
+} from './lib/phi-subject-user-id.js';
 export {
   createHealthMarkerPreset,
   createPresetHealthMarker,

--- a/packages/supabase/src/lib/phi-subject-user-id.spec.ts
+++ b/packages/supabase/src/lib/phi-subject-user-id.spec.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  CARETAKER_MULTIPLE_ACTIVE_PATIENTS_MESSAGE,
+  resolvePhiSubjectUserContextFromSupabase,
+} from './phi-subject-user-id.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+type ProfileMaybeSingle = Promise<{
+  data: { app_role: string } | null;
+  error: null;
+}>;
+type GrantsSelect = Promise<{
+  data: Array<{ patient_user_id: string }> | null;
+  error: null;
+}>;
+
+function makePhiTestClient(opts: {
+  profile: ProfileMaybeSingle;
+  grants: GrantsSelect;
+}): AbstrackSupabaseClient {
+  return {
+    from(table: string) {
+      if (table === 'profiles') {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  maybeSingle: () => opts.profile,
+                };
+              },
+            };
+          },
+        };
+      }
+      if (table === 'caretaker_access') {
+        return {
+          select() {
+            return {
+              eq() {
+                return {
+                  is() {
+                    return opts.grants;
+                  },
+                };
+              },
+            };
+          },
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  } as unknown as AbstrackSupabaseClient;
+}
+
+describe('resolvePhiSubjectUserContextFromSupabase', () => {
+  it('returns validation error when multiple distinct active caretaker grants exist', async () => {
+    const client = makePhiTestClient({
+      profile: Promise.resolve({
+        data: { app_role: 'caretaker' },
+        error: null,
+      }),
+      grants: Promise.resolve({
+        data: [
+          { patient_user_id: '11111111-1111-1111-1111-111111111111' },
+          { patient_user_id: '22222222-2222-2222-2222-222222222222' },
+        ],
+        error: null,
+      }),
+    });
+
+    const res = await resolvePhiSubjectUserContextFromSupabase(
+      client,
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    );
+    expect(res.ok).toBe(false);
+    if (res.ok) {
+      return;
+    }
+    expect(res.error.code).toBe('validation_error');
+    expect(res.error.message).toBe(CARETAKER_MULTIPLE_ACTIVE_PATIENTS_MESSAGE);
+  });
+
+  it('dedupes duplicate patient ids from multiple grant rows', async () => {
+    const patient = '11111111-1111-1111-1111-111111111111';
+    const client = makePhiTestClient({
+      profile: Promise.resolve({
+        data: { app_role: 'caretaker' },
+        error: null,
+      }),
+      grants: Promise.resolve({
+        data: [{ patient_user_id: patient }, { patient_user_id: patient }],
+        error: null,
+      }),
+    });
+
+    const res = await resolvePhiSubjectUserContextFromSupabase(
+      client,
+      'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    );
+    expect(res).toEqual({
+      ok: true,
+      data: {
+        authUserId: 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+        phiSubjectUserId: patient,
+        profileAppRole: 'caretaker',
+      },
+    });
+  });
+});

--- a/packages/supabase/src/lib/phi-subject-user-id.spec.ts
+++ b/packages/supabase/src/lib/phi-subject-user-id.spec.ts
@@ -55,6 +55,24 @@ function makePhiTestClient(opts: {
 }
 
 describe('resolvePhiSubjectUserContextFromSupabase', () => {
+  it('treats missing profile with no caretaker grant as patient self', async () => {
+    const uid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const client = makePhiTestClient({
+      profile: Promise.resolve({ data: null, error: null }),
+      grants: Promise.resolve({ data: [], error: null }),
+    });
+
+    const res = await resolvePhiSubjectUserContextFromSupabase(client, uid);
+    expect(res).toEqual({
+      ok: true,
+      data: {
+        authUserId: uid,
+        phiSubjectUserId: uid,
+        profileAppRole: null,
+      },
+    });
+  });
+
   it('returns validation error when multiple distinct active caretaker grants exist', async () => {
     const client = makePhiTestClient({
       profile: Promise.resolve({

--- a/packages/supabase/src/lib/phi-subject-user-id.spec.ts
+++ b/packages/supabase/src/lib/phi-subject-user-id.spec.ts
@@ -54,6 +54,9 @@ function makePhiTestClient(opts: {
   } as unknown as AbstrackSupabaseClient;
 }
 
+const CARETAKER_NO_ACTIVE_GRANT_MESSAGE =
+  'Your caretaker account is not linked to a patient yet. Ask the patient to send an invite from Settings, then open the link from your email.';
+
 describe('resolvePhiSubjectUserContextFromSupabase', () => {
   it('treats missing profile with no caretaker grant as patient self', async () => {
     const uid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
@@ -72,6 +75,37 @@ describe('resolvePhiSubjectUserContextFromSupabase', () => {
       },
     });
   });
+
+  it.each([
+    {
+      label: 'empty grant rows',
+      grantsData: [] as Array<{ patient_user_id: string }>,
+    },
+    { label: 'null grant rows', grantsData: null },
+  ])(
+    'returns validation_error when profile is caretaker but grants.data is $label',
+    async ({ grantsData }) => {
+      const uid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+      const client = makePhiTestClient({
+        profile: Promise.resolve({
+          data: { app_role: 'caretaker' },
+          error: null,
+        }),
+        grants: Promise.resolve({
+          data: grantsData,
+          error: null,
+        }),
+      });
+
+      const res = await resolvePhiSubjectUserContextFromSupabase(client, uid);
+      expect(res.ok).toBe(false);
+      if (res.ok) {
+        return;
+      }
+      expect(res.error.code).toBe('validation_error');
+      expect(res.error.message).toBe(CARETAKER_NO_ACTIVE_GRANT_MESSAGE);
+    },
+  );
 
   it('returns validation error when multiple distinct active caretaker grants exist', async () => {
     const client = makePhiTestClient({

--- a/packages/supabase/src/lib/phi-subject-user-id.ts
+++ b/packages/supabase/src/lib/phi-subject-user-id.ts
@@ -1,0 +1,114 @@
+/**
+ * Resolves which auth user id owns PHI rows (`user_id` on episodes, presets, markers, food diary).
+ * Patients act as themselves; caretakers act as their linked patient when an active
+ * `caretaker_access` row exists (PRD §7).
+ */
+import { isAppRole, type AppRole } from '@abstrack/types';
+
+import { PresetDataError, toPresetDataError } from './preset-data-error.js';
+import type { PresetDataResult } from './preset-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+/**
+ * Signed-in auth user plus the PHI scope user id used for `user_id` / `patient_user_id` filters.
+ */
+export type PhiSubjectUserContext = {
+  /** Supabase Auth subject (`auth.uid()`). */
+  authUserId: string;
+  /**
+   * Value to use for PHI row ownership (`episodes.user_id`, preset `user_id`, etc.) — the patient
+   * when the signed-in user is an active caretaker.
+   */
+  phiSubjectUserId: string;
+  /** `profiles.app_role` for {@link authUserId}, when the row exists. */
+  profileAppRole: AppRole | null;
+};
+
+function normalizeAppRole(raw: unknown): AppRole | null {
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  return isAppRole(raw) ? raw : null;
+}
+
+/**
+ * Loads profile role and, for caretakers, the active grant’s `patient_user_id` via PostgREST (RLS).
+ *
+ * @param client - Browser or native Supabase client with the user’s session.
+ * @param authUserId - Non-empty `auth.users` id (`session.user.id`).
+ * @returns PHI scope context, or `{ ok: true, data: null }` when `authUserId` is blank (caller
+ *   should treat as signed-out). Caretakers without an active link return a validation error.
+ */
+export async function resolvePhiSubjectUserContextFromSupabase(
+  client: AbstrackSupabaseClient,
+  authUserId: string,
+): Promise<PresetDataResult<PhiSubjectUserContext | null>> {
+  const trimmed = authUserId.trim();
+  if (trimmed === '') {
+    return { ok: true, data: null };
+  }
+
+  try {
+    const profileRes = await client
+      .from('profiles')
+      .select('app_role')
+      .eq('id', trimmed)
+      .maybeSingle();
+
+    if (profileRes.error) {
+      return { ok: false, error: toPresetDataError(profileRes.error) };
+    }
+
+    const profileAppRole = normalizeAppRole(profileRes.data?.app_role);
+
+    if (profileAppRole !== 'caretaker') {
+      return {
+        ok: true,
+        data: {
+          authUserId: trimmed,
+          phiSubjectUserId: trimmed,
+          profileAppRole,
+        },
+      };
+    }
+
+    const grantRes = await client
+      .from('caretaker_access')
+      .select('patient_user_id')
+      .eq('caretaker_user_id', trimmed)
+      .is('revoked_at', null)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (grantRes.error) {
+      return { ok: false, error: toPresetDataError(grantRes.error) };
+    }
+
+    const patientId =
+      grantRes.data?.patient_user_id != null
+        ? String(grantRes.data.patient_user_id).trim()
+        : '';
+
+    if (patientId === '') {
+      return {
+        ok: false,
+        error: new PresetDataError(
+          'validation_error',
+          'Your caretaker account is not linked to a patient yet. Ask the patient to send an invite from Settings, then open the link from your email.',
+        ),
+      };
+    }
+
+    return {
+      ok: true,
+      data: {
+        authUserId: trimmed,
+        phiSubjectUserId: patientId,
+        profileAppRole: 'caretaker',
+      },
+    };
+  } catch (caught) {
+    return { ok: false, error: toPresetDataError(caught) };
+  }
+}

--- a/packages/supabase/src/lib/phi-subject-user-id.ts
+++ b/packages/supabase/src/lib/phi-subject-user-id.ts
@@ -3,10 +3,11 @@
  * Patients act as themselves; caretakers act as their linked patient when an active
  * `caretaker_access` row exists (PRD §7).
  */
-import { isAppRole, type AppRole } from '@abstrack/types';
+import type { AppRole } from '@abstrack/types';
 
 import { PresetDataError, toPresetDataError } from './preset-data-error.js';
 import type { PresetDataResult } from './preset-data.js';
+import { parseProfileAppRole } from './session-claims.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
 /**
@@ -23,13 +24,6 @@ export type PhiSubjectUserContext = {
   /** `profiles.app_role` for {@link authUserId}, when the row exists. */
   profileAppRole: AppRole | null;
 };
-
-function normalizeAppRole(raw: unknown): AppRole | null {
-  if (typeof raw !== 'string') {
-    return null;
-  }
-  return isAppRole(raw) ? raw : null;
-}
 
 /**
  * Shown when the same caretaker has more than one active `caretaker_access` row (different
@@ -147,7 +141,14 @@ export async function resolvePhiSubjectUserContextFromSupabase(
       };
     }
 
-    const profileAppRole = normalizeAppRole(profileRes.data.app_role);
+    const rawAppRole = profileRes.data.app_role as unknown;
+    const profileAppRole = parseProfileAppRole(
+      typeof rawAppRole === 'string' ||
+        rawAppRole === null ||
+        rawAppRole === undefined
+        ? (rawAppRole as string | null | undefined)
+        : undefined,
+    );
 
     if (profileAppRole !== 'caretaker') {
       return {

--- a/packages/supabase/src/lib/phi-subject-user-id.ts
+++ b/packages/supabase/src/lib/phi-subject-user-id.ts
@@ -31,13 +31,79 @@ function normalizeAppRole(raw: unknown): AppRole | null {
   return isAppRole(raw) ? raw : null;
 }
 
+const PROFILE_NOT_READY_MESSAGE =
+  'Your profile could not be loaded yet. Try refreshing, finishing account setup, or signing out and back in.';
+
+/**
+ * Shown when the same caretaker has more than one active `caretaker_access` row (different
+ * patients). Resolvers cannot pick a PHI subject without an explicit patient selection (PRD §7).
+ */
+export const CARETAKER_MULTIPLE_ACTIVE_PATIENTS_MESSAGE =
+  'You have more than one active patient as caretaker. Ask patients to revoke access you no longer need so only one active link remains, then try again.';
+
+/**
+ * Active `caretaker_access` patient scope for this caretaker via PostgREST (RLS).
+ *
+ * The DB enforces at most one active grant **per patient**, not per caretaker, so multiple active
+ * rows for the same caretaker must not be collapsed by `ORDER BY created_at` — that would mis-scope
+ * PHI. When more than one distinct `patient_user_id` is active, returns a validation error.
+ *
+ * @param client - Supabase client with the user’s session.
+ * @param caretakerUserId - `caretaker_access.caretaker_user_id`.
+ * @returns Non-empty patient id, `null` when no active grant exists, PostgREST errors, or
+ *   ambiguous multiple-patient validation failure.
+ */
+async function fetchActiveCaretakerPatientUserId(
+  client: AbstrackSupabaseClient,
+  caretakerUserId: string,
+): Promise<PresetDataResult<string | null>> {
+  const grantRes = await client
+    .from('caretaker_access')
+    .select('patient_user_id')
+    .eq('caretaker_user_id', caretakerUserId)
+    .is('revoked_at', null);
+
+  if (grantRes.error) {
+    return { ok: false, error: toPresetDataError(grantRes.error) };
+  }
+
+  const patientIds = new Set<string>();
+  for (const row of grantRes.data ?? []) {
+    const id =
+      row.patient_user_id != null ? String(row.patient_user_id).trim() : '';
+    if (id !== '') {
+      patientIds.add(id);
+    }
+  }
+
+  if (patientIds.size === 0) {
+    return { ok: true, data: null };
+  }
+  if (patientIds.size > 1) {
+    return {
+      ok: false,
+      error: new PresetDataError(
+        'validation_error',
+        CARETAKER_MULTIPLE_ACTIVE_PATIENTS_MESSAGE,
+      ),
+    };
+  }
+  const [onlyPatientId] = patientIds;
+  return { ok: true, data: onlyPatientId };
+}
+
 /**
  * Loads profile role and, for caretakers, the active grant’s `patient_user_id` via PostgREST (RLS).
  *
  * @param client - Browser or native Supabase client with the user’s session.
  * @param authUserId - Non-empty `auth.users` id (`session.user.id`).
  * @returns PHI scope context, or `{ ok: true, data: null }` when `authUserId` is blank (caller
- *   should treat as signed-out). Caretakers without an active link return a validation error.
+ *   should treat as signed-out). When the **`profiles` row is missing**, we do not assume patient
+ *   semantics: if an active **`caretaker_access`** row exists, the subject resolves as the linked
+ *   patient; otherwise `{ ok: false, validation_error }` so callers fail fast (not-yet-provisioned
+ *   accounts must not write PHI as `authUserId`). Caretakers with a profile but no active link
+ *   return a validation error. Caretakers with **more than one distinct active** `caretaker_access`
+ *   patient also return a validation error (no silent pick among patients).
  */
 export async function resolvePhiSubjectUserContextFromSupabase(
   client: AbstrackSupabaseClient,
@@ -59,7 +125,31 @@ export async function resolvePhiSubjectUserContextFromSupabase(
       return { ok: false, error: toPresetDataError(profileRes.error) };
     }
 
-    const profileAppRole = normalizeAppRole(profileRes.data?.app_role);
+    if (profileRes.data == null) {
+      const grant = await fetchActiveCaretakerPatientUserId(client, trimmed);
+      if (!grant.ok) {
+        return grant;
+      }
+      if (grant.data != null) {
+        return {
+          ok: true,
+          data: {
+            authUserId: trimmed,
+            phiSubjectUserId: grant.data,
+            profileAppRole: 'caretaker',
+          },
+        };
+      }
+      return {
+        ok: false,
+        error: new PresetDataError(
+          'validation_error',
+          PROFILE_NOT_READY_MESSAGE,
+        ),
+      };
+    }
+
+    const profileAppRole = normalizeAppRole(profileRes.data.app_role);
 
     if (profileAppRole !== 'caretaker') {
       return {
@@ -72,25 +162,11 @@ export async function resolvePhiSubjectUserContextFromSupabase(
       };
     }
 
-    const grantRes = await client
-      .from('caretaker_access')
-      .select('patient_user_id')
-      .eq('caretaker_user_id', trimmed)
-      .is('revoked_at', null)
-      .order('created_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (grantRes.error) {
-      return { ok: false, error: toPresetDataError(grantRes.error) };
+    const grant = await fetchActiveCaretakerPatientUserId(client, trimmed);
+    if (!grant.ok) {
+      return grant;
     }
-
-    const patientId =
-      grantRes.data?.patient_user_id != null
-        ? String(grantRes.data.patient_user_id).trim()
-        : '';
-
-    if (patientId === '') {
+    if (grant.data == null) {
       return {
         ok: false,
         error: new PresetDataError(
@@ -104,7 +180,7 @@ export async function resolvePhiSubjectUserContextFromSupabase(
       ok: true,
       data: {
         authUserId: trimmed,
-        phiSubjectUserId: patientId,
+        phiSubjectUserId: grant.data,
         profileAppRole: 'caretaker',
       },
     };

--- a/packages/supabase/src/lib/phi-subject-user-id.ts
+++ b/packages/supabase/src/lib/phi-subject-user-id.ts
@@ -31,9 +31,6 @@ function normalizeAppRole(raw: unknown): AppRole | null {
   return isAppRole(raw) ? raw : null;
 }
 
-const PROFILE_NOT_READY_MESSAGE =
-  'Your profile could not be loaded yet. Try refreshing, finishing account setup, or signing out and back in.';
-
 /**
  * Shown when the same caretaker has more than one active `caretaker_access` row (different
  * patients). Resolvers cannot pick a PHI subject without an explicit patient selection (PRD §7).
@@ -98,12 +95,12 @@ async function fetchActiveCaretakerPatientUserId(
  * @param client - Browser or native Supabase client with the user’s session.
  * @param authUserId - Non-empty `auth.users` id (`session.user.id`).
  * @returns PHI scope context, or `{ ok: true, data: null }` when `authUserId` is blank (caller
- *   should treat as signed-out). When the **`profiles` row is missing**, we do not assume patient
- *   semantics: if an active **`caretaker_access`** row exists, the subject resolves as the linked
- *   patient; otherwise `{ ok: false, validation_error }` so callers fail fast (not-yet-provisioned
- *   accounts must not write PHI as `authUserId`). Caretakers with a profile but no active link
- *   return a validation error. Caretakers with **more than one distinct active** `caretaker_access`
- *   patient also return a validation error (no silent pick among patients).
+ *   should treat as signed-out). When the **`profiles` row is missing**, if an active
+ *   **`caretaker_access`** row exists the subject resolves as the linked patient; if not, we treat
+ *   the user as **patient/self** (`phiSubjectUserId === authUserId`, `profileAppRole: null`) so
+ *   sessions without a provisioned profile row (common patient signup paths) are not blocked.
+ *   When **`profiles.app_role` is `caretaker`** but there is no active grant, callers still get a
+ *   validation error. Multiple distinct active grants for one caretaker also return a validation error.
  */
 export async function resolvePhiSubjectUserContextFromSupabase(
   client: AbstrackSupabaseClient,
@@ -141,11 +138,12 @@ export async function resolvePhiSubjectUserContextFromSupabase(
         };
       }
       return {
-        ok: false,
-        error: new PresetDataError(
-          'validation_error',
-          PROFILE_NOT_READY_MESSAGE,
-        ),
+        ok: true,
+        data: {
+          authUserId: trimmed,
+          phiSubjectUserId: trimmed,
+          profileAppRole: null,
+        },
       };
     }
 

--- a/packages/supabase/src/lib/preset-data.spec.ts
+++ b/packages/supabase/src/lib/preset-data.spec.ts
@@ -247,6 +247,32 @@ describe('preset CRUD helpers (mocked client)', () => {
     expect(from).toHaveBeenCalledWith('health_marker_presets');
   });
 
+  it('listHealthMarkerPresets applies user_id when scopeUserId is set', async () => {
+    const order2 = vi.fn(async () => ({
+      data: [healthMarkerPresetRow],
+      error: null,
+    }));
+    const order1 = vi.fn(() => ({ order: order2 }));
+    const eq = vi.fn(() => ({ order: order1 }));
+    const from = vi.fn(() => ({
+      select: vi.fn(() => ({
+        eq,
+        order: order1,
+      })),
+    }));
+    const client = { from } as unknown as AbstrackSupabaseClient;
+
+    const result = await listHealthMarkerPresets(client, {
+      scopeUserId: 'patient-scope-1',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(eq).toHaveBeenCalledWith('user_id', 'patient-scope-1');
+    if (result.ok) {
+      expect(result.data).toEqual([healthMarkerPresetRow]);
+    }
+  });
+
   it('createHealthMarkerPreset returns inserted row', async () => {
     const from = vi.fn(() => ({
       insert: vi.fn(() => ({

--- a/packages/supabase/src/lib/preset-data.ts
+++ b/packages/supabase/src/lib/preset-data.ts
@@ -374,17 +374,24 @@ export async function reorderPresetSymptoms(
 // --- Health marker presets (header rows) ---
 
 /**
- * Lists the signed-in user’s health marker presets with stable ordering.
+ * Lists health marker presets with stable ordering.
  *
  * @param client - Supabase client.
+ * @param options - When {@link options.scopeUserId} is set, restricts rows to that
+ *   `health_marker_presets.user_id` (PHI subject) so caretaker UIs do not rely on RLS alone for
+ *   preset ownership when listing.
  */
 export async function listHealthMarkerPresets(
   client: AbstrackSupabaseClient,
+  options?: { scopeUserId?: string },
 ): Promise<PresetDataResult<HealthMarkerPresetRow[]>> {
   return wrap(async () => {
-    const result = await client
-      .from('health_marker_presets')
-      .select('*')
+    const scope = options?.scopeUserId?.trim();
+    let query = client.from('health_marker_presets').select('*');
+    if (scope) {
+      query = query.eq('user_id', scope);
+    }
+    const result = await query
       .order('created_at', { ascending: true })
       .order('id', { ascending: true });
     return {
@@ -399,17 +406,21 @@ export async function listHealthMarkerPresets(
  *
  * @param client - Supabase client.
  * @param id - `health_marker_presets.id`.
+ * @param options - When {@link options.scopeUserId} is set, requires that owner id so a preset
+ *   from another user id cannot be read through this helper alone.
  */
 export async function getHealthMarkerPresetById(
   client: AbstrackSupabaseClient,
   id: string,
+  options?: { scopeUserId?: string },
 ): Promise<PresetDataResult<HealthMarkerPresetRow | null>> {
   try {
-    const { data, error } = await client
-      .from('health_marker_presets')
-      .select('*')
-      .eq('id', id)
-      .maybeSingle();
+    const scope = options?.scopeUserId?.trim();
+    let query = client.from('health_marker_presets').select('*').eq('id', id);
+    if (scope) {
+      query = query.eq('user_id', scope);
+    }
+    const { data, error } = await query.maybeSingle();
     if (error) {
       return { ok: false, error: toPresetDataError(error) };
     }
@@ -497,11 +508,33 @@ export async function deleteHealthMarkerPreset(
  *
  * @param client - Supabase client.
  * @param presetId - Parent `health_marker_presets.id`.
+ * @param options - When {@link options.scopeUserId} is set, ensures the preset header belongs to
+ *   that user before listing lines so callers cannot combine another user’s lines with a mismatched
+ *   `user_id` on insert.
  */
 export async function listPresetHealthMarkersForPreset(
   client: AbstrackSupabaseClient,
   presetId: string,
+  options?: { scopeUserId?: string },
 ): Promise<PresetDataResult<PresetHealthMarkerRow[]>> {
+  const scope = options?.scopeUserId?.trim();
+  if (scope) {
+    const preset = await getHealthMarkerPresetById(client, presetId, {
+      scopeUserId: scope,
+    });
+    if (!preset.ok) {
+      return { ok: false, error: preset.error };
+    }
+    if (preset.data == null) {
+      return {
+        ok: false,
+        error: new PresetDataError(
+          'validation_error',
+          'That health marker preset is not available for the current patient scope.',
+        ),
+      };
+    }
+  }
   return wrap(async () => {
     const result = await client
       .from('preset_health_markers')


### PR DESCRIPTION
Closes #151

## Summary

Implements **PRD §7 — caretaker as a separate Auth user**: caretakers sign in with **their own** credentials; the app resolves **`phiSubjectUserId`** (patient row owner) from active **`caretaker_access`** and uses that id for the **same** patient logging surfaces as the patient (episodes, standalone health markers, food diary, presets/templates, media upload queue, etc.) on **Expo mobile** and **user web**. Practitioner app and chart work stay out of scope.

## Behavior

- **Patients:** unchanged — `phiSubjectUserId` matches `auth.uid()` when `profiles.app_role` is not an active caretaker grant path.
- **Caretakers:** PostgREST + RLS (and optional PowerSync offline reads) determine the linked patient; missing/revoked access surfaces a clear validation-style error instead of writing under the caretaker’s auth id.
- **No shared patient password**; patient-only sessions unchanged.

## Key implementation notes

- **Shared:** `resolvePhiSubjectUserContextFromSupabase` + `PhiSubjectUserContext` in `@abstrack/supabase`; mobile wraps with offline-aware `resolveMobilePhiSubjectUserContext` and `useMobilePhiSubjectUserContext` (e.g. refresh after first PowerSync sync).
- **Mobile:** Episode, manage, food diary, symptom/health marker flows, preset/template creates, pending episode media worker, etc. use **PHI subject** for reads/writes and subscription/list keys where needed.
- **User web:** `useWebPhiSubjectUserContext`, shell nav tweaks for caretakers, episode/manage flows, preset/food/standalone health flows, **SymptomPromptFlow** queued writes, and related forms aligned with the same resolver pattern.
- **PowerSync:** `sync-rules.yaml` intent unchanged in this work (RLS mirror); no practitioner changes.

## Testing & quality

- Jest updated for phi/session mocks (`FoodDiaryEntryScreen`, pending media upload worker, `SymptomPromptScreen`, `HealthMarkerPromptScreen`, `EpisodesScreen`, etc.).
- `EpisodeTemplateCreateScreen`: missing `fetchHealthMarkerPresets` import + typed preset rows for strict TS.
- `FoodDiaryEntryScreen`: restored `getMobileSupabaseClient` import; phi mock uses factory `jest.fn()` + `jest.requireMock` to satisfy Jest hoisting and avoid composite `import` TS6305 on specs.