### PR TITLE
feat(ui): add shared InsightSeriesPicker for chart builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,18 +49,23 @@ jobs:
 
       # Prepend any command with "nx record --" to record its logs to Nx Cloud
       # - run: pnpm exec nx record -- echo Hello World
-      - name: Lint and typecheck
-        run: pnpm exec nx run-many -t lint typecheck
+      - name: Packages (lint, typecheck)
+        run: pnpm exec nx run-many -t lint typecheck --projects "packages/*"
 
-      # Tests for all projects except @abstrack/supabase — keeps SUPABASE_SECRET_KEY out of this step.
-      - name: Test (excluding @abstrack/supabase)
-        run: pnpm exec nx run-many -t test --exclude=@abstrack/supabase
+      - name: Packages (test)
+        run: pnpm exec nx run-many -t test --projects "packages/*" --exclude=@abstrack/supabase
 
       # Secret only for preset RLS integration tests; not visible to other actions/steps.
-      - name: Test @abstrack/supabase
+      - name: Packages (test @abstrack/supabase)
         env:
           SUPABASE_SECRET_KEY: ${{ secrets.SUPABASE_SECRET_KEY }}
         run: pnpm exec nx test @abstrack/supabase
+
+      - name: Apps (lint, typecheck)
+        run: pnpm exec nx run-many -t lint typecheck --exclude=@abstrack/types,@abstrack/ui,@abstrack/supabase,@abstrack/powersync
+
+      - name: Apps (test)
+        run: pnpm exec nx run-many -t test --exclude=@abstrack/supabase,@abstrack/types,@abstrack/ui,@abstrack/powersync
       - run: pnpm exec nx run-many -t build --exclude=@abstrack/mobile
 
       - name: Install Playwright (Chromium — @a11y tests run on Chromium only)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,10 +50,10 @@ jobs:
       # Prepend any command with "nx record --" to record its logs to Nx Cloud
       # - run: pnpm exec nx record -- echo Hello World
       - name: Packages (lint, typecheck)
-        run: pnpm exec nx run-many -t lint typecheck --projects "packages/*"
+        run: pnpm exec nx run-many -t lint typecheck -p @abstrack/types,@abstrack/ui,@abstrack/supabase,@abstrack/powersync
 
       - name: Packages (test)
-        run: pnpm exec nx run-many -t test --projects "packages/*" --exclude=@abstrack/supabase
+        run: pnpm exec nx run-many -t test -p @abstrack/types,@abstrack/ui,@abstrack/powersync --exclude=@abstrack/supabase
 
       # Secret only for preset RLS integration tests; not visible to other actions/steps.
       - name: Packages (test @abstrack/supabase)

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "supabase:test": "nx test @abstrack/supabase",
     "supabase:typecheck": "nx run @abstrack/supabase:typecheck",
     "supabase:validate": "nx run-many -t lint test typecheck -p @abstrack/supabase",
+    "packages:validate": "nx run-many -t lint test typecheck --projects \"packages/*\"",
     "lint": "nx run-many -t lint",
     "test": "nx run-many -t test",
     "build": "nx run-many -t build -p web,practitioner && pnpm mobile:typecheck && pnpm supabase:typecheck",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "supabase:test": "nx test @abstrack/supabase",
     "supabase:typecheck": "nx run @abstrack/supabase:typecheck",
     "supabase:validate": "nx run-many -t lint test typecheck -p @abstrack/supabase",
-    "packages:validate": "nx run-many -t lint test typecheck --projects \"packages/*\"",
+    "packages:validate": "nx run-many -t lint test typecheck -p @abstrack/types,@abstrack/ui,@abstrack/supabase,@abstrack/powersync",
     "lint": "nx run-many -t lint",
     "test": "nx run-many -t test",
     "build": "nx run-many -t build -p web,practitioner && pnpm mobile:typecheck && pnpm supabase:typecheck",

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -10,3 +10,10 @@ export { Dialog as Modal } from './lib/Dialog.js';
 export * from './lib/NavigationShell.js';
 export * from './lib/hooks/index.js';
 export * from './lib/styles/theme.js';
