### PR TITLE
feat(supabase): add get_chart_series RPC for server-side chart time-series aggregation

### DIFF
--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -195,3 +195,9 @@ export type {
   UserChartManifestSeries,
 } from './lib/chart-manifest-data.js';
 export { getUserChartManifest } from './lib/chart-manifest-data.js';
+export type {
+  ChartSeriesBucket,
+  ChartSeriesBucketRow,
+  ChartSeriesSelection,
+} from './lib/chart-series-data.js';
+export { getChartSeries } from './lib/chart-series-data.js';

--- a/packages/supabase/src/lib/chart-series-data.spec.ts
+++ b/packages/supabase/src/lib/chart-series-data.spec.ts
@@ -167,4 +167,48 @@ describe('getChartSeries', () => {
     expect(bucket.systolic_avg).toBeNull();
     expect(bucket.diastolic_avg).toBeNull();
   });
+
+  it('returns severity buckets with value_avg/min/max, event_count, and null blood pressure columns', async () => {
+    const rows: ChartSeriesBucketRow[] = [
+      {
+        series_id: 'symptom::headache::severity',
+        bucket_start: '2026-01-15T00:00:00.000Z',
+        value_avg: 3,
+        value_min: 2,
+        value_max: 4,
+        systolic_avg: null,
+        diastolic_avg: null,
+        event_count: 5,
+      },
+    ];
+
+    const result = await getChartSeries(
+      chartSeriesClient(rows),
+      USER_ID,
+      [
+        {
+          series_id: 'symptom::headache::severity',
+          series_type: 'symptom',
+          response_type: 'severity',
+          is_blood_pressure: false,
+        },
+      ],
+      FROM,
+      TO,
+      'week',
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const bucket = result.data[0];
+    expect(bucket.value_avg).toBe(3);
+    expect(bucket.value_min).toBe(2);
+    expect(bucket.value_max).toBe(4);
+    expect(bucket.event_count).toBe(5);
+    expect(bucket.systolic_avg).toBeNull();
+    expect(bucket.diastolic_avg).toBeNull();
+  });
 });

