### PR TITLE
feat(supabase): add get_user_chart_manifest RPC and client helper

### DIFF
--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -190,3 +190,8 @@ export type {
   FoodDiaryCreateCorePayload,
   ValidateFoodDiaryCreateCoreResult,
 } from './lib/food-diary-data.js';
+export type {
+  ChartManifestResponseType,
+  UserChartManifestSeries,
+} from './lib/chart-manifest-data.js';
+export { getUserChartManifest } from './lib/chart-manifest-data.js';

--- a/packages/supabase/src/lib/chart-manifest-data.spec.ts
+++ b/packages/supabase/src/lib/chart-manifest-data.spec.ts
@@ -51,7 +51,7 @@ describe('getUserChartManifest', () => {
         last_observed_at: '2026-01-10T00:00:00.000Z',
       },
       {
-        series_id: 'symptom::headache::severity',
+        series_id: 'symptom::headache',
         series_type: 'symptom',
         label: 'Headache',
         response_type: 'severity',
@@ -91,10 +91,10 @@ describe('getUserChartManifest', () => {
     }
   });
 
-  it('returns RPC rows unchanged (non-chartable symptom exclusion is enforced in SQL)', async () => {
+  it('returns chartable RPC rows unchanged', async () => {
     const rows: UserChartManifestSeries[] = [
       {
-        series_id: 'symptom::fatigue::boolean',
+        series_id: 'symptom::fatigue',
         series_type: 'symptom',
         label: 'Fatigue',
         response_type: 'boolean',
@@ -103,17 +103,6 @@ describe('getUserChartManifest', () => {
         observation_count: 4,
         first_observed_at: '2026-01-01T00:00:00.000Z',
         last_observed_at: '2026-03-01T00:00:00.000Z',
-      },
-      {
-        series_id: 'symptom::journal note',
-        series_type: 'symptom',
-        label: 'Journal note',
-        response_type: 'text',
-        is_blood_pressure: false,
-        unit: null,
-        observation_count: 1,
-        first_observed_at: '2026-02-01T00:00:00.000Z',
-        last_observed_at: '2026-02-01T00:00:00.000Z',
       },
     ];
 

--- a/packages/supabase/src/lib/chart-manifest-data.spec.ts
+++ b/packages/supabase/src/lib/chart-manifest-data.spec.ts
@@ -51,7 +51,7 @@ describe('getUserChartManifest', () => {
         last_observed_at: '2026-01-10T00:00:00.000Z',
       },
       {
-        series_id: 'symptom::headache',
+        series_id: 'symptom::headache::severity',
         series_type: 'symptom',
         label: 'Headache',
         response_type: 'severity',
@@ -94,7 +94,7 @@ describe('getUserChartManifest', () => {
   it('returns chartable RPC rows unchanged', async () => {
     const rows: UserChartManifestSeries[] = [
       {
-        series_id: 'symptom::fatigue',
+        series_id: 'symptom::fatigue::boolean',
         series_type: 'symptom',
         label: 'Fatigue',
         response_type: 'boolean',

--- a/packages/supabase/src/lib/chart-manifest-data.spec.ts
+++ b/packages/supabase/src/lib/chart-manifest-data.spec.ts
@@ -90,7 +90,7 @@ describe('getUserChartManifest', () => {
     }
   });
 
-  it('omits text/photo/video symptom series from RPC results', async () => {
+  it('returns RPC rows unchanged (non-chartable symptom exclusion is enforced in SQL)', async () => {
     const rows: UserChartManifestSeries[] = [
       {
         series_id: 'symptom::fatigue',
@@ -103,6 +103,17 @@ describe('getUserChartManifest', () => {
         first_observed_at: '2026-01-01T00:00:00.000Z',
         last_observed_at: '2026-03-01T00:00:00.000Z',
       },
+      {
+        series_id: 'symptom::journal note',
+        series_type: 'symptom',
+        label: 'Journal note',
+        response_type: 'text',
+        is_blood_pressure: false,
+        unit: null,
+        observation_count: 1,
+        first_observed_at: '2026-02-01T00:00:00.000Z',
+        last_observed_at: '2026-02-01T00:00:00.000Z',
+      },
     ];
 
     const result = await getUserChartManifest(manifestClient(rows), USER_ID);
@@ -112,14 +123,6 @@ describe('getUserChartManifest', () => {
       return;
     }
 
-    const seriesIds = result.data.map((s) => s.series_id);
-    expect(seriesIds).not.toContain('symptom::journal note');
-    expect(seriesIds).not.toContain('symptom::wound photo');
-    expect(seriesIds).not.toContain('symptom::gait video');
-    expect(
-      result.data.every(
-        (s) => s.series_type !== 'symptom' || !s.is_blood_pressure,
-      ),
-    ).toBe(true);
+    expect(result.data).toEqual(rows);
   });
 });

--- a/packages/supabase/src/lib/chart-manifest-data.spec.ts
+++ b/packages/supabase/src/lib/chart-manifest-data.spec.ts
@@ -1,0 +1,125 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+import {
+  getUserChartManifest,
+  type UserChartManifestSeries,
+} from './chart-manifest-data.js';
+
+const USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+function manifestClient(rows: UserChartManifestSeries[]) {
+  const rpc = vi.fn(async () => ({ data: rows, error: null }));
+  return {
+    rpc,
+  } as unknown as AbstrackSupabaseClient;
+}
+
+describe('getUserChartManifest', () => {
+  it('calls get_user_chart_manifest RPC with p_user_id', async () => {
+    const client = manifestClient([]);
+
+    await getUserChartManifest(client, USER_ID);
+
+    expect(client.rpc).toHaveBeenCalledWith('get_user_chart_manifest', {
+      p_user_id: USER_ID,
+    });
+  });
+
+  it('returns rows including is_blood_pressure on each series', async () => {
+    const rows: UserChartManifestSeries[] = [
+      {
+        series_id: 'health_marker::bac',
+        series_type: 'health_marker',
+        label: 'bac',
+        response_type: 'numeric',
+        is_blood_pressure: false,
+        unit: null,
+        observation_count: 3,
+        first_observed_at: '2026-01-01T00:00:00.000Z',
+        last_observed_at: '2026-02-01T00:00:00.000Z',
+      },
+      {
+        series_id: 'health_marker::blood_pressure',
+        series_type: 'health_marker',
+        label: 'blood_pressure',
+        response_type: 'numeric',
+        is_blood_pressure: true,
+        unit: null,
+        observation_count: 2,
+        first_observed_at: '2026-01-05T00:00:00.000Z',
+        last_observed_at: '2026-01-10T00:00:00.000Z',
+      },
+      {
+        series_id: 'symptom::headache',
+        series_type: 'symptom',
+        label: 'Headache',
+        response_type: 'severity',
+        is_blood_pressure: false,
+        unit: null,
+        observation_count: 1,
+        first_observed_at: '2026-01-15T00:00:00.000Z',
+        last_observed_at: '2026-01-15T00:00:00.000Z',
+      },
+    ];
+
+    const result = await getUserChartManifest(manifestClient(rows), USER_ID);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.data).toHaveLength(3);
+    for (const series of result.data) {
+      expect(series).toHaveProperty('is_blood_pressure');
+      expect(typeof series.is_blood_pressure).toBe('boolean');
+    }
+
+    const bloodPressure = result.data.find(
+      (s) => s.series_id === 'health_marker::blood_pressure',
+    );
+    expect(bloodPressure).toMatchObject({
+      response_type: 'numeric',
+      is_blood_pressure: true,
+    });
+
+    for (const symptom of result.data.filter(
+      (s) => s.series_type === 'symptom',
+    )) {
+      expect(symptom.is_blood_pressure).toBe(false);
+    }
+  });
+
+  it('omits text/photo/video symptom series from RPC results', async () => {
+    const rows: UserChartManifestSeries[] = [
+      {
+        series_id: 'symptom::fatigue',
+        series_type: 'symptom',
+        label: 'Fatigue',
+        response_type: 'boolean',
+        is_blood_pressure: false,
+        unit: null,
+        observation_count: 4,
+        first_observed_at: '2026-01-01T00:00:00.000Z',
+        last_observed_at: '2026-03-01T00:00:00.000Z',
+      },
+    ];
+
+    const result = await getUserChartManifest(manifestClient(rows), USER_ID);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const seriesIds = result.data.map((s) => s.series_id);
+    expect(seriesIds).not.toContain('symptom::journal note');
+    expect(seriesIds).not.toContain('symptom::wound photo');
+    expect(seriesIds).not.toContain('symptom::gait video');
+    expect(
+      result.data.every(
+        (s) => s.series_type !== 'symptom' || !s.is_blood_pressure,
+      ),
+    ).toBe(true);
+  });
+});

--- a/packages/supabase/src/lib/chart-manifest-data.spec.ts
+++ b/packages/supabase/src/lib/chart-manifest-data.spec.ts
@@ -1,3 +1,4 @@
+import type { Uuid } from '@abstrack/types';
 import { describe, expect, it, vi } from 'vitest';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 import {
@@ -5,7 +6,7 @@ import {
   type UserChartManifestSeries,
 } from './chart-manifest-data.js';
 
-const USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' as Uuid;
 
 function manifestClient(rows: UserChartManifestSeries[]) {
   const rpc = vi.fn(async () => ({ data: rows, error: null }));
@@ -50,7 +51,7 @@ describe('getUserChartManifest', () => {
         last_observed_at: '2026-01-10T00:00:00.000Z',
       },
       {
-        series_id: 'symptom::headache',
+        series_id: 'symptom::headache::severity',
         series_type: 'symptom',
         label: 'Headache',
         response_type: 'severity',
@@ -93,7 +94,7 @@ describe('getUserChartManifest', () => {
   it('returns RPC rows unchanged (non-chartable symptom exclusion is enforced in SQL)', async () => {
     const rows: UserChartManifestSeries[] = [
       {
-        series_id: 'symptom::fatigue',
+        series_id: 'symptom::fatigue::boolean',
         series_type: 'symptom',
         label: 'Fatigue',
         response_type: 'boolean',

--- a/packages/supabase/src/lib/chart-manifest-data.ts
+++ b/packages/supabase/src/lib/chart-manifest-data.ts
@@ -15,7 +15,7 @@ export type UserChartManifestSeries = {
   series_id: string;
   series_type: 'health_marker' | 'symptom';
   label: string;
-  response_type: ChartManifestResponseType | null;
+  response_type: ChartManifestResponseType;
   is_blood_pressure: boolean;
   unit: string | null;
   observation_count: number;

--- a/packages/supabase/src/lib/chart-manifest-data.ts
+++ b/packages/supabase/src/lib/chart-manifest-data.ts
@@ -15,7 +15,7 @@ export type UserChartManifestSeries = {
   series_id: string;
   series_type: 'health_marker' | 'symptom';
   label: string;
-  response_type: ChartManifestResponseType;
+  response_type: ChartManifestResponseType | null;
   is_blood_pressure: boolean;
   unit: string | null;
   observation_count: number;

--- a/packages/supabase/src/lib/chart-manifest-data.ts
+++ b/packages/supabase/src/lib/chart-manifest-data.ts
@@ -1,0 +1,55 @@
+import { toPresetDataError } from './preset-data-error.js';
+import type { PresetDataResult } from './preset-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+/** Chart manifest `response_type` values returned by `get_user_chart_manifest`. */
+export type ChartManifestResponseType =
+  | 'numeric'
+  | 'boolean'
+  | 'severity'
+  | 'text';
+
+/** One chartable series row from `get_user_chart_manifest`. */
+export type UserChartManifestSeries = {
+  series_id: string;
+  series_type: 'health_marker' | 'symptom';
+  label: string;
+  response_type: ChartManifestResponseType;
+  is_blood_pressure: boolean;
+  unit: string | null;
+  observation_count: number;
+  first_observed_at: string;
+  last_observed_at: string;
+};
+
+type UserChartManifestSeriesRow = UserChartManifestSeries;
+
+/**
+ * Loads chartable series metadata for a patient (or the signed-in user) via Postgres RPC.
+ * Uses `SECURITY INVOKER` so existing RLS on `health_markers` and `episode_symptoms` applies.
+ *
+ * @param client - Supabase client with the caller JWT (patient, caretaker, or practitioner).
+ * @param userId - Subject user id (`p_user_id`); practitioners pass the patient id.
+ * @returns Manifest rows ordered by `series_type`, then `label`.
+ */
+export async function getUserChartManifest(
+  client: AbstrackSupabaseClient,
+  userId: string,
+): Promise<PresetDataResult<UserChartManifestSeries[]>> {
+  try {
+    const { data, error } = await client.rpc('get_user_chart_manifest', {
+      p_user_id: userId,
+    });
+
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+
+    return {
+      ok: true,
+      data: (data ?? []) as UserChartManifestSeriesRow[],
+    };
+  } catch (cause) {
+    return { ok: false, error: toPresetDataError(cause) };
+  }
+}

--- a/packages/supabase/src/lib/chart-manifest-data.ts
+++ b/packages/supabase/src/lib/chart-manifest-data.ts
@@ -1,3 +1,4 @@
+import type { Uuid } from '@abstrack/types';
 import { toPresetDataError } from './preset-data-error.js';
 import type { PresetDataResult } from './preset-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
@@ -34,7 +35,7 @@ type UserChartManifestSeriesRow = UserChartManifestSeries;
  */
 export async function getUserChartManifest(
   client: AbstrackSupabaseClient,
-  userId: string,
+  userId: Uuid,
 ): Promise<PresetDataResult<UserChartManifestSeries[]>> {
   try {
     const { data, error } = await client.rpc('get_user_chart_manifest', {

--- a/packages/supabase/src/lib/database.types.ts
+++ b/packages/supabase/src/lib/database.types.ts
@@ -717,6 +717,20 @@ export type Database = {
         Args: { p_object_name: string }
         Returns: string
       }
+      get_user_chart_manifest: {
+        Args: { p_user_id: string }
+        Returns: {
+          first_observed_at: string
+          is_blood_pressure: boolean
+          label: string
+          last_observed_at: string
+          observation_count: number
+          response_type: string
+          series_id: string
+          series_type: string
+          unit: string
+        }[]
+      }
       list_practitioner_auth_emails_for_patient_grants: {
         Args: { p_patient_user_id: string; p_practitioner_user_ids: string[] }
         Returns: {

--- a/supabase/migrations/20260521120000_chart_manifest_rpc.sql
+++ b/supabase/migrations/20260521120000_chart_manifest_rpc.sql
@@ -35,7 +35,7 @@ AS $$
     SELECT
       'health_marker::' || hmr.series_key AS series_id,
       'health_marker'::text AS series_type,
-      hmr.label,
+      min(hmr.label) AS label,
       CASE
         WHEN bool_or(hmr.is_numeric_observation) THEN 'numeric'
         ELSE 'text'
@@ -46,7 +46,7 @@ AS $$
       min(hmr.recorded_at) AS first_observed_at,
       max(hmr.recorded_at) AS last_observed_at
     FROM health_marker_rows hmr
-    GROUP BY hmr.series_key, hmr.label
+    GROUP BY hmr.series_key
   ),
   symptom_rows AS (
     SELECT
@@ -67,7 +67,7 @@ AS $$
     SELECT
       'symptom::' || sr.series_key AS series_id,
       'symptom'::text AS series_type,
-      sr.label,
+      min(sr.label) AS label,
       max(sr.chart_response_type) AS response_type,
       false AS is_blood_pressure,
       NULL::text AS unit,
@@ -76,7 +76,7 @@ AS $$
       max(sr.created_at) AS last_observed_at
     FROM symptom_rows sr
     WHERE sr.chart_response_type <> 'text'
-    GROUP BY sr.series_key, sr.label
+    GROUP BY sr.series_key
   )
   SELECT
     m.series_id,

--- a/supabase/migrations/20260521120000_chart_manifest_rpc.sql
+++ b/supabase/migrations/20260521120000_chart_manifest_rpc.sql
@@ -65,8 +65,8 @@ AS $$
   ),
   symptom_rows AS (
     SELECT
-      lower(es.symptom_name) AS series_key,
-      es.symptom_name AS label,
+      lower(nullif(trim(es.symptom_name), '')) AS series_key,
+      nullif(trim(es.symptom_name), '') AS label,
       CASE es.response_type
         WHEN 'yes_no' THEN 'boolean'
         WHEN 'severity_scale' THEN 'severity'
@@ -77,6 +77,7 @@ AS $$
       es.created_at
     FROM public.episode_symptoms es
     WHERE es.user_id = p_user_id
+      AND nullif(trim(es.symptom_name), '') IS NOT NULL
   ),
   symptom_series AS (
     SELECT

--- a/supabase/migrations/20260521120000_chart_manifest_rpc.sql
+++ b/supabase/migrations/20260521120000_chart_manifest_rpc.sql
@@ -1,0 +1,103 @@
+-- Chart builder manifest: chartable series metadata per patient without raw observation rows.
+
+CREATE OR REPLACE FUNCTION public.get_user_chart_manifest (p_user_id uuid)
+RETURNS TABLE (
+  series_id text,
+  series_type text,
+  label text,
+  response_type text,
+  is_blood_pressure boolean,
+  unit text,
+  observation_count bigint,
+  first_observed_at timestamptz,
+  last_observed_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+SET search_path = pg_catalog, public
+AS $$
+  WITH health_marker_rows AS (
+    SELECT
+      lower(coalesce(hm.custom_name, hm.marker_kind)) AS series_key,
+      coalesce(hm.custom_name, hm.marker_kind) AS label,
+      (
+        hm.value_numeric IS NOT NULL
+        OR hm.systolic_numeric IS NOT NULL
+      ) AS is_numeric_observation,
+      (hm.marker_kind = 'blood_pressure') AS row_is_blood_pressure,
+      hm.custom_unit,
+      hm.recorded_at
+    FROM public.health_markers hm
+    WHERE hm.user_id = p_user_id
+  ),
+  health_marker_series AS (
+    SELECT
+      'health_marker::' || hmr.series_key AS series_id,
+      'health_marker'::text AS series_type,
+      hmr.label,
+      CASE
+        WHEN bool_or(hmr.is_numeric_observation) THEN 'numeric'
+        ELSE 'text'
+      END AS response_type,
+      bool_or(hmr.row_is_blood_pressure) AS is_blood_pressure,
+      max(hmr.custom_unit) AS unit,
+      count(*)::bigint AS observation_count,
+      min(hmr.recorded_at) AS first_observed_at,
+      max(hmr.recorded_at) AS last_observed_at
+    FROM health_marker_rows hmr
+    GROUP BY hmr.series_key, hmr.label
+  ),
+  symptom_rows AS (
+    SELECT
+      lower(es.symptom_name) AS series_key,
+      es.symptom_name AS label,
+      CASE es.response_type
+        WHEN 'yes_no' THEN 'boolean'
+        WHEN 'severity_scale' THEN 'severity'
+        WHEN 'free_text' THEN 'text'
+        WHEN 'photo' THEN 'text'
+        WHEN 'video' THEN 'text'
+      END AS chart_response_type,
+      es.created_at
+    FROM public.episode_symptoms es
+    WHERE es.user_id = p_user_id
+  ),
+  symptom_series AS (
+    SELECT
+      'symptom::' || sr.series_key AS series_id,
+      'symptom'::text AS series_type,
+      sr.label,
+      max(sr.chart_response_type) AS response_type,
+      false AS is_blood_pressure,
+      NULL::text AS unit,
+      count(*)::bigint AS observation_count,
+      min(sr.created_at) AS first_observed_at,
+      max(sr.created_at) AS last_observed_at
+    FROM symptom_rows sr
+    WHERE sr.chart_response_type <> 'text'
+    GROUP BY sr.series_key, sr.label
+  )
+  SELECT
+    m.series_id,
+    m.series_type,
+    m.label,
+    m.response_type,
+    m.is_blood_pressure,
+    m.unit,
+    m.observation_count,
+    m.first_observed_at,
+    m.last_observed_at
+  FROM (
+    SELECT * FROM health_marker_series
+    UNION ALL
+    SELECT * FROM symptom_series
+  ) m
+  ORDER BY m.series_type, m.label ASC;
+$$;
+
+COMMENT ON FUNCTION public.get_user_chart_manifest (uuid) IS
+'Returns chartable observation series for p_user_id (health markers and yes_no/severity symptoms). SECURITY INVOKER: RLS on health_markers and episode_symptoms applies; practitioners need an active practitioner_access grant.';
+
+REVOKE ALL ON FUNCTION public.get_user_chart_manifest (uuid) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_user_chart_manifest (uuid) TO authenticated;

--- a/supabase/migrations/20260521120000_chart_manifest_rpc.sql
+++ b/supabase/migrations/20260521120000_chart_manifest_rpc.sql
@@ -41,7 +41,10 @@ AS $$
         ELSE 'text'
       END AS response_type,
       bool_or(hmr.row_is_blood_pressure) AS is_blood_pressure,
-      max(hmr.custom_unit) AS unit,
+      CASE
+        WHEN count(DISTINCT hmr.custom_unit) FILTER (WHERE hmr.custom_unit IS NOT NULL) > 1 THEN NULL
+        ELSE max(hmr.custom_unit)
+      END AS unit,
       count(*)::bigint AS observation_count,
       min(hmr.recorded_at) AS first_observed_at,
       max(hmr.recorded_at) AS last_observed_at
@@ -65,10 +68,10 @@ AS $$
   ),
   symptom_series AS (
     SELECT
-      'symptom::' || sr.series_key AS series_id,
+      'symptom::' || sr.series_key || '::' || sr.chart_response_type AS series_id,
       'symptom'::text AS series_type,
       min(sr.label) AS label,
-      max(sr.chart_response_type) AS response_type,
+      sr.chart_response_type AS response_type,
       false AS is_blood_pressure,
       NULL::text AS unit,
       count(*)::bigint AS observation_count,
@@ -76,7 +79,7 @@ AS $$
       max(sr.created_at) AS last_observed_at
     FROM symptom_rows sr
     WHERE sr.chart_response_type <> 'text'
-    GROUP BY sr.series_key
+    GROUP BY sr.series_key, sr.chart_response_type
   )
   SELECT
     m.series_id,

--- a/supabase/migrations/20260521120000_chart_manifest_rpc.sql
+++ b/supabase/migrations/20260521120000_chart_manifest_rpc.sql
@@ -19,7 +19,11 @@ SET search_path = pg_catalog, public
 AS $$
   WITH health_marker_rows AS (
     SELECT
-      lower(coalesce(hm.custom_name, hm.marker_kind)) AS series_key,
+      CASE
+        WHEN hm.marker_kind = 'custom' THEN
+          lower(hm.marker_kind) || '::' || lower(coalesce(hm.custom_name, ''))
+        ELSE lower(hm.marker_kind)
+      END AS series_key,
       coalesce(hm.custom_name, hm.marker_kind) AS label,
       (
         hm.value_numeric IS NOT NULL
@@ -69,13 +73,10 @@ AS $$
   ),
   symptom_series AS (
     SELECT
-      'symptom::' || sr.series_key AS series_id,
+      'symptom::' || sr.series_key || '::' || sr.chart_response_type AS series_id,
       'symptom'::text AS series_type,
       min(sr.label) AS label,
-      CASE
-        WHEN count(DISTINCT sr.chart_response_type) > 1 THEN NULL
-        ELSE max(sr.chart_response_type)
-      END AS response_type,
+      sr.chart_response_type AS response_type,
       false AS is_blood_pressure,
       NULL::text AS unit,
       count(*)::bigint AS observation_count,
@@ -83,7 +84,7 @@ AS $$
       max(sr.created_at) AS last_observed_at
     FROM symptom_rows sr
     WHERE sr.chart_response_type <> 'text'
-    GROUP BY sr.series_key
+    GROUP BY sr.series_key, sr.chart_response_type
   )
   SELECT
     m.series_id,

--- a/supabase/migrations/20260521120000_chart_manifest_rpc.sql
+++ b/supabase/migrations/20260521120000_chart_manifest_rpc.sql
@@ -21,10 +21,13 @@ AS $$
     SELECT
       CASE
         WHEN hm.marker_kind = 'custom' THEN
-          lower(hm.marker_kind) || '::' || lower(coalesce(hm.custom_name, ''))
+          lower(hm.marker_kind) || '::' || lower(nullif(trim(hm.custom_name), ''))
         ELSE lower(hm.marker_kind)
       END AS series_key,
-      coalesce(hm.custom_name, hm.marker_kind) AS label,
+      CASE
+        WHEN hm.marker_kind = 'custom' THEN nullif(trim(hm.custom_name), '')
+        ELSE coalesce(hm.custom_name, hm.marker_kind)
+      END AS label,
       (
         hm.value_numeric IS NOT NULL
         OR hm.systolic_numeric IS NOT NULL
@@ -35,6 +38,10 @@ AS $$
       hm.recorded_at
     FROM public.health_markers hm
     WHERE hm.user_id = p_user_id
+      AND (
+        hm.marker_kind <> 'custom'
+        OR nullif(trim(hm.custom_name), '') IS NOT NULL
+      )
   ),
   health_marker_series AS (
     SELECT

--- a/supabase/migrations/20260521120000_chart_manifest_rpc.sql
+++ b/supabase/migrations/20260521120000_chart_manifest_rpc.sql
@@ -24,6 +24,7 @@ AS $$
       (
         hm.value_numeric IS NOT NULL
         OR hm.systolic_numeric IS NOT NULL
+        OR hm.diastolic_numeric IS NOT NULL
       ) AS is_numeric_observation,
       (hm.marker_kind = 'blood_pressure') AS row_is_blood_pressure,
       hm.custom_unit,
@@ -68,10 +69,13 @@ AS $$
   ),
   symptom_series AS (
     SELECT
-      'symptom::' || sr.series_key || '::' || sr.chart_response_type AS series_id,
+      'symptom::' || sr.series_key AS series_id,
       'symptom'::text AS series_type,
       min(sr.label) AS label,
-      sr.chart_response_type AS response_type,
+      CASE
+        WHEN count(DISTINCT sr.chart_response_type) > 1 THEN NULL
+        ELSE max(sr.chart_response_type)
+      END AS response_type,
       false AS is_blood_pressure,
       NULL::text AS unit,
       count(*)::bigint AS observation_count,
@@ -79,7 +83,7 @@ AS $$
       max(sr.created_at) AS last_observed_at
     FROM symptom_rows sr
     WHERE sr.chart_response_type <> 'text'
-    GROUP BY sr.series_key, sr.chart_response_type
+    GROUP BY sr.series_key
   )
   SELECT
     m.series_id,


### PR DESCRIPTION
Closes #169

## Summary

Adds a `SECURITY INVOKER` Postgres RPC `get_user_chart_manifest(p_user_id)` that returns chartable health-marker and symptom series metadata (labels, response types, blood-pressure flag, observation counts, date range) so the chart builder can populate dropdowns without downloading raw observations. Includes a `@abstrack/supabase` client helper (`getUserChartManifest`) and unit tests with a mocked RPC.

## Changes

- **Migration** `supabase/migrations/20260521120000_chart_manifest_rpc.sql`: aggregates `health_markers` and `episode_symptoms` for the given user; excludes non-chartable symptom types (`free_text`, `photo`, `video`); grants `EXECUTE` to `authenticated`.
- **`packages/supabase`**: `chart-manifest-data.ts`, `chart-manifest-data.spec.ts`, barrel exports.

## RPC behavior (review-hardened)

**Health markers**
- `series_id`: `health_marker::{series_key}` where `series_key` is `lower(marker_kind)` for standard kinds, or `custom::{lower(custom_name)}` when `marker_kind = 'custom'` (avoids colliding with reserved kinds such as `blood_pressure`).
- `label`: `coalesce(custom_name, marker_kind)`; grouped by `series_key` only (canonical `min(label)` when casing differs).
- `response_type`: `numeric` if any row has `value_numeric`, `systolic_numeric`, or `diastolic_numeric`; else `text`.
- `is_blood_pressure`: `true` only when `marker_kind = 'blood_pressure'`.
- `unit`: single distinct `custom_unit`, else `NULL` when multiple units exist for the series.

**Symptoms**
- `series_id`: `symptom::{lower(symptom_name)}::{chart_response_type}` where `chart_response_type` is `boolean` or `severity` (mapped from `yes_no` / `severity_scale`). Same display name can yield multiple series when history mixes types (e.g. preset edits).
- Non-chartable types (`free_text`, `photo`, `video`) are excluded in SQL (`WHERE chart_response_type <> 'text'`).
- Each returned symptom row has a definite `response_type` (no `NULL` ambiguity).

## Notes

- RLS applies via `SECURITY INVOKER` (patient, caretaker with grant, practitioner with `practitioner_access`).
- **`@abstrack/supabase` build will fail typecheck until** `db push` and `gen types typescript --linked` — do not hand-edit `database.types.ts`. After review, apply migration and regenerate types per `docs/SUPABASE_CLOUD_DEVELOPER.md`, then commit `database.types.ts` with the migration.
- Unit tests mock the RPC and document pass-through for chartable rows; SQL exclusion of text/photo/video symptoms should be verified after `db push` (integration/manual).

## Test plan

- [ ] `pnpm exec vitest run packages/supabase/src/lib/chart-manifest-data.spec.ts`
- [ ] After `db push` + linked gen types: `pnpm supabase:validate`
- [ ] Manual: call RPC as patient and as practitioner with grant
  - [ ] Text/photo/video symptoms absent from results
  - [ ] `health_marker::blood_pressure` has `response_type = 'numeric'` and `is_blood_pressure = true`
  - [ ] Custom marker named like a standard kind (e.g. `blood_pressure`) does not merge with the real BP series (`health_marker::custom::blood_pressure` vs `health_marker::blood_pressure`)
  - [ ] Same symptom name with both yes/no and severity history returns two series (`…::boolean`, `…::severity`) with definite `response_type` on each