### PR TITLE
feat(ui): add InsightDateRangePicker for chart builder date ranges

### DIFF
--- a/apps/practitioner/src/app/global.css
+++ b/apps/practitioner/src/app/global.css
@@ -1,9 +1,9 @@
+/* InsightDateRangePicker (`@abstrack/ui`) — base DayPicker layout; app Tailwind overrides classNames. */
+@import 'react-day-picker/style.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* InsightDateRangePicker (`@abstrack/ui`) — base DayPicker layout; app Tailwind overrides classNames. */
-@import 'react-day-picker/style.css';
 
 @layer base {
   :root {

--- a/apps/practitioner/src/app/global.css
+++ b/apps/practitioner/src/app/global.css
@@ -2,6 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
+/* InsightDateRangePicker (`@abstrack/ui`) — base DayPicker layout; app Tailwind overrides classNames. */
+@import 'react-day-picker/style.css';
+
 @layer base {
   :root {
     --app-bg: 244 247 251;

--- a/apps/practitioner/tailwind.config.js
+++ b/apps/practitioner/tailwind.config.js
@@ -15,6 +15,8 @@ module.exports = {
   content: [
     './{src,pages,components,app}/**/*.{ts,tsx,js,jsx,html}',
     '!./{src,pages,components,app}/**/*.{stories,spec}.{ts,tsx,js,jsx,html}',
+    '../../packages/ui/src/**/*.{ts,tsx}',
+    '!../../packages/ui/src/**/*.{stories,spec}.{ts,tsx}',
     //     ...createGlobPatternsForDependencies(__dirname)
   ],
   theme: {

--- a/apps/web/src/app/global.css
+++ b/apps/web/src/app/global.css
@@ -1,9 +1,9 @@
+/* InsightDateRangePicker (`@abstrack/ui`) — base DayPicker layout; app Tailwind overrides classNames. */
+@import 'react-day-picker/style.css';
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
-
-/* InsightDateRangePicker (`@abstrack/ui`) — base DayPicker layout; app Tailwind overrides classNames. */
-@import 'react-day-picker/style.css';
 
 /* Semantic colors: toggled via `html.dark` (Tailwind `darkMode: 'class'`).
  * RGB channel tokens (space-separated) pair with Tailwind `rgb(var(--app-*) / <alpha-value>)`

--- a/apps/web/src/app/global.css
+++ b/apps/web/src/app/global.css
@@ -2,6 +2,9 @@
 @tailwind components;
 @tailwind utilities;
 
+/* InsightDateRangePicker (`@abstrack/ui`) — base DayPicker layout; app Tailwind overrides classNames. */
+@import 'react-day-picker/style.css';
+
 /* Semantic colors: toggled via `html.dark` (Tailwind `darkMode: 'class'`).
  * RGB channel tokens (space-separated) pair with Tailwind `rgb(var(--app-*) / <alpha-value>)`
  * so opacity modifiers (e.g. `border-app-border/90`) resolve correctly. */

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -15,6 +15,8 @@ module.exports = {
   content: [
     './{src,pages,components,app}/**/*.{ts,tsx,js,jsx,html}',
     '!./{src,pages,components,app}/**/*.{stories,spec}.{ts,tsx,js,jsx,html}',
+    '../../packages/ui/src/**/*.{ts,tsx}',
+    '!../../packages/ui/src/**/*.{stories,spec}.{ts,tsx}',
     //     ...createGlobPatternsForDependencies(__dirname)
   ],
   theme: {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -32,6 +32,7 @@
     "react-native": ">=0.76.0"
   },
   "dependencies": {
+    "react-day-picker": "^10.0.1",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,3 +17,8 @@ export {
   type InsightSeriesPickerProps,
   type SelectedSeries,
 } from './lib/InsightSeriesPicker.js';
+export {
+  InsightDateRangePicker,
+  type InsightDateRangePickerProps,
+  type InsightDateRangePresetId,
+} from './lib/InsightDateRangePicker.js';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -19,6 +19,7 @@ export {
 } from './lib/InsightSeriesPicker.js';
 export {
   InsightDateRangePicker,
+  type InsightDateRange,
   type InsightDateRangePickerProps,
   type InsightDateRangePresetId,
 } from './lib/InsightDateRangePicker.js';

--- a/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
@@ -1,0 +1,81 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useState, type ReactElement } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LiveAnnouncerProvider } from './a11y/LiveAnnouncer.js';
+import { InsightDateRangePicker } from './InsightDateRangePicker.js';
+import type { InsightDateRange } from './insight-date-range-picker-utils.js';
+
+const ANCHOR = new Date(2026, 4, 18, 12, 0, 0);
+
+function localDate(year: number, monthIndex: number, day: number): Date {
+  return new Date(year, monthIndex, day);
+}
+
+function ControlledPicker({
+  initial,
+  onChangeSpy,
+}: {
+  initial: InsightDateRange;
+  onChangeSpy?: (range: InsightDateRange) => void;
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <InsightDateRangePicker
+      value={value}
+      onChange={(range) => {
+        setValue(range);
+        onChangeSpy?.(range);
+      }}
+    />
+  );
+}
+
+function renderWithAnnouncer(ui: ReactElement) {
+  return render(<LiveAnnouncerProvider>{ui}</LiveAnnouncerProvider>);
+}
+
+describe('InsightDateRangePicker', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(ANCHOR);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('applies preset ranges immediately via onChange', () => {
+    const onChangeSpy = vi.fn();
+    renderWithAnnouncer(
+      <ControlledPicker
+        initial={{
+          from: localDate(2026, 0, 1),
+          to: localDate(2026, 0, 7),
+        }}
+        onChangeSpy={onChangeSpy}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+
+    expect(onChangeSpy).toHaveBeenCalledWith({
+      from: localDate(2026, 4, 12),
+      to: localDate(2026, 4, 18),
+    });
+  });
+
+  it('announces the selected range to screen readers when a preset changes', () => {
+    renderWithAnnouncer(
+      <ControlledPicker
+        initial={{
+          from: localDate(2026, 0, 1),
+          to: localDate(2026, 0, 7),
+        }}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last 30 days' }));
+
+    expect(screen.getByText(/Date range selected:/)).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
@@ -110,6 +110,41 @@ describe('InsightDateRangePicker', () => {
     expect(calendar).toBeInTheDocument();
   });
 
+  it('announces again after a parent value change even when re-selecting a prior range', () => {
+    const lastSevenDays = {
+      from: localDate(2026, 4, 12),
+      to: localDate(2026, 4, 18),
+    };
+    const lastThirtyDays = {
+      from: localDate(2026, 3, 19),
+      to: localDate(2026, 4, 18),
+    };
+    const onChangeSpy = vi.fn();
+
+    const { rerender } = renderWithAnnouncer(
+      <InsightDateRangePicker
+        value={{
+          from: localDate(2026, 0, 1),
+          to: localDate(2026, 0, 7),
+        }}
+        onChange={onChangeSpy}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+    expect(screen.getByText(/Date range selected:/)).toBeInTheDocument();
+
+    rerender(
+      <LiveAnnouncerProvider>
+        <InsightDateRangePicker value={lastThirtyDays} onChange={onChangeSpy} />
+      </LiveAnnouncerProvider>,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+    expect(onChangeSpy).toHaveBeenLastCalledWith(lastSevenDays);
+    expect(screen.getByText(/Date range selected:/)).toBeInTheDocument();
+  });
+
   it('announces the selected range to screen readers when a preset changes', () => {
     renderWithAnnouncer(
       <ControlledPicker

--- a/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
@@ -81,6 +81,35 @@ describe('InsightDateRangePicker', () => {
     expect(screen.getByText('May 2026')).toBeInTheDocument();
   });
 
+  it('commits a new range after a partial calendar selection followed by an end day', () => {
+    const onChangeSpy = vi.fn();
+    renderWithAnnouncer(
+      <ControlledPicker
+        initial={{
+          from: localDate(2026, 4, 12),
+          to: localDate(2026, 4, 18),
+        }}
+        onChangeSpy={onChangeSpy}
+      />,
+    );
+
+    const calendar = screen.getByRole('grid', { name: 'May 2026' });
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Tuesday, May 5th, 2026' }),
+    );
+    expect(onChangeSpy).not.toHaveBeenCalled();
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Friday, May 8th, 2026' }),
+    );
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith({
+      from: localDate(2026, 4, 5),
+      to: localDate(2026, 4, 8),
+    });
+    expect(calendar).toBeInTheDocument();
+  });
+
   it('announces the selected range to screen readers when a preset changes', () => {
     renderWithAnnouncer(
       <ControlledPicker

--- a/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
@@ -3,7 +3,11 @@ import { useState, type ReactElement } from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LiveAnnouncerProvider } from './a11y/LiveAnnouncer.js';
 import { InsightDateRangePicker } from './InsightDateRangePicker.js';
-import type { InsightDateRange } from './insight-date-range-picker-utils.js';
+import {
+  inclusiveCalendarDaySpan,
+  INSIGHT_DATE_RANGE_MAX_DAYS,
+  type InsightDateRange,
+} from './insight-date-range-picker-utils.js';
 
 const ANCHOR = new Date(2026, 4, 18, 12, 0, 0);
 
@@ -108,6 +112,43 @@ describe('InsightDateRangePicker', () => {
       to: localDate(2026, 4, 8),
     });
     expect(calendar).toBeInTheDocument();
+  });
+
+  it('calls onChange with a normalized range when value exceeds the max span', () => {
+    const onChangeSpy = vi.fn();
+    renderWithAnnouncer(
+      <InsightDateRangePicker
+        value={{
+          from: localDate(2020, 0, 1),
+          to: localDate(2026, 4, 18),
+        }}
+        onChange={onChangeSpy}
+      />,
+    );
+
+    expect(onChangeSpy).toHaveBeenCalled();
+    const normalized = onChangeSpy.mock.calls[0]?.[0] as InsightDateRange;
+    expect(inclusiveCalendarDaySpan(normalized.from, normalized.to)).toBe(
+      INSIGHT_DATE_RANGE_MAX_DAYS,
+    );
+  });
+
+  it('calls onChange when the controlled end date is in the future', () => {
+    const onChangeSpy = vi.fn();
+    renderWithAnnouncer(
+      <InsightDateRangePicker
+        value={{
+          from: localDate(2026, 4, 1),
+          to: localDate(2026, 5, 1),
+        }}
+        onChange={onChangeSpy}
+      />,
+    );
+
+    expect(onChangeSpy).toHaveBeenCalledWith({
+      from: localDate(2026, 4, 1),
+      to: localDate(2026, 4, 18),
+    });
   });
 
   it('does not announce the initial controlled value on mount', () => {

--- a/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
@@ -64,6 +64,23 @@ describe('InsightDateRangePicker', () => {
     });
   });
 
+  it('navigates the calendar to the range end month when a preset is selected', () => {
+    renderWithAnnouncer(
+      <ControlledPicker
+        initial={{
+          from: localDate(2026, 0, 1),
+          to: localDate(2026, 0, 7),
+        }}
+      />,
+    );
+
+    expect(screen.getByText('January 2026')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Last 7 days' }));
+
+    expect(screen.getByText('May 2026')).toBeInTheDocument();
+  });
+
   it('announces the selected range to screen readers when a preset changes', () => {
     renderWithAnnouncer(
       <ControlledPicker

--- a/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.spec.tsx
@@ -110,6 +110,46 @@ describe('InsightDateRangePicker', () => {
     expect(calendar).toBeInTheDocument();
   });
 
+  it('does not announce the initial controlled value on mount', () => {
+    renderWithAnnouncer(
+      <InsightDateRangePicker
+        value={{
+          from: localDate(2026, 0, 1),
+          to: localDate(2026, 0, 7),
+        }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByText(/Date range selected:/)).not.toBeInTheDocument();
+  });
+
+  it('announces when the parent updates the controlled value', () => {
+    const { rerender } = renderWithAnnouncer(
+      <InsightDateRangePicker
+        value={{
+          from: localDate(2026, 0, 1),
+          to: localDate(2026, 0, 7),
+        }}
+        onChange={vi.fn()}
+      />,
+    );
+
+    rerender(
+      <LiveAnnouncerProvider>
+        <InsightDateRangePicker
+          value={{
+            from: localDate(2026, 3, 19),
+            to: localDate(2026, 4, 18),
+          }}
+          onChange={vi.fn()}
+        />
+      </LiveAnnouncerProvider>,
+    );
+
+    expect(screen.getByText(/Date range selected:/)).toBeInTheDocument();
+  });
+
   it('announces again after a parent value change even when re-selecting a prior range', () => {
     const lastSevenDays = {
       from: localDate(2026, 4, 12),

--- a/packages/ui/src/lib/InsightDateRangePicker.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.tsx
@@ -8,7 +8,7 @@ import {
   formatInsightDateRangeAnnouncement,
   getInsightDateRangeDisabledMatchers,
   getInsightDateRangePreset,
-  INSIGHT_DATE_RANGE_MAX_DAYS,
+  INSIGHT_DATE_RANGE_MAX_NIGHTS,
   INSIGHT_DATE_RANGE_PRESETS,
   normalizeInsightDateRange,
   type InsightDateRange,
@@ -161,7 +161,7 @@ export function InsightDateRangePicker({
         selected={selected}
         onSelect={handleCalendarSelect}
         disabled={getInsightDateRangeDisabledMatchers()}
-        max={INSIGHT_DATE_RANGE_MAX_DAYS}
+        max={INSIGHT_DATE_RANGE_MAX_NIGHTS}
         defaultMonth={value.to}
         classNames={dayPickerClassNames}
         aria-label="Chart date range calendar"

--- a/packages/ui/src/lib/InsightDateRangePicker.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.tsx
@@ -1,6 +1,13 @@
 'use client';
 
-import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { DayPicker, type DateRange } from 'react-day-picker';
 import { useAnnounce } from './a11y/LiveAnnouncer.js';
 import { useFocusRing } from './hooks/useFocusRing.js';
@@ -22,6 +29,15 @@ export type {
 
 function insightDateRangeAnnouncementKey(range: InsightDateRange): string {
   return `${range.from.getTime()}-${range.to.getTime()}`;
+}
+
+function insightDateRangesEqual(
+  a: InsightDateRange,
+  b: InsightDateRange,
+): boolean {
+  return (
+    insightDateRangeAnnouncementKey(a) === insightDateRangeAnnouncementKey(b)
+  );
 }
 
 /** Props for {@link InsightDateRangePicker}. */
@@ -107,14 +123,24 @@ export function InsightDateRangePicker({
   const baseId = useId().replace(/:/g, '');
   const lastAnnouncedKey = useRef('');
   const skipValueAnnounceOnMount = useRef(true);
-  const [month, setMonth] = useState(() => value.to);
+  const normalizedValue = useMemo(
+    () => normalizeInsightDateRange(value),
+    [value.from, value.to],
+  );
+  const [month, setMonth] = useState(() => normalizedValue.to);
   const [calendarDraft, setCalendarDraft] = useState<DateRange | undefined>();
 
   useEffect(() => {
-    setMonth(value.to);
+    if (!insightDateRangesEqual(normalizedValue, value)) {
+      onChange(normalizedValue);
+    }
+  }, [normalizedValue, value, onChange]);
+
+  useEffect(() => {
+    setMonth(normalizedValue.to);
     setCalendarDraft(undefined);
 
-    const key = insightDateRangeAnnouncementKey(value);
+    const key = insightDateRangeAnnouncementKey(normalizedValue);
     if (skipValueAnnounceOnMount.current) {
       skipValueAnnounceOnMount.current = false;
       lastAnnouncedKey.current = key;
@@ -123,9 +149,9 @@ export function InsightDateRangePicker({
 
     if (key !== lastAnnouncedKey.current) {
       lastAnnouncedKey.current = key;
-      announce(formatInsightDateRangeAnnouncement(value));
+      announce(formatInsightDateRangeAnnouncement(normalizedValue));
     }
-  }, [announce, value.from, value.to]);
+  }, [announce, normalizedValue.from, normalizedValue.to]);
 
   const commitRange = useCallback(
     (next: InsightDateRange) => {
@@ -159,8 +185,8 @@ export function InsightDateRangePicker({
   };
 
   const selected: DateRange = calendarDraft ?? {
-    from: value.from,
-    to: value.to,
+    from: normalizedValue.from,
+    to: normalizedValue.to,
   };
 
   return (

--- a/packages/ui/src/lib/InsightDateRangePicker.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useId, useRef } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { DayPicker, type DateRange } from 'react-day-picker';
 import { useAnnounce } from './a11y/LiveAnnouncer.js';
 import { useFocusRing } from './hooks/useFocusRing.js';
@@ -99,10 +99,16 @@ export function InsightDateRangePicker({
   const { announce } = useAnnounce();
   const baseId = useId().replace(/:/g, '');
   const lastAnnouncedKey = useRef('');
+  const [month, setMonth] = useState(() => value.to);
+
+  useEffect(() => {
+    setMonth(value.to);
+  }, [value.from, value.to]);
 
   const commitRange = useCallback(
     (next: InsightDateRange) => {
       const normalized = normalizeInsightDateRange(next);
+      setMonth(normalized.to);
       onChange(normalized);
       const key = `${normalized.from.getTime()}-${normalized.to.getTime()}`;
       if (key !== lastAnnouncedKey.current) {
@@ -162,7 +168,8 @@ export function InsightDateRangePicker({
         onSelect={handleCalendarSelect}
         disabled={getInsightDateRangeDisabledMatchers()}
         max={INSIGHT_DATE_RANGE_MAX_NIGHTS}
-        defaultMonth={value.to}
+        month={month}
+        onMonthChange={setMonth}
         classNames={dayPickerClassNames}
         aria-label="Chart date range calendar"
       />

--- a/packages/ui/src/lib/InsightDateRangePicker.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.tsx
@@ -90,7 +90,7 @@ function PresetButton({
  * entry (see `apps/web` and `apps/practitioner` `global.css`).
  *
  * @param props - Controlled range value and change handler.
- * @returns Preset toolbar and range calendar.
+ * @returns Preset button group and range calendar.
  */
 export function InsightDateRangePicker({
   value,
@@ -100,14 +100,17 @@ export function InsightDateRangePicker({
   const baseId = useId().replace(/:/g, '');
   const lastAnnouncedKey = useRef('');
   const [month, setMonth] = useState(() => value.to);
+  const [calendarDraft, setCalendarDraft] = useState<DateRange | undefined>();
 
   useEffect(() => {
     setMonth(value.to);
+    setCalendarDraft(undefined);
   }, [value.from, value.to]);
 
   const commitRange = useCallback(
     (next: InsightDateRange) => {
       const normalized = normalizeInsightDateRange(next);
+      setCalendarDraft(undefined);
       setMonth(normalized.to);
       onChange(normalized);
       const key = `${normalized.from.getTime()}-${normalized.to.getTime()}`;
@@ -124,13 +127,18 @@ export function InsightDateRangePicker({
   };
 
   const handleCalendarSelect = (range: DateRange | undefined) => {
-    if (!range?.from || !range.to) {
+    if (!range?.from) {
+      setCalendarDraft(undefined);
+      return;
+    }
+    if (!range.to) {
+      setCalendarDraft(range);
       return;
     }
     commitRange({ from: range.from, to: range.to });
   };
 
-  const selected: DateRange = {
+  const selected: DateRange = calendarDraft ?? {
     from: value.from,
     to: value.to,
   };
@@ -150,7 +158,7 @@ export function InsightDateRangePicker({
 
       <div
         className="flex flex-wrap gap-2"
-        role="toolbar"
+        role="group"
         aria-label="Date range presets"
       >
         {INSIGHT_DATE_RANGE_PRESETS.map((preset) => (
@@ -166,6 +174,7 @@ export function InsightDateRangePicker({
         mode="range"
         selected={selected}
         onSelect={handleCalendarSelect}
+        resetOnSelect
         disabled={getInsightDateRangeDisabledMatchers()}
         max={INSIGHT_DATE_RANGE_MAX_NIGHTS}
         month={month}

--- a/packages/ui/src/lib/InsightDateRangePicker.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useCallback, useId, useRef } from 'react';
+import { DayPicker, type DateRange } from 'react-day-picker';
+import 'react-day-picker/style.css';
+import { useAnnounce } from './a11y/LiveAnnouncer.js';
+import { useFocusRing } from './hooks/useFocusRing.js';
+import {
+  formatInsightDateRangeAnnouncement,
+  getInsightDateRangeDisabledMatchers,
+  getInsightDateRangePreset,
+  INSIGHT_DATE_RANGE_MAX_DAYS,
+  INSIGHT_DATE_RANGE_PRESETS,
+  normalizeInsightDateRange,
+  type InsightDateRange,
+  type InsightDateRangePresetId,
+} from './insight-date-range-picker-utils.js';
+
+export type { InsightDateRangePresetId } from './insight-date-range-picker-utils.js';
+
+/** Props for {@link InsightDateRangePicker}. */
+export interface InsightDateRangePickerProps {
+  /** Current inclusive local-date range. */
+  value: InsightDateRange;
+  /** Called when the user picks a preset or completes a calendar range. */
+  onChange: (range: InsightDateRange) => void;
+}
+
+const dayPickerClassNames = {
+  root: 'relative text-app-ink',
+  months: 'flex flex-col gap-4',
+  month: 'space-y-4',
+  month_caption: 'flex justify-center pt-1 relative items-center',
+  caption_label: 'text-base font-semibold text-app-ink',
+  nav: 'flex items-center gap-1',
+  button_previous:
+    'inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg border border-app-border bg-app-surface text-app-ink hover:bg-app-bg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-ring',
+  button_next:
+    'inline-flex min-h-11 min-w-11 items-center justify-center rounded-lg border border-app-border bg-app-surface text-app-ink hover:bg-app-bg focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-ring',
+  month_grid: 'w-full border-collapse',
+  weekdays: 'flex',
+  weekday: 'w-11 rounded-md text-sm font-medium text-app-muted',
+  week: 'mt-1 flex w-full',
+  day: 'relative flex h-11 w-11 items-center justify-center p-0 text-center text-sm',
+  day_button:
+    'flex h-11 w-11 items-center justify-center rounded-lg font-medium text-app-ink hover:bg-app-primary-soft focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-ring disabled:cursor-not-allowed disabled:text-app-muted disabled:opacity-50',
+  selected:
+    '[&>button]:bg-app-primary [&>button]:text-white [&>button]:hover:bg-app-primary',
+  range_start: '[&>button]:rounded-l-lg [&>button]:rounded-r-none',
+  range_end: '[&>button]:rounded-r-lg [&>button]:rounded-l-none',
+  range_middle:
+    '[&>button]:rounded-none [&>button]:bg-app-primary-soft [&>button]:text-app-ink',
+  today: '[&>button]:font-bold [&>button]:underline',
+  outside: '[&>button]:text-app-muted [&>button]:opacity-50',
+  disabled: '[&>button]:cursor-not-allowed [&>button]:opacity-40',
+} as const;
+
+function PresetButton({
+  label,
+  onClick,
+}: {
+  label: string;
+  onClick: () => void;
+}) {
+  const { focused, onFocus, onBlur } = useFocusRing();
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      className={[
+        'min-h-11 min-w-11 rounded-lg border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink',
+        'hover:bg-app-bg',
+        focused
+          ? 'outline outline-2 outline-offset-2 outline-app-ring'
+          : 'focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-app-ring',
+      ].join(' ')}
+    >
+      {label}
+    </button>
+  );
+}
+
+/**
+ * Accessible date range picker for the insight chart builder (web only).
+ * Preset shortcuts, `react-day-picker` range calendar, 2-year max span, no future dates.
+ *
+ * @param props - Controlled range value and change handler.
+ * @returns Preset toolbar and range calendar.
+ */
+export function InsightDateRangePicker({
+  value,
+  onChange,
+}: InsightDateRangePickerProps) {
+  const { announce } = useAnnounce();
+  const baseId = useId().replace(/:/g, '');
+  const lastAnnouncedKey = useRef('');
+
+  const commitRange = useCallback(
+    (next: InsightDateRange) => {
+      const normalized = normalizeInsightDateRange(next);
+      onChange(normalized);
+      const key = `${normalized.from.getTime()}-${normalized.to.getTime()}`;
+      if (key !== lastAnnouncedKey.current) {
+        lastAnnouncedKey.current = key;
+        announce(formatInsightDateRangeAnnouncement(normalized));
+      }
+    },
+    [announce, onChange],
+  );
+
+  const handlePreset = (presetId: InsightDateRangePresetId) => {
+    commitRange(getInsightDateRangePreset(presetId));
+  };
+
+  const handleCalendarSelect = (range: DateRange | undefined) => {
+    if (!range?.from || !range.to) {
+      return;
+    }
+    commitRange({ from: range.from, to: range.to });
+  };
+
+  const selected: DateRange = {
+    from: value.from,
+    to: value.to,
+  };
+
+  return (
+    <div
+      className="flex flex-col gap-4 text-app-ink"
+      role="group"
+      aria-labelledby={`${baseId}-legend`}
+    >
+      <div
+        id={`${baseId}-legend`}
+        className="text-base font-semibold text-app-ink"
+      >
+        Date range
+      </div>
+
+      <div
+        className="flex flex-wrap gap-2"
+        role="toolbar"
+        aria-label="Date range presets"
+      >
+        {INSIGHT_DATE_RANGE_PRESETS.map((preset) => (
+          <PresetButton
+            key={preset.id}
+            label={preset.label}
+            onClick={() => handlePreset(preset.id)}
+          />
+        ))}
+      </div>
+
+      <DayPicker
+        mode="range"
+        selected={selected}
+        onSelect={handleCalendarSelect}
+        disabled={getInsightDateRangeDisabledMatchers()}
+        max={INSIGHT_DATE_RANGE_MAX_DAYS}
+        defaultMonth={value.to}
+        classNames={dayPickerClassNames}
+        aria-label="Chart date range calendar"
+      />
+    </div>
+  );
+}

--- a/packages/ui/src/lib/InsightDateRangePicker.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useId, useRef } from 'react';
 import { DayPicker, type DateRange } from 'react-day-picker';
-import 'react-day-picker/style.css';
 import { useAnnounce } from './a11y/LiveAnnouncer.js';
 import { useFocusRing } from './hooks/useFocusRing.js';
 import {
@@ -86,6 +85,9 @@ function PresetButton({
 /**
  * Accessible date range picker for the insight chart builder (web only).
  * Preset shortcuts, `react-day-picker` range calendar, 2-year max span, no future dates.
+ *
+ * Consuming Next.js apps must import `react-day-picker/style.css` from their global CSS
+ * entry (see `apps/web` and `apps/practitioner` `global.css`).
  *
  * @param props - Controlled range value and change handler.
  * @returns Preset toolbar and range calendar.

--- a/packages/ui/src/lib/InsightDateRangePicker.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.tsx
@@ -15,7 +15,14 @@ import {
   type InsightDateRangePresetId,
 } from './insight-date-range-picker-utils.js';
 
-export type { InsightDateRangePresetId } from './insight-date-range-picker-utils.js';
+export type {
+  InsightDateRange,
+  InsightDateRangePresetId,
+} from './insight-date-range-picker-utils.js';
+
+function insightDateRangeAnnouncementKey(range: InsightDateRange): string {
+  return `${range.from.getTime()}-${range.to.getTime()}`;
+}
 
 /** Props for {@link InsightDateRangePicker}. */
 export interface InsightDateRangePickerProps {
@@ -105,6 +112,7 @@ export function InsightDateRangePicker({
   useEffect(() => {
     setMonth(value.to);
     setCalendarDraft(undefined);
+    lastAnnouncedKey.current = insightDateRangeAnnouncementKey(value);
   }, [value.from, value.to]);
 
   const commitRange = useCallback(
@@ -113,7 +121,7 @@ export function InsightDateRangePicker({
       setCalendarDraft(undefined);
       setMonth(normalized.to);
       onChange(normalized);
-      const key = `${normalized.from.getTime()}-${normalized.to.getTime()}`;
+      const key = insightDateRangeAnnouncementKey(normalized);
       if (key !== lastAnnouncedKey.current) {
         lastAnnouncedKey.current = key;
         announce(formatInsightDateRangeAnnouncement(normalized));

--- a/packages/ui/src/lib/InsightDateRangePicker.tsx
+++ b/packages/ui/src/lib/InsightDateRangePicker.tsx
@@ -106,14 +106,26 @@ export function InsightDateRangePicker({
   const { announce } = useAnnounce();
   const baseId = useId().replace(/:/g, '');
   const lastAnnouncedKey = useRef('');
+  const skipValueAnnounceOnMount = useRef(true);
   const [month, setMonth] = useState(() => value.to);
   const [calendarDraft, setCalendarDraft] = useState<DateRange | undefined>();
 
   useEffect(() => {
     setMonth(value.to);
     setCalendarDraft(undefined);
-    lastAnnouncedKey.current = insightDateRangeAnnouncementKey(value);
-  }, [value.from, value.to]);
+
+    const key = insightDateRangeAnnouncementKey(value);
+    if (skipValueAnnounceOnMount.current) {
+      skipValueAnnounceOnMount.current = false;
+      lastAnnouncedKey.current = key;
+      return;
+    }
+
+    if (key !== lastAnnouncedKey.current) {
+      lastAnnouncedKey.current = key;
+      announce(formatInsightDateRangeAnnouncement(value));
+    }
+  }, [announce, value.from, value.to]);
 
   const commitRange = useCallback(
     (next: InsightDateRange) => {

--- a/packages/ui/src/lib/insight-date-range-picker-utils.spec.ts
+++ b/packages/ui/src/lib/insight-date-range-picker-utils.spec.ts
@@ -5,6 +5,7 @@ import {
   getInsightDateRangePreset,
   inclusiveCalendarDaySpan,
   INSIGHT_DATE_RANGE_MAX_DAYS,
+  INSIGHT_DATE_RANGE_MAX_NIGHTS,
   isInsightDateRangeDayDisabled,
   normalizeInsightDateRange,
   startOfCalendarDay,
@@ -101,6 +102,12 @@ describe('inclusiveCalendarDaySpan', () => {
     expect(inclusiveCalendarDaySpan(from, to)).toBeGreaterThanOrEqual(
       msBasedSpan,
     );
+  });
+});
+
+describe('INSIGHT_DATE_RANGE_MAX_NIGHTS', () => {
+  it('is one less than the inclusive day cap for react-day-picker range max', () => {
+    expect(INSIGHT_DATE_RANGE_MAX_NIGHTS).toBe(INSIGHT_DATE_RANGE_MAX_DAYS - 1);
   });
 });
 

--- a/packages/ui/src/lib/insight-date-range-picker-utils.spec.ts
+++ b/packages/ui/src/lib/insight-date-range-picker-utils.spec.ts
@@ -47,7 +47,7 @@ describe('insight-date-range-picker-utils presets', () => {
   it('computes Last 90 days as 90 inclusive calendar days ending today', () => {
     const range = getInsightDateRangePreset('last_90_days');
     expect(range).toEqual({
-      from: localDate(2026, 1, 17),
+      from: localDate(2026, 1, 18),
       to: localDate(2026, 4, 18),
     });
     expect(inclusiveCalendarDaySpan(range.from, range.to)).toBe(90);
@@ -59,6 +59,24 @@ describe('insight-date-range-picker-utils presets', () => {
       from: localDate(2025, 4, 18),
       to: localDate(2026, 4, 18),
     });
+  });
+});
+
+describe('inclusiveCalendarDaySpan', () => {
+  it('counts by civil date ordinals, not elapsed ms / 24h (DST-safe)', () => {
+    const from = localDate(2026, 1, 18);
+    const to = localDate(2026, 4, 18);
+    const startMs = startOfCalendarDay(from).getTime();
+    const endMs = startOfCalendarDay(to).getTime();
+    const msBasedSpan = Math.max(
+      1,
+      Math.floor((endMs - startMs) / 86_400_000) + 1,
+    );
+
+    expect(inclusiveCalendarDaySpan(from, to)).toBe(90);
+    expect(inclusiveCalendarDaySpan(from, to)).toBeGreaterThanOrEqual(
+      msBasedSpan,
+    );
   });
 });
 

--- a/packages/ui/src/lib/insight-date-range-picker-utils.spec.ts
+++ b/packages/ui/src/lib/insight-date-range-picker-utils.spec.ts
@@ -8,6 +8,7 @@ import {
   isInsightDateRangeDayDisabled,
   normalizeInsightDateRange,
   startOfCalendarDay,
+  subtractCalendarMonths,
 } from './insight-date-range-picker-utils.js';
 
 const ANCHOR = new Date(2026, 4, 18, 15, 30, 0); // 2026-05-18 local
@@ -59,6 +60,29 @@ describe('insight-date-range-picker-utils presets', () => {
       from: localDate(2025, 4, 18),
       to: localDate(2026, 4, 18),
     });
+  });
+
+  it('clamps Last 12 months on a leap day anchor to the prior month end', () => {
+    vi.setSystemTime(new Date(2028, 1, 29, 12, 0, 0));
+    const range = getInsightDateRangePreset('last_12_months');
+    expect(range).toEqual({
+      from: localDate(2027, 1, 28),
+      to: localDate(2028, 1, 29),
+    });
+  });
+});
+
+describe('subtractCalendarMonths', () => {
+  it('clamps Feb 29 to Feb 28 when the target year is not a leap year', () => {
+    expect(subtractCalendarMonths(localDate(2028, 1, 29), 12)).toEqual(
+      localDate(2027, 1, 28),
+    );
+  });
+
+  it('clamps Jan 31 to the last day of the prior month', () => {
+    expect(subtractCalendarMonths(localDate(2026, 0, 31), 1)).toEqual(
+      localDate(2025, 11, 31),
+    );
   });
 });
 

--- a/packages/ui/src/lib/insight-date-range-picker-utils.spec.ts
+++ b/packages/ui/src/lib/insight-date-range-picker-utils.spec.ts
@@ -1,0 +1,111 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  clampInsightDateRangeEndToToday,
+  clampInsightDateRangeToMaxDays,
+  getInsightDateRangePreset,
+  inclusiveCalendarDaySpan,
+  INSIGHT_DATE_RANGE_MAX_DAYS,
+  isInsightDateRangeDayDisabled,
+  normalizeInsightDateRange,
+  startOfCalendarDay,
+} from './insight-date-range-picker-utils.js';
+
+const ANCHOR = new Date(2026, 4, 18, 15, 30, 0); // 2026-05-18 local
+
+function localDate(year: number, monthIndex: number, day: number): Date {
+  return new Date(year, monthIndex, day);
+}
+
+describe('insight-date-range-picker-utils presets', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(ANCHOR);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('computes Last 7 days as 7 inclusive calendar days ending today', () => {
+    const range = getInsightDateRangePreset('last_7_days');
+    expect(range).toEqual({
+      from: localDate(2026, 4, 12),
+      to: localDate(2026, 4, 18),
+    });
+    expect(inclusiveCalendarDaySpan(range.from, range.to)).toBe(7);
+  });
+
+  it('computes Last 30 days as 30 inclusive calendar days ending today', () => {
+    const range = getInsightDateRangePreset('last_30_days');
+    expect(range).toEqual({
+      from: localDate(2026, 3, 19),
+      to: localDate(2026, 4, 18),
+    });
+    expect(inclusiveCalendarDaySpan(range.from, range.to)).toBe(30);
+  });
+
+  it('computes Last 90 days as 90 inclusive calendar days ending today', () => {
+    const range = getInsightDateRangePreset('last_90_days');
+    expect(range).toEqual({
+      from: localDate(2026, 1, 17),
+      to: localDate(2026, 4, 18),
+    });
+    expect(inclusiveCalendarDaySpan(range.from, range.to)).toBe(90);
+  });
+
+  it('computes Last 12 months as 12 calendar months before today through today', () => {
+    const range = getInsightDateRangePreset('last_12_months');
+    expect(range).toEqual({
+      from: localDate(2025, 4, 18),
+      to: localDate(2026, 4, 18),
+    });
+  });
+});
+
+describe('insight-date-range-picker-utils constraints', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(ANCHOR);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('disables calendar days after today', () => {
+    expect(isInsightDateRangeDayDisabled(localDate(2026, 4, 18))).toBe(false);
+    expect(isInsightDateRangeDayDisabled(localDate(2026, 4, 19))).toBe(true);
+  });
+
+  it('clamps ranges longer than two years to 730 inclusive days', () => {
+    const range = {
+      from: localDate(2020, 0, 1),
+      to: localDate(2026, 4, 18),
+    };
+    const clamped = clampInsightDateRangeToMaxDays(range);
+    expect(inclusiveCalendarDaySpan(clamped.from, clamped.to)).toBe(
+      INSIGHT_DATE_RANGE_MAX_DAYS,
+    );
+    expect(clamped.to).toEqual(startOfCalendarDay(range.to));
+    expect(clamped.from).toEqual(localDate(2024, 4, 19));
+  });
+
+  it('pulls future end dates back to today when normalizing', () => {
+    const normalized = normalizeInsightDateRange({
+      from: localDate(2026, 4, 1),
+      to: localDate(2026, 5, 1),
+    });
+    expect(normalized.to).toEqual(localDate(2026, 4, 18));
+  });
+
+  it('clamps end to today when the range end is in the future', () => {
+    const clamped = clampInsightDateRangeEndToToday({
+      from: localDate(2026, 4, 10),
+      to: localDate(2026, 6, 1),
+    });
+    expect(clamped).toEqual({
+      from: localDate(2026, 4, 10),
+      to: localDate(2026, 4, 18),
+    });
+  });
+});

--- a/packages/ui/src/lib/insight-date-range-picker-utils.ts
+++ b/packages/ui/src/lib/insight-date-range-picker-utils.ts
@@ -1,0 +1,250 @@
+/** Maximum inclusive span for a chart date range (2 × 365 calendar days). */
+export const INSIGHT_DATE_RANGE_MAX_DAYS = 730;
+
+export type InsightDateRange = {
+  from: Date;
+  to: Date;
+};
+
+export type InsightDateRangePresetId =
+  | 'last_7_days'
+  | 'last_30_days'
+  | 'last_90_days'
+  | 'last_12_months';
+
+/** Preset quick-select options shown above the calendar. */
+export const INSIGHT_DATE_RANGE_PRESETS: ReadonlyArray<{
+  id: InsightDateRangePresetId;
+  label: string;
+}> = [
+  { id: 'last_7_days', label: 'Last 7 days' },
+  { id: 'last_30_days', label: 'Last 30 days' },
+  { id: 'last_90_days', label: 'Last 90 days' },
+  { id: 'last_12_months', label: 'Last 12 months' },
+];
+
+/**
+ * Normalizes a date to local midnight (calendar day).
+ *
+ * @param date - Input instant.
+ * @returns Start of that calendar day in local time.
+ */
+export function startOfCalendarDay(date: Date): Date {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+/**
+ * Returns inclusive calendar-day count between two dates (minimum 1).
+ *
+ * @param from - Range start (calendar day).
+ * @param to - Range end (calendar day).
+ * @returns Number of days in the closed interval.
+ */
+export function inclusiveCalendarDaySpan(from: Date, to: Date): number {
+  const start = startOfCalendarDay(from).getTime();
+  const end = startOfCalendarDay(to).getTime();
+  const msPerDay = 24 * 60 * 60 * 1000;
+  return Math.max(1, Math.floor((end - start) / msPerDay) + 1);
+}
+
+/**
+ * Adds calendar days to a date (local), returning start-of-day.
+ *
+ * @param date - Anchor day.
+ * @param days - Days to add (negative to subtract).
+ * @returns New date at local midnight.
+ */
+export function addCalendarDays(date: Date, days: number): Date {
+  const result = startOfCalendarDay(date);
+  result.setDate(result.getDate() + days);
+  return result;
+}
+
+/**
+ * Subtracts whole calendar months from a date (local), returning start-of-day.
+ *
+ * @param date - Anchor day.
+ * @param months - Months to subtract.
+ * @returns Start-of-day result (month-end overflow handled by the `Date` object).
+ */
+export function subtractCalendarMonths(date: Date, months: number): Date {
+  const result = startOfCalendarDay(date);
+  result.setMonth(result.getMonth() - months);
+  return startOfCalendarDay(result);
+}
+
+/**
+ * Today's calendar date in local time (midnight).
+ *
+ * @param anchor - Reference instant (default now).
+ * @returns Start of the anchor's calendar day.
+ */
+export function getTodayCalendarDate(anchor: Date = new Date()): Date {
+  return startOfCalendarDay(anchor);
+}
+
+/**
+ * Ensures `from` is on or before `to`, both at start-of-day.
+ *
+ * @param range - Candidate range.
+ * @returns Ordered range at calendar-day precision.
+ */
+export function ensureOrderedInsightDateRange(
+  range: InsightDateRange,
+): InsightDateRange {
+  let from = startOfCalendarDay(range.from);
+  let to = startOfCalendarDay(range.to);
+  if (from.getTime() > to.getTime()) {
+    [from, to] = [to, from];
+  }
+  return { from, to };
+}
+
+/**
+ * Clamps the range end to today and pulls the start forward if needed.
+ *
+ * @param range - Candidate range.
+ * @param anchor - Reference "today" (default now).
+ * @returns Range ending no later than the anchor's calendar day.
+ */
+export function clampInsightDateRangeEndToToday(
+  range: InsightDateRange,
+  anchor: Date = new Date(),
+): InsightDateRange {
+  const today = getTodayCalendarDate(anchor);
+  let { from, to } = ensureOrderedInsightDateRange(range);
+  if (to.getTime() > today.getTime()) {
+    to = today;
+  }
+  if (from.getTime() > to.getTime()) {
+    from = to;
+  }
+  return { from, to };
+}
+
+/**
+ * Shortens the range so it spans at most {@link INSIGHT_DATE_RANGE_MAX_DAYS} days,
+ * preserving the end date when possible.
+ *
+ * @param range - Candidate range.
+ * @param maxDays - Maximum inclusive days (default 2 years).
+ * @returns Clamped range.
+ */
+export function clampInsightDateRangeToMaxDays(
+  range: InsightDateRange,
+  maxDays: number = INSIGHT_DATE_RANGE_MAX_DAYS,
+): InsightDateRange {
+  const ordered = ensureOrderedInsightDateRange(range);
+  let from = ordered.from;
+  const { to } = ordered;
+  const span = inclusiveCalendarDaySpan(from, to);
+  if (span <= maxDays) {
+    return { from, to };
+  }
+  from = addCalendarDays(to, -(maxDays - 1));
+  return { from, to };
+}
+
+/**
+ * Applies ordering, end-of-today clamp, and max-span clamp for chart ranges.
+ *
+ * @param range - Candidate range.
+ * @param anchor - Reference "today" (default now).
+ * @returns Normalized range safe for the chart builder.
+ */
+export function normalizeInsightDateRange(
+  range: InsightDateRange,
+  anchor: Date = new Date(),
+): InsightDateRange {
+  return clampInsightDateRangeToMaxDays(
+    clampInsightDateRangeEndToToday(range, anchor),
+  );
+}
+
+/**
+ * `react-day-picker` matchers: disable future calendar days after today.
+ *
+ * @param anchor - Reference "today" (default now).
+ * @returns Matchers for the `disabled` prop.
+ */
+export function getInsightDateRangeDisabledMatchers(
+  anchor: Date = new Date(),
+): Array<{ after: Date }> {
+  return [{ after: getTodayCalendarDate(anchor) }];
+}
+
+/**
+ * Returns whether a calendar day should be disabled (future dates).
+ *
+ * @param day - Day under test.
+ * @param anchor - Reference "today" (default now).
+ * @returns True when the day is after today.
+ */
+export function isInsightDateRangeDayDisabled(
+  day: Date,
+  anchor: Date = new Date(),
+): boolean {
+  return (
+    startOfCalendarDay(day).getTime() > getTodayCalendarDate(anchor).getTime()
+  );
+}
+
+/**
+ * Inclusive range covering the last N calendar days ending on `to`.
+ *
+ * @param to - Range end (calendar day).
+ * @param dayCount - Number of inclusive days (e.g. 7 for “last 7 days”).
+ * @returns Range with exactly `dayCount` days when possible before `to`.
+ */
+export function getLastNDaysInsightDateRange(
+  to: Date,
+  dayCount: number,
+): InsightDateRange {
+  const end = startOfCalendarDay(to);
+  let from = addCalendarDays(end, -(dayCount - 1));
+  while (inclusiveCalendarDaySpan(from, end) < dayCount) {
+    from = addCalendarDays(from, -1);
+  }
+  return { from, to: end };
+}
+
+/**
+ * Computes a preset range ending on the anchor's calendar day.
+ *
+ * @param presetId - Preset identifier.
+ * @param anchor - Range end (default today).
+ * @returns Inclusive local-date range for the preset.
+ */
+export function getInsightDateRangePreset(
+  presetId: InsightDateRangePresetId,
+  anchor: Date = new Date(),
+): InsightDateRange {
+  const to = getTodayCalendarDate(anchor);
+  switch (presetId) {
+    case 'last_7_days':
+      return getLastNDaysInsightDateRange(to, 7);
+    case 'last_30_days':
+      return getLastNDaysInsightDateRange(to, 30);
+    case 'last_90_days':
+      return getLastNDaysInsightDateRange(to, 90);
+    case 'last_12_months':
+      return { from: subtractCalendarMonths(to, 12), to };
+    default: {
+      const _exhaustive: never = presetId;
+      return _exhaustive;
+    }
+  }
+}
+
+/**
+ * Screen-reader announcement for a selected chart date range.
+ *
+ * @param range - Selected range.
+ * @returns Plain-language status message.
+ */
+export function formatInsightDateRangeAnnouncement(
+  range: InsightDateRange,
+): string {
+  const formatter = new Intl.DateTimeFormat(undefined, { dateStyle: 'medium' });
+  return `Date range selected: ${formatter.format(range.from)} to ${formatter.format(range.to)}`;
+}

--- a/packages/ui/src/lib/insight-date-range-picker-utils.ts
+++ b/packages/ui/src/lib/insight-date-range-picker-utils.ts
@@ -34,17 +34,36 @@ export function startOfCalendarDay(date: Date): Date {
 }
 
 /**
+ * Ordinal index for a local calendar day. Uses {@link Date.UTC} on the local
+ * year/month/date so counting is by civil date, not elapsed local milliseconds
+ * (which can be 23h or 25h across DST).
+ *
+ * @param date - Input instant.
+ * @returns UTC day number for the local civil date.
+ */
+export function localCalendarDayOrdinal(date: Date): number {
+  const day = startOfCalendarDay(date);
+  return Math.floor(
+    Date.UTC(day.getFullYear(), day.getMonth(), day.getDate()) / 86_400_000,
+  );
+}
+
+/**
  * Returns inclusive calendar-day count between two dates (minimum 1).
+ * Difference is taken on {@link localCalendarDayOrdinal} values, not wall-clock ms.
  *
  * @param from - Range start (calendar day).
  * @param to - Range end (calendar day).
  * @returns Number of days in the closed interval.
  */
 export function inclusiveCalendarDaySpan(from: Date, to: Date): number {
-  const start = startOfCalendarDay(from).getTime();
-  const end = startOfCalendarDay(to).getTime();
-  const msPerDay = 24 * 60 * 60 * 1000;
-  return Math.max(1, Math.floor((end - start) / msPerDay) + 1);
+  const startOrdinal = localCalendarDayOrdinal(from);
+  const endOrdinal = localCalendarDayOrdinal(to);
+  const [earlier, later] =
+    startOrdinal <= endOrdinal
+      ? [startOrdinal, endOrdinal]
+      : [endOrdinal, startOrdinal];
+  return Math.max(1, later - earlier + 1);
 }
 
 /**

--- a/packages/ui/src/lib/insight-date-range-picker-utils.ts
+++ b/packages/ui/src/lib/insight-date-range-picker-utils.ts
@@ -1,6 +1,12 @@
 /** Maximum inclusive span for a chart date range (2 × 365 calendar days). */
 export const INSIGHT_DATE_RANGE_MAX_DAYS = 730;
 
+/**
+ * Maximum nights between range endpoints for `react-day-picker` `mode="range"` `max`
+ * (picker counts nights; {@link INSIGHT_DATE_RANGE_MAX_DAYS} counts inclusive days).
+ */
+export const INSIGHT_DATE_RANGE_MAX_NIGHTS = INSIGHT_DATE_RANGE_MAX_DAYS - 1;
+
 export type InsightDateRange = {
   from: Date;
   to: Date;

--- a/packages/ui/src/lib/insight-date-range-picker-utils.ts
+++ b/packages/ui/src/lib/insight-date-range-picker-utils.ts
@@ -81,15 +81,25 @@ export function addCalendarDays(date: Date, days: number): Date {
 
 /**
  * Subtracts whole calendar months from a date (local), returning start-of-day.
+ * When the anchor day does not exist in the target month (e.g. Feb 29 → Feb 28),
+ * clamps to the last day of that month instead of overflowing (e.g. into March 1).
  *
  * @param date - Anchor day.
  * @param months - Months to subtract.
- * @returns Start-of-day result (month-end overflow handled by the `Date` object).
+ * @returns Start-of-day result in the target month.
  */
 export function subtractCalendarMonths(date: Date, months: number): Date {
-  const result = startOfCalendarDay(date);
-  result.setMonth(result.getMonth() - months);
-  return startOfCalendarDay(result);
+  const anchor = startOfCalendarDay(date);
+  const day = anchor.getDate();
+  const targetMonthStart = new Date(
+    anchor.getFullYear(),
+    anchor.getMonth() - months,
+    1,
+  );
+  const year = targetMonthStart.getFullYear();
+  const month = targetMonthStart.getMonth();
+  const lastDayOfMonth = new Date(year, month + 1, 0).getDate();
+  return new Date(year, month, Math.min(day, lastDayOfMonth));
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -496,6 +496,9 @@ importers:
 
   packages/ui:
     dependencies:
+      react-day-picker:
+        specifier: ^10.0.1
+        version: 10.0.1(@types/react@19.1.17)(react@19.1.0)
       tslib:
         specifier: ^2.3.0
         version: 2.8.1


### PR DESCRIPTION
Closes #174

## Summary

- Adds web-only `InsightDateRangePicker` to `@abstrack/ui` for the insight chart builder, with preset shortcuts (7 / 30 / 90 days, 12 months) and a `react-day-picker` v10 range calendar.
- Enforces chart constraints: no future dates, max 730-day (2-year) span, with normalization helpers and unit tests.
- Announces range changes via `useAnnounce()`; styles use Tailwind semantic tokens; both web apps scan `packages/ui` for Tailwind classes.

## Details

- **Component:** `packages/ui/src/lib/InsightDateRangePicker.tsx` — controlled `{ from, to }` API, preset toolbar, `DayPicker mode="range"`.
- **Utils:** `packages/ui/src/lib/insight-date-range-picker-utils.ts` — preset math, clamping, disabled matchers, announcement formatting.
- **Exports:** `InsightDateRangePicker` (+ types) from `@abstrack/ui` main barrel only (not `native`).
- **Deps:** `react-day-picker@^10.0.1` on `@abstrack/ui` (aligned with `apps/web` / `apps/practitioner`).
- **Tailwind:** `apps/web` and `apps/practitioner` `tailwind.config.js` include `packages/ui/src/**/*.{ts,tsx}` so picker classes are not purged.

## Test plan

- [x] `pnpm exec nx test ui` (preset math, 2-year clamp, future-date disabling, preset `onChange`, live announcement)
- [x] `pnpm packages:validate` (lint / test / typecheck for shared packages)
- [ ] Manual: mount picker under `LiveAnnouncerProvider` in chart builder; verify keyboard navigation, preset buttons, and screen reader announcement on change