--- a/packages/supabase/src/lib/chart-series-data.spec.ts
+++ b/packages/supabase/src/lib/chart-series-data.spec.ts
@@ -1,0 +1,170 @@
+import type { Uuid } from '@abstrack/types';
+import { describe, expect, it, vi } from 'vitest';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+import {
+  getChartSeries,
+  type ChartSeriesBucketRow,
+  type ChartSeriesSelection,
+} from './chart-series-data.js';
+
+const USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' as Uuid;
+const FROM = '2026-01-01T00:00:00.000Z';
+const TO = '2026-03-01T00:00:00.000Z';
+
+const SERIES: ChartSeriesSelection[] = [
+  {
+    series_id: 'health_marker::blood_pressure',
+    series_type: 'health_marker',
+    response_type: 'numeric',
+    is_blood_pressure: true,
+  },
+];
+
+function chartSeriesClient(rows: ChartSeriesBucketRow[]) {
+  const rpc = vi.fn(async () => ({ data: rows, error: null }));
+  return {
+    rpc,
+  } as unknown as AbstrackSupabaseClient;
+}
+
+describe('getChartSeries', () => {
+  it('calls get_chart_series RPC with user, series, range, and bucket', async () => {
+    const client = chartSeriesClient([]);
+
+    await getChartSeries(client, USER_ID, SERIES, FROM, TO, 'week');
+
+    expect(client.rpc).toHaveBeenCalledWith('get_chart_series', {
+      p_user_id: USER_ID,
+      p_series: SERIES,
+      p_from: FROM,
+      p_to: TO,
+      p_bucket: 'week',
+    });
+  });
+
+  it('returns blood pressure buckets with systolic/diastolic averages and null value_*', async () => {
+    const rows: ChartSeriesBucketRow[] = [
+      {
+        series_id: 'health_marker::blood_pressure',
+        bucket_start: '2026-01-06T00:00:00.000Z',
+        value_avg: null,
+        value_min: null,
+        value_max: null,
+        systolic_avg: 128,
+        diastolic_avg: 82,
+        event_count: null,
+      },
+    ];
+
+    const result = await getChartSeries(
+      chartSeriesClient(rows),
+      USER_ID,
+      SERIES,
+      FROM,
+      TO,
+      'week',
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.data).toEqual(rows);
+    const bucket = result.data[0];
+    expect(bucket.value_avg).toBeNull();
+    expect(bucket.value_min).toBeNull();
+    expect(bucket.value_max).toBeNull();
+    expect(bucket.systolic_avg).toBe(128);
+    expect(bucket.diastolic_avg).toBe(82);
+    expect(bucket.event_count).toBeNull();
+  });
+
+  it('returns numeric buckets with value_avg/min/max and null blood pressure columns', async () => {
+    const rows: ChartSeriesBucketRow[] = [
+      {
+        series_id: 'health_marker::bac',
+        bucket_start: '2026-01-01T00:00:00.000Z',
+        value_avg: 0.04,
+        value_min: 0.02,
+        value_max: 0.06,
+        systolic_avg: null,
+        diastolic_avg: null,
+        event_count: null,
+      },
+    ];
+
+    const result = await getChartSeries(
+      chartSeriesClient(rows),
+      USER_ID,
+      [
+        {
+          series_id: 'health_marker::bac',
+          series_type: 'health_marker',
+          response_type: 'numeric',
+          is_blood_pressure: false,
+        },
+      ],
+      FROM,
+      TO,
+      'day',
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const bucket = result.data[0];
+    expect(bucket.value_avg).toBe(0.04);
+    expect(bucket.value_min).toBe(0.02);
+    expect(bucket.value_max).toBe(0.06);
+    expect(bucket.systolic_avg).toBeNull();
+    expect(bucket.diastolic_avg).toBeNull();
+    expect(bucket.event_count).toBeNull();
+  });
+
+  it('returns boolean buckets with event_count only (other value columns null)', async () => {
+    const rows: ChartSeriesBucketRow[] = [
+      {
+        series_id: 'symptom::fatigue::boolean',
+        bucket_start: '2026-02-01T00:00:00.000Z',
+        value_avg: null,
+        value_min: null,
+        value_max: null,
+        systolic_avg: null,
+        diastolic_avg: null,
+        event_count: 3,
+      },
+    ];
+
+    const result = await getChartSeries(
+      chartSeriesClient(rows),
+      USER_ID,
+      [
+        {
+          series_id: 'symptom::fatigue::boolean',
+          series_type: 'symptom',
+          response_type: 'boolean',
+          is_blood_pressure: false,
+        },
+      ],
+      FROM,
+      TO,
+      'month',
+    );
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    const bucket = result.data[0];
+    expect(bucket.event_count).toBe(3);
+    expect(bucket.value_avg).toBeNull();
+    expect(bucket.value_min).toBeNull();
+    expect(bucket.value_max).toBeNull();
+    expect(bucket.systolic_avg).toBeNull();
+    expect(bucket.diastolic_avg).toBeNull();
+  });
+});

--- a/packages/supabase/src/lib/chart-series-data.ts
+++ b/packages/supabase/src/lib/chart-series-data.ts
@@ -1,0 +1,104 @@
+import type { Uuid } from '@abstrack/types';
+import type { PostgrestError } from '@supabase/supabase-js';
+import { toPresetDataError } from './preset-data-error.js';
+import type { PresetDataResult } from './preset-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+/** Time bucket granularity for `get_chart_series`. */
+export type ChartSeriesBucket = 'day' | 'week' | 'month';
+
+/** One series selection passed to `get_chart_series` (`p_series` JSON array element). */
+export type ChartSeriesSelection = {
+  series_id: string;
+  series_type: 'health_marker' | 'symptom';
+  response_type: 'numeric' | 'boolean' | 'severity';
+  is_blood_pressure: boolean;
+};
+
+/** One pre-bucketed row from `get_chart_series`. */
+export type ChartSeriesBucketRow = {
+  series_id: string;
+  bucket_start: string;
+  value_avg: number | null;
+  value_min: number | null;
+  value_max: number | null;
+  systolic_avg: number | null;
+  diastolic_avg: number | null;
+  event_count: number | null;
+};
+
+type ChartSeriesBucketRowRaw = ChartSeriesBucketRow;
+
+type GetChartSeriesRpcArgs = {
+  p_user_id: Uuid;
+  p_series: ChartSeriesSelection[];
+  p_from: string;
+  p_to: string;
+  p_bucket: ChartSeriesBucket;
+};
+
+/**
+ * Invokes `get_chart_series` before the RPC appears in generated `database.types.ts`.
+ * Remove this shim after `supabase gen types typescript --linked` includes the function.
+ */
+function rpcGetChartSeries(
+  client: AbstrackSupabaseClient,
+  args: GetChartSeriesRpcArgs,
+): Promise<{
+  data: ChartSeriesBucketRow[] | null;
+  error: PostgrestError | null;
+}> {
+  type RpcClient = {
+    rpc(
+      fn: 'get_chart_series',
+      rpcArgs: GetChartSeriesRpcArgs,
+    ): Promise<{
+      data: ChartSeriesBucketRow[] | null;
+      error: PostgrestError | null;
+    }>;
+  };
+
+  return (client as unknown as RpcClient).rpc('get_chart_series', args);
+}
+
+/**
+ * Loads pre-bucketed time-series points for selected chart series via Postgres RPC.
+ * Uses `SECURITY INVOKER` so existing RLS on `health_markers` and `episode_symptoms` applies.
+ *
+ * @param client - Supabase client with the caller JWT (patient, caretaker, or practitioner).
+ * @param userId - Subject user id (`p_user_id`).
+ * @param series - One to three manifest series descriptors (`p_series`).
+ * @param from - Range start (`p_from`), inclusive.
+ * @param to - Range end (`p_to`), inclusive.
+ * @param bucket - Bucket size: `day`, `week`, or `month` (`p_bucket`).
+ * @returns Bucketed rows for all requested series, ordered by `series_id` then `bucket_start`.
+ */
+export async function getChartSeries(
+  client: AbstrackSupabaseClient,
+  userId: Uuid,
+  series: ChartSeriesSelection[],
+  from: string,
+  to: string,
+  bucket: ChartSeriesBucket,
+): Promise<PresetDataResult<ChartSeriesBucketRow[]>> {
+  try {
+    const { data, error } = await rpcGetChartSeries(client, {
+      p_user_id: userId,
+      p_series: series,
+      p_from: from,
+      p_to: to,
+      p_bucket: bucket,
+    });
+
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+
+    return {
+      ok: true,
+      data: (data ?? []) as ChartSeriesBucketRowRaw[],
+    };
+  } catch (cause) {
+    return { ok: false, error: toPresetDataError(cause) };
+  }
+}

--- a/packages/supabase/src/lib/chart-series-data.ts
+++ b/packages/supabase/src/lib/chart-series-data.ts
@@ -15,7 +15,13 @@ export type ChartSeriesSelection = {
   is_blood_pressure: boolean;
 };
 
-/** One pre-bucketed row from `get_chart_series`. */
+/**
+ * One pre-bucketed row from `get_chart_series`.
+ *
+ * For severity symptoms, `value_*` aggregates rated observations only (NULL severities
+ * excluded by SQL aggregates); `event_count` is total `severity_scale` rows in the bucket
+ * (logging frequency), including rows without a rating.
+ */
 export type ChartSeriesBucketRow = {
   series_id: string;
   bucket_start: string;

--- a/packages/supabase/src/lib/database.types.ts
+++ b/packages/supabase/src/lib/database.types.ts
@@ -717,6 +717,25 @@ export type Database = {
         Args: { p_object_name: string }
         Returns: string
       }
+      get_chart_series: {
+        Args: {
+          p_bucket: string
+          p_from: string
+          p_series: Json
+          p_to: string
+          p_user_id: string
+        }
+        Returns: {
+          bucket_start: string
+          diastolic_avg: number
+          event_count: number
+          series_id: string
+          systolic_avg: number
+          value_avg: number
+          value_max: number
+          value_min: number
+        }[]
+      }
       get_user_chart_manifest: {
         Args: { p_user_id: string }
         Returns: {

--- a/supabase/migrations/20260522120000_chart_series_rpc.sql
+++ b/supabase/migrations/20260522120000_chart_series_rpc.sql
@@ -89,6 +89,11 @@ BEGIN
         USING ERRCODE = '22023';
     END IF;
 
+    IF sid <> lower(sid) THEN
+      RAISE EXCEPTION 'get_chart_series: series_id must be lowercase (manifest format) %', sid
+        USING ERRCODE = '22023';
+    END IF;
+
     IF sid = ANY (seen_series_ids) THEN
       RAISE EXCEPTION 'get_chart_series: duplicate series_id %', sid
         USING ERRCODE = '22023';
@@ -165,7 +170,7 @@ BEGIN
       sd.series_id,
       sd.response_type,
       sd.is_blood_pressure,
-      regexp_replace(sd.series_id, '^health_marker::', '') AS marker_series_key
+      lower(regexp_replace(sd.series_id, '^health_marker::', '')) AS marker_series_key
     FROM series_defs sd
     WHERE sd.series_type = 'health_marker'
   ),
@@ -173,7 +178,7 @@ BEGIN
     SELECT
       sd.series_id,
       sd.response_type,
-      split_part(regexp_replace(sd.series_id, '^symptom::', ''), '::', 1) AS symptom_series_key
+      (regexp_match(sd.series_id, '^symptom::(.+)::(boolean|severity)$'))[1] AS symptom_series_key
     FROM series_defs sd
     WHERE sd.series_type = 'symptom'
   ),
@@ -287,3 +292,9 @@ COMMENT ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamp
 
 REVOKE ALL ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) TO authenticated;
+
+-- Range scans for chart RPCs (and manifest) filter by user_id and created_at.
+CREATE INDEX IF NOT EXISTS episode_symptoms_user_created_at_idx ON public.episode_symptoms (user_id, created_at DESC);
+
+COMMENT ON INDEX public.episode_symptoms_user_created_at_idx IS
+'Supports per-user symptom history range queries (e.g. get_chart_series, get_user_chart_manifest).';

--- a/supabase/migrations/20260522120000_chart_series_rpc.sql
+++ b/supabase/migrations/20260522120000_chart_series_rpc.sql
@@ -24,6 +24,14 @@ SET search_path = pg_catalog, public
 AS $$
 DECLARE
   series_count int;
+  elem jsonb;
+  sid text;
+  stype text;
+  rtype text;
+  is_bp boolean;
+  seen_series_ids text[] := ARRAY[]::text[];
+  symptom_match text[];
+  hm_suffix text;
 BEGIN
   IF p_bucket NOT IN ('day', 'week', 'month') THEN
     RAISE EXCEPTION 'get_chart_series: p_bucket must be day, week, or month'
@@ -46,6 +54,102 @@ BEGIN
     RAISE EXCEPTION 'get_chart_series: p_from must be less than or equal to p_to'
       USING ERRCODE = '22023';
   END IF;
+
+  FOR elem IN
+    SELECT value
+    FROM jsonb_array_elements(p_series)
+  LOOP
+    IF jsonb_typeof(elem) <> 'object' THEN
+      RAISE EXCEPTION 'get_chart_series: each p_series element must be a JSON object'
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF NOT (
+      elem ? 'series_id'
+      AND elem ? 'series_type'
+      AND elem ? 'response_type'
+      AND elem ? 'is_blood_pressure'
+    ) THEN
+      RAISE EXCEPTION 'get_chart_series: each p_series element must include series_id, series_type, response_type, and is_blood_pressure'
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF jsonb_typeof(elem -> 'is_blood_pressure') <> 'boolean' THEN
+      RAISE EXCEPTION 'get_chart_series: is_blood_pressure must be a JSON boolean'
+        USING ERRCODE = '22023';
+    END IF;
+
+    sid := nullif(trim(elem ->> 'series_id'), '');
+    stype := nullif(trim(elem ->> 'series_type'), '');
+    rtype := nullif(trim(elem ->> 'response_type'), '');
+    is_bp := (elem ->> 'is_blood_pressure')::boolean;
+
+    IF sid IS NULL OR stype IS NULL OR rtype IS NULL THEN
+      RAISE EXCEPTION 'get_chart_series: series_id, series_type, and response_type must be non-empty strings'
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF sid = ANY (seen_series_ids) THEN
+      RAISE EXCEPTION 'get_chart_series: duplicate series_id %', sid
+        USING ERRCODE = '22023';
+    END IF;
+
+    seen_series_ids := array_append(seen_series_ids, sid);
+
+    IF stype = 'health_marker' THEN
+      IF rtype <> 'numeric' THEN
+        RAISE EXCEPTION 'get_chart_series: health_marker series % requires response_type numeric', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF sid NOT LIKE 'health_marker::%' OR length(sid) <= length('health_marker::') THEN
+        RAISE EXCEPTION 'get_chart_series: invalid health_marker series_id %', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      hm_suffix := substring(sid FROM length('health_marker::') + 1);
+
+      IF is_bp AND hm_suffix <> 'blood_pressure' THEN
+        RAISE EXCEPTION 'get_chart_series: is_blood_pressure true requires series_id health_marker::blood_pressure'
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF NOT is_bp AND hm_suffix = 'blood_pressure' THEN
+        RAISE EXCEPTION 'get_chart_series: health_marker::blood_pressure requires is_blood_pressure true'
+          USING ERRCODE = '22023';
+      END IF;
+    ELSIF stype = 'symptom' THEN
+      IF rtype NOT IN ('boolean', 'severity') THEN
+        RAISE EXCEPTION 'get_chart_series: symptom series % requires response_type boolean or severity', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF is_bp THEN
+        RAISE EXCEPTION 'get_chart_series: symptom series must have is_blood_pressure false'
+          USING ERRCODE = '22023';
+      END IF;
+
+      symptom_match := regexp_match(sid, '^symptom::(.+)::(boolean|severity)$');
+
+      IF symptom_match IS NULL THEN
+        RAISE EXCEPTION 'get_chart_series: invalid symptom series_id % (expected symptom::<name>::boolean|severity)', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF symptom_match[2] <> rtype THEN
+        RAISE EXCEPTION 'get_chart_series: series_id suffix must match response_type for %', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF nullif(trim(symptom_match[1]), '') IS NULL THEN
+        RAISE EXCEPTION 'get_chart_series: symptom series_id must include a non-empty symptom name'
+          USING ERRCODE = '22023';
+      END IF;
+    ELSE
+      RAISE EXCEPTION 'get_chart_series: unsupported series_type %', stype
+        USING ERRCODE = '22023';
+    END IF;
+  END LOOP;
 
   RETURN QUERY
   WITH series_defs AS (
@@ -75,24 +179,32 @@ BEGIN
   ),
   health_marker_match AS (
     SELECT
-      hm.*,
-      CASE
-        WHEN hm.marker_kind = 'custom' THEN
-          lower(hm.marker_kind) || '::' || lower(nullif(trim(hm.custom_name), ''))
-        ELSE lower(hm.marker_kind)
-      END AS row_series_key
-    FROM public.health_markers hm
-    WHERE hm.user_id = p_user_id
+      hmd.series_id,
+      hmd.is_blood_pressure,
+      hm.recorded_at,
+      hm.value_numeric,
+      hm.systolic_numeric,
+      hm.diastolic_numeric
+    FROM health_marker_defs hmd
+    INNER JOIN public.health_markers hm
+      ON hm.user_id = p_user_id
       AND hm.recorded_at >= p_from
       AND hm.recorded_at <= p_to
       AND (
         hm.marker_kind <> 'custom'
         OR nullif(trim(hm.custom_name), '') IS NOT NULL
       )
+      AND (
+        CASE
+          WHEN hm.marker_kind = 'custom' THEN
+            lower(hm.marker_kind) || '::' || lower(nullif(trim(hm.custom_name), ''))
+          ELSE lower(hm.marker_kind)
+        END
+      ) = hmd.marker_series_key
   ),
   blood_pressure_buckets AS (
     SELECT
-      hmd.series_id,
+      hmm.series_id,
       date_trunc(p_bucket, hmm.recorded_at) AS bucket_start,
       NULL::numeric AS value_avg,
       NULL::numeric AS value_min,
@@ -100,15 +212,13 @@ BEGIN
       avg(hmm.systolic_numeric) AS systolic_avg,
       avg(hmm.diastolic_numeric) AS diastolic_avg,
       NULL::bigint AS event_count
-    FROM health_marker_defs hmd
-    INNER JOIN health_marker_match hmm
-      ON hmm.row_series_key = hmd.marker_series_key
-    WHERE hmd.is_blood_pressure
-    GROUP BY hmd.series_id, date_trunc(p_bucket, hmm.recorded_at)
+    FROM health_marker_match hmm
+    WHERE hmm.is_blood_pressure
+    GROUP BY hmm.series_id, date_trunc(p_bucket, hmm.recorded_at)
   ),
   numeric_health_marker_buckets AS (
     SELECT
-      hmd.series_id,
+      hmm.series_id,
       date_trunc(p_bucket, hmm.recorded_at) AS bucket_start,
       avg(hmm.value_numeric) AS value_avg,
       min(hmm.value_numeric) AS value_min,
@@ -116,13 +226,10 @@ BEGIN
       NULL::numeric AS systolic_avg,
       NULL::numeric AS diastolic_avg,
       NULL::bigint AS event_count
-    FROM health_marker_defs hmd
-    INNER JOIN health_marker_match hmm
-      ON hmm.row_series_key = hmd.marker_series_key
-    WHERE NOT hmd.is_blood_pressure
-      AND hmd.response_type = 'numeric'
+    FROM health_marker_match hmm
+    WHERE NOT hmm.is_blood_pressure
       AND hmm.value_numeric IS NOT NULL
-    GROUP BY hmd.series_id, date_trunc(p_bucket, hmm.recorded_at)
+    GROUP BY hmm.series_id, date_trunc(p_bucket, hmm.recorded_at)
   ),
   symptom_boolean_buckets AS (
     SELECT
@@ -176,7 +283,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) IS
-'Returns pre-bucketed chart series for p_user_id and selected manifest series (health markers and symptoms). Validates p_bucket (day|week|month), p_series length (1–3), and p_from <= p_to. Severity series: value_avg/min/max ignore NULL response_severity; event_count is total severity_scale rows in the bucket (symptom logging frequency per PRD §9). SECURITY INVOKER: RLS on health_markers and episode_symptoms applies.';
+'Returns pre-bucketed chart series for p_user_id and selected manifest series (health markers and symptoms). Validates p_bucket (day|week|month), p_series shape (1–3 unique manifest-aligned series objects), and p_from <= p_to. Severity series: value_avg/min/max ignore NULL response_severity; event_count is total severity_scale rows in the bucket (symptom logging frequency per PRD §9). SECURITY INVOKER: RLS on health_markers and episode_symptoms applies.';
 
 REVOKE ALL ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) TO authenticated;

