### PR TITLE
feat(ui): add accessible InsightComposedChart renderer with Recharts

### DIFF
--- a/packages/supabase/src/lib/chart-series-query.spec.ts
+++ b/packages/supabase/src/lib/chart-series-query.spec.ts
@@ -28,6 +28,7 @@ const PARAMS: GetChartSeriesParams = {
   p_from: FROM,
   p_to: TO,
   p_bucket: 'week',
+  p_timezone: 'America/New_York',
 };
 
 function chartSeriesClient(rows: ChartSeriesBucketRow[]) {
@@ -38,7 +39,7 @@ function chartSeriesClient(rows: ChartSeriesBucketRow[]) {
 }
 
 describe('getChartSeries', () => {
-  it('calls get_chart_series RPC with user, series, range, and bucket', async () => {
+  it('calls get_chart_series RPC with user, series, range, bucket, and timezone', async () => {
     const client = chartSeriesClient([]);
 
     await getChartSeries(client, PARAMS);

--- a/packages/supabase/src/lib/chart-series-query.ts
+++ b/packages/supabase/src/lib/chart-series-query.ts
@@ -40,6 +40,11 @@ export interface GetChartSeriesParams {
   p_from: string;
   p_to: string;
   p_bucket: ChartSeriesBucket;
+  /**
+   * IANA timezone for bucket boundaries (e.g. `America/Chicago`).
+   * Must match `patientTimeZone` on `InsightComposedChart` (`@abstrack/ui`).
+   */
+  p_timezone: string;
 }
 
 /**
@@ -47,7 +52,7 @@ export interface GetChartSeriesParams {
  * Uses `SECURITY INVOKER` so existing RLS on `health_markers` and `episode_symptoms` applies.
  *
  * @param client - Supabase client with the caller JWT.
- * @param params - RPC arguments (`p_user_id`, `p_series`, `p_from`, `p_to`, `p_bucket`).
+ * @param params - RPC arguments (`p_user_id`, `p_series`, `p_from`, `p_to`, `p_bucket`, `p_timezone`).
  * @returns Bucketed rows from Postgres on success (`data` is unchanged RPC output).
  */
 export async function getChartSeries(
@@ -61,6 +66,7 @@ export async function getChartSeries(
       p_from: params.p_from,
       p_to: params.p_to,
       p_bucket: params.p_bucket,
+      p_timezone: params.p_timezone,
     });
 
     if (error) {

--- a/packages/supabase/src/lib/database.types.ts
+++ b/packages/supabase/src/lib/database.types.ts
@@ -722,6 +722,7 @@ export type Database = {
           p_bucket: string
           p_from: string
           p_series: Json
+          p_timezone: string
           p_to: string
           p_user_id: string
         }

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -33,6 +33,7 @@
   },
   "dependencies": {
     "react-day-picker": "^10.0.1",
+    "recharts": "^3.8.1",
     "tslib": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -23,3 +23,14 @@ export {
   type InsightDateRangePickerProps,
   type InsightDateRangePresetId,
 } from './lib/InsightDateRangePicker.js';
+export {
+  InsightComposedChart,
+  type ChartSeriesBucketMetrics,
+  type ChartSeriesRow,
+  type InsightChartBucket,
+  type InsightComposedChartProps,
+} from './lib/InsightComposedChart.js';
+export {
+  pivotChartSeriesBucketRows,
+  type ChartSeriesBucketRowInput,
+} from './lib/insight-composed-chart-utils.js';

--- a/packages/ui/src/lib/InsightComposedChart.spec.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.spec.tsx
@@ -4,6 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ChartSeriesRow } from './InsightComposedChart.types.js';
 import type { SelectedSeries } from './InsightSeriesPicker.types.js';
 import {
+  chartSeriesBpBandKey,
   chartSeriesDiastolicAvgKey,
   chartSeriesSystolicAvgKey,
   chartSeriesValueAvgKey,
@@ -149,6 +150,8 @@ describe('InsightComposedChart', () => {
       ),
     ).toBe(true);
     expect(rechartsMocks.Area).toHaveLength(1);
+    expect(rechartsMocks.Area[0]?.dataKey).toBe(chartSeriesBpBandKey(seriesId));
+    expect(rechartsMocks.Area[0]?.baseLine).toBeUndefined();
   });
 
   it('renders ReferenceLine only for buckets where event_count is greater than zero', () => {

--- a/packages/ui/src/lib/InsightComposedChart.spec.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.spec.tsx
@@ -1,0 +1,275 @@
+import { render, screen, within } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ChartSeriesRow } from './InsightComposedChart.types.js';
+import type { SelectedSeries } from './InsightSeriesPicker.types.js';
+import {
+  chartSeriesDiastolicAvgKey,
+  chartSeriesSystolicAvgKey,
+  chartSeriesValueAvgKey,
+} from './insight-composed-chart-utils.js';
+
+const rechartsMocks = vi.hoisted(() => ({
+  Line: [] as Record<string, unknown>[],
+  Bar: [] as Record<string, unknown>[],
+  Scatter: [] as Record<string, unknown>[],
+  Area: [] as Record<string, unknown>[],
+  ReferenceLine: [] as Record<string, unknown>[],
+}));
+
+function captureMock(name: keyof typeof rechartsMocks) {
+  return function MockComponent(props: Record<string, unknown>) {
+    rechartsMocks[name].push(props);
+    return <div data-testid={`mock-${name}`} />;
+  };
+}
+
+vi.mock('recharts', () => ({
+  ResponsiveContainer: ({ children }: { children: ReactNode }) => (
+    <div data-testid="responsive-container">{children}</div>
+  ),
+  ComposedChart: ({ children }: { children: ReactNode }) => (
+    <div data-testid="composed-chart">{children}</div>
+  ),
+  CartesianGrid: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  Tooltip: () => null,
+  Line: captureMock('Line'),
+  Bar: captureMock('Bar'),
+  Scatter: captureMock('Scatter'),
+  Area: captureMock('Area'),
+  ReferenceLine: captureMock('ReferenceLine'),
+}));
+
+import { InsightComposedChart } from './InsightComposedChart.js';
+
+function baseSeries(
+  overrides: Partial<SelectedSeries> &
+    Pick<SelectedSeries, 'seriesId' | 'chartType'>,
+): SelectedSeries {
+  return {
+    seriesType: 'health_marker',
+    responseType: 'numeric',
+    isBloodPressure: false,
+    label: overrides.label ?? overrides.seriesId,
+    unit: overrides.unit ?? null,
+    color: overrides.color ?? '#1d4ed8',
+    ...overrides,
+  };
+}
+
+function bucketRow(
+  bucketStart: string,
+  seriesId: string,
+  metrics: ChartSeriesRow['series'][string],
+): ChartSeriesRow {
+  return {
+    bucketStart,
+    series: { [seriesId]: metrics },
+  };
+}
+
+function mergeRows(...rows: ChartSeriesRow[]): ChartSeriesRow[] {
+  const merged = new Map<string, ChartSeriesRow>();
+  for (const row of rows) {
+    const existing = merged.get(row.bucketStart);
+    if (existing) {
+      existing.series = { ...existing.series, ...row.series };
+    } else {
+      merged.set(row.bucketStart, {
+        bucketStart: row.bucketStart,
+        series: { ...row.series },
+      });
+    }
+  }
+  return [...merged.values()].sort((a, b) =>
+    a.bucketStart.localeCompare(b.bucketStart),
+  );
+}
+
+describe('InsightComposedChart', () => {
+  beforeEach(() => {
+    for (const key of Object.keys(
+      rechartsMocks,
+    ) as (keyof typeof rechartsMocks)[]) {
+      rechartsMocks[key] = [];
+    }
+  });
+
+  it('renders exactly two Line components for bp_band and never a single Line alone', () => {
+    const seriesId = 'health_marker::blood_pressure';
+    const selected = baseSeries({
+      seriesId,
+      chartType: 'bp_band',
+      isBloodPressure: true,
+      label: 'Blood pressure',
+      unit: 'mmHg',
+    });
+    const data = mergeRows(
+      bucketRow('2026-01-01T00:00:00.000Z', seriesId, {
+        value_avg: null,
+        systolic_avg: 130,
+        diastolic_avg: 85,
+        event_count: null,
+      }),
+      bucketRow('2026-02-01T00:00:00.000Z', seriesId, {
+        value_avg: null,
+        systolic_avg: 128,
+        diastolic_avg: 82,
+        event_count: null,
+      }),
+    );
+
+    render(
+      <InsightComposedChart
+        series={[selected]}
+        data={data}
+        bucket="month"
+        loading={false}
+        summary="Blood pressure trend."
+      />,
+    );
+
+    const lines = rechartsMocks.Line.filter(
+      (props) =>
+        props.dataKey === chartSeriesSystolicAvgKey(seriesId) ||
+        props.dataKey === chartSeriesDiastolicAvgKey(seriesId),
+    );
+    expect(lines).toHaveLength(2);
+    expect(
+      lines.some(
+        (props) => props.dataKey === chartSeriesSystolicAvgKey(seriesId),
+      ),
+    ).toBe(true);
+    expect(
+      lines.some(
+        (props) => props.dataKey === chartSeriesDiastolicAvgKey(seriesId),
+      ),
+    ).toBe(true);
+    expect(rechartsMocks.Area).toHaveLength(1);
+  });
+
+  it('renders ReferenceLine only for buckets where event_count is greater than zero', () => {
+    const seriesId = 'symptom::nausea::boolean';
+    const selected = baseSeries({
+      seriesId,
+      chartType: 'event',
+      seriesType: 'symptom',
+      responseType: 'boolean',
+      label: 'Nausea',
+    });
+    const data = mergeRows(
+      bucketRow('2026-01-01T00:00:00.000Z', seriesId, {
+        value_avg: null,
+        systolic_avg: null,
+        diastolic_avg: null,
+        event_count: 0,
+      }),
+      bucketRow('2026-02-01T00:00:00.000Z', seriesId, {
+        value_avg: null,
+        systolic_avg: null,
+        diastolic_avg: null,
+        event_count: 2,
+      }),
+      bucketRow('2026-03-01T00:00:00.000Z', seriesId, {
+        value_avg: null,
+        systolic_avg: null,
+        diastolic_avg: null,
+        event_count: null,
+      }),
+    );
+
+    render(
+      <InsightComposedChart
+        series={[selected]}
+        data={data}
+        bucket="month"
+        loading={false}
+        summary="Nausea events."
+      />,
+    );
+
+    expect(rechartsMocks.ReferenceLine).toHaveLength(1);
+    expect(rechartsMocks.ReferenceLine[0]?.x).toBe('2026-02-01T00:00:00.000Z');
+  });
+
+  it('includes separate systolic and diastolic columns for blood pressure in the accessible table', () => {
+    const seriesId = 'health_marker::blood_pressure';
+    const selected = baseSeries({
+      seriesId,
+      chartType: 'bp_band',
+      isBloodPressure: true,
+      label: 'Blood pressure',
+      unit: 'mmHg',
+    });
+
+    render(
+      <InsightComposedChart
+        series={[selected]}
+        data={[
+          bucketRow('2026-01-01T00:00:00.000Z', seriesId, {
+            value_avg: null,
+            systolic_avg: 120,
+            diastolic_avg: 80,
+            event_count: null,
+          }),
+        ]}
+        bucket="day"
+        loading={false}
+        summary="Blood pressure table."
+      />,
+    );
+
+    const table = screen.getByRole('table', { hidden: true });
+    const headers = within(table).getAllByRole('columnheader', {
+      hidden: true,
+    });
+    expect(headers.map((cell) => cell.textContent)).toEqual(
+      expect.arrayContaining([
+        'Blood pressure (systolic)',
+        'Blood pressure (diastolic)',
+      ]),
+    );
+  });
+
+  it.each([
+    ['line', 'Line'] as const,
+    ['bar', 'Bar'] as const,
+    ['scatter', 'Scatter'] as const,
+  ])(
+    'renders %s chart type with the matching Recharts component',
+    (chartType, component) => {
+      const seriesId = 'health_marker::bac';
+      const selected = baseSeries({
+        seriesId,
+        chartType,
+        label: 'BAC',
+        unit: '%',
+      });
+
+      render(
+        <InsightComposedChart
+          series={[selected]}
+          data={[
+            bucketRow('2026-01-01T00:00:00.000Z', seriesId, {
+              value_avg: 0.05,
+              systolic_avg: null,
+              diastolic_avg: null,
+              event_count: null,
+            }),
+          ]}
+          bucket="week"
+          loading={false}
+          summary={`${chartType} chart.`}
+        />,
+      );
+
+      const valueKey = chartSeriesValueAvgKey(seriesId);
+      const rendered = rechartsMocks[component].filter(
+        (props) => props.dataKey === valueKey,
+      );
+      expect(rendered).toHaveLength(1);
+    },
+  );
+});

--- a/packages/ui/src/lib/InsightComposedChart.spec.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.spec.tsx
@@ -128,6 +128,7 @@ describe('InsightComposedChart', () => {
         bucket="month"
         loading={false}
         summary="Blood pressure trend."
+        patientTimeZone="UTC"
       />,
     );
 
@@ -187,6 +188,7 @@ describe('InsightComposedChart', () => {
         bucket="month"
         loading={false}
         summary="Nausea events."
+        patientTimeZone="UTC"
       />,
     );
 
@@ -218,6 +220,7 @@ describe('InsightComposedChart', () => {
         bucket="day"
         loading={false}
         summary="Blood pressure table."
+        patientTimeZone="UTC"
       />,
     );
 
@@ -262,6 +265,7 @@ describe('InsightComposedChart', () => {
           bucket="week"
           loading={false}
           summary={`${chartType} chart.`}
+          patientTimeZone="UTC"
         />,
       );
 
@@ -272,4 +276,46 @@ describe('InsightComposedChart', () => {
       expect(rendered).toHaveLength(1);
     },
   );
+
+  it('shows an alert instead of the chart when three distinct value units are selected', () => {
+    render(
+      <InsightComposedChart
+        series={[
+          baseSeries({ seriesId: 'bac', chartType: 'line', unit: '%' }),
+          baseSeries({
+            seriesId: 'glucose',
+            chartType: 'line',
+            unit: 'mmol/L',
+          }),
+          baseSeries({ seriesId: 'hr', chartType: 'line', unit: 'bpm' }),
+        ]}
+        data={[]}
+        bucket="day"
+        loading={false}
+        summary="Unsupported combination."
+        patientTimeZone="UTC"
+      />,
+    );
+
+    expect(screen.getByRole('alert')).toHaveTextContent(
+      /at most 2 different measurement units/i,
+    );
+    expect(screen.queryByTestId('composed-chart')).not.toBeInTheDocument();
+  });
+
+  it('shows a patient timezone note when showPatientTimeZoneNote is true', () => {
+    render(
+      <InsightComposedChart
+        series={[baseSeries({ seriesId: 'bac', chartType: 'line', unit: '%' })]}
+        data={[]}
+        bucket="day"
+        loading={false}
+        summary="BAC trend."
+        patientTimeZone="America/Chicago"
+        showPatientTimeZoneNote
+      />,
+    );
+
+    expect(screen.getByText(/patient's local timezone/i)).toBeInTheDocument();
+  });
 });

--- a/packages/ui/src/lib/InsightComposedChart.spec.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.spec.tsx
@@ -304,6 +304,9 @@ describe('InsightComposedChart', () => {
       /at most 2 different measurement units/i,
     );
     expect(screen.queryByTestId('composed-chart')).not.toBeInTheDocument();
+    expect(
+      screen.queryByText(/no data for this range/i),
+    ).not.toBeInTheDocument();
   });
 
   it('shows a patient timezone note when showPatientTimeZoneNote is true', () => {

--- a/packages/ui/src/lib/InsightComposedChart.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.tsx
@@ -354,7 +354,7 @@ export function InsightComposedChart({
           </div>
         )}
 
-        {!loading && chartData.length === 0 ? (
+        {!loading && !unsupportedMessage && chartData.length === 0 ? (
           <p className="mt-2 text-sm text-app-muted">No data for this range.</p>
         ) : null}
       </figure>

--- a/packages/ui/src/lib/InsightComposedChart.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.tsx
@@ -1,0 +1,370 @@
+'use client';
+
+import { Fragment, useMemo, type ReactNode } from 'react';
+import {
+  Area,
+  Bar,
+  CartesianGrid,
+  ComposedChart,
+  Line,
+  ReferenceLine,
+  ResponsiveContainer,
+  Scatter,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+import {
+  assignInsightChartYAxes,
+  buildInsightChartTableColumns,
+  chartSeriesDiastolicAvgKey,
+  chartSeriesSystolicAvgKey,
+  chartSeriesValueAvgKey,
+  flattenChartSeriesRows,
+  formatInsightChartBucketLabel,
+  formatInsightChartTableCell,
+  readInsightChartTableMetric,
+  type InsightValueYAxisId,
+} from './insight-composed-chart-utils.js';
+import type {
+  ChartSeriesRow,
+  InsightComposedChartProps,
+} from './InsightComposedChart.types.js';
+import type { SelectedSeries } from './InsightSeriesPicker.types.js';
+
+export type {
+  ChartSeriesBucketMetrics,
+  ChartSeriesRow,
+  InsightChartBucket,
+  InsightComposedChartProps,
+} from './InsightComposedChart.types.js';
+
+const CHART_HEIGHT_PX = 320;
+
+function yAxisLabelForUnit(
+  series: SelectedSeries[],
+  axisId: InsightValueYAxisId,
+): string | undefined {
+  if (axisId === 'bp') {
+    const bp = series.find((item) => item.chartType === 'bp_band');
+    return bp?.unit ?? 'mmHg';
+  }
+
+  const match = series.find((item) => {
+    if (item.chartType === 'event' || item.chartType === 'bp_band') {
+      return false;
+    }
+    const assigned = assignInsightChartYAxes(series).get(item.seriesId);
+    return assigned === axisId;
+  });
+
+  if (!match) {
+    return undefined;
+  }
+
+  if (match.responseType === 'severity') {
+    return 'Severity';
+  }
+
+  return match.unit ?? undefined;
+}
+
+function renderValueSeries(
+  item: SelectedSeries,
+  yAxisId: InsightValueYAxisId,
+): ReactNode {
+  const valueKey = chartSeriesValueAvgKey(item.seriesId);
+  const common = {
+    name: item.label,
+    dataKey: valueKey,
+    yAxisId,
+    stroke: item.color,
+    fill: item.color,
+    isAnimationActive: false,
+  } as const;
+
+  switch (item.chartType) {
+    case 'line':
+      return (
+        <Line
+          key={item.seriesId}
+          {...common}
+          type="monotone"
+          dot={{ r: 3, fill: item.color }}
+          connectNulls
+        />
+      );
+    case 'bar':
+      return <Bar key={item.seriesId} {...common} />;
+    case 'scatter':
+      return (
+        <Scatter
+          key={item.seriesId}
+          {...common}
+          fill={item.color}
+          legendType="circle"
+          shape="circle"
+        />
+      );
+    default:
+      return null;
+  }
+}
+
+function renderBloodPressureBand(
+  item: SelectedSeries,
+  chartData: Record<string, string | number | null>[],
+): ReactNode {
+  const systolicKey = chartSeriesSystolicAvgKey(item.seriesId);
+  const diastolicKey = chartSeriesDiastolicAvgKey(item.seriesId);
+  const baseLine = chartData.map((row) => ({
+    x: row.bucketStart as string,
+    y: row[diastolicKey] as number | null,
+  }));
+
+  return (
+    <>
+      <Area
+        key={`${item.seriesId}-area`}
+        type="monotone"
+        dataKey={systolicKey}
+        yAxisId="bp"
+        stroke="none"
+        fill={item.color}
+        fillOpacity={0.2}
+        dot={false}
+        activeDot={false}
+        baseLine={baseLine as never}
+        isAnimationActive={false}
+        connectNulls
+      />
+      <Line
+        key={`${item.seriesId}-systolic`}
+        type="monotone"
+        dataKey={systolicKey}
+        yAxisId="bp"
+        name={`${item.label} (systolic)`}
+        stroke={item.color}
+        dot={false}
+        connectNulls
+        isAnimationActive={false}
+      />
+      <Line
+        key={`${item.seriesId}-diastolic`}
+        type="monotone"
+        dataKey={diastolicKey}
+        yAxisId="bp"
+        name={`${item.label} (diastolic)`}
+        stroke={item.color}
+        strokeDasharray="4 3"
+        dot={false}
+        connectNulls
+        isAnimationActive={false}
+      />
+    </>
+  );
+}
+
+function renderEventMarkers(
+  item: SelectedSeries,
+  data: ChartSeriesRow[],
+): ReactNode[] {
+  return data
+    .filter((row) => {
+      const count = row.series[item.seriesId]?.event_count;
+      return count !== null && count !== undefined && count > 0;
+    })
+    .map((row) => (
+      <ReferenceLine
+        key={`${item.seriesId}-${row.bucketStart}`}
+        x={row.bucketStart}
+        stroke={item.color}
+        strokeWidth={2}
+        strokeOpacity={0.85}
+        ifOverflow="visible"
+        label={{
+          value: item.label,
+          position: 'insideTop',
+          fill: item.color,
+          fontSize: 10,
+        }}
+      />
+    ));
+}
+
+/**
+ * Accessible multi-series insight chart (web only) using Recharts `ComposedChart`.
+ * Renders server-prepared bucketed series with a figcaption summary and data table.
+ *
+ * @param props - Selected series manifest, pivoted bucket rows, bucket size, loading flag, and summary.
+ * @returns Chart figure with visually hidden tabular alternative.
+ */
+export function InsightComposedChart({
+  series,
+  data,
+  bucket,
+  loading,
+  summary,
+}: InsightComposedChartProps) {
+  const chartData = useMemo(() => flattenChartSeriesRows(data), [data]);
+  const yAxisAssignments = useMemo(
+    () => assignInsightChartYAxes(series),
+    [series],
+  );
+  const tableColumns = useMemo(
+    () => buildInsightChartTableColumns(series),
+    [series],
+  );
+
+  const usesLeftAxis = [...yAxisAssignments.values()].includes('left');
+  const usesRightAxis = [...yAxisAssignments.values()].includes('right');
+  const usesBpAxis = [...yAxisAssignments.values()].includes('bp');
+
+  const bucketTickFormatter = (value: string) =>
+    formatInsightChartBucketLabel(value, bucket);
+
+  return (
+    <div className="space-y-3">
+      <figure
+        aria-busy={loading ? true : undefined}
+        aria-labelledby="insight-chart-summary"
+        className="rounded-xl border border-app-border bg-app-surface p-4"
+      >
+        <figcaption
+          id="insight-chart-summary"
+          className="mb-3 text-sm text-app-ink"
+        >
+          {summary}
+        </figcaption>
+
+        {loading ? (
+          <p className="text-sm text-app-muted" role="status">
+            Loading chart…
+          </p>
+        ) : (
+          <div
+            className="h-80 w-full min-w-0"
+            aria-hidden={chartData.length === 0}
+          >
+            <ResponsiveContainer width="100%" height={CHART_HEIGHT_PX}>
+              <ComposedChart
+                data={chartData}
+                margin={{ top: 12, right: 16, bottom: 8, left: 8 }}
+              >
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  className="stroke-app-border"
+                />
+                <XAxis
+                  dataKey="bucketStart"
+                  tickFormatter={bucketTickFormatter}
+                  tick={{ fill: 'currentColor', fontSize: 12 }}
+                />
+                {usesLeftAxis ? (
+                  <YAxis
+                    yAxisId="left"
+                    orientation="left"
+                    tick={{ fill: 'currentColor', fontSize: 12 }}
+                    label={{
+                      value: yAxisLabelForUnit(series, 'left'),
+                      angle: -90,
+                      position: 'insideLeft',
+                    }}
+                  />
+                ) : null}
+                {usesRightAxis ? (
+                  <YAxis
+                    yAxisId="right"
+                    orientation="right"
+                    tick={{ fill: 'currentColor', fontSize: 12 }}
+                    label={{
+                      value: yAxisLabelForUnit(series, 'right'),
+                      angle: 90,
+                      position: 'insideRight',
+                    }}
+                  />
+                ) : null}
+                {usesBpAxis ? (
+                  <YAxis
+                    yAxisId="bp"
+                    orientation="left"
+                    tick={{ fill: 'currentColor', fontSize: 12 }}
+                    label={{
+                      value: yAxisLabelForUnit(series, 'bp'),
+                      angle: -90,
+                      position: 'insideLeft',
+                    }}
+                  />
+                ) : null}
+                <Tooltip
+                  labelFormatter={(label) => bucketTickFormatter(String(label))}
+                />
+                {series.map((item) => {
+                  if (item.chartType === 'bp_band') {
+                    return (
+                      <Fragment key={item.seriesId}>
+                        {renderBloodPressureBand(item, chartData)}
+                      </Fragment>
+                    );
+                  }
+                  if (item.chartType === 'event') {
+                    return (
+                      <Fragment key={item.seriesId}>
+                        {renderEventMarkers(item, data)}
+                      </Fragment>
+                    );
+                  }
+                  const yAxisId = yAxisAssignments.get(item.seriesId);
+                  if (!yAxisId) {
+                    return null;
+                  }
+                  return renderValueSeries(item, yAxisId);
+                })}
+              </ComposedChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+
+        {!loading && chartData.length === 0 ? (
+          <p className="mt-2 text-sm text-app-muted">No data for this range.</p>
+        ) : null}
+      </figure>
+
+      <table className="sr-only">
+        <caption>Detailed chart data by {bucket}</caption>
+        <thead>
+          <tr>
+            <th scope="col">Period</th>
+            {tableColumns.map((column) => (
+              <th key={column.id} scope="col">
+                {column.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {data.map((row) => (
+            <tr key={row.bucketStart}>
+              <th scope="row">
+                {formatInsightChartBucketLabel(row.bucketStart, bucket)}
+              </th>
+              {tableColumns.map((column) => {
+                const selected = series.find(
+                  (item) => item.seriesId === column.seriesId,
+                );
+                const metric = readInsightChartTableMetric(row, column);
+                return (
+                  <td key={column.id}>
+                    {column.kind === 'event_count'
+                      ? formatInsightChartTableCell(metric)
+                      : formatInsightChartTableCell(metric, selected?.unit)}
+                  </td>
+                );
+              })}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/ui/src/lib/InsightComposedChart.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.tsx
@@ -17,6 +17,8 @@ import {
 import {
   assignInsightChartYAxes,
   buildInsightChartTableColumns,
+  chartSeriesBpBandKey,
+  enrichInsightChartDataForBloodPressure,
   getInsightChartUnsupportedMessage,
   chartSeriesDiastolicAvgKey,
   chartSeriesSystolicAvgKey,
@@ -113,30 +115,23 @@ function renderValueSeries(
   }
 }
 
-function renderBloodPressureBand(
-  item: SelectedSeries,
-  chartData: Record<string, string | number | null>[],
-): ReactNode {
+function renderBloodPressureBand(item: SelectedSeries): ReactNode {
   const systolicKey = chartSeriesSystolicAvgKey(item.seriesId);
   const diastolicKey = chartSeriesDiastolicAvgKey(item.seriesId);
-  const baseLine = chartData.map((row) => ({
-    x: row.bucketStart as string,
-    y: row[diastolicKey] as number | null,
-  }));
+  const bandKey = chartSeriesBpBandKey(item.seriesId);
 
   return (
     <>
       <Area
         key={`${item.seriesId}-area`}
         type="monotone"
-        dataKey={systolicKey}
+        dataKey={bandKey}
         yAxisId="bp"
         stroke="none"
         fill={item.color}
         fillOpacity={0.2}
         dot={false}
         activeDot={false}
-        baseLine={baseLine as never}
         isAnimationActive={false}
         connectNulls
       />
@@ -210,7 +205,14 @@ export function InsightComposedChart({
   patientTimeZone,
   showPatientTimeZoneNote = false,
 }: InsightComposedChartProps) {
-  const chartData = useMemo(() => flattenChartSeriesRows(data), [data]);
+  const chartData = useMemo(
+    () =>
+      enrichInsightChartDataForBloodPressure(
+        flattenChartSeriesRows(data),
+        series,
+      ),
+    [data, series],
+  );
   const yAxisAssignments = useMemo(
     () => assignInsightChartYAxes(series),
     [series],
@@ -330,7 +332,7 @@ export function InsightComposedChart({
                   if (item.chartType === 'bp_band') {
                     return (
                       <Fragment key={item.seriesId}>
-                        {renderBloodPressureBand(item, chartData)}
+                        {renderBloodPressureBand(item)}
                       </Fragment>
                     );
                   }

--- a/packages/ui/src/lib/InsightComposedChart.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Fragment, useMemo, type ReactNode } from 'react';
+import { Fragment, useId, useMemo, type ReactNode } from 'react';
 import {
   Area,
   Bar,
@@ -17,11 +17,13 @@ import {
 import {
   assignInsightChartYAxes,
   buildInsightChartTableColumns,
+  getInsightChartUnsupportedMessage,
   chartSeriesDiastolicAvgKey,
   chartSeriesSystolicAvgKey,
   chartSeriesValueAvgKey,
   flattenChartSeriesRows,
   formatInsightChartBucketLabel,
+  formatInsightChartPatientTimeZoneNote,
   formatInsightChartTableCell,
   readInsightChartTableMetric,
   type InsightValueYAxisId,
@@ -43,6 +45,7 @@ const CHART_HEIGHT_PX = 320;
 
 function yAxisLabelForUnit(
   series: SelectedSeries[],
+  yAxisAssignments: Map<string, InsightValueYAxisId | null>,
   axisId: InsightValueYAxisId,
 ): string | undefined {
   if (axisId === 'bp') {
@@ -54,8 +57,7 @@ function yAxisLabelForUnit(
     if (item.chartType === 'event' || item.chartType === 'bp_band') {
       return false;
     }
-    const assigned = assignInsightChartYAxes(series).get(item.seriesId);
-    return assigned === axisId;
+    return yAxisAssignments.get(item.seriesId) === axisId;
   });
 
   if (!match) {
@@ -205,6 +207,8 @@ export function InsightComposedChart({
   bucket,
   loading,
   summary,
+  patientTimeZone,
+  showPatientTimeZoneNote = false,
 }: InsightComposedChartProps) {
   const chartData = useMemo(() => flattenChartSeriesRows(data), [data]);
   const yAxisAssignments = useMemo(
@@ -215,31 +219,46 @@ export function InsightComposedChart({
     () => buildInsightChartTableColumns(series),
     [series],
   );
+  const unsupportedMessage = useMemo(
+    () => getInsightChartUnsupportedMessage(series),
+    [series],
+  );
 
   const usesLeftAxis = [...yAxisAssignments.values()].includes('left');
   const usesRightAxis = [...yAxisAssignments.values()].includes('right');
   const usesBpAxis = [...yAxisAssignments.values()].includes('bp');
 
-  const bucketTickFormatter = (value: string) =>
-    formatInsightChartBucketLabel(value, bucket);
+  const bucketTickFormatter = useMemo(
+    () => (value: string) =>
+      formatInsightChartBucketLabel(value, bucket, patientTimeZone),
+    [bucket, patientTimeZone],
+  );
+  const summaryId = `${useId().replace(/:/g, '')}-summary`;
 
   return (
     <div className="space-y-3">
       <figure
         aria-busy={loading ? true : undefined}
-        aria-labelledby="insight-chart-summary"
+        aria-labelledby={summaryId}
         className="rounded-xl border border-app-border bg-app-surface p-4"
       >
-        <figcaption
-          id="insight-chart-summary"
-          className="mb-3 text-sm text-app-ink"
-        >
+        <figcaption id={summaryId} className="mb-3 text-sm text-app-ink">
           {summary}
         </figcaption>
+
+        {showPatientTimeZoneNote ? (
+          <p className="mb-3 text-xs text-app-muted">
+            {formatInsightChartPatientTimeZoneNote(patientTimeZone)}
+          </p>
+        ) : null}
 
         {loading ? (
           <p className="text-sm text-app-muted" role="status">
             Loading chart…
+          </p>
+        ) : unsupportedMessage ? (
+          <p className="text-sm text-app-muted" role="alert">
+            {unsupportedMessage}
           </p>
         ) : (
           <div
@@ -266,7 +285,11 @@ export function InsightComposedChart({
                     orientation="left"
                     tick={{ fill: 'currentColor', fontSize: 12 }}
                     label={{
-                      value: yAxisLabelForUnit(series, 'left'),
+                      value: yAxisLabelForUnit(
+                        series,
+                        yAxisAssignments,
+                        'left',
+                      ),
                       angle: -90,
                       position: 'insideLeft',
                     }}
@@ -278,7 +301,11 @@ export function InsightComposedChart({
                     orientation="right"
                     tick={{ fill: 'currentColor', fontSize: 12 }}
                     label={{
-                      value: yAxisLabelForUnit(series, 'right'),
+                      value: yAxisLabelForUnit(
+                        series,
+                        yAxisAssignments,
+                        'right',
+                      ),
                       angle: 90,
                       position: 'insideRight',
                     }}
@@ -290,7 +317,7 @@ export function InsightComposedChart({
                     orientation="left"
                     tick={{ fill: 'currentColor', fontSize: 12 }}
                     label={{
-                      value: yAxisLabelForUnit(series, 'bp'),
+                      value: yAxisLabelForUnit(series, yAxisAssignments, 'bp'),
                       angle: -90,
                       position: 'insideLeft',
                     }}
@@ -346,7 +373,11 @@ export function InsightComposedChart({
           {data.map((row) => (
             <tr key={row.bucketStart}>
               <th scope="row">
-                {formatInsightChartBucketLabel(row.bucketStart, bucket)}
+                {formatInsightChartBucketLabel(
+                  row.bucketStart,
+                  bucket,
+                  patientTimeZone,
+                )}
               </th>
               {tableColumns.map((column) => {
                 const selected = series.find(

--- a/packages/ui/src/lib/InsightComposedChart.types.ts
+++ b/packages/ui/src/lib/InsightComposedChart.types.ts
@@ -39,9 +39,9 @@ export interface InsightComposedChartProps {
   summary: string;
   /**
    * IANA timezone for bucket axis and table labels (e.g. `America/Chicago`).
-   * Use the **patient's** timezone so day/week/month boundaries match how they
-   * experience dates; pass the viewer device zone only when the patient is viewing
-   * their own chart.
+   * Must be the same value as `p_timezone` on {@link getChartSeries} so server
+   * `bucket_start` values and labels stay aligned. Use the **patient's** timezone;
+   * pass the device zone only when the patient views their own chart.
    */
   patientTimeZone: string;
   /**

--- a/packages/ui/src/lib/InsightComposedChart.types.ts
+++ b/packages/ui/src/lib/InsightComposedChart.types.ts
@@ -1,0 +1,42 @@
+import type {
+  ChartTypeChoice,
+  SelectedSeries,
+} from './InsightSeriesPicker.types.js';
+
+/** Time bucket granularity for insight charts (matches `get_chart_series`). */
+export type InsightChartBucket = 'day' | 'week' | 'month';
+
+/**
+ * Aggregated metrics for one selected series in one time bucket.
+ * Field names align with `get_chart_series` RPC columns.
+ */
+export interface ChartSeriesBucketMetrics {
+  value_avg: number | null;
+  value_min?: number | null;
+  value_max?: number | null;
+  systolic_avg: number | null;
+  diastolic_avg: number | null;
+  event_count: number | null;
+}
+
+/**
+ * One row of pre-pivoted chart data (one bucket, all selected series).
+ * Keys in `series` are manifest `series_id` values.
+ */
+export interface ChartSeriesRow {
+  /** ISO `bucket_start` timestamp from `get_chart_series`. */
+  bucketStart: string;
+  series: Record<string, ChartSeriesBucketMetrics>;
+}
+
+/** Props for {@link InsightComposedChart}. */
+export interface InsightComposedChartProps {
+  series: SelectedSeries[];
+  data: ChartSeriesRow[];
+  bucket: InsightChartBucket;
+  loading: boolean;
+  /** Plain-English summary of the chart for screen readers — required. */
+  summary: string;
+}
+
+export type { ChartTypeChoice, SelectedSeries };

--- a/packages/ui/src/lib/InsightComposedChart.types.ts
+++ b/packages/ui/src/lib/InsightComposedChart.types.ts
@@ -37,6 +37,19 @@ export interface InsightComposedChartProps {
   loading: boolean;
   /** Plain-English summary of the chart for screen readers — required. */
   summary: string;
+  /**
+   * IANA timezone for bucket axis and table labels (e.g. `America/Chicago`).
+   * Use the **patient's** timezone so day/week/month boundaries match how they
+   * experience dates; pass the viewer device zone only when the patient is viewing
+   * their own chart.
+   */
+  patientTimeZone: string;
+  /**
+   * When true, shows that period labels use the patient's local timezone.
+   * Enable for practitioner views; omit or set false when the patient views their own chart.
+   * @defaultValue false
+   */
+  showPatientTimeZoneNote?: boolean;
 }
 
 export type { ChartTypeChoice, SelectedSeries };

--- a/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
@@ -36,6 +36,26 @@ const glucoseRow: ChartableManifestRow = {
   ...baseManifestFields,
 };
 
+const bacRow: ChartableManifestRow = {
+  series_id: 'bac-1',
+  series_type: 'health_marker',
+  label: 'BAC',
+  response_type: 'numeric',
+  is_blood_pressure: false,
+  unit: '%',
+  ...baseManifestFields,
+};
+
+const heartRateRow: ChartableManifestRow = {
+  series_id: 'hr-1',
+  series_type: 'health_marker',
+  label: 'Heart rate',
+  response_type: 'numeric',
+  is_blood_pressure: false,
+  unit: 'bpm',
+  ...baseManifestFields,
+};
+
 const severityRow: ChartableManifestRow = {
   series_id: 'symptom-1',
   series_type: 'symptom',
@@ -68,7 +88,9 @@ const textNotesRow: ChartManifestRow = {
 
 const manifest = [
   bloodPressureRow,
+  bacRow,
   glucoseRow,
+  heartRateRow,
   severityRow,
   booleanRow,
   textNotesRow,
@@ -136,6 +158,36 @@ describe('InsightSeriesPicker', () => {
         isBloodPressure: true,
       }),
     ]);
+  });
+
+  it('omits series that would introduce a third distinct value unit from later slots', () => {
+    render(
+      <ControlledPicker
+        initial={[
+          createSelectedSeriesFromManifestRow(bacRow, 0)!,
+          createSelectedSeriesFromManifestRow(glucoseRow, 1)!,
+        ]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add another series' }));
+
+    const slotThree = screen.getByLabelText('Data series 3', {
+      selector: 'select',
+    });
+
+    expect(
+      within(slotThree).queryByRole('option', { name: 'Heart rate' }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(slotThree).queryByRole('option', { name: 'Brain fog' }),
+    ).not.toBeInTheDocument();
+    expect(
+      within(slotThree).getByRole('option', { name: 'Vomiting' }),
+    ).toBeInTheDocument();
+    expect(
+      within(slotThree).getByRole('option', { name: /Blood pressure/i }),
+    ).toBeInTheDocument();
   });
 
   it('hides extra slots when the parent clears value externally', () => {

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -25,6 +25,7 @@ import {
   isChartTypeSelectorHidden,
   MAX_SERIES_SLOTS,
   mergeSeriesSelectionAtSlot,
+  wouldManifestRowExceedDistinctNonBpValueUnitLimit,
 } from './insight-series-picker-utils.js';
 import type {
   ChartableManifestRow,
@@ -219,7 +220,16 @@ function optionsForSlot(
       .filter((_, index) => index !== slotIndex)
       .map((series) => series.seriesId),
   );
-  return manifest.filter((row) => !selectedElsewhere.has(row.series_id));
+  return manifest.filter((row) => {
+    if (selectedElsewhere.has(row.series_id)) {
+      return false;
+    }
+    return !wouldManifestRowExceedDistinctNonBpValueUnitLimit(
+      value,
+      row,
+      slotIndex,
+    );
+  });
 }
 
 /**
@@ -292,7 +302,14 @@ export function InsightSeriesPicker({
     }
 
     const selected = createSelectedSeriesFromManifestRow(row, slotIndex);
-    if (!selected) {
+    if (
+      !selected ||
+      wouldManifestRowExceedDistinctNonBpValueUnitLimit(
+        seriesValue,
+        row,
+        slotIndex,
+      )
+    ) {
       return;
     }
 

--- a/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
@@ -6,6 +6,7 @@ import {
   chartSeriesBpBandKey,
   chartSeriesDiastolicAvgKey,
   chartSeriesSystolicAvgKey,
+  chartSeriesValueAvgKey,
   enrichInsightChartDataForBloodPressure,
   flattenChartSeriesRows,
   formatInsightChartBucketLabel,
@@ -103,6 +104,31 @@ describe('wouldExceedDistinctNonBpValueUnitLimit', () => {
     ];
     const next = series({ seriesId: 'hr', chartType: 'line', unit: 'bpm' });
     expect(wouldExceedDistinctNonBpValueUnitLimit(current, next)).toBe(true);
+  });
+});
+
+describe('chart series data keys', () => {
+  it('uses encoded flat keys so Recharts does not treat series IDs as object paths', () => {
+    const seriesId = 'health_marker::custom::hdl.ldl';
+    const key = chartSeriesValueAvgKey(seriesId);
+    const flat = flattenChartSeriesRows([
+      {
+        bucketStart: '2026-01-01T00:00:00.000Z',
+        series: {
+          [seriesId]: {
+            value_avg: 1.2,
+            systolic_avg: null,
+            diastolic_avg: null,
+            event_count: null,
+          },
+        },
+      },
+    ])[0];
+
+    expect(key).not.toContain('.');
+    expect(key.startsWith('ics_')).toBe(true);
+    expect(flat[key]).toBe(1.2);
+    expect(flat[`${seriesId}__value_avg`]).toBeUndefined();
   });
 });
 

--- a/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
@@ -3,7 +3,12 @@ import type { SelectedSeries } from './InsightSeriesPicker.types.js';
 import {
   assignInsightChartYAxes,
   buildInsightChartTableColumns,
+  formatInsightChartBucketLabel,
+  formatInsightChartPatientTimeZoneNote,
+  getInsightChartUnsupportedMessage,
+  isInsightChartSeriesSupported,
   pivotChartSeriesBucketRows,
+  wouldExceedDistinctNonBpValueUnitLimit,
 } from './insight-composed-chart-utils.js';
 
 function series(
@@ -47,6 +52,20 @@ describe('assignInsightChartYAxes', () => {
     expect(axes.get('glucose')).toBe('right');
   });
 
+  it('assigns null to a third distinct non-BP value unit instead of sharing the right axis', () => {
+    const manifest = [
+      series({ seriesId: 'bac', chartType: 'line', unit: '%' }),
+      series({ seriesId: 'glucose', chartType: 'line', unit: 'mmol/L' }),
+      series({ seriesId: 'hr', chartType: 'line', unit: 'bpm' }),
+    ];
+    const axes = assignInsightChartYAxes(manifest);
+    expect(axes.get('bac')).toBe('left');
+    expect(axes.get('glucose')).toBe('right');
+    expect(axes.get('hr')).toBe(null);
+    expect(isInsightChartSeriesSupported(manifest)).toBe(false);
+    expect(getInsightChartUnsupportedMessage(manifest)).toBeTruthy();
+  });
+
   it('returns null for event series', () => {
     const manifest = [
       series({
@@ -59,6 +78,57 @@ describe('assignInsightChartYAxes', () => {
     expect(
       assignInsightChartYAxes(manifest).get('symptom::nausea::boolean'),
     ).toBe(null);
+  });
+});
+
+describe('wouldExceedDistinctNonBpValueUnitLimit', () => {
+  it('allows a third series when it reuses an existing unit', () => {
+    const current = [
+      series({ seriesId: 'bac', chartType: 'line', unit: '%' }),
+      series({ seriesId: 'glucose', chartType: 'line', unit: 'mmol/L' }),
+    ];
+    const next = series({ seriesId: 'bac-2', chartType: 'bar', unit: '%' });
+    expect(wouldExceedDistinctNonBpValueUnitLimit(current, next)).toBe(false);
+  });
+
+  it('blocks a third distinct unit', () => {
+    const current = [
+      series({ seriesId: 'bac', chartType: 'line', unit: '%' }),
+      series({ seriesId: 'glucose', chartType: 'line', unit: 'mmol/L' }),
+    ];
+    const next = series({ seriesId: 'hr', chartType: 'line', unit: 'bpm' });
+    expect(wouldExceedDistinctNonBpValueUnitLimit(current, next)).toBe(true);
+  });
+});
+
+describe('formatInsightChartBucketLabel', () => {
+  const midnightUtc = '2026-01-01T00:00:00.000Z';
+
+  it('formats using the patient timezone instead of the viewer device zone', () => {
+    const inUtc = formatInsightChartBucketLabel(midnightUtc, 'day', 'UTC');
+    const inNewYork = formatInsightChartBucketLabel(
+      midnightUtc,
+      'day',
+      'America/New_York',
+    );
+
+    expect(inUtc).toContain('Jan');
+    expect(inUtc).toContain('1');
+    expect(inNewYork).toContain('Dec');
+    expect(inNewYork).toContain('31');
+  });
+
+  it('includes the year for week buckets', () => {
+    const label = formatInsightChartBucketLabel(midnightUtc, 'week', 'UTC');
+    expect(label).toContain('2026');
+  });
+});
+
+describe('formatInsightChartPatientTimeZoneNote', () => {
+  it('mentions the patient local timezone', () => {
+    expect(formatInsightChartPatientTimeZoneNote('America/New_York')).toMatch(
+      /patient's local timezone/i,
+    );
   });
 });
 

--- a/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
@@ -3,6 +3,11 @@ import type { SelectedSeries } from './InsightSeriesPicker.types.js';
 import {
   assignInsightChartYAxes,
   buildInsightChartTableColumns,
+  chartSeriesBpBandKey,
+  chartSeriesDiastolicAvgKey,
+  chartSeriesSystolicAvgKey,
+  enrichInsightChartDataForBloodPressure,
+  flattenChartSeriesRows,
   formatInsightChartBucketLabel,
   formatInsightChartPatientTimeZoneNote,
   getInsightChartUnsupportedMessage,
@@ -101,25 +106,58 @@ describe('wouldExceedDistinctNonBpValueUnitLimit', () => {
   });
 });
 
-describe('formatInsightChartBucketLabel', () => {
-  const midnightUtc = '2026-01-01T00:00:00.000Z';
+describe('enrichInsightChartDataForBloodPressure', () => {
+  it('adds [diastolic, systolic] range tuples for bp_band series', () => {
+    const seriesId = 'health_marker::blood_pressure';
+    const chartData = enrichInsightChartDataForBloodPressure(
+      flattenChartSeriesRows([
+        {
+          bucketStart: '2026-01-01T00:00:00.000Z',
+          series: {
+            [seriesId]: {
+              value_avg: null,
+              systolic_avg: 130,
+              diastolic_avg: 85,
+              event_count: null,
+            },
+          },
+        },
+      ]),
+      [
+        series({
+          seriesId,
+          chartType: 'bp_band',
+          isBloodPressure: true,
+        }),
+      ],
+    );
 
-  it('formats using the patient timezone instead of the viewer device zone', () => {
-    const inUtc = formatInsightChartBucketLabel(midnightUtc, 'day', 'UTC');
-    const inNewYork = formatInsightChartBucketLabel(
-      midnightUtc,
+    expect(chartData[0]?.[chartSeriesBpBandKey(seriesId)]).toEqual([85, 130]);
+    expect(chartData[0]?.[chartSeriesSystolicAvgKey(seriesId)]).toBe(130);
+    expect(chartData[0]?.[chartSeriesDiastolicAvgKey(seriesId)]).toBe(85);
+  });
+});
+
+describe('formatInsightChartBucketLabel', () => {
+  it('formats patient-local bucket_start in the same timezone as get_chart_series', () => {
+    const patientLocalMidnight = '2026-01-01T05:00:00.000Z';
+    const label = formatInsightChartBucketLabel(
+      patientLocalMidnight,
       'day',
       'America/New_York',
     );
 
-    expect(inUtc).toContain('Jan');
-    expect(inUtc).toContain('1');
-    expect(inNewYork).toContain('Dec');
-    expect(inNewYork).toContain('31');
+    expect(label).toContain('Jan');
+    expect(label).toContain('1');
+    expect(label).not.toMatch(/Dec/i);
   });
 
   it('includes the year for week buckets', () => {
-    const label = formatInsightChartBucketLabel(midnightUtc, 'week', 'UTC');
+    const label = formatInsightChartBucketLabel(
+      '2026-01-01T00:00:00.000Z',
+      'week',
+      'UTC',
+    );
     expect(label).toContain('2026');
   });
 });

--- a/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import type { SelectedSeries } from './InsightSeriesPicker.types.js';
+import {
+  assignInsightChartYAxes,
+  buildInsightChartTableColumns,
+  pivotChartSeriesBucketRows,
+} from './insight-composed-chart-utils.js';
+
+function series(
+  overrides: Partial<SelectedSeries> &
+    Pick<SelectedSeries, 'seriesId' | 'chartType'>,
+): SelectedSeries {
+  return {
+    seriesType: 'health_marker',
+    responseType: 'numeric',
+    isBloodPressure: false,
+    label: overrides.seriesId,
+    unit: null,
+    color: '#000',
+    ...overrides,
+  };
+}
+
+describe('assignInsightChartYAxes', () => {
+  it('assigns blood pressure to the bp axis and shares numeric units on the left', () => {
+    const manifest = [
+      series({ seriesId: 'bac', chartType: 'line', unit: '%' }),
+      series({
+        seriesId: 'bp',
+        chartType: 'bp_band',
+        isBloodPressure: true,
+        unit: 'mmHg',
+      }),
+    ];
+    const axes = assignInsightChartYAxes(manifest);
+    expect(axes.get('bac')).toBe('left');
+    expect(axes.get('bp')).toBe('bp');
+  });
+
+  it('puts the second distinct unit on the right axis', () => {
+    const manifest = [
+      series({ seriesId: 'bac', chartType: 'line', unit: '%' }),
+      series({ seriesId: 'glucose', chartType: 'line', unit: 'mmol/L' }),
+    ];
+    const axes = assignInsightChartYAxes(manifest);
+    expect(axes.get('bac')).toBe('left');
+    expect(axes.get('glucose')).toBe('right');
+  });
+
+  it('returns null for event series', () => {
+    const manifest = [
+      series({
+        seriesId: 'symptom::nausea::boolean',
+        chartType: 'event',
+        seriesType: 'symptom',
+        responseType: 'boolean',
+      }),
+    ];
+    expect(
+      assignInsightChartYAxes(manifest).get('symptom::nausea::boolean'),
+    ).toBe(null);
+  });
+});
+
+describe('pivotChartSeriesBucketRows', () => {
+  it('merges long-format RPC rows into one row per bucket', () => {
+    const pivoted = pivotChartSeriesBucketRows([
+      {
+        series_id: 'bac',
+        bucket_start: '2026-01-01T00:00:00.000Z',
+        value_avg: 0.05,
+        systolic_avg: null,
+        diastolic_avg: null,
+        event_count: null,
+      },
+      {
+        series_id: 'glucose',
+        bucket_start: '2026-01-01T00:00:00.000Z',
+        value_avg: 6.1,
+        systolic_avg: null,
+        diastolic_avg: null,
+        event_count: null,
+      },
+    ]);
+
+    expect(pivoted).toHaveLength(1);
+    expect(pivoted[0]?.series.bac?.value_avg).toBe(0.05);
+    expect(pivoted[0]?.series.glucose?.value_avg).toBe(6.1);
+  });
+});
+
+describe('buildInsightChartTableColumns', () => {
+  it('creates separate systolic and diastolic headers for blood pressure', () => {
+    const columns = buildInsightChartTableColumns([
+      series({
+        seriesId: 'bp',
+        chartType: 'bp_band',
+        isBloodPressure: true,
+        label: 'Blood pressure',
+      }),
+    ]);
+    expect(columns.map((column) => column.label)).toEqual([
+      'Blood pressure (systolic)',
+      'Blood pressure (diastolic)',
+    ]);
+  });
+});

--- a/packages/ui/src/lib/insight-composed-chart-utils.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.ts
@@ -44,6 +44,103 @@ export function insightChartUnitKey(series: SelectedSeries): string {
 export type InsightValueYAxisId = 'left' | 'right' | 'bp';
 
 /**
+ * Maximum distinct measurement units for non–blood-pressure value series.
+ * The chart exposes one left and one right numeric/severity axis (BP uses `bp`).
+ */
+export const MAX_DISTINCT_NON_BP_VALUE_UNITS = 2;
+
+/**
+ * Whether a selected series consumes a value Y-axis unit slot (not BP or event markers).
+ *
+ * @param series - Selected series metadata.
+ */
+export function countsTowardInsightChartValueUnitLimit(
+  series: Pick<
+    SelectedSeries,
+    'chartType' | 'unit' | 'responseType' | 'isBloodPressure'
+  >,
+): boolean {
+  return series.chartType !== 'event' && series.chartType !== 'bp_band';
+}
+
+/**
+ * Distinct non–blood-pressure value unit keys already present in the selection.
+ *
+ * @param series - Selected series (in slot order).
+ * @param excludeSlotIndex - Optional slot to omit (e.g. the slot being edited).
+ */
+export function getDistinctNonBpValueUnitKeys(
+  series: SelectedSeries[],
+  excludeSlotIndex?: number,
+): string[] {
+  const keys: string[] = [];
+  for (const [index, item] of series.entries()) {
+    if (excludeSlotIndex !== undefined && index === excludeSlotIndex) {
+      continue;
+    }
+    if (!countsTowardInsightChartValueUnitLimit(item)) {
+      continue;
+    }
+    const unitKey = insightChartUnitKey(item);
+    if (!keys.includes(unitKey)) {
+      keys.push(unitKey);
+    }
+  }
+  return keys;
+}
+
+/**
+ * Whether adding `candidate` would exceed {@link MAX_DISTINCT_NON_BP_VALUE_UNITS}.
+ *
+ * @param current - Current selection.
+ * @param candidate - Proposed series for a slot.
+ * @param excludeSlotIndex - Slot being replaced (if any).
+ */
+export function wouldExceedDistinctNonBpValueUnitLimit(
+  current: SelectedSeries[],
+  candidate: SelectedSeries,
+  excludeSlotIndex?: number,
+): boolean {
+  if (!countsTowardInsightChartValueUnitLimit(candidate)) {
+    return false;
+  }
+  const existing = getDistinctNonBpValueUnitKeys(current, excludeSlotIndex);
+  const candidateKey = insightChartUnitKey(candidate);
+  if (existing.includes(candidateKey)) {
+    return false;
+  }
+  return existing.length >= MAX_DISTINCT_NON_BP_VALUE_UNITS;
+}
+
+/**
+ * @param series - Selected series for the chart.
+ * @returns `true` when every value series fits on the supported Y-axes.
+ */
+export function isInsightChartSeriesSupported(
+  series: SelectedSeries[],
+): boolean {
+  return (
+    getDistinctNonBpValueUnitKeys(series).length <=
+    MAX_DISTINCT_NON_BP_VALUE_UNITS
+  );
+}
+
+/**
+ * User-facing explanation when the selection exceeds supported Y-axis units.
+ *
+ * @param series - Selected series for the chart.
+ * @returns Message when unsupported; otherwise `undefined`.
+ */
+export function getInsightChartUnsupportedMessage(
+  series: SelectedSeries[],
+): string | undefined {
+  if (isInsightChartSeriesSupported(series)) {
+    return undefined;
+  }
+  return `This chart supports at most ${MAX_DISTINCT_NON_BP_VALUE_UNITS} different measurement units at once (blood pressure uses its own axis). Remove a series or choose series that share units.`;
+}
+
+/**
  * Maps each series to its Y-axis id (`null` for event markers with no axis).
  *
  * @param series - Selected series in chart order.
@@ -53,19 +150,7 @@ export function assignInsightChartYAxes(
   series: SelectedSeries[],
 ): Map<string, InsightValueYAxisId | null> {
   const assignments = new Map<string, InsightValueYAxisId | null>();
-  const valueSeries = series.filter((item) => item.chartType !== 'event');
-  const nonBpValue = valueSeries.filter((item) => item.chartType !== 'bp_band');
-
-  const unitOrder: string[] = [];
-  for (const item of nonBpValue) {
-    const unitKey = insightChartUnitKey(item);
-    if (!unitOrder.includes(unitKey)) {
-      unitOrder.push(unitKey);
-    }
-  }
-
-  const primaryUnit = unitOrder[0];
-  const secondaryUnit = unitOrder[1];
+  const unitOrder = getDistinctNonBpValueUnitKeys(series);
 
   for (const item of series) {
     if (item.chartType === 'event') {
@@ -77,11 +162,17 @@ export function assignInsightChartYAxes(
       continue;
     }
 
-    const unitKey = insightChartUnitKey(item);
-    assignments.set(item.seriesId, unitKey === primaryUnit ? 'left' : 'right');
+    const unitIndex = unitOrder.indexOf(insightChartUnitKey(item));
+    if (unitIndex < 0 || unitIndex >= MAX_DISTINCT_NON_BP_VALUE_UNITS) {
+      assignments.set(item.seriesId, null);
+    } else if (unitIndex === 0) {
+      assignments.set(item.seriesId, 'left');
+    } else {
+      assignments.set(item.seriesId, 'right');
+    }
   }
 
-  if (secondaryUnit === undefined) {
+  if (unitOrder.length <= 1) {
     for (const [seriesId, axisId] of assignments) {
       if (axisId === 'right') {
         assignments.set(seriesId, 'left');
@@ -118,29 +209,86 @@ export function flattenChartSeriesRows(
 }
 
 /**
- * @param bucketStart - ISO bucket timestamp.
+ * @param timeZone - IANA timezone identifier.
+ * @returns `true` when `Intl` accepts the zone.
+ */
+export function isValidIanaTimeZone(timeZone: string): boolean {
+  try {
+    Intl.DateTimeFormat(undefined, { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolves a patient timezone for chart labels, falling back to UTC when invalid.
+ *
+ * @param patientTimeZone - Preferred IANA timezone.
+ * @returns Valid IANA timezone id.
+ */
+export function resolveInsightChartTimeZone(patientTimeZone: string): string {
+  return isValidIanaTimeZone(patientTimeZone) ? patientTimeZone : 'UTC';
+}
+
+/**
+ * @param patientTimeZone - IANA timezone id.
+ * @returns Display name for the timezone (e.g. `Eastern Standard Time`).
+ */
+export function formatIanaTimeZoneForDisplay(patientTimeZone: string): string {
+  const zone = resolveInsightChartTimeZone(patientTimeZone);
+  const parts = new Intl.DateTimeFormat(undefined, {
+    timeZone: zone,
+    timeZoneName: 'long',
+  }).formatToParts(new Date());
+  return parts.find((part) => part.type === 'timeZoneName')?.value ?? zone;
+}
+
+/**
+ * Caption explaining that chart period labels use the patient's timezone.
+ *
+ * @param patientTimeZone - IANA timezone id.
+ * @returns Practitioner-facing note text.
+ */
+export function formatInsightChartPatientTimeZoneNote(
+  patientTimeZone: string,
+): string {
+  const label = formatIanaTimeZoneForDisplay(patientTimeZone);
+  return `Period labels use the patient's local timezone (${label}).`;
+}
+
+/**
+ * @param bucketStart - ISO `bucket_start` from `get_chart_series`.
  * @param bucket - Bucket granularity.
+ * @param patientTimeZone - IANA timezone for label formatting (patient-local).
  * @returns Human-readable bucket label for axes and table headers.
  */
 export function formatInsightChartBucketLabel(
   bucketStart: string,
   bucket: InsightChartBucket,
+  patientTimeZone: string,
 ): string {
   const date = new Date(bucketStart);
   if (Number.isNaN(date.getTime())) {
     return bucketStart;
   }
+
+  const timeZone = resolveInsightChartTimeZone(patientTimeZone);
+
   if (bucket === 'month') {
-    return date.toLocaleDateString(undefined, {
+    return new Intl.DateTimeFormat(undefined, {
+      timeZone,
       month: 'short',
       year: 'numeric',
-    });
+    }).format(date);
   }
-  return date.toLocaleDateString(undefined, {
+
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone,
     month: 'short',
     day: 'numeric',
     year: bucket === 'week' ? 'numeric' : undefined,
-  });
+  }).format(date);
 }
 
 /**

--- a/packages/ui/src/lib/insight-composed-chart-utils.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.ts
@@ -25,6 +25,17 @@ export function chartSeriesEventCountKey(seriesId: string): string {
   return `${seriesId}__event_count`;
 }
 
+/** Recharts range `dataKey` for blood pressure band fill (`[diastolic, systolic]`). */
+export function chartSeriesBpBandKey(seriesId: string): string {
+  return `${seriesId}__bp_band`;
+}
+
+/** One flattened row passed to Recharts `ComposedChart`. */
+export type InsightChartDataRow = Record<
+  string,
+  string | number | null | ReadonlyArray<number | null>
+>;
+
 /**
  * Unit key used to group numeric/severity series on shared Y-axes.
  *
@@ -191,9 +202,9 @@ export function assignInsightChartYAxes(
  */
 export function flattenChartSeriesRows(
   rows: ChartSeriesRow[],
-): Record<string, string | number | null>[] {
+): InsightChartDataRow[] {
   return rows.map((row) => {
-    const flat: Record<string, string | number | null> = {
+    const flat: InsightChartDataRow = {
       bucketStart: row.bucketStart,
     };
 
@@ -205,6 +216,35 @@ export function flattenChartSeriesRows(
     }
 
     return flat;
+  });
+}
+
+/**
+ * Adds Recharts range-area tuples `[diastolic, systolic]` for each `bp_band` series.
+ *
+ * @param chartData - Output of {@link flattenChartSeriesRows}.
+ * @param series - Selected series manifest.
+ * @returns Rows enriched with {@link chartSeriesBpBandKey} when both BP values exist.
+ */
+export function enrichInsightChartDataForBloodPressure(
+  chartData: InsightChartDataRow[],
+  series: SelectedSeries[],
+): InsightChartDataRow[] {
+  const bpSeries = series.filter((item) => item.chartType === 'bp_band');
+  if (bpSeries.length === 0) {
+    return chartData;
+  }
+
+  return chartData.map((row) => {
+    const enriched: InsightChartDataRow = { ...row };
+    for (const item of bpSeries) {
+      const systolic = row[chartSeriesSystolicAvgKey(item.seriesId)];
+      const diastolic = row[chartSeriesDiastolicAvgKey(item.seriesId)];
+      if (typeof systolic === 'number' && typeof diastolic === 'number') {
+        enriched[chartSeriesBpBandKey(item.seriesId)] = [diastolic, systolic];
+      }
+    }
+    return enriched;
   });
 }
 
@@ -258,9 +298,9 @@ export function formatInsightChartPatientTimeZoneNote(
 }
 
 /**
- * @param bucketStart - ISO `bucket_start` from `get_chart_series`.
+ * @param bucketStart - ISO `bucket_start` from `get_chart_series` (bucketed in `patientTimeZone`).
  * @param bucket - Bucket granularity.
- * @param patientTimeZone - IANA timezone for label formatting (patient-local).
+ * @param patientTimeZone - IANA timezone used for RPC bucketing and label formatting.
  * @returns Human-readable bucket label for axes and table headers.
  */
 export function formatInsightChartBucketLabel(

--- a/packages/ui/src/lib/insight-composed-chart-utils.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.ts
@@ -5,29 +5,64 @@ import type {
   InsightChartBucket,
 } from './InsightComposedChart.types.js';
 
+/** Metric suffix encoded into a flat Recharts row property. */
+type InsightChartSeriesField =
+  | 'value_avg'
+  | 'systolic_avg'
+  | 'diastolic_avg'
+  | 'event_count'
+  | 'bp_band';
+
+/**
+ * Encodes a manifest `series_id` for use in flat object keys.
+ * Recharts treats string `dataKey` values as object paths, so IDs containing `.`
+ * or `[]` (e.g. custom marker names) must not appear literally in keys.
+ *
+ * @param seriesId - Manifest series id from `get_user_chart_manifest`.
+ * @returns Base64url-safe token with no path-reserved characters.
+ */
+export function encodeInsightChartSeriesId(seriesId: string): string {
+  const bytes = new TextEncoder().encode(seriesId);
+  let binary = '';
+  for (const byte of bytes) {
+    binary += String.fromCharCode(byte);
+  }
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+}
+
+function insightChartSeriesFieldKey(
+  seriesId: string,
+  field: InsightChartSeriesField,
+): string {
+  return `ics_${encodeInsightChartSeriesId(seriesId)}__${field}`;
+}
+
 /** Recharts `dataKey` for a series average value. */
 export function chartSeriesValueAvgKey(seriesId: string): string {
-  return `${seriesId}__value_avg`;
+  return insightChartSeriesFieldKey(seriesId, 'value_avg');
 }
 
 /** Recharts `dataKey` for systolic average (blood pressure band). */
 export function chartSeriesSystolicAvgKey(seriesId: string): string {
-  return `${seriesId}__systolic_avg`;
+  return insightChartSeriesFieldKey(seriesId, 'systolic_avg');
 }
 
 /** Recharts `dataKey` for diastolic average (blood pressure band). */
 export function chartSeriesDiastolicAvgKey(seriesId: string): string {
-  return `${seriesId}__diastolic_avg`;
+  return insightChartSeriesFieldKey(seriesId, 'diastolic_avg');
 }
 
 /** Recharts field for boolean event counts per bucket. */
 export function chartSeriesEventCountKey(seriesId: string): string {
-  return `${seriesId}__event_count`;
+  return insightChartSeriesFieldKey(seriesId, 'event_count');
 }
 
 /** Recharts range `dataKey` for blood pressure band fill (`[diastolic, systolic]`). */
 export function chartSeriesBpBandKey(seriesId: string): string {
-  return `${seriesId}__bp_band`;
+  return insightChartSeriesFieldKey(seriesId, 'bp_band');
 }
 
 /** One flattened row passed to Recharts `ComposedChart`. */

--- a/packages/ui/src/lib/insight-composed-chart-utils.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.ts
@@ -1,0 +1,286 @@
+import type { SelectedSeries } from './InsightSeriesPicker.types.js';
+import type {
+  ChartSeriesBucketMetrics,
+  ChartSeriesRow,
+  InsightChartBucket,
+} from './InsightComposedChart.types.js';
+
+/** Recharts `dataKey` for a series average value. */
+export function chartSeriesValueAvgKey(seriesId: string): string {
+  return `${seriesId}__value_avg`;
+}
+
+/** Recharts `dataKey` for systolic average (blood pressure band). */
+export function chartSeriesSystolicAvgKey(seriesId: string): string {
+  return `${seriesId}__systolic_avg`;
+}
+
+/** Recharts `dataKey` for diastolic average (blood pressure band). */
+export function chartSeriesDiastolicAvgKey(seriesId: string): string {
+  return `${seriesId}__diastolic_avg`;
+}
+
+/** Recharts field for boolean event counts per bucket. */
+export function chartSeriesEventCountKey(seriesId: string): string {
+  return `${seriesId}__event_count`;
+}
+
+/**
+ * Unit key used to group numeric/severity series on shared Y-axes.
+ *
+ * @param series - Selected series metadata.
+ * @returns Stable unit grouping key.
+ */
+export function insightChartUnitKey(series: SelectedSeries): string {
+  if (series.unit) {
+    return series.unit;
+  }
+  if (series.responseType === 'severity') {
+    return '__severity__';
+  }
+  return '__unitless__';
+}
+
+export type InsightValueYAxisId = 'left' | 'right' | 'bp';
+
+/**
+ * Maps each series to its Y-axis id (`null` for event markers with no axis).
+ *
+ * @param series - Selected series in chart order.
+ * @returns Map from `seriesId` to axis id or `null`.
+ */
+export function assignInsightChartYAxes(
+  series: SelectedSeries[],
+): Map<string, InsightValueYAxisId | null> {
+  const assignments = new Map<string, InsightValueYAxisId | null>();
+  const valueSeries = series.filter((item) => item.chartType !== 'event');
+  const nonBpValue = valueSeries.filter((item) => item.chartType !== 'bp_band');
+
+  const unitOrder: string[] = [];
+  for (const item of nonBpValue) {
+    const unitKey = insightChartUnitKey(item);
+    if (!unitOrder.includes(unitKey)) {
+      unitOrder.push(unitKey);
+    }
+  }
+
+  const primaryUnit = unitOrder[0];
+  const secondaryUnit = unitOrder[1];
+
+  for (const item of series) {
+    if (item.chartType === 'event') {
+      assignments.set(item.seriesId, null);
+      continue;
+    }
+    if (item.chartType === 'bp_band') {
+      assignments.set(item.seriesId, 'bp');
+      continue;
+    }
+
+    const unitKey = insightChartUnitKey(item);
+    assignments.set(item.seriesId, unitKey === primaryUnit ? 'left' : 'right');
+  }
+
+  if (secondaryUnit === undefined) {
+    for (const [seriesId, axisId] of assignments) {
+      if (axisId === 'right') {
+        assignments.set(seriesId, 'left');
+      }
+    }
+  }
+
+  return assignments;
+}
+
+/**
+ * Flattens {@link ChartSeriesRow} data for Recharts `ComposedChart`.
+ *
+ * @param rows - Pivoted bucket rows.
+ * @returns Flat records keyed by {@link chartSeriesValueAvgKey} and related helpers.
+ */
+export function flattenChartSeriesRows(
+  rows: ChartSeriesRow[],
+): Record<string, string | number | null>[] {
+  return rows.map((row) => {
+    const flat: Record<string, string | number | null> = {
+      bucketStart: row.bucketStart,
+    };
+
+    for (const [seriesId, metrics] of Object.entries(row.series)) {
+      flat[chartSeriesValueAvgKey(seriesId)] = metrics.value_avg;
+      flat[chartSeriesSystolicAvgKey(seriesId)] = metrics.systolic_avg;
+      flat[chartSeriesDiastolicAvgKey(seriesId)] = metrics.diastolic_avg;
+      flat[chartSeriesEventCountKey(seriesId)] = metrics.event_count;
+    }
+
+    return flat;
+  });
+}
+
+/**
+ * @param bucketStart - ISO bucket timestamp.
+ * @param bucket - Bucket granularity.
+ * @returns Human-readable bucket label for axes and table headers.
+ */
+export function formatInsightChartBucketLabel(
+  bucketStart: string,
+  bucket: InsightChartBucket,
+): string {
+  const date = new Date(bucketStart);
+  if (Number.isNaN(date.getTime())) {
+    return bucketStart;
+  }
+  if (bucket === 'month') {
+    return date.toLocaleDateString(undefined, {
+      month: 'short',
+      year: 'numeric',
+    });
+  }
+  return date.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: bucket === 'week' ? 'numeric' : undefined,
+  });
+}
+
+/**
+ * @param value - Numeric cell value.
+ * @param unit - Optional unit suffix.
+ * @returns Display string for the accessible data table.
+ */
+export function formatInsightChartTableCell(
+  value: number | null | undefined,
+  unit?: string | null,
+): string {
+  if (value === null || value === undefined) {
+    return 'No data';
+  }
+  const formatted = Number.isInteger(value) ? String(value) : value.toFixed(2);
+  return unit ? `${formatted} ${unit}` : formatted;
+}
+
+export interface InsightChartTableColumn {
+  id: string;
+  label: string;
+  seriesId: string;
+  kind: 'value_avg' | 'systolic_avg' | 'diastolic_avg' | 'event_count';
+}
+
+/**
+ * Builds accessible table columns for the selected series manifest.
+ *
+ * @param series - Selected series.
+ * @returns Column descriptors (blood pressure uses systolic and diastolic columns).
+ */
+export function buildInsightChartTableColumns(
+  series: SelectedSeries[],
+): InsightChartTableColumn[] {
+  const columns: InsightChartTableColumn[] = [];
+
+  for (const item of series) {
+    if (item.chartType === 'bp_band') {
+      columns.push(
+        {
+          id: `${item.seriesId}-systolic`,
+          label: `${item.label} (systolic)`,
+          seriesId: item.seriesId,
+          kind: 'systolic_avg',
+        },
+        {
+          id: `${item.seriesId}-diastolic`,
+          label: `${item.label} (diastolic)`,
+          seriesId: item.seriesId,
+          kind: 'diastolic_avg',
+        },
+      );
+      continue;
+    }
+
+    if (item.chartType === 'event') {
+      columns.push({
+        id: `${item.seriesId}-events`,
+        label: `${item.label} (events)`,
+        seriesId: item.seriesId,
+        kind: 'event_count',
+      });
+      continue;
+    }
+
+    const unitSuffix = item.unit ? ` (${item.unit})` : '';
+    columns.push({
+      id: `${item.seriesId}-value`,
+      label: `${item.label}${unitSuffix}`,
+      seriesId: item.seriesId,
+      kind: 'value_avg',
+    });
+  }
+
+  return columns;
+}
+
+/**
+ * Reads a metric from a bucket row for table rendering.
+ *
+ * @param row - Chart row.
+ * @param column - Table column descriptor.
+ * @returns Metric value for the cell.
+ */
+export function readInsightChartTableMetric(
+  row: ChartSeriesRow,
+  column: InsightChartTableColumn,
+): number | null {
+  const metrics: ChartSeriesBucketMetrics | undefined =
+    row.series[column.seriesId];
+  if (!metrics) {
+    return null;
+  }
+  return metrics[column.kind];
+}
+
+/**
+ * Raw bucket row from `get_chart_series` (`ChartSeriesBucketRow` in `@abstrack/supabase`).
+ * Declared here so `@abstrack/ui` does not depend on `@abstrack/supabase`.
+ */
+export interface ChartSeriesBucketRowInput {
+  series_id: string;
+  bucket_start: string;
+  value_avg: number | null;
+  value_min?: number | null;
+  value_max?: number | null;
+  systolic_avg: number | null;
+  diastolic_avg: number | null;
+  event_count: number | null;
+}
+
+/**
+ * Pivots long-format RPC rows into {@link ChartSeriesRow} records for {@link InsightComposedChart}.
+ *
+ * @param rows - Output of `get_chart_series`.
+ * @returns One row per bucket with nested per-series metrics.
+ */
+export function pivotChartSeriesBucketRows(
+  rows: ChartSeriesBucketRowInput[],
+): ChartSeriesRow[] {
+  const byBucket = new Map<string, ChartSeriesRow>();
+
+  for (const row of rows) {
+    let chartRow = byBucket.get(row.bucket_start);
+    if (!chartRow) {
+      chartRow = { bucketStart: row.bucket_start, series: {} };
+      byBucket.set(row.bucket_start, chartRow);
+    }
+
+    chartRow.series[row.series_id] = {
+      value_avg: row.value_avg,
+      value_min: row.value_min,
+      value_max: row.value_max,
+      systolic_avg: row.systolic_avg,
+      diastolic_avg: row.diastolic_avg,
+      event_count: row.event_count,
+    };
+  }
+
+  return [...byBucket.values()].sort((a, b) =>
+    a.bucketStart.localeCompare(b.bucketStart),
+  );
+}

--- a/packages/ui/src/lib/insight-series-picker-utils.ts
+++ b/packages/ui/src/lib/insight-series-picker-utils.ts
@@ -1,3 +1,4 @@
+import { wouldExceedDistinctNonBpValueUnitLimit } from './insight-composed-chart-utils.js';
 import type {
   ChartableManifestRow,
   ChartManifestRow,
@@ -206,4 +207,23 @@ export function canAddAnotherSeries(
   }
   const lastVisibleIndex = visibleSlotCount - 1;
   return value[lastVisibleIndex] !== undefined;
+}
+
+/**
+ * Whether selecting `row` in `slotIndex` would exceed supported chart Y-axis units.
+ *
+ * @param value - Current selected series.
+ * @param row - Manifest row under consideration.
+ * @param slotIndex - Slot being filled or updated.
+ */
+export function wouldManifestRowExceedDistinctNonBpValueUnitLimit(
+  value: SelectedSeries[],
+  row: ChartableManifestRow,
+  slotIndex: number,
+): boolean {
+  const candidate = createSelectedSeriesFromManifestRow(row, slotIndex);
+  if (!candidate) {
+    return true;
+  }
+  return wouldExceedDistinctNonBpValueUnitLimit(value, candidate, slotIndex);
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -499,6 +499,9 @@ importers:
       react-day-picker:
         specifier: ^10.0.1
         version: 10.0.1(@types/react@19.1.17)(react@19.1.0)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react-is@19.2.4)(react@19.1.0)(redux@5.0.1)
       tslib:
         specifier: ^2.3.0
         version: 2.8.1

--- a/supabase/migrations/20260523120000_chart_series_patient_timezone.sql
+++ b/supabase/migrations/20260523120000_chart_series_patient_timezone.sql
@@ -1,0 +1,337 @@
+-- Bucket chart series in the patient's IANA timezone (aligns with InsightComposedChart labels).
+
+DROP FUNCTION IF EXISTS public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text);
+
+CREATE OR REPLACE FUNCTION public.get_chart_series (
+  p_user_id uuid,
+  p_series jsonb,
+  p_from timestamptz,
+  p_to timestamptz,
+  p_bucket text,
+  p_timezone text
+)
+RETURNS TABLE (
+  series_id text,
+  bucket_start timestamptz,
+  value_avg numeric,
+  value_min numeric,
+  value_max numeric,
+  systolic_avg numeric,
+  diastolic_avg numeric,
+  event_count bigint
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+STABLE
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  series_count int;
+  elem jsonb;
+  sid text;
+  stype text;
+  rtype text;
+  is_bp boolean;
+  seen_series_ids text[] := ARRAY[]::text[];
+  symptom_match text[];
+  hm_suffix text;
+  tz text;
+BEGIN
+  tz := nullif(trim(p_timezone), '');
+
+  IF tz IS NULL THEN
+    RAISE EXCEPTION 'get_chart_series: p_timezone must be a non-empty IANA timezone name'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_timezone_names
+    WHERE name = tz
+  ) THEN
+    RAISE EXCEPTION 'get_chart_series: invalid IANA timezone %', tz
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_bucket NOT IN ('day', 'week', 'month') THEN
+    RAISE EXCEPTION 'get_chart_series: p_bucket must be day, week, or month'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF jsonb_typeof(p_series) IS DISTINCT FROM 'array' THEN
+    RAISE EXCEPTION 'get_chart_series: p_series must be a JSON array'
+      USING ERRCODE = '22023';
+  END IF;
+
+  series_count := jsonb_array_length(p_series);
+
+  IF series_count < 1 OR series_count > 3 THEN
+    RAISE EXCEPTION 'get_chart_series: p_series must contain 1 to 3 series'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_from > p_to THEN
+    RAISE EXCEPTION 'get_chart_series: p_from must be less than or equal to p_to'
+      USING ERRCODE = '22023';
+  END IF;
+
+  FOR elem IN
+    SELECT value
+    FROM jsonb_array_elements(p_series)
+  LOOP
+    IF jsonb_typeof(elem) <> 'object' THEN
+      RAISE EXCEPTION 'get_chart_series: each p_series element must be a JSON object'
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF NOT (
+      elem ? 'series_id'
+      AND elem ? 'series_type'
+      AND elem ? 'response_type'
+      AND elem ? 'is_blood_pressure'
+    ) THEN
+      RAISE EXCEPTION 'get_chart_series: each p_series element must include series_id, series_type, response_type, and is_blood_pressure'
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF jsonb_typeof(elem -> 'is_blood_pressure') <> 'boolean' THEN
+      RAISE EXCEPTION 'get_chart_series: is_blood_pressure must be a JSON boolean'
+        USING ERRCODE = '22023';
+    END IF;
+
+    sid := nullif(trim(elem ->> 'series_id'), '');
+    stype := nullif(trim(elem ->> 'series_type'), '');
+    rtype := nullif(trim(elem ->> 'response_type'), '');
+    is_bp := (elem ->> 'is_blood_pressure')::boolean;
+
+    IF sid IS NULL OR stype IS NULL OR rtype IS NULL THEN
+      RAISE EXCEPTION 'get_chart_series: series_id, series_type, and response_type must be non-empty strings'
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF sid <> lower(sid) THEN
+      RAISE EXCEPTION 'get_chart_series: series_id must be lowercase (manifest format) %', sid
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF sid = ANY (seen_series_ids) THEN
+      RAISE EXCEPTION 'get_chart_series: duplicate series_id %', sid
+        USING ERRCODE = '22023';
+    END IF;
+
+    seen_series_ids := array_append(seen_series_ids, sid);
+
+    IF stype = 'health_marker' THEN
+      IF rtype <> 'numeric' THEN
+        RAISE EXCEPTION 'get_chart_series: health_marker series % requires response_type numeric', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF sid NOT LIKE 'health_marker::%' OR length(sid) <= length('health_marker::') THEN
+        RAISE EXCEPTION 'get_chart_series: invalid health_marker series_id %', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      hm_suffix := substring(sid FROM length('health_marker::') + 1);
+
+      IF is_bp AND hm_suffix <> 'blood_pressure' THEN
+        RAISE EXCEPTION 'get_chart_series: is_blood_pressure true requires series_id health_marker::blood_pressure'
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF NOT is_bp AND hm_suffix = 'blood_pressure' THEN
+        RAISE EXCEPTION 'get_chart_series: health_marker::blood_pressure requires is_blood_pressure true'
+          USING ERRCODE = '22023';
+      END IF;
+    ELSIF stype = 'symptom' THEN
+      IF rtype NOT IN ('boolean', 'severity') THEN
+        RAISE EXCEPTION 'get_chart_series: symptom series % requires response_type boolean or severity', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF is_bp THEN
+        RAISE EXCEPTION 'get_chart_series: symptom series must have is_blood_pressure false'
+          USING ERRCODE = '22023';
+      END IF;
+
+      symptom_match := regexp_match(sid, '^symptom::(.+)::(boolean|severity)$');
+
+      IF symptom_match IS NULL THEN
+        RAISE EXCEPTION 'get_chart_series: invalid symptom series_id % (expected symptom::<name>::boolean|severity)', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF symptom_match[2] <> rtype THEN
+        RAISE EXCEPTION 'get_chart_series: series_id suffix must match response_type for %', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF nullif(trim(symptom_match[1]), '') IS NULL THEN
+        RAISE EXCEPTION 'get_chart_series: symptom series_id must include a non-empty symptom name'
+          USING ERRCODE = '22023';
+      END IF;
+    ELSE
+      RAISE EXCEPTION 'get_chart_series: unsupported series_type %', stype
+        USING ERRCODE = '22023';
+    END IF;
+  END LOOP;
+
+  RETURN QUERY
+  WITH series_defs AS (
+    SELECT
+      elem->>'series_id' AS series_id,
+      elem->>'series_type' AS series_type,
+      elem->>'response_type' AS response_type,
+      COALESCE((elem->>'is_blood_pressure')::boolean, false) AS is_blood_pressure
+    FROM jsonb_array_elements(p_series) AS elem
+  ),
+  health_marker_defs AS (
+    SELECT
+      sd.series_id,
+      sd.response_type,
+      sd.is_blood_pressure,
+      lower(regexp_replace(sd.series_id, '^health_marker::', '')) AS marker_series_key
+    FROM series_defs sd
+    WHERE sd.series_type = 'health_marker'
+  ),
+  symptom_defs AS (
+    SELECT
+      sd.series_id,
+      sd.response_type,
+      (regexp_match(sd.series_id, '^symptom::(.+)::(boolean|severity)$'))[1] AS symptom_series_key
+    FROM series_defs sd
+    WHERE sd.series_type = 'symptom'
+  ),
+  health_marker_match AS (
+    SELECT
+      hmd.series_id,
+      hmd.is_blood_pressure,
+      hm.recorded_at,
+      hm.value_numeric,
+      hm.systolic_numeric,
+      hm.diastolic_numeric
+    FROM health_marker_defs hmd
+    INNER JOIN public.health_markers hm
+      ON hm.user_id = p_user_id
+      AND hm.recorded_at >= p_from
+      AND hm.recorded_at <= p_to
+      AND (
+        hm.marker_kind <> 'custom'
+        OR nullif(trim(hm.custom_name), '') IS NOT NULL
+      )
+      AND (
+        CASE
+          WHEN hm.marker_kind = 'custom' THEN
+            lower(hm.marker_kind) || '::' || lower(nullif(trim(hm.custom_name), ''))
+          ELSE lower(hm.marker_kind)
+        END
+      ) = hmd.marker_series_key
+  ),
+  health_marker_bucketed AS (
+    SELECT
+      hmm.series_id,
+      hmm.is_blood_pressure,
+      hmm.value_numeric,
+      hmm.systolic_numeric,
+      hmm.diastolic_numeric,
+      (
+        date_trunc(p_bucket, hmm.recorded_at AT TIME ZONE tz)
+        AT TIME ZONE tz
+      ) AS bucket_start
+    FROM health_marker_match hmm
+  ),
+  blood_pressure_buckets AS (
+    SELECT
+      hmb.series_id,
+      hmb.bucket_start,
+      NULL::numeric AS value_avg,
+      NULL::numeric AS value_min,
+      NULL::numeric AS value_max,
+      avg(hmb.systolic_numeric) AS systolic_avg,
+      avg(hmb.diastolic_numeric) AS diastolic_avg,
+      NULL::bigint AS event_count
+    FROM health_marker_bucketed hmb
+    WHERE hmb.is_blood_pressure
+    GROUP BY hmb.series_id, hmb.bucket_start
+  ),
+  numeric_health_marker_buckets AS (
+    SELECT
+      hmb.series_id,
+      hmb.bucket_start,
+      avg(hmb.value_numeric) AS value_avg,
+      min(hmb.value_numeric) AS value_min,
+      max(hmb.value_numeric) AS value_max,
+      NULL::numeric AS systolic_avg,
+      NULL::numeric AS diastolic_avg,
+      NULL::bigint AS event_count
+    FROM health_marker_bucketed hmb
+    WHERE NOT hmb.is_blood_pressure
+      AND hmb.value_numeric IS NOT NULL
+    GROUP BY hmb.series_id, hmb.bucket_start
+  ),
+  symptom_boolean_buckets AS (
+    SELECT
+      sd.series_id,
+      (
+        date_trunc(p_bucket, es.created_at AT TIME ZONE tz)
+        AT TIME ZONE tz
+      ) AS bucket_start,
+      NULL::numeric AS value_avg,
+      NULL::numeric AS value_min,
+      NULL::numeric AS value_max,
+      NULL::numeric AS systolic_avg,
+      NULL::numeric AS diastolic_avg,
+      count(*) FILTER (WHERE es.response_boolean IS TRUE)::bigint AS event_count
+    FROM symptom_defs sd
+    INNER JOIN public.episode_symptoms es
+      ON es.user_id = p_user_id
+      AND es.created_at >= p_from
+      AND es.created_at <= p_to
+      AND lower(nullif(trim(es.symptom_name), '')) = sd.symptom_series_key
+      AND es.response_type = 'yes_no'
+    WHERE sd.response_type = 'boolean'
+    GROUP BY
+      sd.series_id,
+      date_trunc(p_bucket, es.created_at AT TIME ZONE tz) AT TIME ZONE tz
+  ),
+  symptom_severity_buckets AS (
+    SELECT
+      sd.series_id,
+      (
+        date_trunc(p_bucket, es.created_at AT TIME ZONE tz)
+        AT TIME ZONE tz
+      ) AS bucket_start,
+      avg(es.response_severity) AS value_avg,
+      min(es.response_severity) AS value_min,
+      max(es.response_severity) AS value_max,
+      NULL::numeric AS systolic_avg,
+      NULL::numeric AS diastolic_avg,
+      count(*)::bigint AS event_count
+    FROM symptom_defs sd
+    INNER JOIN public.episode_symptoms es
+      ON es.user_id = p_user_id
+      AND es.created_at >= p_from
+      AND es.created_at <= p_to
+      AND lower(nullif(trim(es.symptom_name), '')) = sd.symptom_series_key
+      AND es.response_type = 'severity_scale'
+    WHERE sd.response_type = 'severity'
+    GROUP BY
+      sd.series_id,
+      date_trunc(p_bucket, es.created_at AT TIME ZONE tz) AT TIME ZONE tz
+  )
+  SELECT * FROM blood_pressure_buckets
+  UNION ALL
+  SELECT * FROM numeric_health_marker_buckets
+  UNION ALL
+  SELECT * FROM symptom_boolean_buckets
+  UNION ALL
+  SELECT * FROM symptom_severity_buckets
+  ORDER BY 1, 2;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text, text) IS
+'Returns pre-bucketed chart series for p_user_id and selected manifest series. Buckets use date_trunc in p_timezone (IANA name, validated against pg_timezone_names) so bucket_start aligns with patient-local chart labels. Validates p_bucket (day|week|month), p_series (1–3 series), and p_from <= p_to. Severity: value_* ignores NULL response_severity; event_count is total severity_scale rows per bucket. SECURITY INVOKER.';
+
+REVOKE ALL ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text, text) TO authenticated;


### PR DESCRIPTION
Closes #175

## Summary

Adds the shared web-only `InsightComposedChart` component for the week 9 insight chart builder. It renders server-prepared, pivoted bucket data with Recharts `ComposedChart`, supports all chart types from `InsightSeriesPicker` (line, bar, scatter, blood pressure band, event markers), and provides an accessible text alternative per `docs/A11Y.md`.

## Changes

- **`InsightComposedChart`** — multi-series chart with unit-aware left/right Y-axes, dedicated BP axis, vertical `ReferenceLine` markers for boolean events, and loading/empty states
- **`ChartSeriesRow` / pivot helper** — `pivotChartSeriesBucketRows()` maps long-format `get_chart_series` RPC rows into chart-ready rows without coupling `@abstrack/ui` to `@abstrack/supabase`
- **Accessibility** — `<figure>` + `<figcaption>` from required `summary` prop; visually hidden data table (separate systolic/diastolic columns for blood pressure)
- **Dependency** — `recharts@^3.8.1` added to `@abstrack/ui`
- **Exports** — `InsightComposedChart`, types, and `pivotChartSeriesBucketRows` from `@abstrack/ui` (not exported from `native.ts`)

## Test plan

- [x] `pnpm exec nx test ui` (or `vitest` in `packages/ui`) — `InsightComposedChart.spec.tsx` and `insight-composed-chart-utils.spec.ts`
- [x] `pnpm exec nx build ui`
- [ ] Manual: wire chart builder page with `getChartSeries` → `pivotChartSeriesBucketRows` → `InsightComposedChart` in `apps/web` or `apps/practitioner`
- [ ] Manual: screen reader smoke — figcaption summary and hidden table expose bucketed values