+export {
+  InsightSeriesPicker,
+  type ChartManifestRow,
+  type ChartTypeChoice,
+  type InsightSeriesPickerProps,
+  type SelectedSeries,
+} from './lib/InsightSeriesPicker.js';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,6 +12,11 @@ export * from './lib/hooks/index.js';
 export * from './lib/styles/theme.js';
 export {
   InsightSeriesPicker,
+  filterChartableManifestRows,
+  isChartableManifestRow,
+  type ChartableManifestRow,
+  type ChartableResponseType,
+  type ChartManifestResponseType,
   type ChartManifestRow,
   type ChartTypeChoice,
   type InsightSeriesPickerProps,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -12,11 +12,6 @@ export * from './lib/hooks/index.js';
 export * from './lib/styles/theme.js';
 export {
   InsightSeriesPicker,
-  filterChartableManifestRows,
-  isChartableManifestRow,
-  type ChartableManifestRow,
-  type ChartableResponseType,
-  type ChartManifestResponseType,
   type ChartManifestRow,
   type ChartTypeChoice,
   type InsightSeriesPickerProps,

--- a/packages/ui/src/lib/Button.tsx
+++ b/packages/ui/src/lib/Button.tsx
@@ -180,11 +180,11 @@ export function Button({
       disabled={disabled}
       onPress={onPress}
       onFocus={(e) => {
-        onFocus(e);
+        onFocus();
         onFocusProp?.(e);
       }}
       onBlur={(e) => {
-        onBlur(e);
+        onBlur();
         onBlurProp?.(e);
       }}
       style={(state) => {

--- a/packages/ui/src/lib/Input.tsx
+++ b/packages/ui/src/lib/Input.tsx
@@ -101,11 +101,11 @@ export function Input({
           : {})}
         placeholderTextColor={rest.placeholderTextColor ?? palette.mutedText}
         onFocus={(e) => {
-          onFocus(e);
+          onFocus();
           onFocusProp?.(e);
         }}
         onBlur={(e) => {
-          onBlur(e);
+          onBlur();
           onBlurProp?.(e);
         }}
         style={[

--- a/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
@@ -482,6 +482,40 @@ describe('InsightSeriesPicker', () => {
     ).toBe(false);
   });
 
+  it('calls onChange on mount when the controlled value exceeds three series', () => {
+    const onChange = vi.fn();
+    const seriesAt = (row: ChartableManifestRow, slotIndex: number) => {
+      const series = createSelectedSeriesFromManifestRow(row, slotIndex);
+      if (!series) {
+        throw new Error(`Expected chartable fixture for ${row.series_id}`);
+      }
+      return series;
+    };
+    const oversizedValue: SelectedSeries[] = [
+      seriesAt(glucoseRow, 0),
+      seriesAt(severityRow, 1),
+      seriesAt(booleanRow, 2),
+      { ...seriesAt(glucoseRow, 0), seriesId: 'orphan-4', label: 'Orphan' },
+    ];
+
+    render(
+      <InsightSeriesPicker
+        manifest={manifest}
+        value={oversizedValue}
+        onChange={onChange}
+      />,
+    );
+
+    expect(onChange).toHaveBeenCalledTimes(1);
+    const clamped = onChange.mock.calls[0]?.[0] as SelectedSeries[];
+    expect(clamped).toHaveLength(3);
+    expect(clamped.map((series) => series.seriesId)).toEqual([
+      glucoseRow.series_id,
+      severityRow.series_id,
+      booleanRow.series_id,
+    ]);
+  });
+
   it('clamps onChange to three series when chart type changes with an oversized value', () => {
     const onChange = vi.fn();
     const seriesAt = (row: ChartableManifestRow, slotIndex: number) => {

--- a/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
@@ -38,6 +38,7 @@ const severityRow: ChartManifestRow = {
   label: 'Brain fog',
   response_type: 'severity',
   is_blood_pressure: false,
+  unit: null,
   ...baseManifestFields,
 };
 
@@ -47,10 +48,27 @@ const booleanRow: ChartManifestRow = {
   label: 'Vomiting',
   response_type: 'boolean',
   is_blood_pressure: false,
+  unit: null,
   ...baseManifestFields,
 };
 
-const manifest = [bloodPressureRow, glucoseRow, severityRow, booleanRow];
+const textNotesRow: ChartManifestRow = {
+  series_id: 'health_marker::custom::notes',
+  series_type: 'health_marker',
+  label: 'Daily notes',
+  response_type: 'text',
+  is_blood_pressure: false,
+  unit: null,
+  ...baseManifestFields,
+};
+
+const manifest = [
+  bloodPressureRow,
+  glucoseRow,
+  severityRow,
+  booleanRow,
+  textNotesRow,
+];
 
 function ControlledPicker({
   initial = [] as SelectedSeries[],
@@ -183,7 +201,7 @@ describe('InsightSeriesPicker', () => {
       },
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Remove series 1' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Clear series 1' }));
 
     expect(
       screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
@@ -211,7 +229,7 @@ describe('InsightSeriesPicker', () => {
       },
     );
 
-    fireEvent.click(screen.getByRole('button', { name: 'Remove series 1' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Clear series 1' }));
 
     expect(
       screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
@@ -257,6 +275,21 @@ describe('InsightSeriesPicker', () => {
     expect(
       screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
     ).toHaveLength(3);
+  });
+
+  it('omits non-chartable text manifest rows from the series selector', () => {
+    render(<ControlledPicker />);
+
+    const options = within(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+    ).getAllByRole('option');
+
+    expect(options.map((option) => option.textContent)).not.toContain(
+      'Daily notes',
+    );
+    expect(
+      options.some((option) => option.textContent?.includes('Daily notes')),
+    ).toBe(false);
   });
 
   it('assigns palette colors by slot index', () => {

--- a/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
@@ -87,14 +87,18 @@ function ControlledPicker({
 
 describe('InsightSeriesPicker', () => {
   it('auto-selects bp_band and hides the chart-type dropdown for blood pressure', () => {
-    const onChange = vi.fn();
-    render(
-      <InsightSeriesPicker
-        manifest={manifest}
-        value={[]}
-        onChange={onChange}
-      />,
+    render(<ControlledPicker />);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      {
+        target: { value: glucoseRow.series_id },
+      },
     );
+
+    expect(
+      screen.getByLabelText('Chart type for series 1', { selector: 'select' }),
+    ).toBeInTheDocument();
 
     fireEvent.change(
       screen.getByLabelText('Data series 1', { selector: 'select' }),
@@ -103,19 +107,49 @@ describe('InsightSeriesPicker', () => {
       },
     );
 
+    expect(screen.getByText(/Series 1: Blood pressure/)).toBeInTheDocument();
     expect(
       screen.queryByLabelText('Chart type for series 1', {
         selector: 'select',
       }),
     ).not.toBeInTheDocument();
-    expect(onChange).toHaveBeenCalledWith([
-      expect.objectContaining({
-        seriesId: bloodPressureRow.series_id,
-        chartType: 'bp_band',
-        isBloodPressure: true,
-        color: '#1d4ed8',
-      }),
-    ]);
+  });
+
+  it('hides extra slots when the parent clears value externally', () => {
+    function ExternalResetPicker() {
+      const [value, setValue] = useState<SelectedSeries[]>([]);
+      return (
+        <>
+          <button type="button" onClick={() => setValue([])}>
+            Reset selection
+          </button>
+          <InsightSeriesPicker
+            manifest={manifest}
+            value={value}
+            onChange={setValue}
+          />
+        </>
+      );
+    }
+
+    render(<ExternalResetPicker />);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      {
+        target: { value: glucoseRow.series_id },
+      },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Reset selection' }));
+
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(1);
   });
 
   it('shows only slot 1 until Add another series reveals slot 2', () => {

--- a/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
@@ -2,9 +2,13 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { useState } from 'react';
 import {
   InsightSeriesPicker,
-  type ChartManifestRow,
   type SelectedSeries,
 } from './InsightSeriesPicker.js';
+import type {
+  ChartableManifestRow,
+  ChartManifestRow,
+} from './InsightSeriesPicker.types.js';
+import { createSelectedSeriesFromManifestRow } from './insight-series-picker-utils.js';
 
 const baseManifestFields = {
   observation_count: 5,
@@ -22,7 +26,7 @@ const bloodPressureRow: ChartManifestRow = {
   ...baseManifestFields,
 };
 
-const glucoseRow: ChartManifestRow = {
+const glucoseRow: ChartableManifestRow = {
   series_id: 'glucose-1',
   series_type: 'health_marker',
   label: 'Blood glucose',
@@ -32,7 +36,7 @@ const glucoseRow: ChartManifestRow = {
   ...baseManifestFields,
 };
 
-const severityRow: ChartManifestRow = {
+const severityRow: ChartableManifestRow = {
   series_id: 'symptom-1',
   series_type: 'symptom',
   label: 'Brain fog',
@@ -42,7 +46,7 @@ const severityRow: ChartManifestRow = {
   ...baseManifestFields,
 };
 
-const booleanRow: ChartManifestRow = {
+const booleanRow: ChartableManifestRow = {
   series_id: 'symptom-2',
   series_type: 'symptom',
   label: 'Vomiting',
@@ -72,22 +76,28 @@ const manifest = [
 
 function ControlledPicker({
   initial = [] as SelectedSeries[],
+  onChangeSpy,
 }: {
   initial?: SelectedSeries[];
+  onChangeSpy?: (series: SelectedSeries[]) => void;
 }) {
   const [value, setValue] = useState(initial);
   return (
     <InsightSeriesPicker
       manifest={manifest}
       value={value}
-      onChange={setValue}
+      onChange={(next) => {
+        onChangeSpy?.(next);
+        setValue(next);
+      }}
     />
   );
 }
 
 describe('InsightSeriesPicker', () => {
   it('auto-selects bp_band and hides the chart-type dropdown for blood pressure', () => {
-    render(<ControlledPicker />);
+    const onChangeSpy = vi.fn();
+    render(<ControlledPicker onChangeSpy={onChangeSpy} />);
 
     fireEvent.change(
       screen.getByLabelText('Data series 1', { selector: 'select' }),
@@ -99,6 +109,12 @@ describe('InsightSeriesPicker', () => {
     expect(
       screen.getByLabelText('Chart type for series 1', { selector: 'select' }),
     ).toBeInTheDocument();
+    expect(onChangeSpy).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        seriesId: glucoseRow.series_id,
+        chartType: 'line',
+      }),
+    ]);
 
     fireEvent.change(
       screen.getByLabelText('Data series 1', { selector: 'select' }),
@@ -113,6 +129,13 @@ describe('InsightSeriesPicker', () => {
         selector: 'select',
       }),
     ).not.toBeInTheDocument();
+    expect(onChangeSpy).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        seriesId: bloodPressureRow.series_id,
+        chartType: 'bp_band',
+        isBloodPressure: true,
+      }),
+    ]);
   });
 
   it('hides extra slots when the parent clears value externally', () => {
@@ -209,7 +232,8 @@ describe('InsightSeriesPicker', () => {
   });
 
   it('auto-selects event and hides chart-type for boolean series', () => {
-    render(<ControlledPicker />);
+    const onChangeSpy = vi.fn();
+    render(<ControlledPicker onChangeSpy={onChangeSpy} />);
 
     fireEvent.change(
       screen.getByLabelText('Data series 1', { selector: 'select' }),
@@ -223,6 +247,13 @@ describe('InsightSeriesPicker', () => {
         selector: 'select',
       }),
     ).not.toBeInTheDocument();
+    expect(onChangeSpy).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        seriesId: booleanRow.series_id,
+        chartType: 'event',
+        responseType: 'boolean',
+      }),
+    ]);
   });
 
   it('clears slot 1 on remove but keeps the slot visible', () => {
@@ -243,6 +274,37 @@ describe('InsightSeriesPicker', () => {
     expect(
       screen.getByLabelText('Data series 1', { selector: 'select' }),
     ).toHaveValue('');
+  });
+
+  it('preserves later slots when an earlier slot series changes', () => {
+    const onChangeSpy = vi.fn();
+    render(<ControlledPicker onChangeSpy={onChangeSpy} />);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      { target: { value: glucoseRow.series_id } },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+    fireEvent.change(
+      screen.getByLabelText('Data series 2', { selector: 'select' }),
+      { target: { value: severityRow.series_id } },
+    );
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      { target: { value: bloodPressureRow.series_id } },
+    );
+
+    expect(onChangeSpy).toHaveBeenLastCalledWith([
+      expect.objectContaining({
+        seriesId: bloodPressureRow.series_id,
+        chartType: 'bp_band',
+      }),
+      expect.objectContaining({ seriesId: severityRow.series_id }),
+    ]);
+    expect(
+      screen.getByLabelText('Data series 2', { selector: 'select' }),
+    ).toHaveValue(severityRow.series_id);
   });
 
   it('removes later slots when an earlier slot is cleared', () => {
@@ -324,6 +386,46 @@ describe('InsightSeriesPicker', () => {
     expect(
       options.some((option) => option.textContent?.includes('Daily notes')),
     ).toBe(false);
+  });
+
+  it('clamps onChange to three series when chart type changes with an oversized value', () => {
+    const onChange = vi.fn();
+    const seriesAt = (row: ChartableManifestRow, slotIndex: number) => {
+      const series = createSelectedSeriesFromManifestRow(row, slotIndex);
+      if (!series) {
+        throw new Error(`Expected chartable fixture for ${row.series_id}`);
+      }
+      return series;
+    };
+    const oversizedValue: SelectedSeries[] = [
+      seriesAt(glucoseRow, 0),
+      seriesAt(severityRow, 1),
+      seriesAt(booleanRow, 2),
+      { ...seriesAt(glucoseRow, 0), seriesId: 'orphan-4', label: 'Orphan' },
+    ];
+
+    render(
+      <InsightSeriesPicker
+        manifest={manifest}
+        value={oversizedValue}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByLabelText('Chart type for series 1', { selector: 'select' }),
+      { target: { value: 'bar' } },
+    );
+
+    const lastCall = onChange.mock.calls.at(-1)?.[0] as SelectedSeries[];
+    expect(lastCall).toHaveLength(3);
+    expect(lastCall[0]).toMatchObject({
+      seriesId: glucoseRow.series_id,
+      chartType: 'bar',
+    });
+    expect(lastCall.some((series) => series.seriesId === 'orphan-4')).toBe(
+      false,
+    );
   });
 
   it('assigns palette colors by slot index', () => {

--- a/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
@@ -335,6 +335,100 @@ describe('InsightSeriesPicker', () => {
     ).not.toBeInTheDocument();
   });
 
+  it('reveals slot 3 with one Add after clearing it via the empty series option', () => {
+    const onChangeSpy = vi.fn();
+    render(<ControlledPicker onChangeSpy={onChangeSpy} />);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      { target: { value: glucoseRow.series_id } },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+    fireEvent.change(
+      screen.getByLabelText('Data series 2', { selector: 'select' }),
+      { target: { value: severityRow.series_id } },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+    fireEvent.change(
+      screen.getByLabelText('Data series 3', { selector: 'select' }),
+      { target: { value: booleanRow.series_id } },
+    );
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 3', { selector: 'select' }),
+      {
+        target: { value: '' },
+      },
+    );
+
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(2);
+    expect(onChangeSpy).toHaveBeenLastCalledWith([
+      expect.objectContaining({ seriesId: glucoseRow.series_id }),
+      expect.objectContaining({ seriesId: severityRow.series_id }),
+    ]);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(3);
+    expect(
+      screen.getByLabelText('Data series 3', { selector: 'select' }),
+    ).toHaveValue('');
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 3', { selector: 'select' }),
+      {
+        target: { value: booleanRow.series_id },
+      },
+    );
+
+    expect(onChangeSpy).toHaveBeenLastCalledWith([
+      expect.objectContaining({ seriesId: glucoseRow.series_id }),
+      expect.objectContaining({ seriesId: severityRow.series_id }),
+      expect.objectContaining({
+        seriesId: booleanRow.series_id,
+        chartType: 'event',
+      }),
+    ]);
+  });
+
+  it('reveals slot 3 with one Add after removing it via Remove series 3', () => {
+    render(<ControlledPicker />);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      { target: { value: glucoseRow.series_id } },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+    fireEvent.change(
+      screen.getByLabelText('Data series 2', { selector: 'select' }),
+      { target: { value: severityRow.series_id } },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+    fireEvent.change(
+      screen.getByLabelText('Data series 3', { selector: 'select' }),
+      { target: { value: booleanRow.series_id } },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove series 3' }));
+
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(3);
+    expect(
+      screen.getByLabelText('Data series 3', { selector: 'select' }),
+    ).toHaveValue('');
+  });
+
   it('enforces a maximum of three series', () => {
     render(<ControlledPicker />);
 

--- a/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
@@ -1,0 +1,287 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { useState } from 'react';
+import {
+  InsightSeriesPicker,
+  type ChartManifestRow,
+  type SelectedSeries,
+} from './InsightSeriesPicker.js';
+
+const baseManifestFields = {
+  observation_count: 5,
+  first_observed_at: '2026-01-01T00:00:00Z',
+  last_observed_at: '2026-02-01T00:00:00Z',
+};
+
+const bloodPressureRow: ChartManifestRow = {
+  series_id: 'bp-1',
+  series_type: 'health_marker',
+  label: 'Blood pressure',
+  response_type: 'numeric',
+  is_blood_pressure: true,
+  unit: 'mmHg',
+  ...baseManifestFields,
+};
+
+const glucoseRow: ChartManifestRow = {
+  series_id: 'glucose-1',
+  series_type: 'health_marker',
+  label: 'Blood glucose',
+  response_type: 'numeric',
+  is_blood_pressure: false,
+  unit: 'mmol/L',
+  ...baseManifestFields,
+};
+
+const severityRow: ChartManifestRow = {
+  series_id: 'symptom-1',
+  series_type: 'symptom',
+  label: 'Brain fog',
+  response_type: 'severity',
+  is_blood_pressure: false,
+  ...baseManifestFields,
+};
+
+const booleanRow: ChartManifestRow = {
+  series_id: 'symptom-2',
+  series_type: 'symptom',
+  label: 'Vomiting',
+  response_type: 'boolean',
+  is_blood_pressure: false,
+  ...baseManifestFields,
+};
+
+const manifest = [bloodPressureRow, glucoseRow, severityRow, booleanRow];
+
+function ControlledPicker({
+  initial = [] as SelectedSeries[],
+}: {
+  initial?: SelectedSeries[];
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <InsightSeriesPicker
+      manifest={manifest}
+      value={value}
+      onChange={setValue}
+    />
+  );
+}
+
+describe('InsightSeriesPicker', () => {
+  it('auto-selects bp_band and hides the chart-type dropdown for blood pressure', () => {
+    const onChange = vi.fn();
+    render(
+      <InsightSeriesPicker
+        manifest={manifest}
+        value={[]}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      {
+        target: { value: bloodPressureRow.series_id },
+      },
+    );
+
+    expect(
+      screen.queryByLabelText('Chart type for series 1', {
+        selector: 'select',
+      }),
+    ).not.toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        seriesId: bloodPressureRow.series_id,
+        chartType: 'bp_band',
+        isBloodPressure: true,
+        color: '#1d4ed8',
+      }),
+    ]);
+  });
+
+  it('shows only slot 1 until Add another series reveals slot 2', () => {
+    render(<ControlledPicker />);
+
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(1);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      {
+        target: { value: glucoseRow.series_id },
+      },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(2);
+  });
+
+  it('constrains chart-type options by response_type', () => {
+    render(<ControlledPicker />);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      {
+        target: { value: glucoseRow.series_id },
+      },
+    );
+
+    const chartTypeSelect = screen.getByLabelText('Chart type for series 1', {
+      selector: 'select',
+    });
+    const options = within(chartTypeSelect)
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+
+    expect(options).toEqual(['Line', 'Bar', 'Scatter']);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      {
+        target: { value: severityRow.series_id },
+      },
+    );
+
+    const severityOptions = within(
+      screen.getByLabelText('Chart type for series 1', { selector: 'select' }),
+    )
+      .getAllByRole('option')
+      .map((option) => option.textContent);
+
+    expect(severityOptions).toEqual(['Line', 'Bar']);
+  });
+
+  it('auto-selects event and hides chart-type for boolean series', () => {
+    render(<ControlledPicker />);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      {
+        target: { value: booleanRow.series_id },
+      },
+    );
+
+    expect(
+      screen.queryByLabelText('Chart type for series 1', {
+        selector: 'select',
+      }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('clears slot 1 on remove but keeps the slot visible', () => {
+    render(<ControlledPicker />);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      {
+        target: { value: glucoseRow.series_id },
+      },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove series 1' }));
+
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(1);
+    expect(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+    ).toHaveValue('');
+  });
+
+  it('removes later slots when an earlier slot is cleared', () => {
+    render(<ControlledPicker />);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      {
+        target: { value: glucoseRow.series_id },
+      },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 2', { selector: 'select' }),
+      {
+        target: { value: severityRow.series_id },
+      },
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove series 1' }));
+
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(1);
+    expect(
+      screen.queryByRole('button', { name: 'Add another series' }),
+    ).not.toBeInTheDocument();
+  });
+
+  it('enforces a maximum of three series', () => {
+    render(<ControlledPicker />);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      {
+        target: { value: glucoseRow.series_id },
+      },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 2', { selector: 'select' }),
+      {
+        target: { value: severityRow.series_id },
+      },
+    );
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(3);
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 3', { selector: 'select' }),
+      {
+        target: { value: booleanRow.series_id },
+      },
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Add another series' }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.getAllByLabelText(/Data series \d/, { selector: 'select' }),
+    ).toHaveLength(3);
+  });
+
+  it('assigns palette colors by slot index', () => {
+    const onChange = vi.fn();
+    render(
+      <InsightSeriesPicker
+        manifest={manifest}
+        value={[]}
+        onChange={onChange}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+      {
+        target: { value: glucoseRow.series_id },
+      },
+    );
+
+    expect(onChange).toHaveBeenCalledWith([
+      expect.objectContaining({
+        seriesId: glucoseRow.series_id,
+        chartType: 'line',
+        color: '#1d4ed8',
+      }),
+    ]);
+  });
+});

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -18,27 +18,11 @@ import type {
 } from './InsightSeriesPicker.types.js';
 
 export type {
-  ChartableManifestRow,
-  ChartableResponseType,
-  ChartManifestResponseType,
   ChartManifestRow,
   ChartTypeChoice,
   InsightSeriesPickerProps,
   SelectedSeries,
 } from './InsightSeriesPicker.types.js';
-
-export {
-  INSIGHT_SERIES_SLOT_COLORS,
-  canAddAnotherSeries,
-  chartTypeChoiceLabel,
-  computeVisibleSlotCount,
-  createSelectedSeriesFromManifestRow,
-  defaultChartTypeForManifestRow,
-  filterChartableManifestRows,
-  getChartTypeChoicesForManifestRow,
-  isChartableManifestRow,
-  isChartTypeSelectorHidden,
-} from './insight-series-picker-utils.js';
 
 const MAX_SERIES_SLOTS = 3;
 
@@ -165,9 +149,15 @@ export function InsightSeriesPicker({
   );
 
   useEffect(() => {
-    setRevealedSlotCount((current) =>
-      Math.max(current, Math.min(MAX_SERIES_SLOTS, Math.max(1, value.length))),
-    );
+    setRevealedSlotCount((current) => {
+      const nextUnfilledCap =
+        value.length === 0 ? 1 : Math.min(MAX_SERIES_SLOTS, value.length + 1);
+      const minForFilled = Math.max(1, value.length);
+      return Math.min(
+        MAX_SERIES_SLOTS,
+        Math.max(minForFilled, Math.min(current, nextUnfilledCap)),
+      );
+    });
   }, [value.length]);
 
   const visibleSlotCount = computeVisibleSlotCount(value, revealedSlotCount);

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -1,22 +1,26 @@
 'use client';
 
-import { useEffect, useId, useState, type CSSProperties } from 'react';
+import { useEffect, useId, useMemo, useState, type CSSProperties } from 'react';
 import {
   canAddAnotherSeries,
   chartTypeChoiceLabel,
   computeVisibleSlotCount,
   createSelectedSeriesFromManifestRow,
+  filterChartableManifestRows,
   getChartTypeChoicesForManifestRow,
   isChartTypeSelectorHidden,
 } from './insight-series-picker-utils.js';
 import type {
-  ChartManifestRow,
+  ChartableManifestRow,
   ChartTypeChoice,
   InsightSeriesPickerProps,
   SelectedSeries,
 } from './InsightSeriesPicker.types.js';
 
 export type {
+  ChartableManifestRow,
+  ChartableResponseType,
+  ChartManifestResponseType,
   ChartManifestRow,
   ChartTypeChoice,
   InsightSeriesPickerProps,
@@ -30,7 +34,9 @@ export {
   computeVisibleSlotCount,
   createSelectedSeriesFromManifestRow,
   defaultChartTypeForManifestRow,
+  filterChartableManifestRows,
   getChartTypeChoicesForManifestRow,
+  isChartableManifestRow,
   isChartTypeSelectorHidden,
 } from './insight-series-picker-utils.js';
 
@@ -104,17 +110,31 @@ const colorSwatchStyles = (color: string): CSSProperties => ({
 });
 
 function findManifestRow(
-  manifest: ChartManifestRow[],
+  manifest: ChartableManifestRow[],
   seriesId: string,
-): ChartManifestRow | undefined {
+): ChartableManifestRow | undefined {
   return manifest.find((row) => row.series_id === seriesId);
 }
 
+/**
+ * Accessible label for the slot remove/clear control.
+ * Slot 1 clears in place; slots 2–3 remove the slot from view.
+ *
+ * @param slotIndex - Zero-based slot index (0–2).
+ * @returns Button text matching the action.
+ */
+function seriesSlotActionLabel(slotIndex: number): string {
+  if (slotIndex === 0) {
+    return 'Clear series 1';
+  }
+  return `Remove series ${slotIndex + 1}`;
+}
+
 function optionsForSlot(
-  manifest: ChartManifestRow[],
+  manifest: ChartableManifestRow[],
   value: SelectedSeries[],
   slotIndex: number,
-): ChartManifestRow[] {
+): ChartableManifestRow[] {
   const selectedElsewhere = new Set(
     value
       .filter((_, index) => index !== slotIndex)
@@ -135,6 +155,10 @@ export function InsightSeriesPicker({
   value,
   onChange,
 }: InsightSeriesPickerProps) {
+  const chartableManifest = useMemo(
+    () => filterChartableManifestRows(manifest),
+    [manifest],
+  );
   const baseId = useId().replace(/:/g, '');
   const [revealedSlotCount, setRevealedSlotCount] = useState(() =>
     Math.min(MAX_SERIES_SLOTS, Math.max(1, value.length)),
@@ -160,13 +184,18 @@ export function InsightSeriesPicker({
       return;
     }
 
-    const row = findManifestRow(manifest, seriesId);
+    const row = findManifestRow(chartableManifest, seriesId);
     if (!row) {
       return;
     }
 
+    const selected = createSelectedSeriesFromManifestRow(row, slotIndex);
+    if (!selected) {
+      return;
+    }
+
     const next = value.slice(0, slotIndex);
-    next[slotIndex] = createSelectedSeriesFromManifestRow(row, slotIndex);
+    next[slotIndex] = selected;
     onChange(next.slice(0, MAX_SERIES_SLOTS));
   };
 
@@ -178,16 +207,21 @@ export function InsightSeriesPicker({
     if (!current) {
       return;
     }
-    const row = findManifestRow(manifest, current.seriesId);
+    const row = findManifestRow(chartableManifest, current.seriesId);
     if (!row) {
       return;
     }
-    const next = [...value];
-    next[slotIndex] = createSelectedSeriesFromManifestRow(
+    const selected = createSelectedSeriesFromManifestRow(
       row,
       slotIndex,
       chartType,
     );
+    if (!selected) {
+      return;
+    }
+
+    const next = [...value];
+    next[slotIndex] = selected;
     onChange(next);
   };
 
@@ -206,11 +240,15 @@ export function InsightSeriesPicker({
         {Array.from({ length: visibleSlotCount }, (_, slotIndex) => {
           const selected = value[slotIndex];
           const row = selected
-            ? findManifestRow(manifest, selected.seriesId)
+            ? findManifestRow(chartableManifest, selected.seriesId)
             : undefined;
           const seriesSelectId = `${baseId}-series-${slotIndex}`;
           const chartTypeSelectId = `${baseId}-chart-type-${slotIndex}`;
-          const slotOptions = optionsForSlot(manifest, value, slotIndex);
+          const slotOptions = optionsForSlot(
+            chartableManifest,
+            value,
+            slotIndex,
+          );
           const chartTypeHidden = row ? isChartTypeSelectorHidden(row) : true;
 
           return (
@@ -297,9 +335,7 @@ export function InsightSeriesPicker({
                 style={removeButtonStyles}
                 onClick={() => handleRemove(slotIndex)}
               >
-                {selected
-                  ? `Remove series ${slotIndex + 1}`
-                  : `Clear series ${slotIndex + 1}`}
+                {seriesSlotActionLabel(slotIndex)}
               </button>
             </div>
           );

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -142,11 +142,11 @@ function PickerSelect({
         ...styles.focusRing(focused),
       }}
       onFocus={(event) => {
-        onFocusRing(event as never);
+        onFocusRing();
         onFocus?.(event);
       }}
       onBlur={(event) => {
-        onBlurRing(event as never);
+        onBlurRing();
         onBlur?.(event);
       }}
     />
@@ -172,11 +172,11 @@ function PickerButton({
         ...styles.focusRing(focused),
       }}
       onFocus={(event) => {
-        onFocusRing(event as never);
+        onFocusRing();
         onFocus?.(event);
       }}
       onBlur={(event) => {
-        onBlurRing(event as never);
+        onBlurRing();
         onBlur?.(event);
       }}
     />
@@ -243,6 +243,13 @@ export function InsightSeriesPicker({
     () => filterChartableManifestRows(manifest),
     [manifest],
   );
+
+  useEffect(() => {
+    if (value.length > MAX_SERIES_SLOTS) {
+      onChange(clampSeriesValue(value));
+    }
+  }, [value, onChange]);
+
   const baseId = useId().replace(/:/g, '');
   const [revealedSlotCount, setRevealedSlotCount] = useState(() =>
     Math.min(MAX_SERIES_SLOTS, Math.max(1, seriesValue.length)),

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -181,7 +181,7 @@ export function InsightSeriesPicker({
   const handleSeriesChange = (slotIndex: number, seriesId: string) => {
     if (!seriesId) {
       onChange(clampSeriesValue(seriesValue.slice(0, slotIndex)));
-      setRevealedSlotCount(1);
+      setRevealedSlotCount(Math.max(1, slotIndex));
       return;
     }
 

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -1,6 +1,20 @@
 'use client';
 
-import { useEffect, useId, useMemo, useState, type CSSProperties } from 'react';
+import {
+  useEffect,
+  useId,
+  useMemo,
+  useState,
+  type CSSProperties,
+  type SelectHTMLAttributes,
+  type ButtonHTMLAttributes,
+} from 'react';
+import { useFocusRing } from './hooks/useFocusRing.js';
+import {
+  defaultPalette,
+  highContrastPalette,
+  type UiPalette,
+} from './styles/theme.js';
 import {
   canAddAnotherSeries,
   chartTypeChoiceLabel,
@@ -26,72 +40,148 @@ export type {
   SelectedSeries,
 } from './InsightSeriesPicker.types.js';
 
-const fieldStyles: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 6,
-};
+function insightSeriesPickerStyles(palette: UiPalette) {
+  const field: CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 6,
+  };
 
-const labelStyles: CSSProperties = {
-  fontSize: 16,
-  fontWeight: 600,
-};
+  const label: CSSProperties = {
+    fontSize: 16,
+    fontWeight: 600,
+    color: palette.text,
+  };
 
-const selectStyles: CSSProperties = {
-  minHeight: 44,
-  fontSize: 16,
-  padding: '8px 12px',
-  borderRadius: 8,
-  border: '1px solid #d4d4d4',
-};
+  const select: CSSProperties = {
+    minHeight: 44,
+    fontSize: 16,
+    padding: '8px 12px',
+    borderRadius: 8,
+    border: `1px solid ${palette.border}`,
+    backgroundColor: palette.surface,
+    color: palette.text,
+  };
 
-const slotStyles: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 12,
-  padding: 12,
-  border: '1px solid #d4d4d4',
-  borderRadius: 8,
-};
+  const slot: CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 12,
+    padding: 12,
+    border: `1px solid ${palette.border}`,
+    borderRadius: 8,
+    backgroundColor: palette.surface,
+  };
 
-const rootStyles: CSSProperties = {
-  display: 'flex',
-  flexDirection: 'column',
-  gap: 16,
-};
+  const root: CSSProperties = {
+    display: 'flex',
+    flexDirection: 'column',
+    gap: 16,
+    color: palette.text,
+  };
 
-const addButtonStyles: CSSProperties = {
-  alignSelf: 'flex-start',
-  minHeight: 44,
-  minWidth: 44,
-  padding: '8px 16px',
-  fontSize: 16,
-  borderRadius: 8,
-  border: '1px solid #d4d4d4',
-  background: '#ffffff',
-  cursor: 'pointer',
-};
+  const secondaryButton: CSSProperties = {
+    alignSelf: 'flex-start',
+    minHeight: 44,
+    minWidth: 44,
+    padding: '8px 16px',
+    fontSize: 16,
+    borderRadius: 8,
+    border: `1px solid ${palette.border}`,
+    backgroundColor: palette.surface,
+    color: palette.text,
+    cursor: 'pointer',
+  };
 
-const removeButtonStyles: CSSProperties = {
-  alignSelf: 'flex-start',
-  minHeight: 44,
-  minWidth: 44,
-  padding: '8px 16px',
-  fontSize: 16,
-  borderRadius: 8,
-  border: '1px solid #d4d4d4',
-  background: '#ffffff',
-  cursor: 'pointer',
-};
+  const colorSwatch = (color: string): CSSProperties => ({
+    width: 16,
+    height: 16,
+    borderRadius: 4,
+    backgroundColor: color,
+    border: `1px solid ${palette.mutedText}`,
+    flexShrink: 0,
+  });
 
-const colorSwatchStyles = (color: string): CSSProperties => ({
-  width: 16,
-  height: 16,
-  borderRadius: 4,
-  backgroundColor: color,
-  border: '1px solid #525252',
-  flexShrink: 0,
-});
+  const focusRing = (focused: boolean): CSSProperties =>
+    focused
+      ? {
+          outline: '2px solid',
+          outlineColor: palette.focusRing,
+          outlineOffset: 2,
+        }
+      : {};
+
+  return {
+    field,
+    label,
+    select,
+    slot,
+    root,
+    secondaryButton,
+    colorSwatch,
+    focusRing,
+  };
+}
+
+function PickerSelect({
+  palette,
+  style,
+  onFocus,
+  onBlur,
+  ...rest
+}: SelectHTMLAttributes<HTMLSelectElement> & { palette: UiPalette }) {
+  const { focused, onFocus: onFocusRing, onBlur: onBlurRing } = useFocusRing();
+  const styles = insightSeriesPickerStyles(palette);
+
+  return (
+    <select
+      {...rest}
+      style={{
+        ...styles.select,
+        ...style,
+        ...styles.focusRing(focused),
+      }}
+      onFocus={(event) => {
+        onFocusRing(event as never);
+        onFocus?.(event);
+      }}
+      onBlur={(event) => {
+        onBlurRing(event as never);
+        onBlur?.(event);
+      }}
+    />
+  );
+}
+
+function PickerButton({
+  palette,
+  style,
+  onFocus,
+  onBlur,
+  ...rest
+}: ButtonHTMLAttributes<HTMLButtonElement> & { palette: UiPalette }) {
+  const { focused, onFocus: onFocusRing, onBlur: onBlurRing } = useFocusRing();
+  const styles = insightSeriesPickerStyles(palette);
+
+  return (
+    <button
+      {...rest}
+      style={{
+        ...styles.secondaryButton,
+        ...style,
+        ...styles.focusRing(focused),
+      }}
+      onFocus={(event) => {
+        onFocusRing(event as never);
+        onFocus?.(event);
+      }}
+      onBlur={(event) => {
+        onBlurRing(event as never);
+        onBlur?.(event);
+      }}
+    />
+  );
+}
 
 function findManifestRow(
   manifest: ChartableManifestRow[],
@@ -143,7 +233,11 @@ export function InsightSeriesPicker({
   manifest,
   value,
   onChange,
+  highContrast = false,
 }: InsightSeriesPickerProps) {
+  const palette = highContrast ? highContrastPalette : defaultPalette;
+  const styles = useMemo(() => insightSeriesPickerStyles(palette), [palette]);
+
   const seriesValue = useMemo(() => clampSeriesValue(value), [value]);
   const chartableManifest = useMemo(
     () => filterChartableManifestRows(manifest),
@@ -234,9 +328,9 @@ export function InsightSeriesPicker({
   };
 
   return (
-    <div style={rootStyles}>
+    <div style={styles.root}>
       <fieldset style={{ border: 'none', margin: 0, padding: 0 }}>
-        <legend style={{ ...labelStyles, marginBottom: 8 }}>
+        <legend style={{ ...styles.label, marginBottom: 8 }}>
           Chart series
         </legend>
 
@@ -257,7 +351,7 @@ export function InsightSeriesPicker({
           return (
             <div
               key={slotIndex}
-              style={{ ...slotStyles, marginBottom: 12 }}
+              style={{ ...styles.slot, marginBottom: 12 }}
               role="group"
               aria-labelledby={`${baseId}-slot-${slotIndex}-legend`}
             >
@@ -274,7 +368,7 @@ export function InsightSeriesPicker({
                 {selected ? (
                   <>
                     <span
-                      style={colorSwatchStyles(selected.color)}
+                      style={styles.colorSwatch(selected.color)}
                       aria-hidden
                     />
                     <span>
@@ -286,13 +380,13 @@ export function InsightSeriesPicker({
                 )}
               </div>
 
-              <div style={fieldStyles}>
-                <label htmlFor={seriesSelectId} style={labelStyles}>
+              <div style={styles.field}>
+                <label htmlFor={seriesSelectId} style={styles.label}>
                   {`Data series ${slotIndex + 1}`}
                 </label>
-                <select
+                <PickerSelect
+                  palette={palette}
                   id={seriesSelectId}
-                  style={selectStyles}
                   value={selected?.seriesId ?? ''}
                   onChange={(event) =>
                     handleSeriesChange(slotIndex, event.target.value)
@@ -305,17 +399,17 @@ export function InsightSeriesPicker({
                       {option.unit ? ` (${option.unit})` : ''}
                     </option>
                   ))}
-                </select>
+                </PickerSelect>
               </div>
 
               {!chartTypeHidden && row ? (
-                <div style={fieldStyles}>
-                  <label htmlFor={chartTypeSelectId} style={labelStyles}>
+                <div style={styles.field}>
+                  <label htmlFor={chartTypeSelectId} style={styles.label}>
                     {`Chart type for series ${slotIndex + 1}`}
                   </label>
-                  <select
+                  <PickerSelect
+                    palette={palette}
                     id={chartTypeSelectId}
-                    style={selectStyles}
                     value={selected?.chartType ?? ''}
                     onChange={(event) =>
                       handleChartTypeChange(
@@ -329,30 +423,30 @@ export function InsightSeriesPicker({
                         {chartTypeChoiceLabel(choice)}
                       </option>
                     ))}
-                  </select>
+                  </PickerSelect>
                 </div>
               ) : null}
 
-              <button
+              <PickerButton
                 type="button"
-                style={removeButtonStyles}
+                palette={palette}
                 onClick={() => handleRemove(slotIndex)}
               >
                 {seriesSlotActionLabel(slotIndex)}
-              </button>
+              </PickerButton>
             </div>
           );
         })}
       </fieldset>
 
       {showAddAnother ? (
-        <button
+        <PickerButton
           type="button"
-          style={addButtonStyles}
+          palette={palette}
           onClick={handleAddAnother}
         >
           Add another series
-        </button>
+        </PickerButton>
       ) : null}
     </div>
   );

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -9,6 +9,8 @@ import {
   filterChartableManifestRows,
   getChartTypeChoicesForManifestRow,
   isChartTypeSelectorHidden,
+  MAX_SERIES_SLOTS,
+  mergeSeriesSelectionAtSlot,
 } from './insight-series-picker-utils.js';
 import type {
   ChartableManifestRow,
@@ -23,8 +25,6 @@ export type {
   InsightSeriesPickerProps,
   SelectedSeries,
 } from './InsightSeriesPicker.types.js';
-
-const MAX_SERIES_SLOTS = 3;
 
 const fieldStyles: CSSProperties = {
   display: 'flex',
@@ -114,6 +114,11 @@ function seriesSlotActionLabel(slotIndex: number): string {
   return `Remove series ${slotIndex + 1}`;
 }
 
+/** Enforces the chart builder maximum of three selected series. */
+function clampSeriesValue(value: SelectedSeries[]): SelectedSeries[] {
+  return value.slice(0, MAX_SERIES_SLOTS);
+}
+
 function optionsForSlot(
   manifest: ChartableManifestRow[],
   value: SelectedSeries[],
@@ -139,29 +144,35 @@ export function InsightSeriesPicker({
   value,
   onChange,
 }: InsightSeriesPickerProps) {
+  const seriesValue = useMemo(() => clampSeriesValue(value), [value]);
   const chartableManifest = useMemo(
     () => filterChartableManifestRows(manifest),
     [manifest],
   );
   const baseId = useId().replace(/:/g, '');
   const [revealedSlotCount, setRevealedSlotCount] = useState(() =>
-    Math.min(MAX_SERIES_SLOTS, Math.max(1, value.length)),
+    Math.min(MAX_SERIES_SLOTS, Math.max(1, seriesValue.length)),
   );
 
   useEffect(() => {
     setRevealedSlotCount((current) => {
       const nextUnfilledCap =
-        value.length === 0 ? 1 : Math.min(MAX_SERIES_SLOTS, value.length + 1);
-      const minForFilled = Math.max(1, value.length);
+        seriesValue.length === 0
+          ? 1
+          : Math.min(MAX_SERIES_SLOTS, seriesValue.length + 1);
+      const minForFilled = Math.max(1, seriesValue.length);
       return Math.min(
         MAX_SERIES_SLOTS,
         Math.max(minForFilled, Math.min(current, nextUnfilledCap)),
       );
     });
-  }, [value.length]);
+  }, [seriesValue.length]);
 
-  const visibleSlotCount = computeVisibleSlotCount(value, revealedSlotCount);
-  const showAddAnother = canAddAnotherSeries(value, visibleSlotCount);
+  const visibleSlotCount = computeVisibleSlotCount(
+    seriesValue,
+    revealedSlotCount,
+  );
+  const showAddAnother = canAddAnotherSeries(seriesValue, visibleSlotCount);
 
   const handleAddAnother = () => {
     setRevealedSlotCount((current) => Math.min(MAX_SERIES_SLOTS, current + 1));
@@ -169,7 +180,7 @@ export function InsightSeriesPicker({
 
   const handleSeriesChange = (slotIndex: number, seriesId: string) => {
     if (!seriesId) {
-      onChange(value.slice(0, slotIndex));
+      onChange(clampSeriesValue(seriesValue.slice(0, slotIndex)));
       setRevealedSlotCount(1);
       return;
     }
@@ -184,16 +195,18 @@ export function InsightSeriesPicker({
       return;
     }
 
-    const next = value.slice(0, slotIndex);
-    next[slotIndex] = selected;
-    onChange(next.slice(0, MAX_SERIES_SLOTS));
+    onChange(
+      clampSeriesValue(
+        mergeSeriesSelectionAtSlot(seriesValue, slotIndex, selected),
+      ),
+    );
   };
 
   const handleChartTypeChange = (
     slotIndex: number,
     chartType: ChartTypeChoice,
   ) => {
-    const current = value[slotIndex];
+    const current = seriesValue[slotIndex];
     if (!current) {
       return;
     }
@@ -210,13 +223,13 @@ export function InsightSeriesPicker({
       return;
     }
 
-    const next = [...value];
+    const next = seriesValue.slice();
     next[slotIndex] = selected;
-    onChange(next);
+    onChange(clampSeriesValue(next));
   };
 
   const handleRemove = (slotIndex: number) => {
-    onChange(value.slice(0, slotIndex));
+    onChange(clampSeriesValue(seriesValue.slice(0, slotIndex)));
     setRevealedSlotCount(Math.max(1, slotIndex));
   };
 
@@ -228,7 +241,7 @@ export function InsightSeriesPicker({
         </legend>
 
         {Array.from({ length: visibleSlotCount }, (_, slotIndex) => {
-          const selected = value[slotIndex];
+          const selected = seriesValue[slotIndex];
           const row = selected
             ? findManifestRow(chartableManifest, selected.seriesId)
             : undefined;
@@ -236,7 +249,7 @@ export function InsightSeriesPicker({
           const chartTypeSelectId = `${baseId}-chart-type-${slotIndex}`;
           const slotOptions = optionsForSlot(
             chartableManifest,
-            value,
+            seriesValue,
             slotIndex,
           );
           const chartTypeHidden = row ? isChartTypeSelectorHidden(row) : true;

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -1,0 +1,320 @@
+'use client';
+
+import { useEffect, useId, useState, type CSSProperties } from 'react';
+import {
+  canAddAnotherSeries,
+  chartTypeChoiceLabel,
+  computeVisibleSlotCount,
+  createSelectedSeriesFromManifestRow,
+  getChartTypeChoicesForManifestRow,
+  isChartTypeSelectorHidden,
+} from './insight-series-picker-utils.js';
+import type {
+  ChartManifestRow,
+  ChartTypeChoice,
+  InsightSeriesPickerProps,
+  SelectedSeries,
+} from './InsightSeriesPicker.types.js';
+
+export type {
+  ChartManifestRow,
+  ChartTypeChoice,
+  InsightSeriesPickerProps,
+  SelectedSeries,
+} from './InsightSeriesPicker.types.js';
+
+export {
+  INSIGHT_SERIES_SLOT_COLORS,
+  canAddAnotherSeries,
+  chartTypeChoiceLabel,
+  computeVisibleSlotCount,
+  createSelectedSeriesFromManifestRow,
+  defaultChartTypeForManifestRow,
+  getChartTypeChoicesForManifestRow,
+  isChartTypeSelectorHidden,
+} from './insight-series-picker-utils.js';
+
+const MAX_SERIES_SLOTS = 3;
+
+const fieldStyles: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 6,
+};
+
+const labelStyles: CSSProperties = {
+  fontSize: 16,
+  fontWeight: 600,
+};
+
+const selectStyles: CSSProperties = {
+  minHeight: 44,
+  fontSize: 16,
+  padding: '8px 12px',
+  borderRadius: 8,
+  border: '1px solid #d4d4d4',
+};
+
+const slotStyles: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 12,
+  padding: 12,
+  border: '1px solid #d4d4d4',
+  borderRadius: 8,
+};
+
+const rootStyles: CSSProperties = {
+  display: 'flex',
+  flexDirection: 'column',
+  gap: 16,
+};
+
+const addButtonStyles: CSSProperties = {
+  alignSelf: 'flex-start',
+  minHeight: 44,
+  minWidth: 44,
+  padding: '8px 16px',
+  fontSize: 16,
+  borderRadius: 8,
+  border: '1px solid #d4d4d4',
+  background: '#ffffff',
+  cursor: 'pointer',
+};
+
+const removeButtonStyles: CSSProperties = {
+  alignSelf: 'flex-start',
+  minHeight: 44,
+  minWidth: 44,
+  padding: '8px 16px',
+  fontSize: 16,
+  borderRadius: 8,
+  border: '1px solid #d4d4d4',
+  background: '#ffffff',
+  cursor: 'pointer',
+};
+
+const colorSwatchStyles = (color: string): CSSProperties => ({
+  width: 16,
+  height: 16,
+  borderRadius: 4,
+  backgroundColor: color,
+  border: '1px solid #525252',
+  flexShrink: 0,
+});
+
+function findManifestRow(
+  manifest: ChartManifestRow[],
+  seriesId: string,
+): ChartManifestRow | undefined {
+  return manifest.find((row) => row.series_id === seriesId);
+}
+
+function optionsForSlot(
+  manifest: ChartManifestRow[],
+  value: SelectedSeries[],
+  slotIndex: number,
+): ChartManifestRow[] {
+  const selectedElsewhere = new Set(
+    value
+      .filter((_, index) => index !== slotIndex)
+      .map((series) => series.seriesId),
+  );
+  return manifest.filter((row) => !selectedElsewhere.has(row.series_id));
+}
+
+/**
+ * Series and chart-type picker for the insight chart builder (web only).
+ * Supports up to three series with progressive slot disclosure.
+ *
+ * @param props - Manifest rows, selected series, and change handler.
+ * @returns Accessible form controls for series selection.
+ */
+export function InsightSeriesPicker({
+  manifest,
+  value,
+  onChange,
+}: InsightSeriesPickerProps) {
+  const baseId = useId().replace(/:/g, '');
+  const [revealedSlotCount, setRevealedSlotCount] = useState(() =>
+    Math.min(MAX_SERIES_SLOTS, Math.max(1, value.length)),
+  );
+
+  useEffect(() => {
+    setRevealedSlotCount((current) =>
+      Math.max(current, Math.min(MAX_SERIES_SLOTS, Math.max(1, value.length))),
+    );
+  }, [value.length]);
+
+  const visibleSlotCount = computeVisibleSlotCount(value, revealedSlotCount);
+  const showAddAnother = canAddAnotherSeries(value, visibleSlotCount);
+
+  const handleAddAnother = () => {
+    setRevealedSlotCount((current) => Math.min(MAX_SERIES_SLOTS, current + 1));
+  };
+
+  const handleSeriesChange = (slotIndex: number, seriesId: string) => {
+    if (!seriesId) {
+      onChange(value.slice(0, slotIndex));
+      setRevealedSlotCount(1);
+      return;
+    }
+
+    const row = findManifestRow(manifest, seriesId);
+    if (!row) {
+      return;
+    }
+
+    const next = value.slice(0, slotIndex);
+    next[slotIndex] = createSelectedSeriesFromManifestRow(row, slotIndex);
+    onChange(next.slice(0, MAX_SERIES_SLOTS));
+  };
+
+  const handleChartTypeChange = (
+    slotIndex: number,
+    chartType: ChartTypeChoice,
+  ) => {
+    const current = value[slotIndex];
+    if (!current) {
+      return;
+    }
+    const row = findManifestRow(manifest, current.seriesId);
+    if (!row) {
+      return;
+    }
+    const next = [...value];
+    next[slotIndex] = createSelectedSeriesFromManifestRow(
+      row,
+      slotIndex,
+      chartType,
+    );
+    onChange(next);
+  };
+
+  const handleRemove = (slotIndex: number) => {
+    onChange(value.slice(0, slotIndex));
+    setRevealedSlotCount(Math.max(1, slotIndex));
+  };
+
+  return (
+    <div style={rootStyles}>
+      <fieldset style={{ border: 'none', margin: 0, padding: 0 }}>
+        <legend style={{ ...labelStyles, marginBottom: 8 }}>
+          Chart series
+        </legend>
+
+        {Array.from({ length: visibleSlotCount }, (_, slotIndex) => {
+          const selected = value[slotIndex];
+          const row = selected
+            ? findManifestRow(manifest, selected.seriesId)
+            : undefined;
+          const seriesSelectId = `${baseId}-series-${slotIndex}`;
+          const chartTypeSelectId = `${baseId}-chart-type-${slotIndex}`;
+          const slotOptions = optionsForSlot(manifest, value, slotIndex);
+          const chartTypeHidden = row ? isChartTypeSelectorHidden(row) : true;
+
+          return (
+            <div
+              key={slotIndex}
+              style={{ ...slotStyles, marginBottom: 12 }}
+              role="group"
+              aria-labelledby={`${baseId}-slot-${slotIndex}-legend`}
+            >
+              <div
+                id={`${baseId}-slot-${slotIndex}-legend`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 8,
+                  fontWeight: 600,
+                  fontSize: 16,
+                }}
+              >
+                {selected ? (
+                  <>
+                    <span
+                      style={colorSwatchStyles(selected.color)}
+                      aria-hidden
+                    />
+                    <span>
+                      Series {slotIndex + 1}: {selected.label}
+                    </span>
+                  </>
+                ) : (
+                  <span>Series {slotIndex + 1}</span>
+                )}
+              </div>
+
+              <div style={fieldStyles}>
+                <label htmlFor={seriesSelectId} style={labelStyles}>
+                  {`Data series ${slotIndex + 1}`}
+                </label>
+                <select
+                  id={seriesSelectId}
+                  style={selectStyles}
+                  value={selected?.seriesId ?? ''}
+                  onChange={(event) =>
+                    handleSeriesChange(slotIndex, event.target.value)
+                  }
+                >
+                  <option value="">Select a series…</option>
+                  {slotOptions.map((option) => (
+                    <option key={option.series_id} value={option.series_id}>
+                      {option.label}
+                      {option.unit ? ` (${option.unit})` : ''}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              {!chartTypeHidden && row ? (
+                <div style={fieldStyles}>
+                  <label htmlFor={chartTypeSelectId} style={labelStyles}>
+                    {`Chart type for series ${slotIndex + 1}`}
+                  </label>
+                  <select
+                    id={chartTypeSelectId}
+                    style={selectStyles}
+                    value={selected?.chartType ?? ''}
+                    onChange={(event) =>
+                      handleChartTypeChange(
+                        slotIndex,
+                        event.target.value as ChartTypeChoice,
+                      )
+                    }
+                  >
+                    {getChartTypeChoicesForManifestRow(row).map((choice) => (
+                      <option key={choice} value={choice}>
+                        {chartTypeChoiceLabel(choice)}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+              ) : null}
+
+              <button
+                type="button"
+                style={removeButtonStyles}
+                onClick={() => handleRemove(slotIndex)}
+              >
+                {selected
+                  ? `Remove series ${slotIndex + 1}`
+                  : `Clear series ${slotIndex + 1}`}
+              </button>
+            </div>
+          );
+        })}
+      </fieldset>
+
+      {showAddAnother ? (
+        <button
+          type="button"
+          style={addButtonStyles}
+          onClick={handleAddAnother}
+        >
+          Add another series
+        </button>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/lib/InsightSeriesPicker.types.ts
+++ b/packages/ui/src/lib/InsightSeriesPicker.types.ts
@@ -42,7 +42,7 @@ export interface SelectedSeries {
   responseType: ChartableResponseType;
   isBloodPressure: boolean;
   label: string;
-  unit?: string | null;
+  unit: string | null;
   chartType: ChartTypeChoice;
   /** Assigned automatically from {@link INSIGHT_SERIES_SLOT_COLORS}; not user-configurable. */
   color: string;

--- a/packages/ui/src/lib/InsightSeriesPicker.types.ts
+++ b/packages/ui/src/lib/InsightSeriesPicker.types.ts
@@ -54,4 +54,6 @@ export interface InsightSeriesPickerProps {
   manifest: ChartManifestRow[];
   value: SelectedSeries[];
   onChange: (series: SelectedSeries[]) => void;
+  /** Stronger borders and text for high-contrast presentation. */
+  highContrast?: boolean;
 }

--- a/packages/ui/src/lib/InsightSeriesPicker.types.ts
+++ b/packages/ui/src/lib/InsightSeriesPicker.types.ts
@@ -1,0 +1,35 @@
+/** Chartable series metadata row from `get_user_chart_manifest`. */
+export interface ChartManifestRow {
+  series_id: string;
+  series_type: 'health_marker' | 'symptom';
+  label: string;
+  response_type: 'numeric' | 'boolean' | 'severity';
+  is_blood_pressure: boolean;
+  unit?: string;
+  observation_count: number;
+  first_observed_at: string;
+  last_observed_at: string;
+}
+
+/** Chart rendering mode for one selected series. */
+export type ChartTypeChoice = 'line' | 'bar' | 'scatter' | 'event' | 'bp_band';
+
+/** One series chosen in the chart builder with display metadata. */
+export interface SelectedSeries {
+  seriesId: string;
+  seriesType: 'health_marker' | 'symptom';
+  responseType: 'numeric' | 'boolean' | 'severity';
+  isBloodPressure: boolean;
+  label: string;
+  unit?: string;
+  chartType: ChartTypeChoice;
+  /** Assigned automatically from {@link INSIGHT_SERIES_SLOT_COLORS}; not user-configurable. */
+  color: string;
+}
+
+/** Props for {@link InsightSeriesPicker}. */
+export interface InsightSeriesPickerProps {
+  manifest: ChartManifestRow[];
+  value: SelectedSeries[];
+  onChange: (series: SelectedSeries[]) => void;
+}

--- a/packages/ui/src/lib/InsightSeriesPicker.types.ts
+++ b/packages/ui/src/lib/InsightSeriesPicker.types.ts
@@ -1,15 +1,36 @@
-/** Chartable series metadata row from `get_user_chart_manifest`. */
+/**
+ * `response_type` values returned by `get_user_chart_manifest`.
+ * Matches {@link UserChartManifestSeries} in `@abstrack/supabase`.
+ */
+export type ChartManifestResponseType =
+  | 'numeric'
+  | 'boolean'
+  | 'severity'
+  | 'text';
+
+/** Manifest row shape from `get_user_chart_manifest` (snake_case RPC fields). */
 export interface ChartManifestRow {
   series_id: string;
   series_type: 'health_marker' | 'symptom';
   label: string;
-  response_type: 'numeric' | 'boolean' | 'severity';
+  response_type: ChartManifestResponseType;
   is_blood_pressure: boolean;
-  unit?: string;
+  unit: string | null;
   observation_count: number;
   first_observed_at: string;
   last_observed_at: string;
 }
+
+/** Response types the chart builder can render (excludes e.g. `text`). */
+export type ChartableResponseType = Exclude<ChartManifestResponseType, 'text'>;
+
+/**
+ * Manifest row eligible for the series picker (at least one chart type applies).
+ * Narrow with {@link isChartableManifestRow}.
+ */
+export type ChartableManifestRow = ChartManifestRow & {
+  response_type: ChartableResponseType;
+};
 
 /** Chart rendering mode for one selected series. */
 export type ChartTypeChoice = 'line' | 'bar' | 'scatter' | 'event' | 'bp_band';
@@ -18,10 +39,10 @@ export type ChartTypeChoice = 'line' | 'bar' | 'scatter' | 'event' | 'bp_band';
 export interface SelectedSeries {
   seriesId: string;
   seriesType: 'health_marker' | 'symptom';
-  responseType: 'numeric' | 'boolean' | 'severity';
+  responseType: ChartableResponseType;
   isBloodPressure: boolean;
   label: string;
-  unit?: string;
+  unit?: string | null;
   chartType: ChartTypeChoice;
   /** Assigned automatically from {@link INSIGHT_SERIES_SLOT_COLORS}; not user-configurable. */
   color: string;
@@ -29,6 +50,7 @@ export interface SelectedSeries {
 
 /** Props for {@link InsightSeriesPicker}. */
 export interface InsightSeriesPickerProps {
+  /** Full RPC manifest; non-chartable rows (e.g. `text`) are omitted from the picker. */
   manifest: ChartManifestRow[];
   value: SelectedSeries[];
   onChange: (series: SelectedSeries[]) => void;

--- a/packages/ui/src/lib/TextArea.tsx
+++ b/packages/ui/src/lib/TextArea.tsx
@@ -109,11 +109,11 @@ export function TextArea({
         placeholderTextColor={rest.placeholderTextColor ?? palette.mutedText}
         textAlignVertical="top"
         onFocus={(e) => {
-          onFocus(e);
+          onFocus();
           onFocusProp?.(e);
         }}
         onBlur={(e) => {
-          onBlur(e);
+          onBlur();
           onBlurProp?.(e);
         }}
         style={[

--- a/packages/ui/src/lib/hooks/useFocusRing.spec.tsx
+++ b/packages/ui/src/lib/hooks/useFocusRing.spec.tsx
@@ -27,7 +27,7 @@ describe('useFocusRing', () => {
       );
     });
     act(() => {
-      result.current.onFocus({} as never);
+      result.current.onFocus();
     });
 
     expect(result.current.focused).toBe(true);
@@ -42,7 +42,7 @@ describe('useFocusRing', () => {
       );
     });
     act(() => {
-      result.current.onFocus({} as never);
+      result.current.onFocus();
     });
 
     expect(result.current.focused).toBe(false);
@@ -57,12 +57,12 @@ describe('useFocusRing', () => {
       );
     });
     act(() => {
-      result.current.onFocus({} as never);
+      result.current.onFocus();
     });
     expect(result.current.focused).toBe(true);
 
     act(() => {
-      result.current.onBlur({} as never);
+      result.current.onBlur();
     });
     expect(result.current.focused).toBe(false);
   });

--- a/packages/ui/src/lib/hooks/useFocusRing.ts
+++ b/packages/ui/src/lib/hooks/useFocusRing.ts
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
 import { Platform } from 'react-native';
-import type { NativeSyntheticEvent, TargetedEvent } from 'react-native';
 
 /**
  * True after a likely keyboard-navigation key until the next primary-pointer
@@ -78,11 +77,12 @@ function attachFocusVisibleModalityListeners(): () => void {
  * On native, focus ring state stays false (callers typically gate styles with `Platform.OS === 'web'`).
  *
  * @returns `focused` flag plus `onFocus` / `onBlur` handlers to spread onto a focusable view.
+ * Handlers take no arguments so they are safe to compose with web DOM and React Native focus events.
  */
 export function useFocusRing(): {
   focused: boolean;
-  onFocus: (e: NativeSyntheticEvent<TargetedEvent>) => void;
-  onBlur: (e: NativeSyntheticEvent<TargetedEvent>) => void;
+  onFocus: () => void;
+  onBlur: () => void;
 } {
   const [focused, setFocused] = useState(false);
 

--- a/packages/ui/src/lib/insight-series-picker-utils.spec.ts
+++ b/packages/ui/src/lib/insight-series-picker-utils.spec.ts
@@ -7,6 +7,8 @@ import {
   getChartTypeChoicesForManifestRow,
   isChartableManifestRow,
   isChartTypeSelectorHidden,
+  MAX_SERIES_SLOTS,
+  mergeSeriesSelectionAtSlot,
 } from './insight-series-picker-utils.js';
 import type {
   ChartableManifestRow,
@@ -39,6 +41,28 @@ const bpRow: ChartableManifestRow = {
   series_id: 'bp-1',
   label: 'Blood pressure',
   is_blood_pressure: true,
+};
+
+const glucoseRow: ChartableManifestRow = {
+  ...numericRow,
+  series_id: 'glucose-1',
+  label: 'Blood glucose',
+};
+
+const severityRow: ChartableManifestRow = {
+  ...numericRow,
+  series_id: 'symptom-1',
+  series_type: 'symptom',
+  label: 'Brain fog',
+  response_type: 'severity',
+};
+
+const booleanRow: ChartableManifestRow = {
+  ...numericRow,
+  series_id: 'symptom-2',
+  series_type: 'symptom',
+  label: 'Vomiting',
+  response_type: 'boolean',
 };
 
 /** Test helper: chartable fixtures must produce a selected series. */
@@ -110,12 +134,43 @@ describe('insight-series-picker-utils', () => {
 
   it('caps visible slots when value is cleared but revealed count stayed high', () => {
     expect(computeVisibleSlotCount([], 2)).toBe(1);
-    expect(computeVisibleSlotCount([], 3)).toBe(1);
+    expect(computeVisibleSlotCount([], MAX_SERIES_SLOTS)).toBe(1);
+  });
+
+  it('preserves distinct later slots when an earlier slot changes', () => {
+    const first = selectedFromRow(glucoseRow, 0);
+    const second = selectedFromRow(severityRow, 1);
+    const third = selectedFromRow(booleanRow, 2);
+
+    const merged = mergeSeriesSelectionAtSlot(
+      [first, second, third],
+      0,
+      selectedFromRow(bpRow, 0),
+    );
+
+    expect(merged).toHaveLength(3);
+    expect(merged[0]?.seriesId).toBe(bpRow.series_id);
+    expect(merged[1]?.seriesId).toBe(severityRow.series_id);
+    expect(merged[2]?.seriesId).toBe(booleanRow.series_id);
+  });
+
+  it('drops tail slots that duplicate an earlier selection after a change', () => {
+    const first = selectedFromRow(glucoseRow, 0);
+    const second = selectedFromRow(severityRow, 1);
+
+    const merged = mergeSeriesSelectionAtSlot(
+      [first, second],
+      0,
+      selectedFromRow(severityRow, 0),
+    );
+
+    expect(merged).toHaveLength(1);
+    expect(merged[0]?.seriesId).toBe(severityRow.series_id);
   });
 
   it('reports when another series can be added', () => {
     expect(canAddAnotherSeries([], 1)).toBe(false);
     expect(canAddAnotherSeries([selectedFromRow(numericRow)], 1)).toBe(true);
-    expect(canAddAnotherSeries([], 3)).toBe(false);
+    expect(canAddAnotherSeries([], MAX_SERIES_SLOTS)).toBe(false);
   });
 });

--- a/packages/ui/src/lib/insight-series-picker-utils.spec.ts
+++ b/packages/ui/src/lib/insight-series-picker-utils.spec.ts
@@ -1,0 +1,65 @@
+import {
+  canAddAnotherSeries,
+  computeVisibleSlotCount,
+  createSelectedSeriesFromManifestRow,
+  getChartTypeChoicesForManifestRow,
+  isChartTypeSelectorHidden,
+} from './insight-series-picker-utils.js';
+import type {
+  ChartManifestRow,
+  SelectedSeries,
+} from './InsightSeriesPicker.types.js';
+
+const numericRow: ChartManifestRow = {
+  series_id: 'n-1',
+  series_type: 'health_marker',
+  label: 'Weight',
+  response_type: 'numeric',
+  is_blood_pressure: false,
+  observation_count: 1,
+  first_observed_at: '2026-01-01',
+  last_observed_at: '2026-01-02',
+};
+
+const bpRow: ChartManifestRow = {
+  ...numericRow,
+  series_id: 'bp-1',
+  label: 'Blood pressure',
+  is_blood_pressure: true,
+};
+
+describe('insight-series-picker-utils', () => {
+  it('returns chart-type choices per manifest row', () => {
+    expect(getChartTypeChoicesForManifestRow(bpRow)).toEqual(['bp_band']);
+    expect(getChartTypeChoicesForManifestRow(numericRow)).toEqual([
+      'line',
+      'bar',
+      'scatter',
+    ]);
+  });
+
+  it('hides the chart-type selector when only one choice exists', () => {
+    expect(isChartTypeSelectorHidden(bpRow)).toBe(true);
+    expect(isChartTypeSelectorHidden(numericRow)).toBe(false);
+  });
+
+  it('computes visible slot counts from value and revealed slots', () => {
+    expect(computeVisibleSlotCount([], 1)).toBe(1);
+    expect(computeVisibleSlotCount([{} as SelectedSeries], 1)).toBe(1);
+    expect(computeVisibleSlotCount([{} as SelectedSeries], 2)).toBe(2);
+    expect(
+      computeVisibleSlotCount([{} as SelectedSeries, {} as SelectedSeries], 1),
+    ).toBe(2);
+  });
+
+  it('reports when another series can be added', () => {
+    expect(canAddAnotherSeries([], 1)).toBe(false);
+    expect(
+      canAddAnotherSeries(
+        [createSelectedSeriesFromManifestRow(numericRow, 0)],
+        1,
+      ),
+    ).toBe(true);
+    expect(canAddAnotherSeries([], 3)).toBe(false);
+  });
+});

--- a/packages/ui/src/lib/insight-series-picker-utils.spec.ts
+++ b/packages/ui/src/lib/insight-series-picker-utils.spec.ts
@@ -108,6 +108,11 @@ describe('insight-series-picker-utils', () => {
     ).toBe(2);
   });
 
+  it('caps visible slots when value is cleared but revealed count stayed high', () => {
+    expect(computeVisibleSlotCount([], 2)).toBe(1);
+    expect(computeVisibleSlotCount([], 3)).toBe(1);
+  });
+
   it('reports when another series can be added', () => {
     expect(canAddAnotherSeries([], 1)).toBe(false);
     expect(canAddAnotherSeries([selectedFromRow(numericRow)], 1)).toBe(true);

--- a/packages/ui/src/lib/insight-series-picker-utils.spec.ts
+++ b/packages/ui/src/lib/insight-series-picker-utils.spec.ts
@@ -2,33 +2,89 @@ import {
   canAddAnotherSeries,
   computeVisibleSlotCount,
   createSelectedSeriesFromManifestRow,
+  defaultChartTypeForManifestRow,
+  filterChartableManifestRows,
   getChartTypeChoicesForManifestRow,
+  isChartableManifestRow,
   isChartTypeSelectorHidden,
 } from './insight-series-picker-utils.js';
 import type {
+  ChartableManifestRow,
+  ChartManifestResponseType,
   ChartManifestRow,
   SelectedSeries,
 } from './InsightSeriesPicker.types.js';
 
-const numericRow: ChartManifestRow = {
+const numericRow: ChartableManifestRow = {
   series_id: 'n-1',
   series_type: 'health_marker',
   label: 'Weight',
   response_type: 'numeric',
   is_blood_pressure: false,
+  unit: null,
   observation_count: 1,
   first_observed_at: '2026-01-01',
   last_observed_at: '2026-01-02',
 };
 
-const bpRow: ChartManifestRow = {
+const textRow: ChartManifestRow = {
+  ...numericRow,
+  series_id: 'notes-1',
+  label: 'Free-text notes',
+  response_type: 'text',
+};
+
+const bpRow: ChartableManifestRow = {
   ...numericRow,
   series_id: 'bp-1',
   label: 'Blood pressure',
   is_blood_pressure: true,
 };
 
+/** Test helper: chartable fixtures must produce a selected series. */
+function selectedFromRow(
+  row: ChartableManifestRow,
+  slotIndex = 0,
+): SelectedSeries {
+  const series = createSelectedSeriesFromManifestRow(row, slotIndex);
+  if (!series) {
+    throw new Error(
+      `Expected chartable fixture ${row.series_id} to map to a series`,
+    );
+  }
+  return series;
+}
+
 describe('insight-series-picker-utils', () => {
+  it('identifies chartable manifest rows and filters out text', () => {
+    expect(isChartableManifestRow(numericRow)).toBe(true);
+    expect(isChartableManifestRow(textRow)).toBe(false);
+    expect(filterChartableManifestRows([numericRow, textRow])).toEqual([
+      numericRow,
+    ]);
+  });
+
+  it('treats unknown response_type values as non-chartable without throwing', () => {
+    const futureRow: ChartManifestRow = {
+      ...numericRow,
+      series_id: 'future-1',
+      response_type: 'likert' as ChartManifestResponseType,
+    };
+
+    expect(getChartTypeChoicesForManifestRow(futureRow)).toEqual([]);
+    expect(isChartableManifestRow(futureRow)).toBe(false);
+    expect(defaultChartTypeForManifestRow(futureRow)).toBeUndefined();
+    expect(
+      filterChartableManifestRows([numericRow, futureRow, textRow]),
+    ).toEqual([numericRow]);
+  });
+
+  it('returns undefined from createSelectedSeriesFromManifestRow when chart type cannot be resolved', () => {
+    expect(
+      createSelectedSeriesFromManifestRow(numericRow, 0, 'bp_band'),
+    ).toBeUndefined();
+  });
+
   it('returns chart-type choices per manifest row', () => {
     expect(getChartTypeChoicesForManifestRow(bpRow)).toEqual(['bp_band']);
     expect(getChartTypeChoicesForManifestRow(numericRow)).toEqual([
@@ -54,12 +110,7 @@ describe('insight-series-picker-utils', () => {
 
   it('reports when another series can be added', () => {
     expect(canAddAnotherSeries([], 1)).toBe(false);
-    expect(
-      canAddAnotherSeries(
-        [createSelectedSeriesFromManifestRow(numericRow, 0)],
-        1,
-      ),
-    ).toBe(true);
+    expect(canAddAnotherSeries([selectedFromRow(numericRow)], 1)).toBe(true);
     expect(canAddAnotherSeries([], 3)).toBe(false);
   });
 });

--- a/packages/ui/src/lib/insight-series-picker-utils.ts
+++ b/packages/ui/src/lib/insight-series-picker-utils.ts
@@ -145,9 +145,12 @@ export function computeVisibleSlotCount(
   value: SelectedSeries[],
   revealedSlotCount: number,
 ): number {
-  const fromValue =
-    value.length === 0 ? 1 : Math.min(3, Math.max(1, value.length));
-  return Math.min(3, Math.max(1, revealedSlotCount, fromValue));
+  const filledCount = value.length;
+  const nextUnfilledCap = filledCount === 0 ? 1 : Math.min(3, filledCount + 1);
+  return Math.min(
+    3,
+    Math.max(filledCount, Math.min(revealedSlotCount, nextUnfilledCap), 1),
+  );
 }
 
 /**

--- a/packages/ui/src/lib/insight-series-picker-utils.ts
+++ b/packages/ui/src/lib/insight-series-picker-utils.ts
@@ -5,6 +5,9 @@ import type {
   SelectedSeries,
 } from './InsightSeriesPicker.types.js';
 
+/** Maximum number of series the chart builder allows. */
+export const MAX_SERIES_SLOTS = 3;
+
 /**
  * Whether a manifest row can be selected in the chart builder.
  *
@@ -29,12 +32,12 @@ export function filterChartableManifestRows(
   return manifest.filter(isChartableManifestRow);
 }
 
-/** Fixed accessible colors for series slots 1–3 (not user-configurable). */
+/** Fixed accessible colors per slot (length must match {@link MAX_SERIES_SLOTS}). */
 export const INSIGHT_SERIES_SLOT_COLORS = [
   '#1d4ed8',
   '#b45309',
   '#047857',
-] as const;
+] as const satisfies readonly [string, string, string];
 
 const CHART_TYPE_LABELS: Record<ChartTypeChoice, string> = {
   line: 'Line',
@@ -135,20 +138,54 @@ export function createSelectedSeriesFromManifestRow(
 }
 
 /**
+ * Applies a series selection at `slotIndex`, keeping later slots when still valid and
+ * distinct; drops tail entries that duplicate an earlier `seriesId`.
+ *
+ * @param value - Current selected series (already clamped to {@link MAX_SERIES_SLOTS}).
+ * @param slotIndex - Slot being updated.
+ * @param selected - New selection for that slot.
+ * @returns Updated series list (not re-clamped; caller should clamp if needed).
+ */
+export function mergeSeriesSelectionAtSlot(
+  value: SelectedSeries[],
+  slotIndex: number,
+  selected: SelectedSeries,
+): SelectedSeries[] {
+  const next = value.slice();
+  next[slotIndex] = selected;
+
+  const usedIds = new Set(
+    next.slice(0, slotIndex + 1).map((series) => series.seriesId),
+  );
+  const merged = next.slice(0, slotIndex + 1);
+
+  for (let i = slotIndex + 1; i < next.length; i++) {
+    const tail = next[i];
+    if (tail && !usedIds.has(tail.seriesId)) {
+      merged.push(tail);
+      usedIds.add(tail.seriesId);
+    }
+  }
+
+  return merged;
+}
+
+/**
  * Computes how many series slots should be visible for the current value and reveal count.
  *
- * @param value - Currently selected series (up to 3).
- * @param revealedSlotCount - Slots revealed via “Add another series” (1–3).
- * @returns Visible slot count between 1 and 3.
+ * @param value - Currently selected series (up to {@link MAX_SERIES_SLOTS}).
+ * @param revealedSlotCount - Slots revealed via “Add another series”.
+ * @returns Visible slot count between 1 and {@link MAX_SERIES_SLOTS}.
  */
 export function computeVisibleSlotCount(
   value: SelectedSeries[],
   revealedSlotCount: number,
 ): number {
   const filledCount = value.length;
-  const nextUnfilledCap = filledCount === 0 ? 1 : Math.min(3, filledCount + 1);
+  const nextUnfilledCap =
+    filledCount === 0 ? 1 : Math.min(MAX_SERIES_SLOTS, filledCount + 1);
   return Math.min(
-    3,
+    MAX_SERIES_SLOTS,
     Math.max(filledCount, Math.min(revealedSlotCount, nextUnfilledCap), 1),
   );
 }
@@ -164,7 +201,7 @@ export function canAddAnotherSeries(
   value: SelectedSeries[],
   visibleSlotCount: number,
 ): boolean {
-  if (visibleSlotCount >= 3) {
+  if (visibleSlotCount >= MAX_SERIES_SLOTS) {
     return false;
   }
   const lastVisibleIndex = visibleSlotCount - 1;

--- a/packages/ui/src/lib/insight-series-picker-utils.ts
+++ b/packages/ui/src/lib/insight-series-picker-utils.ts
@@ -1,0 +1,151 @@
+import type {
+  ChartManifestRow,
+  ChartTypeChoice,
+  SelectedSeries,
+} from './InsightSeriesPicker.types.js';
+
+/** Fixed accessible colors for series slots 1–3 (not user-configurable). */
+export const INSIGHT_SERIES_SLOT_COLORS = [
+  '#1d4ed8',
+  '#b45309',
+  '#047857',
+] as const;
+
+const CHART_TYPE_LABELS: Record<ChartTypeChoice, string> = {
+  line: 'Line',
+  bar: 'Bar',
+  scatter: 'Scatter',
+  event: 'Event markers',
+  bp_band: 'Blood pressure band',
+};
+
+/**
+ * Returns chart-type choices allowed for a manifest row.
+ *
+ * @param row - Manifest row describing the series.
+ * @returns Allowed chart types for the row.
+ */
+export function getChartTypeChoicesForManifestRow(
+  row: ChartManifestRow,
+): ChartTypeChoice[] {
+  if (row.is_blood_pressure) {
+    return ['bp_band'];
+  }
+  switch (row.response_type) {
+    case 'numeric':
+      return ['line', 'bar', 'scatter'];
+    case 'severity':
+      return ['line', 'bar'];
+    case 'boolean':
+      return ['event'];
+    default:
+      return [];
+  }
+}
+
+/**
+ * Whether the chart-type dropdown should be hidden (single forced choice).
+ *
+ * @param row - Manifest row describing the series.
+ * @returns `true` when only one chart type applies.
+ */
+export function isChartTypeSelectorHidden(row: ChartManifestRow): boolean {
+  return getChartTypeChoicesForManifestRow(row).length <= 1;
+}
+
+/**
+ * Default chart type for a manifest row (first allowed choice).
+ *
+ * @param row - Manifest row describing the series.
+ * @returns Default chart type.
+ */
+export function defaultChartTypeForManifestRow(
+  row: ChartManifestRow,
+): ChartTypeChoice {
+  const choices = getChartTypeChoicesForManifestRow(row);
+  const first = choices[0];
+  if (!first) {
+    throw new Error(
+      `No chart type available for series ${row.series_id} (${row.response_type})`,
+    );
+  }
+  return first;
+}
+
+/**
+ * Human-readable label for a chart type option.
+ *
+ * @param chartType - Chart type choice.
+ * @returns Display label.
+ */
+export function chartTypeChoiceLabel(chartType: ChartTypeChoice): string {
+  return CHART_TYPE_LABELS[chartType];
+}
+
+/**
+ * Builds a {@link SelectedSeries} from a manifest row and slot index (assigns color).
+ *
+ * @param row - Manifest row for the series.
+ * @param slotIndex - Zero-based slot index (0–2).
+ * @param chartType - Optional chart type; defaults to the row's allowed default.
+ * @returns Selected series state for the chart builder.
+ */
+export function createSelectedSeriesFromManifestRow(
+  row: ChartManifestRow,
+  slotIndex: number,
+  chartType?: ChartTypeChoice,
+): SelectedSeries {
+  const resolvedChartType = chartType ?? defaultChartTypeForManifestRow(row);
+  const allowed = getChartTypeChoicesForManifestRow(row);
+  if (!allowed.includes(resolvedChartType)) {
+    throw new Error(
+      `Chart type ${resolvedChartType} is not allowed for series ${row.series_id}`,
+    );
+  }
+
+  return {
+    seriesId: row.series_id,
+    seriesType: row.series_type,
+    responseType: row.response_type,
+    isBloodPressure: row.is_blood_pressure,
+    label: row.label,
+    unit: row.unit,
+    chartType: resolvedChartType,
+    color:
+      INSIGHT_SERIES_SLOT_COLORS[slotIndex] ?? INSIGHT_SERIES_SLOT_COLORS[0],
+  };
+}
+
+/**
+ * Computes how many series slots should be visible for the current value and reveal count.
+ *
+ * @param value - Currently selected series (up to 3).
+ * @param revealedSlotCount - Slots revealed via “Add another series” (1–3).
+ * @returns Visible slot count between 1 and 3.
+ */
+export function computeVisibleSlotCount(
+  value: SelectedSeries[],
+  revealedSlotCount: number,
+): number {
+  const fromValue =
+    value.length === 0 ? 1 : Math.min(3, Math.max(1, value.length));
+  return Math.min(3, Math.max(1, revealedSlotCount, fromValue));
+}
+
+/**
+ * Whether “Add another series” should be offered.
+ *
+ * @param value - Currently selected series.
+ * @param visibleSlotCount - Number of slots currently shown.
+ * @returns `true` when another slot can be added.
+ */
+export function canAddAnotherSeries(
+  value: SelectedSeries[],
+  visibleSlotCount: number,
+): boolean {
+  if (visibleSlotCount >= 3) {
+    return false;
+  }
+  const lastVisibleIndex = visibleSlotCount - 1;
+  return value[lastVisibleIndex] !== undefined;
+}

--- a/packages/ui/src/lib/insight-series-picker-utils.ts
+++ b/packages/ui/src/lib/insight-series-picker-utils.ts
@@ -1,8 +1,33 @@
 import type {
+  ChartableManifestRow,
   ChartManifestRow,
   ChartTypeChoice,
   SelectedSeries,
 } from './InsightSeriesPicker.types.js';
+
+/**
+ * Whether a manifest row can be selected in the chart builder.
+ *
+ * @param row - Row from `get_user_chart_manifest`.
+ * @returns `true` when the row has at least one allowed chart type.
+ */
+export function isChartableManifestRow(
+  row: ChartManifestRow,
+): row is ChartableManifestRow {
+  return getChartTypeChoicesForManifestRow(row).length > 0;
+}
+
+/**
+ * Returns only manifest rows the chart builder can plot.
+ *
+ * @param manifest - Full RPC manifest (may include unsupported `response_type` values).
+ * @returns Rows with at least one allowed chart type.
+ */
+export function filterChartableManifestRows(
+  manifest: ChartManifestRow[],
+): ChartableManifestRow[] {
+  return manifest.filter(isChartableManifestRow);
+}
 
 /** Fixed accessible colors for series slots 1–3 (not user-configurable). */
 export const INSIGHT_SERIES_SLOT_COLORS = [
@@ -38,6 +63,8 @@ export function getChartTypeChoicesForManifestRow(
       return ['line', 'bar'];
     case 'boolean':
       return ['event'];
+    case 'text':
+      return [];
     default:
       return [];
   }
@@ -49,7 +76,7 @@ export function getChartTypeChoicesForManifestRow(
  * @param row - Manifest row describing the series.
  * @returns `true` when only one chart type applies.
  */
-export function isChartTypeSelectorHidden(row: ChartManifestRow): boolean {
+export function isChartTypeSelectorHidden(row: ChartableManifestRow): boolean {
   return getChartTypeChoicesForManifestRow(row).length <= 1;
 }
 
@@ -57,19 +84,12 @@ export function isChartTypeSelectorHidden(row: ChartManifestRow): boolean {
  * Default chart type for a manifest row (first allowed choice).
  *
  * @param row - Manifest row describing the series.
- * @returns Default chart type.
+ * @returns Default chart type, or `undefined` when the row has no chart types.
  */
 export function defaultChartTypeForManifestRow(
   row: ChartManifestRow,
-): ChartTypeChoice {
-  const choices = getChartTypeChoicesForManifestRow(row);
-  const first = choices[0];
-  if (!first) {
-    throw new Error(
-      `No chart type available for series ${row.series_id} (${row.response_type})`,
-    );
-  }
-  return first;
+): ChartTypeChoice | undefined {
+  return getChartTypeChoicesForManifestRow(row)[0];
 }
 
 /**
@@ -88,19 +108,17 @@ export function chartTypeChoiceLabel(chartType: ChartTypeChoice): string {
  * @param row - Manifest row for the series.
  * @param slotIndex - Zero-based slot index (0–2).
  * @param chartType - Optional chart type; defaults to the row's allowed default.
- * @returns Selected series state for the chart builder.
+ * @returns Selected series state, or `undefined` when the row has no valid chart type.
  */
 export function createSelectedSeriesFromManifestRow(
-  row: ChartManifestRow,
+  row: ChartableManifestRow,
   slotIndex: number,
   chartType?: ChartTypeChoice,
-): SelectedSeries {
-  const resolvedChartType = chartType ?? defaultChartTypeForManifestRow(row);
+): SelectedSeries | undefined {
   const allowed = getChartTypeChoicesForManifestRow(row);
-  if (!allowed.includes(resolvedChartType)) {
-    throw new Error(
-      `Chart type ${resolvedChartType} is not allowed for series ${row.series_id}`,
-    );
+  const resolvedChartType = chartType ?? allowed[0];
+  if (!resolvedChartType || !allowed.includes(resolvedChartType)) {
+    return undefined;
   }
 
   return {


### PR DESCRIPTION
Closes #173

## Summary

- Adds a web-only `InsightSeriesPicker` in `@abstrack/ui` for the chart builder series step (up to 3 slots, manifest-driven series + constrained chart types).
- Auto-selects `bp_band` / `event` when only one chart type applies; assigns slot colors from a fixed accessible palette.
- Exports types and component from the main `@abstrack/ui` entry only (not `native.ts`).

## Test plan

- [x] `pnpm exec vitest run` in `packages/ui` (InsightSeriesPicker + utils specs)
- [x] `pnpm exec nx run ui:build`
- [ ] Manual: mount in `apps/web` / `apps/practitioner` chart builder; keyboard through series selects, chart-type selects, Add another series, and remove
- [ ] Screen reader: verify labeled selects and slot group names