--- a/supabase/migrations/20260522120000_chart_series_rpc.sql
+++ b/supabase/migrations/20260522120000_chart_series_rpc.sql
@@ -17,18 +17,44 @@ RETURNS TABLE (
   diastolic_avg numeric,
   event_count bigint
 )
-LANGUAGE sql
+LANGUAGE plpgsql
 SECURITY INVOKER
 STABLE
 SET search_path = pg_catalog, public
 AS $$
+DECLARE
+  series_count int;
+BEGIN
+  IF p_bucket NOT IN ('day', 'week', 'month') THEN
+    RAISE EXCEPTION 'get_chart_series: p_bucket must be day, week, or month'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF jsonb_typeof(p_series) IS DISTINCT FROM 'array' THEN
+    RAISE EXCEPTION 'get_chart_series: p_series must be a JSON array'
+      USING ERRCODE = '22023';
+  END IF;
+
+  series_count := jsonb_array_length(p_series);
+
+  IF series_count < 1 OR series_count > 3 THEN
+    RAISE EXCEPTION 'get_chart_series: p_series must contain 1 to 3 series'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_from > p_to THEN
+    RAISE EXCEPTION 'get_chart_series: p_from must be less than or equal to p_to'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
   WITH series_defs AS (
     SELECT
       elem->>'series_id' AS series_id,
       elem->>'series_type' AS series_type,
       elem->>'response_type' AS response_type,
       COALESCE((elem->>'is_blood_pressure')::boolean, false) AS is_blood_pressure
-    FROM jsonb_array_elements(COALESCE(p_series, '[]'::jsonb)) AS elem
+    FROM jsonb_array_elements(p_series) AS elem
   ),
   health_marker_defs AS (
     SELECT
@@ -135,6 +161,7 @@ AS $$
       AND es.created_at <= p_to
       AND lower(nullif(trim(es.symptom_name), '')) = sd.symptom_series_key
       AND es.response_type = 'severity_scale'
+      AND es.response_severity IS NOT NULL
     WHERE sd.response_type = 'severity'
     GROUP BY sd.series_id, date_trunc(p_bucket, es.created_at)
   )
