### PR TITLE
feat(practitioner): add grant-based patient directory, helper, and RLS for patient display names

### DIFF
--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -12,7 +12,8 @@ import {
   createMobileSupabaseClient,
   getMobileSupabaseClient,
 } from '../lib/supabase-wiring';
-import * as mobilePhiSubject from '../lib/phi-subject/resolve-mobile-phi-subject-user-context';
+import * as mobilePhiHook from '../lib/auth/use-mobile-phi-subject-user-context';
+import * as mobileNetinfo from '../lib/network/mobile-device-netinfo';
 
 jest.mock('@abstrack/supabase', () => {
   const actual =
@@ -745,41 +746,49 @@ describe('mobile auth state sync', () => {
     jest.mocked(SecureStore.getItemAsync).mockResolvedValue('false');
     jest.mocked(getMobileSupabaseClient).mockReturnValue(mockClient);
 
-    const phiResolveSpy = jest
-      .spyOn(mobilePhiSubject, 'resolveMobilePhiSubjectUserContext')
-      .mockResolvedValue({
-        ok: true,
-        data: {
-          authUserId: 'user-1',
-          phiSubjectUserId: 'user-1',
-          profileAppRole: 'patient',
-        },
+    /**
+     * Home `activeEpisodeLoading` stays true until PHI scope and the network active-episode probe
+     * finish. Spy the hook (not only `resolveMobilePhiSubjectUserContext`) so CI does not burn the
+     * full `asyncUtilTimeout` waiting on async auth/NetInfo/focus-effect ordering.
+     */
+    const phiHookSpy = jest
+      .spyOn(mobilePhiHook, 'useMobilePhiSubjectUserContext')
+      .mockReturnValue({
+        loading: false,
+        errorMessage: null,
+        authUserId: 'user-1',
+        phiSubjectUserId: 'user-1',
+        profileAppRole: 'patient',
+        refresh: jest.fn(),
       });
+    const netConnectedSpy = jest
+      .spyOn(mobileNetinfo, 'fetchMobileDeviceIsConnected')
+      .mockResolvedValue(true);
 
     /** Same as tab navigation test: cold `App` bootstrap must not await an unresolved `getInitialURL()`. */
     const getInitialUrlSpy = jest
       .spyOn(Linking, 'getInitialURL')
       .mockResolvedValue(null);
     try {
-      const { findByText, findByTestId, queryByLabelText, queryByText } =
+      const { findByText, findByTestId, findByLabelText, queryByText } =
         render(<App />);
 
       await findByText('Welcome to ABStrack');
 
-      // Home mounts the CTA while PHI scope + active-episode probes run; wait until loading copy
-      // is gone and the start (not resume) control is exposed (see HomeScreen + EpisodeStartHomeCta).
-      const startEpisodeButton = await waitFor(() => {
-        expect(queryByText('Checking for an episode in progress…')).toBeNull();
-        const button = queryByLabelText("I'm having an episode");
-        expect(button).toBeTruthy();
-        return button;
+      // Wait for Home to leave the active-episode probe spinner, then the start CTA (not resume).
+      await waitFor(() => {
+        expect(
+          queryByText('Checking for an episode in progress…'),
+        ).toBeNull();
       });
+      const startEpisodeButton = await findByLabelText("I'm having an episode");
 
       fireEvent.press(startEpisodeButton);
       expect(await findByTestId('episode-start-screen-title')).toBeTruthy();
     } finally {
       getInitialUrlSpy.mockRestore();
-      phiResolveSpy.mockRestore();
+      phiHookSpy.mockRestore();
+      netConnectedSpy.mockRestore();
     }
   });
 

--- a/apps/practitioner/specs/patients-page.spec.tsx
+++ b/apps/practitioner/specs/patients-page.spec.tsx
@@ -1,0 +1,102 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { LiveAnnouncerProvider } from '@abstrack/ui/a11y-web';
+import { PractitionerPatientsPage } from '../src/components/practitioner-patients-page';
+
+const listActivePractitionerPatientDirectory = jest.fn();
+
+jest.mock('@abstrack/supabase/browser', () => ({
+  getSupabaseBrowserClient: jest.fn(() => ({})),
+}));
+
+jest.mock('@abstrack/supabase', () => {
+  const actual =
+    jest.requireActual<typeof import('@abstrack/supabase')>(
+      '@abstrack/supabase',
+    );
+  return {
+    ...actual,
+    listActivePractitionerPatientDirectory: (...args: unknown[]) =>
+      listActivePractitionerPatientDirectory(...args),
+  };
+});
+
+function renderPatientsPage() {
+  return render(
+    <LiveAnnouncerProvider>
+      <PractitionerPatientsPage />
+    </LiveAnnouncerProvider>,
+  );
+}
+
+describe('PractitionerPatientsPage', () => {
+  beforeEach(() => {
+    listActivePractitionerPatientDirectory.mockReset();
+  });
+
+  it('shows an empty state when there are no active grants', async () => {
+    listActivePractitionerPatientDirectory.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+
+    renderPatientsPage();
+
+    expect(
+      await screen.findByRole('heading', { name: 'No patients yet' }),
+    ).toBeTruthy();
+    expect(screen.getByText(/send an invite from Settings/i)).toBeTruthy();
+  });
+
+  it('renders keyboard-reachable patient links', async () => {
+    listActivePractitionerPatientDirectory.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          grantId: 'grant-1',
+          patientUserId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+          patientDisplayName: 'Jordan Lee',
+          grantedAt: '2026-05-01T10:00:00.000Z',
+        },
+      ],
+    });
+
+    renderPatientsPage();
+
+    const link = await screen.findByRole('link', {
+      name: /Jordan Lee, access granted/i,
+    });
+    expect(link.getAttribute('href')).toBe(
+      '/patients/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+    );
+  });
+
+  it('shows an error with retry when the directory load fails', async () => {
+    listActivePractitionerPatientDirectory.mockResolvedValue({
+      ok: false,
+      error: {
+        code: 'unknown',
+        message: 'Something went wrong. Please try again.',
+        name: 'PresetDataError',
+      },
+    });
+
+    renderPatientsPage();
+
+    expect(
+      await screen.findByRole('button', { name: 'Try again' }),
+    ).toBeTruthy();
+
+    listActivePractitionerPatientDirectory.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Try again' }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('heading', { name: 'No patients yet' }),
+      ).toBeTruthy();
+    });
+  });
+});

