### PR TITLE
feat(practitioner): add read-only episode media viewer with signed URLs and full-size photo modal

### DIFF
--- a/apps/practitioner/csp-config.js
+++ b/apps/practitioner/csp-config.js
@@ -84,6 +84,15 @@ function buildPractitionerCspDirectives(opts) {
 
   const connectSrc = Array.from(connectParts).join(' ');
 
+  const imgParts = new Set(["'self'", 'blob:', 'data:']);
+  const mediaParts = new Set(["'self'", 'blob:']);
+  if (origins) {
+    imgParts.add(origins.httpOrigin);
+    mediaParts.add(origins.httpOrigin);
+  }
+  const imgSrc = Array.from(imgParts).join(' ');
+  const mediaSrc = Array.from(mediaParts).join(' ');
+
   const scriptParts = ["'self'", "'unsafe-inline'"];
   if (isDev) {
     scriptParts.push("'unsafe-eval'");
@@ -94,7 +103,8 @@ function buildPractitionerCspDirectives(opts) {
     "default-src 'self'",
     `script-src ${scriptParts.join(' ')}`,
     "style-src 'self' 'unsafe-inline'",
-    "img-src 'self' blob: data:",
+    `img-src ${imgSrc}`,
+    `media-src ${mediaSrc}`,
     "font-src 'self'",
     `connect-src ${connectSrc}`,
     "worker-src 'self' blob:",

--- a/apps/practitioner/package.json
+++ b/apps/practitioner/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@abstrack/supabase": "workspace:*",
+    "@abstrack/types": "workspace:*",
     "@abstrack/ui": "workspace:*",
     "next": "~16.0.1",
     "qrcode": "^1.5.4",

--- a/apps/practitioner/specs/patient-detail-page.spec.tsx
+++ b/apps/practitioner/specs/patient-detail-page.spec.tsx
@@ -811,6 +811,92 @@ describe('PractitionerPatientDetailPage', () => {
     );
   });
 
+  it('loads video symptom media via signed URL and renders an inline video player', async () => {
+    const episodeId = 'eeeeeeee-bbbb-cccc-dddd-aaaaaaaaaaaa';
+    const symptomId = 'sym-video-1';
+
+    loadPractitionerPatientObservationReadModel.mockResolvedValue({
+      ok: true,
+      data: {
+        patientUserId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        patientDisplayName: 'Alex Kim',
+        moreEpisodesOmitted: false,
+        standaloneHealthMarkersTruncated: false,
+        standaloneFoodDiaryTruncated: false,
+        standaloneTimeline: [],
+        episodesWithTimelines: [
+          {
+            episode: episodeRow(),
+            moreSymptomsOmitted: false,
+            moreHealthMarkersOmitted: false,
+            moreFoodDiaryOmitted: false,
+            timeline: [
+              {
+                kind: 'symptom',
+                sortAt: '2026-04-01T12:05:00.000Z',
+                id: symptomId,
+                label: 'Tremor clip',
+                detail: 'Video',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    listEpisodeMediaForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          episode_symptom_id: symptomId,
+          storage_object_key: 'user/ep/video-1.mp4',
+          thumbnail_storage_key: null,
+          media_type: 'video',
+          upload_completed_at: '2026-04-01T12:05:01.000Z',
+          duration_seconds: 12,
+        },
+      ],
+    });
+
+    createEpisodeMediaSignedDisplayUrl.mockResolvedValue({
+      signedUrl: 'https://example.test/signed-video',
+      errorMessage: null,
+    });
+
+    render(
+      <LiveAnnouncerProvider>
+        <PractitionerPatientDetailPage patientUserId="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" />
+      </LiveAnnouncerProvider>,
+    );
+
+    await screen.findByText('Alex Kim');
+    clickDetailsToggle('Show episode timeline');
+
+    fireEvent.click(await screen.findByRole('button', { name: /view video/i }));
+
+    await waitFor(() => {
+      expect(listEpisodeMediaForEpisode).toHaveBeenCalledWith(
+        expect.anything(),
+        episodeId,
+        { episodeSymptomIds: [symptomId] },
+      );
+    });
+
+    const viewer = screen.getByTestId('practitioner-symptom-media-viewer');
+    await waitFor(() => {
+      expect(viewer.querySelector('video')).toBeTruthy();
+    });
+    const video = viewer.querySelector('video');
+    expect(video!.hasAttribute('controls')).toBe(true);
+    expect(video!.getAttribute('src')).toBe(
+      'https://example.test/signed-video',
+    );
+    expect(screen.queryByRole('dialog')).toBeNull();
+    expect(
+      screen.queryByRole('button', { name: /view full size/i }),
+    ).toBeNull();
+  });
+
   it('reopens the full-size photo modal after Close without reloading media', async () => {
     loadPractitionerPatientObservationReadModel.mockResolvedValue({
       ok: true,
@@ -897,7 +983,7 @@ describe('PractitionerPatientDetailPage', () => {
 
     fireEvent.click(openFullSize);
     const dialogAgain = await screen.findByRole('dialog');
-    fireEvent.click(within(dialogAgain).getByTestId('photo-modal-backdrop'));
+    fireEvent.click(within(dialogAgain).getByTestId('photo-modal-scrim'));
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).toBeNull();
     });

--- a/apps/practitioner/specs/patient-detail-page.spec.tsx
+++ b/apps/practitioner/specs/patient-detail-page.spec.tsx
@@ -802,6 +802,7 @@ describe('PractitionerPatientDetailPage', () => {
     await waitFor(() => {
       expect(createEpisodeMediaSignedDisplayUrl).toHaveBeenCalledTimes(2);
     });
+    expect(listEpisodeMediaForEpisode).toHaveBeenCalledTimes(1);
     const refreshedPreview = screen
       .getByRole('button', { name: /view full size photo for rash photo/i })
       .querySelector('img');
@@ -896,9 +897,7 @@ describe('PractitionerPatientDetailPage', () => {
 
     fireEvent.click(openFullSize);
     const dialogAgain = await screen.findByRole('dialog');
-    fireEvent.click(
-      screen.getByRole('button', { name: /close photo viewer/i }),
-    );
+    fireEvent.click(within(dialogAgain).getByTestId('photo-modal-backdrop'));
     await waitFor(() => {
       expect(screen.queryByRole('dialog')).toBeNull();
     });

--- a/apps/practitioner/specs/patient-detail-page.spec.tsx
+++ b/apps/practitioner/specs/patient-detail-page.spec.tsx
@@ -36,6 +36,8 @@ function clickDetailsToggle(label: string, index = 0): void {
 }
 
 const loadPractitionerPatientObservationReadModel = jest.fn();
+const listEpisodeMediaForEpisode = jest.fn();
+const createEpisodeMediaSignedDisplayUrl = jest.fn();
 
 jest.mock('@abstrack/supabase/browser', () => ({
   getSupabaseBrowserClient: jest.fn(() => ({})),
@@ -50,6 +52,10 @@ jest.mock('@abstrack/supabase', () => {
     ...actual,
     loadPractitionerPatientObservationReadModel: (...args: unknown[]) =>
       loadPractitionerPatientObservationReadModel(...args),
+    listEpisodeMediaForEpisode: (...args: unknown[]) =>
+      listEpisodeMediaForEpisode(...args),
+    createEpisodeMediaSignedDisplayUrl: (...args: unknown[]) =>
+      createEpisodeMediaSignedDisplayUrl(...args),
   };
 });
 
@@ -66,6 +72,8 @@ function episodeRow(): PractitionerPatientEpisodeRow {
 describe('PractitionerPatientDetailPage', () => {
   beforeEach(() => {
     loadPractitionerPatientObservationReadModel.mockReset();
+    listEpisodeMediaForEpisode.mockReset();
+    createEpisodeMediaSignedDisplayUrl.mockReset();
   });
 
   it('shows an alert when the read model returns permission_denied', async () => {
@@ -690,6 +698,214 @@ describe('PractitionerPatientDetailPage', () => {
     expect(screen.queryByText('PatientB-4')).toBeNull();
     clickDetailsToggle('Show standalone entries');
     expect(screen.getByText('PatientB-4')).toBeTruthy();
+  });
+
+  it('loads photo symptom media via signed URL and supports refresh after display error', async () => {
+    const episodeId = 'eeeeeeee-bbbb-cccc-dddd-aaaaaaaaaaaa';
+    const symptomId = 'sym-photo-1';
+
+    loadPractitionerPatientObservationReadModel.mockResolvedValue({
+      ok: true,
+      data: {
+        patientUserId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        patientDisplayName: 'Alex Kim',
+        moreEpisodesOmitted: false,
+        standaloneHealthMarkersTruncated: false,
+        standaloneFoodDiaryTruncated: false,
+        standaloneTimeline: [],
+        episodesWithTimelines: [
+          {
+            episode: episodeRow(),
+            moreSymptomsOmitted: false,
+            moreHealthMarkersOmitted: false,
+            moreFoodDiaryOmitted: false,
+            timeline: [
+              {
+                kind: 'symptom',
+                sortAt: '2026-04-01T12:05:00.000Z',
+                id: symptomId,
+                label: 'Rash photo',
+                detail: 'Photo',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    listEpisodeMediaForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          episode_symptom_id: symptomId,
+          storage_object_key: 'user/ep/photo-1.jpg',
+          thumbnail_storage_key: null,
+          media_type: 'photo',
+          upload_completed_at: '2026-04-01T12:05:01.000Z',
+          duration_seconds: null,
+        },
+      ],
+    });
+
+    createEpisodeMediaSignedDisplayUrl
+      .mockResolvedValueOnce({
+        signedUrl: 'https://example.test/signed-photo',
+        errorMessage: null,
+      })
+      .mockResolvedValueOnce({
+        signedUrl: 'https://example.test/signed-photo-refreshed',
+        errorMessage: null,
+      });
+
+    render(
+      <LiveAnnouncerProvider>
+        <PractitionerPatientDetailPage patientUserId="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" />
+      </LiveAnnouncerProvider>,
+    );
+
+    await screen.findByText('Alex Kim');
+    clickDetailsToggle('Show episode timeline');
+
+    const viewPhoto = await screen.findByRole('button', {
+      name: /view photo/i,
+    });
+    fireEvent.click(viewPhoto);
+
+    await waitFor(() => {
+      expect(listEpisodeMediaForEpisode).toHaveBeenCalledWith(
+        expect.anything(),
+        episodeId,
+        { episodeSymptomIds: [symptomId] },
+      );
+    });
+
+    const previewButton = await screen.findByRole('button', {
+      name: /view full size photo for rash photo/i,
+    });
+    const previewImg = previewButton.querySelector('img');
+    expect(previewImg).toBeTruthy();
+    expect(previewImg!.getAttribute('src')).toBe(
+      'https://example.test/signed-photo',
+    );
+
+    fireEvent.error(previewImg!);
+
+    const viewer = screen.getByTestId('practitioner-symptom-media-viewer');
+    expect(within(viewer).getByRole('alert').textContent).toMatch(
+      /link expired or unavailable/i,
+    );
+
+    fireEvent.click(
+      within(viewer).getByRole('button', { name: /refresh media link/i }),
+    );
+
+    await waitFor(() => {
+      expect(createEpisodeMediaSignedDisplayUrl).toHaveBeenCalledTimes(2);
+    });
+    const refreshedPreview = screen
+      .getByRole('button', { name: /view full size photo for rash photo/i })
+      .querySelector('img');
+    expect(refreshedPreview?.getAttribute('src')).toBe(
+      'https://example.test/signed-photo-refreshed',
+    );
+  });
+
+  it('reopens the full-size photo modal after Close without reloading media', async () => {
+    loadPractitionerPatientObservationReadModel.mockResolvedValue({
+      ok: true,
+      data: {
+        patientUserId: 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        patientDisplayName: 'Alex Kim',
+        moreEpisodesOmitted: false,
+        standaloneHealthMarkersTruncated: false,
+        standaloneFoodDiaryTruncated: false,
+        standaloneTimeline: [],
+        episodesWithTimelines: [
+          {
+            episode: episodeRow(),
+            moreSymptomsOmitted: false,
+            moreHealthMarkersOmitted: false,
+            moreFoodDiaryOmitted: false,
+            timeline: [
+              {
+                kind: 'symptom',
+                sortAt: '2026-04-01T12:05:00.000Z',
+                id: 'sym-photo-reopen',
+                label: 'Rash photo',
+                detail: 'Photo',
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    listEpisodeMediaForEpisode.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          episode_symptom_id: 'sym-photo-reopen',
+          storage_object_key: 'user/ep/photo-reopen.jpg',
+          thumbnail_storage_key: null,
+          media_type: 'photo',
+          upload_completed_at: '2026-04-01T12:05:01.000Z',
+          duration_seconds: null,
+        },
+      ],
+    });
+
+    createEpisodeMediaSignedDisplayUrl.mockResolvedValue({
+      signedUrl: 'https://example.test/signed-photo',
+      errorMessage: null,
+    });
+
+    HTMLDialogElement.prototype.showModal =
+      HTMLDialogElement.prototype.showModal ||
+      function showModal(this: HTMLDialogElement) {
+        this.open = true;
+      };
+    HTMLDialogElement.prototype.close =
+      HTMLDialogElement.prototype.close ||
+      function close(this: HTMLDialogElement) {
+        this.open = false;
+        this.dispatchEvent(new Event('close'));
+      };
+
+    render(
+      <LiveAnnouncerProvider>
+        <PractitionerPatientDetailPage patientUserId="aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" />
+      </LiveAnnouncerProvider>,
+    );
+
+    await screen.findByText('Alex Kim');
+    clickDetailsToggle('Show episode timeline');
+    fireEvent.click(await screen.findByRole('button', { name: /view photo/i }));
+
+    const openFullSize = await screen.findByRole('button', {
+      name: /view full size photo for rash photo/i,
+    });
+
+    fireEvent.click(openFullSize);
+    const dialog = await screen.findByRole('dialog');
+    expect(dialog).toBeTruthy();
+
+    fireEvent.click(within(dialog).getByRole('button', { name: /^close$/i }));
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    fireEvent.click(openFullSize);
+    const dialogAgain = await screen.findByRole('dialog');
+    fireEvent.click(
+      screen.getByRole('button', { name: /close photo viewer/i }),
+    );
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).toBeNull();
+    });
+
+    fireEvent.click(openFullSize);
+    expect(await screen.findByRole('dialog')).toBeTruthy();
+    expect(createEpisodeMediaSignedDisplayUrl).toHaveBeenCalledTimes(1);
   });
 
   it('uses expandable disclosure when timeline rows carry detailFull', async () => {

--- a/apps/practitioner/src/app/patients/[patientId]/practitioner-patient-detail-page.tsx
+++ b/apps/practitioner/src/app/patients/[patientId]/practitioner-patient-detail-page.tsx
@@ -7,12 +7,14 @@ import {
   PRACTITIONER_PATIENT_EPISODE_HISTORY_CAP,
   PRACTITIONER_PATIENT_OBSERVATION_GRANT_DENIED_MESSAGE,
   PRACTITIONER_STANDALONE_OBSERVATION_CAP,
+  type AbstrackSupabaseClient,
   type EpisodeTimelineItem,
   type PractitionerPatientEpisodeRow,
   type PractitionerPatientObservationReadModel,
 } from '@abstrack/supabase';
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { PractitionerSymptomMediaViewer } from '../../../components/practitioner-symptom-media-viewer';
 import Link from 'next/link';
 import {
   useCallback,
@@ -42,6 +44,25 @@ function formatObservationTimestamp(iso: string): string {
     dateStyle: 'medium',
     timeStyle: 'short',
   });
+}
+
+/**
+ * When the merged timeline shows a photo/video symptom placeholder (`Photo` / `Video`), returns the
+ * media kind for {@link PractitionerSymptomMediaViewer}; otherwise `null`.
+ */
+function symptomMediaKindFromTimelineRow(
+  row: EpisodeTimelineItem,
+): 'photo' | 'video' | null {
+  if (row.kind !== 'symptom') {
+    return null;
+  }
+  if (row.detail === 'Photo') {
+    return 'photo';
+  }
+  if (row.detail === 'Video') {
+    return 'video';
+  }
+  return null;
 }
 
 function observationKindNoun(kind: EpisodeTimelineItem['kind']): string {
@@ -186,9 +207,14 @@ function EpisodeObservationTruncationNotice({
 function PractitionerObservationTimelineList({
   rows,
   rowKeyPrefix,
+  episodeId,
+  supabase,
 }: {
   rows: EpisodeTimelineItem[];
   rowKeyPrefix: string;
+  /** When set, photo/video symptom rows can load episode media via signed URLs. */
+  episodeId?: string;
+  supabase?: AbstrackSupabaseClient;
 }) {
   return (
     <ul
@@ -200,6 +226,7 @@ function PractitionerObservationTimelineList({
         const kind = observationKindNoun(row.kind);
         const previewDetail = row.detail.trim() ? row.detail : '—';
         const ann = `${kind} at ${time}. ${row.label}. ${previewDetail}.`;
+        const mediaKind = symptomMediaKindFromTimelineRow(row);
         return (
           <li
             key={`${rowKeyPrefix}-${row.kind}-${row.id}`}
@@ -211,10 +238,20 @@ function PractitionerObservationTimelineList({
               {kind} · {time}
             </span>
             <span className="mt-0.5 block font-medium">{row.label}</span>
-            <PractitionerTimelineObservationDetail
-              detail={row.detail}
-              detailFull={row.detailFull}
-            />
+            {mediaKind && episodeId && supabase ? (
+              <PractitionerSymptomMediaViewer
+                supabase={supabase}
+                episodeId={episodeId}
+                episodeSymptomId={row.id}
+                mediaKind={mediaKind}
+                symptomLabel={row.label}
+              />
+            ) : (
+              <PractitionerTimelineObservationDetail
+                detail={row.detail}
+                detailFull={row.detailFull}
+              />
+            )}
           </li>
         );
       })}
@@ -233,6 +270,7 @@ function PractitionerEpisodeTimelineCard({
   moreHealthMarkersOmitted,
   moreFoodDiaryOmitted,
   regionId,
+  supabase,
 }: {
   episode: PractitionerPatientEpisodeRow;
   timeline: EpisodeTimelineItem[];
@@ -240,6 +278,7 @@ function PractitionerEpisodeTimelineCard({
   moreHealthMarkersOmitted: boolean;
   moreFoodDiaryOmitted: boolean;
   regionId: string;
+  supabase: AbstrackSupabaseClient;
 }) {
   const hasObservations = timeline.length > 0;
   const [listMounted, setListMounted] = useState(false);
@@ -312,6 +351,8 @@ function PractitionerEpisodeTimelineCard({
             <PractitionerObservationTimelineList
               rows={timeline}
               rowKeyPrefix={`${episode.id}`}
+              episodeId={episode.id}
+              supabase={supabase}
             />
           ) : (
             <p className="mt-4 text-sm text-app-muted" role="status">
@@ -686,6 +727,7 @@ export function PractitionerPatientDetailPage({
                       moreHealthMarkersOmitted={moreHealthMarkersOmitted}
                       moreFoodDiaryOmitted={moreFoodDiaryOmitted}
                       regionId={regionId}
+                      supabase={supabase}
                     />
                   </section>
                 );

--- a/apps/practitioner/src/components/practitioner-symptom-media-viewer.tsx
+++ b/apps/practitioner/src/components/practitioner-symptom-media-viewer.tsx
@@ -313,17 +313,21 @@ export function PractitionerSymptomMediaViewer({
                     closePhotoModal();
                   }}
                 >
-                  <div className="fixed inset-0 flex items-center justify-center p-4">
-                    <div
-                      role="presentation"
-                      aria-hidden="true"
-                      data-testid="photo-modal-backdrop"
-                      className="absolute inset-0 h-full w-full cursor-default bg-black/60"
-                      onClick={closePhotoModal}
-                    />
+                  <div
+                    data-testid="photo-modal-scrim"
+                    className="fixed inset-0 flex cursor-default items-center justify-center bg-black/60 p-4"
+                    onClick={(event) => {
+                      if (event.target === event.currentTarget) {
+                        closePhotoModal();
+                      }
+                    }}
+                  >
                     <div
                       role="document"
-                      className="relative z-10 flex max-h-[95vh] max-w-[min(95vw,64rem)] flex-col gap-4 rounded-2xl border border-app-border/90 bg-app-surface p-4 text-app-ink shadow-xl"
+                      className="flex max-h-[95vh] max-w-[min(95vw,64rem)] flex-col gap-4 rounded-2xl border border-app-border/90 bg-app-surface p-4 text-app-ink shadow-xl"
+                      onClick={(event) => {
+                        event.stopPropagation();
+                      }}
                     >
                       <div className="flex flex-wrap items-start justify-between gap-3">
                         <h2

--- a/apps/practitioner/src/components/practitioner-symptom-media-viewer.tsx
+++ b/apps/practitioner/src/components/practitioner-symptom-media-viewer.tsx
@@ -72,8 +72,14 @@ export function PractitionerSymptomMediaViewer({
   const { announce } = useAnnounce();
   const [state, setState] = useState<MediaViewState>({ phase: 'idle' });
   const photoDialogRef = useRef<HTMLDialogElement>(null);
+  const photoDialogCloseButtonRef = useRef<HTMLButtonElement>(null);
   const photoDialogTitleId = useId();
   const loadInFlightRef = useRef(false);
+  /** Last signed object key + media type; used to refresh without re-listing `episode_media`. */
+  const readyStorageRef = useRef<{
+    storageKey: string;
+    mediaType: 'photo' | 'video';
+  } | null>(null);
 
   const closePhotoModal = useCallback(() => {
     const el = photoDialogRef.current;
@@ -86,17 +92,65 @@ export function PractitionerSymptomMediaViewer({
     const el = photoDialogRef.current;
     if (el) {
       setDialogModalOpen(el, true);
+      queueMicrotask(() => {
+        photoDialogCloseButtonRef.current?.focus();
+      });
     }
     announce(`Full size photo opened for ${symptomLabel}.`, {
       politeness: 'polite',
     });
   }, [announce, symptomLabel]);
 
+  const signStorageKey = useCallback(
+    async (
+      rawKey: string,
+      mediaType: 'photo' | 'video',
+      options?: { announceLoaded?: boolean },
+    ): Promise<void> => {
+      const storageKey = rawKey.trim();
+      const { signedUrl, errorMessage } =
+        await createEpisodeMediaSignedDisplayUrl(
+          supabase,
+          storageKey,
+          EPISODE_MEDIA_SIGNED_URL_TTL_SECONDS,
+        );
+      const signingFailure =
+        typeof errorMessage === 'string' ? errorMessage.trim() : '';
+      readyStorageRef.current = { storageKey, mediaType };
+      setState({
+        phase: 'ready',
+        storageKey,
+        signedUrl,
+        mediaType,
+        loadError: signedUrl
+          ? null
+          : signingFailure !== ''
+            ? signingFailure
+            : 'Could not create media link.',
+      });
+      if (signedUrl) {
+        if (options?.announceLoaded !== false) {
+          announce(
+            `${mediaType === 'video' ? 'Video' : 'Photo'} loaded for ${symptomLabel}.`,
+            { politeness: 'polite' },
+          );
+        }
+        return;
+      }
+      announce(
+        signingFailure !== '' ? signingFailure : 'Could not create media link.',
+        { politeness: 'assertive' },
+      );
+    },
+    [announce, supabase, symptomLabel],
+  );
+
   const loadMedia = useCallback(async () => {
     if (loadInFlightRef.current) {
       return;
     }
     loadInFlightRef.current = true;
+    readyStorageRef.current = null;
     setState({ phase: 'loading' });
     try {
       const listed = await listEpisodeMediaForEpisode(supabase, episodeId, {
@@ -115,42 +169,10 @@ export function PractitionerSymptomMediaViewer({
         announce(message, { politeness: 'polite' });
         return;
       }
-      const rawKey = row.storage_object_key;
-      const { signedUrl, errorMessage } =
-        await createEpisodeMediaSignedDisplayUrl(
-          supabase,
-          rawKey,
-          EPISODE_MEDIA_SIGNED_URL_TTL_SECONDS,
-        );
       const mediaType: 'photo' | 'video' = isMediaType(row.media_type)
         ? row.media_type
         : mediaKind;
-      const signingFailure =
-        typeof errorMessage === 'string' ? errorMessage.trim() : '';
-      setState({
-        phase: 'ready',
-        storageKey: rawKey.trim(),
-        signedUrl,
-        mediaType,
-        loadError: signedUrl
-          ? null
-          : signingFailure !== ''
-            ? signingFailure
-            : 'Could not create media link.',
-      });
-      if (signedUrl) {
-        announce(
-          `${mediaType === 'video' ? 'Video' : 'Photo'} loaded for ${symptomLabel}.`,
-          { politeness: 'polite' },
-        );
-      } else {
-        announce(
-          signingFailure !== ''
-            ? signingFailure
-            : 'Could not create media link.',
-          { politeness: 'assertive' },
-        );
-      }
+      await signStorageKey(row.storage_object_key, mediaType);
     } catch {
       const message = 'Unable to load media preview.';
       setState({ phase: 'error', message });
@@ -163,9 +185,37 @@ export function PractitionerSymptomMediaViewer({
     episodeId,
     episodeSymptomId,
     mediaKind,
+    signStorageKey,
     supabase,
-    symptomLabel,
   ]);
+
+  /**
+   * Re-signs {@link MediaViewState} `storageKey` after expiry without re-querying `episode_media`.
+   * Falls back to {@link loadMedia} when no key is stored yet.
+   */
+  const refreshMediaLink = useCallback(async () => {
+    if (loadInFlightRef.current) {
+      return;
+    }
+    const cached = readyStorageRef.current;
+    if (!cached?.storageKey) {
+      await loadMedia();
+      return;
+    }
+    loadInFlightRef.current = true;
+    setState({ phase: 'loading' });
+    try {
+      await signStorageKey(cached.storageKey, cached.mediaType, {
+        announceLoaded: false,
+      });
+    } catch {
+      const message = 'Unable to load media preview.';
+      setState({ phase: 'error', message });
+      announce(message, { politeness: 'assertive' });
+    } finally {
+      loadInFlightRef.current = false;
+    }
+  }, [announce, loadMedia, signStorageKey]);
 
   const onDisplayError = useCallback(() => {
     closeDialogIfOpen(photoDialogRef.current);
@@ -264,10 +314,11 @@ export function PractitionerSymptomMediaViewer({
                   }}
                 >
                   <div className="fixed inset-0 flex items-center justify-center p-4">
-                    <button
-                      type="button"
+                    <div
+                      role="presentation"
+                      aria-hidden="true"
+                      data-testid="photo-modal-backdrop"
                       className="absolute inset-0 h-full w-full cursor-default bg-black/60"
-                      aria-label="Close photo viewer"
                       onClick={closePhotoModal}
                     />
                     <div
@@ -282,6 +333,7 @@ export function PractitionerSymptomMediaViewer({
                           {symptomLabel}
                         </h2>
                         <button
+                          ref={photoDialogCloseButtonRef}
                           type="button"
                           className="inline-flex min-h-11 shrink-0 items-center rounded-lg border border-app-border px-4 py-2 text-sm font-semibold text-app-ink transition hover:bg-app-muted/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
                           onClick={closePhotoModal}
@@ -310,7 +362,7 @@ export function PractitionerSymptomMediaViewer({
           <button
             type="button"
             className="inline-flex min-h-11 items-center rounded-lg border border-app-border px-3 py-2 text-sm font-semibold text-app-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-            onClick={() => void loadMedia()}
+            onClick={() => void refreshMediaLink()}
           >
             Refresh media link
           </button>

--- a/apps/practitioner/src/components/practitioner-symptom-media-viewer.tsx
+++ b/apps/practitioner/src/components/practitioner-symptom-media-viewer.tsx
@@ -1,0 +1,321 @@
+'use client';
+
+import {
+  createEpisodeMediaSignedDisplayUrl,
+  listEpisodeMediaForEpisode,
+  type AbstrackSupabaseClient,
+} from '@abstrack/supabase';
+import { isMediaType } from '@abstrack/types';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { useCallback, useId, useRef, useState } from 'react';
+
+/**
+ * Opens or closes a modal `<dialog>` without throwing when already in that state.
+ *
+ * @param el - Native dialog element.
+ * @param open - Whether the dialog should be shown modally.
+ */
+function setDialogModalOpen(el: HTMLDialogElement, open: boolean): void {
+  if (open) {
+    if (!el.open) {
+      el.showModal();
+    }
+  } else if (el.open) {
+    el.close();
+  }
+}
+
+function closeDialogIfOpen(el: HTMLDialogElement | null): void {
+  if (el?.open) {
+    el.close();
+  }
+}
+
+/** Short-lived signed URL TTL (seconds); matches user apps episode history galleries. */
+const EPISODE_MEDIA_SIGNED_URL_TTL_SECONDS = 120;
+
+type PractitionerSymptomMediaViewerProps = {
+  supabase: AbstrackSupabaseClient;
+  episodeId: string;
+  episodeSymptomId: string;
+  mediaKind: 'photo' | 'video';
+  /** Symptom label for accessible names (e.g. “Rash”). */
+  symptomLabel: string;
+};
+
+type MediaViewState =
+  | { phase: 'idle' }
+  | { phase: 'loading' }
+  | {
+      phase: 'ready';
+      storageKey: string;
+      signedUrl: string | null;
+      mediaType: 'photo' | 'video';
+      loadError: string | null;
+    }
+  | { phase: 'error'; message: string };
+
+/**
+ * Read-only practitioner viewer for one symptom's episode media: lists `episode_media` under RLS,
+ * signs via Storage (`episode-media` bucket), renders `<img>` / `<video>`, and refreshes on expiry.
+ *
+ * @param props - Episode and symptom ids plus media kind from the timeline row.
+ * @returns Lazy-load control and signed-URL media preview for a photo or video symptom.
+ */
+export function PractitionerSymptomMediaViewer({
+  supabase,
+  episodeId,
+  episodeSymptomId,
+  mediaKind,
+  symptomLabel,
+}: PractitionerSymptomMediaViewerProps) {
+  const { announce } = useAnnounce();
+  const [state, setState] = useState<MediaViewState>({ phase: 'idle' });
+  const photoDialogRef = useRef<HTMLDialogElement>(null);
+  const photoDialogTitleId = useId();
+  const loadInFlightRef = useRef(false);
+
+  const closePhotoModal = useCallback(() => {
+    const el = photoDialogRef.current;
+    if (el) {
+      setDialogModalOpen(el, false);
+    }
+  }, []);
+
+  const openPhotoModal = useCallback(() => {
+    const el = photoDialogRef.current;
+    if (el) {
+      setDialogModalOpen(el, true);
+    }
+    announce(`Full size photo opened for ${symptomLabel}.`, {
+      politeness: 'polite',
+    });
+  }, [announce, symptomLabel]);
+
+  const loadMedia = useCallback(async () => {
+    if (loadInFlightRef.current) {
+      return;
+    }
+    loadInFlightRef.current = true;
+    setState({ phase: 'loading' });
+    try {
+      const listed = await listEpisodeMediaForEpisode(supabase, episodeId, {
+        episodeSymptomIds: [episodeSymptomId],
+      });
+      if (!listed.ok) {
+        const message = listed.error.message;
+        setState({ phase: 'error', message });
+        announce(message, { politeness: 'assertive' });
+        return;
+      }
+      const row = listed.data[0];
+      if (!row?.storage_object_key?.trim()) {
+        const message = 'No media file is available for this symptom.';
+        setState({ phase: 'error', message });
+        announce(message, { politeness: 'polite' });
+        return;
+      }
+      const rawKey = row.storage_object_key;
+      const { signedUrl, errorMessage } =
+        await createEpisodeMediaSignedDisplayUrl(
+          supabase,
+          rawKey,
+          EPISODE_MEDIA_SIGNED_URL_TTL_SECONDS,
+        );
+      const mediaType: 'photo' | 'video' = isMediaType(row.media_type)
+        ? row.media_type
+        : mediaKind;
+      const signingFailure =
+        typeof errorMessage === 'string' ? errorMessage.trim() : '';
+      setState({
+        phase: 'ready',
+        storageKey: rawKey.trim(),
+        signedUrl,
+        mediaType,
+        loadError: signedUrl
+          ? null
+          : signingFailure !== ''
+            ? signingFailure
+            : 'Could not create media link.',
+      });
+      if (signedUrl) {
+        announce(
+          `${mediaType === 'video' ? 'Video' : 'Photo'} loaded for ${symptomLabel}.`,
+          { politeness: 'polite' },
+        );
+      } else {
+        announce(
+          signingFailure !== ''
+            ? signingFailure
+            : 'Could not create media link.',
+          { politeness: 'assertive' },
+        );
+      }
+    } catch {
+      const message = 'Unable to load media preview.';
+      setState({ phase: 'error', message });
+      announce(message, { politeness: 'assertive' });
+    } finally {
+      loadInFlightRef.current = false;
+    }
+  }, [
+    announce,
+    episodeId,
+    episodeSymptomId,
+    mediaKind,
+    supabase,
+    symptomLabel,
+  ]);
+
+  const onDisplayError = useCallback(() => {
+    closeDialogIfOpen(photoDialogRef.current);
+    setState((prev) => {
+      if (prev.phase !== 'ready' || !prev.signedUrl) {
+        return prev;
+      }
+      return {
+        ...prev,
+        signedUrl: null,
+        loadError: 'Link expired or unavailable.',
+      };
+    });
+    announce('Media link expired or unavailable. Refresh to try again.', {
+      politeness: 'assertive',
+    });
+  }, [announce]);
+
+  const viewLabel = mediaKind === 'video' ? 'View video' : 'View photo';
+  const regionLabel = `${mediaKind === 'video' ? 'Video' : 'Photo'} for ${symptomLabel}`;
+
+  return (
+    <div
+      className="mt-2"
+      role="region"
+      aria-label={regionLabel}
+      data-testid="practitioner-symptom-media-viewer"
+    >
+      {state.phase === 'idle' ? (
+        <button
+          type="button"
+          className="inline-flex min-h-11 items-center rounded-lg border border-app-border px-3 py-2 text-sm font-semibold text-app-primary transition hover:bg-app-muted/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          onClick={() => void loadMedia()}
+        >
+          {viewLabel}
+        </button>
+      ) : null}
+
+      {state.phase === 'loading' ? (
+        <p className="text-sm text-app-muted" role="status" aria-live="polite">
+          Loading media…
+        </p>
+      ) : null}
+
+      {state.phase === 'error' ? (
+        <div className="space-y-2">
+          <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+            {state.message}
+          </p>
+          <button
+            type="button"
+            className="inline-flex min-h-11 items-center rounded-lg border border-app-border px-3 py-2 text-sm font-semibold text-app-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            onClick={() => void loadMedia()}
+          >
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {state.phase === 'ready' ? (
+        <div className="space-y-2">
+          {state.signedUrl ? (
+            state.mediaType === 'video' ? (
+              <video
+                src={state.signedUrl}
+                controls
+                className="max-h-72 w-full rounded-lg bg-black object-contain"
+                onError={onDisplayError}
+              />
+            ) : (
+              <>
+                <button
+                  type="button"
+                  className="block w-full rounded-lg text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                  onClick={openPhotoModal}
+                  aria-label={`View full size photo for ${symptomLabel}`}
+                >
+                  <img
+                    src={state.signedUrl}
+                    alt=""
+                    aria-hidden
+                    className="max-h-72 w-full rounded-lg bg-black/5 object-contain"
+                    onError={onDisplayError}
+                  />
+                  <span className="mt-2 inline-flex min-h-11 items-center text-sm font-semibold text-app-primary underline underline-offset-4">
+                    View full size
+                  </span>
+                </button>
+                <dialog
+                  ref={photoDialogRef}
+                  className="m-0 max-h-none max-w-none border-0 bg-transparent p-0 backdrop:bg-black/60"
+                  aria-labelledby={photoDialogTitleId}
+                  onCancel={(event) => {
+                    event.preventDefault();
+                    closePhotoModal();
+                  }}
+                >
+                  <div className="fixed inset-0 flex items-center justify-center p-4">
+                    <button
+                      type="button"
+                      className="absolute inset-0 h-full w-full cursor-default bg-black/60"
+                      aria-label="Close photo viewer"
+                      onClick={closePhotoModal}
+                    />
+                    <div
+                      role="document"
+                      className="relative z-10 flex max-h-[95vh] max-w-[min(95vw,64rem)] flex-col gap-4 rounded-2xl border border-app-border/90 bg-app-surface p-4 text-app-ink shadow-xl"
+                    >
+                      <div className="flex flex-wrap items-start justify-between gap-3">
+                        <h2
+                          id={photoDialogTitleId}
+                          className="text-lg font-semibold text-app-ink"
+                        >
+                          {symptomLabel}
+                        </h2>
+                        <button
+                          type="button"
+                          className="inline-flex min-h-11 shrink-0 items-center rounded-lg border border-app-border px-4 py-2 text-sm font-semibold text-app-ink transition hover:bg-app-muted/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                          onClick={closePhotoModal}
+                        >
+                          Close
+                        </button>
+                      </div>
+                      <div className="min-h-0 flex-1 overflow-auto">
+                        <img
+                          src={state.signedUrl}
+                          alt={`${symptomLabel} photo`}
+                          className="mx-auto max-h-[calc(95vh-8rem)] w-auto max-w-full object-contain"
+                          onError={onDisplayError}
+                        />
+                      </div>
+                    </div>
+                  </div>
+                </dialog>
+              </>
+            )
+          ) : (
+            <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+              {state.loadError ?? 'Link expired or unavailable.'}
+            </p>
+          )}
+          <button
+            type="button"
+            className="inline-flex min-h-11 items-center rounded-lg border border-app-border px-3 py-2 text-sm font-semibold text-app-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            onClick={() => void loadMedia()}
+          >
+            Refresh media link
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/practitioner/src/csp-config.spec.ts
+++ b/apps/practitioner/src/csp-config.spec.ts
@@ -69,6 +69,10 @@ connect-src 'self' https://abc.supabase.co wss://abc.supabase.co`;
     expect(value).toContain('connect-src');
     expect(value).toContain('https://abc.supabase.co');
     expect(value).toContain('wss://abc.supabase.co');
+    expect(value).toContain('img-src');
+    expect(value).toContain('media-src');
+    expect(value).toMatch(/img-src[^;]*https:\/\/abc\.supabase\.co/);
+    expect(value).toMatch(/media-src[^;]*https:\/\/abc\.supabase\.co/);
     expect(value).toContain('upgrade-insecure-requests');
   });
 

--- a/apps/practitioner/tsconfig.json
+++ b/apps/practitioner/tsconfig.json
@@ -50,6 +50,9 @@
   ],
   "references": [
     {
+      "path": "../../packages/types"
+    },
+    {
       "path": "../../packages/ui"
     },
     {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -395,6 +395,9 @@ importers:
       '@abstrack/supabase':
         specifier: workspace:*
         version: link:../../packages/supabase
+      '@abstrack/types':
+        specifier: workspace:*
+        version: link:../../packages/types
       '@abstrack/ui':
         specifier: workspace:*
         version: link:../../packages/ui


### PR DESCRIPTION
Closes #155

## Summary

- Adds read-only photo/video viewing on the practitioner patient detail timeline for symptom rows logged as media (PRD §10 / ROADMAP Week 8).
- New `PractitionerSymptomMediaViewer`: lazy-load per symptom via `listEpisodeMediaForEpisode` + `createEpisodeMediaSignedDisplayUrl` (120s TTL), using the publishable browser client only (no secret keys).
- Photos: inline preview plus a full-size `<dialog>` modal (Close, Escape, click-outside on backdrop); signed URL refresh/retry on signing or display failure (same pattern as user apps).
- Videos: inline `<video controls>` (native fullscreen unchanged).
- CSP: allow Supabase project origin on `img-src` and `media-src` so signed Storage URLs load.
- Adds `@abstrack/types` to practitioner `package.json` and the matching `tsconfig` project reference.

## Security

Private `episode-media` bucket + existing RLS; practitioners sign URLs under the same model as web/mobile (no client-side decrypt, no service-role keys in the app bundle).

## Test plan

- [ ] `pnpm practitioner:validate` (or `nx run @abstrack/practitioner:lint` + `test`)
- [ ] `pnpm build` (practitioner Next build)
- [ ] Manual: MFA practitioner → patient with photo/video symptoms → expand episode → **View photo** / **View video**
- [ ] Photo: open full-size modal, close via **Close**, backdrop click, and Escape; reopen without reloading media
- [ ] Let signed URL expire (or simulate): error + **Refresh media link** works
- [ ] Confirm photo/video render (CSP not blocking Storage host)