@@ -146,10 +173,11 @@ AS $$
   UNION ALL
   SELECT * FROM symptom_severity_buckets
   ORDER BY 1, 2;
+END;
 $$;
 
 COMMENT ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) IS
-'Returns pre-bucketed chart series for p_user_id and selected manifest series (health markers and symptoms). SECURITY INVOKER: RLS on health_markers and episode_symptoms applies.';
+'Returns pre-bucketed chart series for p_user_id and selected manifest series (health markers and symptoms). Validates p_bucket (day|week|month), p_series length (1–3), and p_from <= p_to. SECURITY INVOKER: RLS on health_markers and episode_symptoms applies.';
 
 REVOKE ALL ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) TO authenticated;

--- a/supabase/migrations/20260522120000_chart_series_rpc.sql
+++ b/supabase/migrations/20260522120000_chart_series_rpc.sql
@@ -1,0 +1,155 @@
+-- Chart builder time-series: pre-bucketed aggregates for 1–3 selected series (SECURITY INVOKER).
+
+CREATE OR REPLACE FUNCTION public.get_chart_series (
+  p_user_id uuid,
+  p_series jsonb,
+  p_from timestamptz,
+  p_to timestamptz,
+  p_bucket text
+)
+RETURNS TABLE (
+  series_id text,
+  bucket_start timestamptz,
+  value_avg numeric,
+  value_min numeric,
+  value_max numeric,
+  systolic_avg numeric,
+  diastolic_avg numeric,
+  event_count bigint
+)
+LANGUAGE sql
+SECURITY INVOKER
+STABLE
+SET search_path = pg_catalog, public
+AS $$
+  WITH series_defs AS (
+    SELECT
+      elem->>'series_id' AS series_id,
+      elem->>'series_type' AS series_type,
+      elem->>'response_type' AS response_type,
+      COALESCE((elem->>'is_blood_pressure')::boolean, false) AS is_blood_pressure
+    FROM jsonb_array_elements(COALESCE(p_series, '[]'::jsonb)) AS elem
+  ),
+  health_marker_defs AS (
+    SELECT
+      sd.series_id,
+      sd.response_type,
+      sd.is_blood_pressure,
+      regexp_replace(sd.series_id, '^health_marker::', '') AS marker_series_key
+    FROM series_defs sd
+    WHERE sd.series_type = 'health_marker'
+  ),
+  symptom_defs AS (
+    SELECT
+      sd.series_id,
+      sd.response_type,
+      split_part(regexp_replace(sd.series_id, '^symptom::', ''), '::', 1) AS symptom_series_key
+    FROM series_defs sd
+    WHERE sd.series_type = 'symptom'
+  ),
+  health_marker_match AS (
+    SELECT
+      hm.*,
+      CASE
+        WHEN hm.marker_kind = 'custom' THEN
+          lower(hm.marker_kind) || '::' || lower(nullif(trim(hm.custom_name), ''))
+        ELSE lower(hm.marker_kind)
+      END AS row_series_key
+    FROM public.health_markers hm
+    WHERE hm.user_id = p_user_id
+      AND hm.recorded_at >= p_from
+      AND hm.recorded_at <= p_to
+      AND (
+        hm.marker_kind <> 'custom'
+        OR nullif(trim(hm.custom_name), '') IS NOT NULL
+      )
+  ),
+  blood_pressure_buckets AS (
+    SELECT
+      hmd.series_id,
+      date_trunc(p_bucket, hmm.recorded_at) AS bucket_start,
+      NULL::numeric AS value_avg,
+      NULL::numeric AS value_min,
+      NULL::numeric AS value_max,
+      avg(hmm.systolic_numeric) AS systolic_avg,
+      avg(hmm.diastolic_numeric) AS diastolic_avg,
+      NULL::bigint AS event_count
+    FROM health_marker_defs hmd
+    INNER JOIN health_marker_match hmm
+      ON hmm.row_series_key = hmd.marker_series_key
+    WHERE hmd.is_blood_pressure
+    GROUP BY hmd.series_id, date_trunc(p_bucket, hmm.recorded_at)
+  ),
+  numeric_health_marker_buckets AS (
+    SELECT
+      hmd.series_id,
+      date_trunc(p_bucket, hmm.recorded_at) AS bucket_start,
+      avg(hmm.value_numeric) AS value_avg,
+      min(hmm.value_numeric) AS value_min,
+      max(hmm.value_numeric) AS value_max,
+      NULL::numeric AS systolic_avg,
+      NULL::numeric AS diastolic_avg,
+      NULL::bigint AS event_count
+    FROM health_marker_defs hmd
+    INNER JOIN health_marker_match hmm
+      ON hmm.row_series_key = hmd.marker_series_key
+    WHERE NOT hmd.is_blood_pressure
+      AND hmd.response_type = 'numeric'
+      AND hmm.value_numeric IS NOT NULL
+    GROUP BY hmd.series_id, date_trunc(p_bucket, hmm.recorded_at)
+  ),
+  symptom_boolean_buckets AS (
+    SELECT
+      sd.series_id,
+      date_trunc(p_bucket, es.created_at) AS bucket_start,
+      NULL::numeric AS value_avg,
+      NULL::numeric AS value_min,
+      NULL::numeric AS value_max,
+      NULL::numeric AS systolic_avg,
+      NULL::numeric AS diastolic_avg,
+      count(*) FILTER (WHERE es.response_boolean IS TRUE)::bigint AS event_count
+    FROM symptom_defs sd
+    INNER JOIN public.episode_symptoms es
+      ON es.user_id = p_user_id
+      AND es.created_at >= p_from
+      AND es.created_at <= p_to
+      AND lower(nullif(trim(es.symptom_name), '')) = sd.symptom_series_key
+      AND es.response_type = 'yes_no'
+    WHERE sd.response_type = 'boolean'
+    GROUP BY sd.series_id, date_trunc(p_bucket, es.created_at)
+  ),
+  symptom_severity_buckets AS (
+    SELECT
+      sd.series_id,
+      date_trunc(p_bucket, es.created_at) AS bucket_start,
+      avg(es.response_severity) AS value_avg,
+      min(es.response_severity) AS value_min,
+      max(es.response_severity) AS value_max,
+      NULL::numeric AS systolic_avg,
+      NULL::numeric AS diastolic_avg,
+      count(*)::bigint AS event_count
+    FROM symptom_defs sd
+    INNER JOIN public.episode_symptoms es
+      ON es.user_id = p_user_id
+      AND es.created_at >= p_from
+      AND es.created_at <= p_to
+      AND lower(nullif(trim(es.symptom_name), '')) = sd.symptom_series_key
+      AND es.response_type = 'severity_scale'
+    WHERE sd.response_type = 'severity'
+    GROUP BY sd.series_id, date_trunc(p_bucket, es.created_at)
+  )
+  SELECT * FROM blood_pressure_buckets
+  UNION ALL
+  SELECT * FROM numeric_health_marker_buckets
+  UNION ALL
+  SELECT * FROM symptom_boolean_buckets
+  UNION ALL
+  SELECT * FROM symptom_severity_buckets
+  ORDER BY 1, 2;
+$$;
+
+COMMENT ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) IS
+'Returns pre-bucketed chart series for p_user_id and selected manifest series (health markers and symptoms). SECURITY INVOKER: RLS on health_markers and episode_symptoms applies.';
+
+REVOKE ALL ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) TO authenticated;