--- a/apps/practitioner/src/app/patients/[patientId]/page.tsx
+++ b/apps/practitioner/src/app/patients/[patientId]/page.tsx
@@ -1,5 +1,6 @@
 type PatientDetailPageProps = {
-  params: { patientId: string };
+  /** Next.js 16 passes dynamic route params as a Promise (await before use). */
+  params: Promise<{ patientId: string }>;
 };
 
 /**
@@ -8,8 +9,10 @@ type PatientDetailPageProps = {
  * @param props - Dynamic route params.
  * @returns Patient detail shell.
  */
-export default function PatientDetailPage({ params }: PatientDetailPageProps) {
-  const { patientId } = params;
+export default async function PatientDetailPage({
+  params,
+}: PatientDetailPageProps) {
+  const { patientId } = await params;
 
   return (
     <div

--- a/apps/practitioner/src/app/patients/page.tsx
+++ b/apps/practitioner/src/app/patients/page.tsx
@@ -1,19 +1,10 @@
+import { PractitionerPatientsPage } from '@/components/practitioner-patients-page';
+
 /**
- * Practitioner patient directory entry point (placeholder). Authorization for PHI remains enforced
- * by Supabase RLS; this route is gated in `patients/layout.tsx` until MFA requirements are met.
+ * Practitioner patient directory: active `practitioner_access` grants (RLS + MFA gate in layout).
  *
- * @returns Patient workspace shell.
+ * @returns Patient workspace list.
  */
 export default function PatientsPage() {
-  return (
-    <div
-      id="practitioner-patients-home"
-      className="mx-auto max-w-3xl px-4 py-8 sm:px-6"
-    >
-      <h1 className="text-2xl font-semibold text-app-ink">Patients</h1>
-      <p className="mt-2 text-sm text-app-muted">
-        Patient workflows will appear here once connected to your account.
-      </p>
-    </div>
-  );
+  return <PractitionerPatientsPage />;
 }

--- a/apps/practitioner/src/components/practitioner-patients-page.tsx
+++ b/apps/practitioner/src/components/practitioner-patients-page.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import {
+  formatPractitionerPatientDirectoryLabel,
+  formatPractitionerPatientGrantedAt,
+  listActivePractitionerPatientDirectory,
+  type PractitionerPatientDirectoryEntry,
+} from '@abstrack/supabase';
+import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import Link from 'next/link';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+
+type LoadState =
+  | { kind: 'loading' }
+  | { kind: 'ready'; patients: PractitionerPatientDirectoryEntry[] }
+  | { kind: 'error'; message: string };
+
+/**
+ * Practitioner dashboard: patients with an active `practitioner_access` grant (RLS + MFA gate in
+ * parent layout). Accessible list with keyboard-reachable links and empty/error states.
+ *
+ * @returns Patient directory page content.
+ */
+export function PractitionerPatientsPage() {
+  const { announce } = useAnnounce();
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const listId = useId();
+  const listHeadingId = `${listId}-heading`;
+  const [loadState, setLoadState] = useState<LoadState>({ kind: 'loading' });
+
+  const loadPatients = useCallback(async () => {
+    setLoadState({ kind: 'loading' });
+    const result = await listActivePractitionerPatientDirectory(supabase);
+    if (!result.ok) {
+      const message =
+        result.error.code === 'permission_denied'
+          ? 'Patient access requires two-factor sign-in for this session. Sign out, sign in again, and complete MFA when prompted.'
+          : result.error.message;
+      setLoadState({ kind: 'error', message });
+      announce(message, { politeness: 'assertive' });
+      return;
+    }
+    setLoadState({ kind: 'ready', patients: result.data });
+    const count = result.data.length;
+    announce(
+      count === 0
+        ? 'No patients with active access.'
+        : count === 1
+          ? '1 patient with active access.'
+          : `${count} patients with active access.`,
+      { politeness: 'polite' },
+    );
+  }, [announce, supabase]);
+
+  useEffect(() => {
+    void loadPatients();
+  }, [loadPatients]);
+
+  const patients = loadState.kind === 'ready' ? loadState.patients : [];
+  const isLoading = loadState.kind === 'loading';
+  const errorMessage = loadState.kind === 'error' ? loadState.message : null;
+
+  return (
+    <div
+      id="practitioner-patients-home"
+      className="mx-auto max-w-3xl px-4 py-8 sm:px-6"
+    >
+      <header>
+        <h1 className="text-2xl font-semibold text-app-ink">Patients</h1>
+        <p className="mt-2 text-sm text-app-muted">
+          People who have granted you access to their ABStrack health records.
+        </p>
+      </header>
+
+      {isLoading ? (
+        <p
+          className="mt-8 text-sm text-app-muted"
+          role="status"
+          aria-live="polite"
+          aria-busy="true"
+        >
+          Loading your patient list…
+        </p>
+      ) : null}
+
+      {errorMessage ? (
+        <div
+          className="mt-8 rounded-xl border border-app-border bg-app-surface p-5 shadow-soft"
+          role="alert"
+        >
+          <p className="text-sm text-app-ink">{errorMessage}</p>
+          <button
+            type="button"
+            onClick={() => void loadPatients()}
+            className="mt-4 inline-flex min-h-11 items-center justify-center rounded-md bg-app-primary px-4 py-2 text-sm font-medium text-white transition hover:brightness-105 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            Try again
+          </button>
+        </div>
+      ) : null}
+
+      {!isLoading && !errorMessage && patients.length === 0 ? (
+        <div
+          className="mt-8 rounded-xl border border-dashed border-app-border bg-app-surface/60 p-6"
+          role="status"
+          aria-labelledby="practitioner-patients-empty-heading"
+        >
+          <h2
+            id="practitioner-patients-empty-heading"
+            className="text-lg font-semibold text-app-ink"
+          >
+            No patients yet
+          </h2>
+          <p className="mt-2 text-sm text-app-muted">
+            When a patient adds you as their practitioner in the ABStrack app,
+            they will appear here. Ask them to send an invite from Settings in
+            the patient or caretaker mobile app.
+          </p>
+        </div>
+      ) : null}
+
+      {!isLoading && !errorMessage && patients.length > 0 ? (
+        <section className="mt-8" aria-labelledby={listHeadingId}>
+          <h2 id={listHeadingId} className="sr-only">
+            Patients with active access
+          </h2>
+          <ul className="space-y-3" role="list">
+            {patients.map((patient) => {
+              const label = formatPractitionerPatientDirectoryLabel(
+                patient.patientUserId,
+                patient.patientDisplayName,
+              );
+              const grantedLabel = formatPractitionerPatientGrantedAt(
+                patient.grantedAt,
+              );
+              return (
+                <li key={patient.grantId}>
+                  <Link
+                    href={`/patients/${patient.patientUserId}`}
+                    className="flex min-h-11 flex-col justify-center rounded-xl border border-app-border bg-app-surface px-4 py-3 shadow-soft transition hover:border-app-primary/40 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                    aria-label={`${label}, access granted ${grantedLabel}`}
+                  >
+                    <span className="text-base font-medium text-app-ink">
+                      {label}
+                    </span>
+                    <span className="mt-0.5 text-sm text-app-muted">
+                      Access granted {grantedLabel}
+                    </span>
+                  </Link>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -138,6 +138,12 @@ export {
   type EpisodeTimelineItem,
   upsertEpisodeTimelineItem,
 } from './lib/episode-observation-timeline.js';
+export type { PractitionerPatientDirectoryEntry } from './lib/practitioner-patient-directory-data.js';
+export {
+  formatPractitionerPatientDirectoryLabel,
+  formatPractitionerPatientGrantedAt,
+  listActivePractitionerPatientDirectory,
+} from './lib/practitioner-patient-directory-data.js';
 export {
   createFoodDiaryEntry,
   deleteFoodDiaryEntry,

--- a/packages/supabase/src/lib/practitioner-patient-directory-data.spec.ts
+++ b/packages/supabase/src/lib/practitioner-patient-directory-data.spec.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+import {
+  formatPractitionerPatientDirectoryLabel,
+  formatPractitionerPatientGrantedAt,
+  listActivePractitionerPatientDirectory,
+} from './practitioner-patient-directory-data.js';
+
+describe('formatPractitionerPatientDirectoryLabel', () => {
+  it('uses trimmed display_name when present', () => {
+    expect(
+      formatPractitionerPatientDirectoryLabel(
+        'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        '  Alex  ',
+      ),
+    ).toBe('Alex');
+  });
+
+  it('falls back to a short patient id token when display_name is empty', () => {
+    expect(
+      formatPractitionerPatientDirectoryLabel(
+        'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        null,
+      ),
+    ).toBe('Patient AAAAAAAA');
+  });
+});
+
+describe('formatPractitionerPatientGrantedAt', () => {
+  it('formats a valid ISO timestamp', () => {
+    const formatted = formatPractitionerPatientGrantedAt(
+      '2026-05-01T12:00:00.000Z',
+    );
+    expect(formatted.length).toBeGreaterThan(0);
+    expect(formatted).not.toBe('2026-05-01T12:00:00.000Z');
+  });
+});
+
+describe('listActivePractitionerPatientDirectory', () => {
+  it('returns an empty list when there are no active grants', async () => {
+    const order = vi.fn(async () => ({ data: [], error: null }));
+    const is = vi.fn(() => ({ order }));
+    const select = vi.fn(() => ({ is }));
+    const client = {
+      from: vi.fn(() => ({ select })),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await listActivePractitionerPatientDirectory(client);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual([]);
+    }
+    expect(client.from).toHaveBeenCalledWith('practitioner_access');
+    expect(client.from).toHaveBeenCalledTimes(1);
+  });
+
+  it('merges grant rows with patient display names', async () => {
+    const grantOrder = vi.fn(async () => ({
+      data: [
+        {
+          id: 'grant-1',
+          patient_user_id: 'patient-1',
+          created_at: '2026-05-01T10:00:00.000Z',
+        },
+      ],
+      error: null,
+    }));
+    const grantIs = vi.fn(() => ({ order: grantOrder }));
+    const grantSelect = vi.fn(() => ({ is: grantIs }));
+
+    const profileIn = vi.fn(async () => ({
+      data: [{ id: 'patient-1', display_name: 'Sam' }],
+      error: null,
+    }));
+    const profileSelect = vi.fn(() => ({ in: profileIn }));
+
+    const client = {
+      from: vi.fn((table: string) => {
+        if (table === 'practitioner_access') {
+          return { select: grantSelect };
+        }
+        if (table === 'profiles') {
+          return { select: profileSelect };
+        }
+        throw new Error(`unexpected table ${table}`);
+      }),
+    } as unknown as AbstrackSupabaseClient;
+
+    const result = await listActivePractitionerPatientDirectory(client);
+
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.data).toEqual([
+        {
+          grantId: 'grant-1',
+          patientUserId: 'patient-1',
+          patientDisplayName: 'Sam',
+          grantedAt: '2026-05-01T10:00:00.000Z',
+        },
+      ]);
+    }
+    expect(profileIn).toHaveBeenCalledWith('id', ['patient-1']);
+  });
+});

--- a/packages/supabase/src/lib/practitioner-patient-directory-data.ts
+++ b/packages/supabase/src/lib/practitioner-patient-directory-data.ts
@@ -1,0 +1,117 @@
+import { toPresetDataError } from './preset-data-error.js';
+import type { PresetDataResult } from './preset-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+/** One active practitioner_access grant with optional patient profile label fields. */
+export type PractitionerPatientDirectoryEntry = {
+  grantId: string;
+  patientUserId: string;
+  patientDisplayName: string | null;
+  grantedAt: string;
+};
+
+/**
+ * Accessible list label when `display_name` is unset (no email in directory; grant id only).
+ *
+ * @param patientUserId - Patient auth user id from `practitioner_access.patient_user_id`.
+ * @param patientDisplayName - `profiles.display_name` when RLS allows.
+ * @returns Primary link text for the patient row.
+ */
+export function formatPractitionerPatientDirectoryLabel(
+  patientUserId: string,
+  patientDisplayName: string | null,
+): string {
+  const trimmed = patientDisplayName?.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  const compact = patientUserId.replace(/-/g, '').slice(0, 8).toUpperCase();
+  return `Patient ${compact}`;
+}
+
+type PractitionerAccessGrantRow = {
+  id: string;
+  patient_user_id: string;
+  created_at: string;
+};
+
+type PatientProfileLabelRow = {
+  id: string;
+  display_name: string | null;
+};
+
+/**
+ * Lists patients who have granted the signed-in practitioner an active `practitioner_access` row.
+ * Grant rows use existing RLS; patient `display_name` requires
+ * `profiles_practitioner_granted_patient_select` (same MFA path as PHI).
+ *
+ * @param client - Browser Supabase client (practitioner session).
+ * @returns Sorted directory entries (oldest grant first).
+ */
+export async function listActivePractitionerPatientDirectory(
+  client: AbstrackSupabaseClient,
+): Promise<PresetDataResult<PractitionerPatientDirectoryEntry[]>> {
+  try {
+    const { data: grantRows, error: grantError } = await client
+      .from('practitioner_access')
+      .select('id, patient_user_id, created_at')
+      .is('revoked_at', null)
+      .order('created_at', { ascending: true });
+
+    if (grantError) {
+      return { ok: false, error: toPresetDataError(grantError) };
+    }
+
+    const grants = (grantRows ?? []) as PractitionerAccessGrantRow[];
+    if (grants.length === 0) {
+      return { ok: true, data: [] };
+    }
+
+    const patientIds = [...new Set(grants.map((row) => row.patient_user_id))];
+
+    const { data: profileRows, error: profileError } = await client
+      .from('profiles')
+      .select('id, display_name')
+      .in('id', patientIds);
+
+    if (profileError) {
+      return { ok: false, error: toPresetDataError(profileError) };
+    }
+
+    const displayByPatientId = new Map<string, string | null>();
+    for (const row of (profileRows ?? []) as PatientProfileLabelRow[]) {
+      displayByPatientId.set(row.id, row.display_name ?? null);
+    }
+
+    const entries: PractitionerPatientDirectoryEntry[] = grants.map(
+      (grant) => ({
+        grantId: grant.id,
+        patientUserId: grant.patient_user_id,
+        patientDisplayName:
+          displayByPatientId.get(grant.patient_user_id) ?? null,
+        grantedAt: grant.created_at,
+      }),
+    );
+
+    return { ok: true, data: entries };
+  } catch (error) {
+    return {
+      ok: false,
+      error: toPresetDataError(error),
+    };
+  }
+}
+
+/**
+ * @param iso - `practitioner_access.created_at` timestamp.
+ * @returns Locale-formatted grant date for list secondary text.
+ */
+export function formatPractitionerPatientGrantedAt(iso: string): string {
+  const t = Date.parse(iso);
+  if (!Number.isFinite(t)) {
+    return iso;
+  }
+  return new Date(t).toLocaleDateString(undefined, {
+    dateStyle: 'medium',
+  });
+}

--- a/supabase/migrations/20260518120000_profiles_practitioner_granted_patient_select.sql
+++ b/supabase/migrations/20260518120000_profiles_practitioner_granted_patient_select.sql
@@ -1,0 +1,11 @@
+-- Practitioner patient directory: read patient profile display names only for active grants,
+-- using the same MFA + grant checks as PHI via user_has_practitioner_access(patient_user_id).
+
+CREATE POLICY profiles_practitioner_granted_patient_select ON public.profiles
+  FOR SELECT
+  TO authenticated
+  USING (
+    app_role = 'patient'
+    AND public.user_has_practitioner_access (id));
+
+COMMENT ON POLICY profiles_practitioner_granted_patient_select ON public.profiles IS 'Practitioner may SELECT patient profiles for active practitioner_access grants; MFA rules match user_has_practitioner_access (password-gated AAL2).';


### PR DESCRIPTION
Close #153

## Summary

- Replace the `/patients` placeholder with an accessible client directory that lists patients with an active `practitioner_access` row (non-revoked), using the normal practitioner Supabase session—no service role in the browser.
- Add `listActivePractitionerPatientDirectory` in `@abstrack/supabase` plus unit tests; export formatter helpers for list labels and grant dates.
- Add RLS policy `profiles_practitioner_granted_patient_select` so practitioners can read `profiles.display_name` for granted patients under the same `user_has_practitioner_access` / MFA rules as PHI.
- Fix `/patients/[patientId]` for Next.js 16 by awaiting `params` (Promise).
- Add practitioner page tests for empty state, links, and error retry.

## Test plan

- [ ] `pnpm exec jest apps/practitioner/specs/patients-page.spec.tsx`
- [ ] `pnpm exec vitest run packages/supabase/src/lib/practitioner-patient-directory-data.spec.ts`
- [ ] Manual: sign in as practitioner with MFA, open `/patients`, confirm list / empty state / Try again on failure; open a patient row and confirm detail route loads without `params` warning.

## Follow-up (schema)

After review, apply the migration and regenerate types per `docs/SUPABASE_CLOUD_DEVELOPER.md` (`db push` → `gen types --linked`) so cloud matches the new `profiles` policy; until then, names fall back to the short “Patient …” label when profile rows are not readable.