--- a/supabase/migrations/20260522120000_chart_series_rpc.sql
+++ b/supabase/migrations/20260522120000_chart_series_rpc.sql
@@ -161,7 +161,6 @@ BEGIN
       AND es.created_at <= p_to
       AND lower(nullif(trim(es.symptom_name), '')) = sd.symptom_series_key
       AND es.response_type = 'severity_scale'
-      AND es.response_severity IS NOT NULL
     WHERE sd.response_type = 'severity'
     GROUP BY sd.series_id, date_trunc(p_bucket, es.created_at)
   )
@@ -177,7 +176,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) IS
-'Returns pre-bucketed chart series for p_user_id and selected manifest series (health markers and symptoms). Validates p_bucket (day|week|month), p_series length (1–3), and p_from <= p_to. SECURITY INVOKER: RLS on health_markers and episode_symptoms applies.';
+'Returns pre-bucketed chart series for p_user_id and selected manifest series (health markers and symptoms). Validates p_bucket (day|week|month), p_series length (1–3), and p_from <= p_to. Severity series: value_avg/min/max ignore NULL response_severity; event_count is total severity_scale rows in the bucket (symptom logging frequency per PRD §9). SECURITY INVOKER: RLS on health_markers and episode_symptoms applies.';
 
 REVOKE ALL ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text) TO authenticated;


### PR DESCRIPTION
Closes #170

## Summary

Adds `get_chart_series`, a `SECURITY INVOKER` Postgres RPC that returns pre-bucketed time-series data for 1–3 user-selected chart series (health markers and symptoms), so the chart builder does not download raw observation history. Includes a `@abstrack/supabase` client helper (`getChartSeries`) and unit tests that mock the RPC and assert return shapes for blood pressure, numeric, and boolean series.

## Changes

- **Migration** `20260522120000_chart_series_rpc.sql`: `get_chart_series(p_user_id, p_series, p_from, p_to, p_bucket)` unions bucketed aggregates for:
  - Blood pressure (`systolic_avg` / `diastolic_avg`)
  - Numeric health markers (`value_avg` / `value_min` / `value_max`)
  - Boolean symptoms (`event_count` = true responses only)
  - Severity symptoms (`value_*` + `event_count` = total observations)
- **`packages/supabase`**: `chart-series-data.ts`, exports, and `chart-series-data.spec.ts`
- Temporary `rpcGetChartSeries` shim until `database.types.ts` is regenerated after cloud push

## Deploy / types (Sarah)

After review, from repo root:

```bash
pnpm dlx supabase db push
pnpm dlx supabase gen types typescript --linked --schema public > packages/supabase/src/lib/database.types.ts
pnpm exec prettier --write packages/supabase/src/lib/database.types.ts