### PR TITLE
feat(web): add insights chart builder with chart RPC fix, manifest labels, and app-token theming

### DIFF
--- a/apps/practitioner/src/app/global.css
+++ b/apps/practitioner/src/app/global.css
@@ -54,6 +54,16 @@
     --app-shadow-header: 0 1px 0 rgba(0, 0, 0, 0.35);
   }
 
+  /* react-day-picker: map accent colors to semantic app tokens (light + html.dark). */
+  .rdp-root {
+    --rdp-accent-color: rgb(var(--app-primary) / 1);
+    --rdp-accent-background-color: rgb(var(--app-primary-soft) / 1);
+    --rdp-range_middle-color: rgb(var(--app-ink) / 1);
+    --rdp-range_start-color: rgb(var(--app-surface) / 1);
+    --rdp-range_end-color: rgb(var(--app-surface) / 1);
+    color: rgb(var(--app-ink) / 1);
+  }
+
   body {
     color: rgb(var(--app-ink) / 1);
     background-color: rgb(var(--app-bg) / 1);

--- a/apps/practitioner/src/components/theme/ThemeMenu.tsx
+++ b/apps/practitioner/src/components/theme/ThemeMenu.tsx
@@ -3,13 +3,19 @@
 import {
   useEffect,
   useId,
+  useLayoutEffect,
   useRef,
   useState,
+  type CSSProperties,
   type KeyboardEvent as ReactKeyboardEvent,
 } from 'react';
+import { createPortal } from 'react-dom';
 import { useTheme } from './ThemeProvider';
 import { IconCheck, IconComputer, IconMoon, IconSun } from './ThemeIcons';
 import type { ThemePreference } from '@/lib/theme-storage';
+
+/** Above app chrome, charts, and Recharts tooltip layers. */
+const THEME_MENU_POPOVER_Z_INDEX = 5000;
 
 const OPTIONS: {
   value: ThemePreference;
@@ -38,15 +44,35 @@ const OPTIONS: {
 ];
 
 /**
+ * Positions the theme radiogroup popover under the trigger using viewport coordinates.
+ *
+ * @param trigger - Theme menu disclosure button.
+ * @returns Fixed-position style for the portaled popover.
+ */
+function getThemeMenuPanelStyle(trigger: HTMLButtonElement): CSSProperties {
+  const rect = trigger.getBoundingClientRect();
+  return {
+    position: 'fixed',
+    top: rect.bottom + 8,
+    right: Math.max(8, window.innerWidth - rect.right),
+    zIndex: THEME_MENU_POPOVER_Z_INDEX,
+  };
+}
+
+/**
  * Theme preference control: disclosure button plus a popup implemented as a radiogroup.
+ * The popover is portaled to `document.body` so sticky header stacking does not cover it.
  *
  * @returns Theme picker UI.
  */
 export function ThemeMenu() {
   const { preference, setPreference } = useTheme();
   const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
+  const [panelStyle, setPanelStyle] = useState<CSSProperties>({
+    visibility: 'hidden',
+  });
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const wasOpenRef = useRef(false);
   const groupId = useId();
@@ -57,6 +83,29 @@ export function ThemeMenu() {
       : preference === 'dark'
         ? IconMoon
         : IconComputer;
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return;
+    }
+    const updatePosition = () => {
+      const trigger = triggerRef.current;
+      if (!trigger) {
+        return;
+      }
+      setPanelStyle({
+        ...getThemeMenuPanelStyle(trigger),
+        visibility: 'visible',
+      });
+    };
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [open]);
 
   useEffect(() => {
     if (!open) {
@@ -86,10 +135,14 @@ export function ThemeMenu() {
       return;
     }
     const onPointerDown = (e: MouseEvent | TouchEvent) => {
-      const el = rootRef.current;
-      if (el && !el.contains(e.target as Node)) {
-        setOpen(false);
+      const target = e.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        panelRef.current?.contains(target)
+      ) {
+        return;
       }
+      setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -139,8 +192,61 @@ export function ThemeMenu() {
     }
   };
 
+  const panel = open ? (
+    <div
+      ref={panelRef}
+      id={groupId}
+      role="radiogroup"
+      aria-label="Theme"
+      style={panelStyle}
+      className="min-w-[13.5rem] rounded-xl border border-app-border bg-app-surface py-1 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]"
+      onKeyDown={handleRadiogroupKeyDown}
+    >
+      {OPTIONS.map(({ value, label, description, Icon }, index) => {
+        const selected = preference === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            ref={(el) => {
+              itemRefs.current[index] = el;
+            }}
+            role="radio"
+            aria-checked={selected}
+            tabIndex={selected ? 0 : -1}
+            className="flex w-full items-start gap-3 px-3 py-2.5 text-left transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-app-ring"
+            onClick={() => {
+              setPreference(value);
+              setOpen(false);
+            }}
+          >
+            <Icon
+              className="mt-0.5 h-5 w-5 shrink-0 text-app-muted"
+              aria-hidden
+            />
+            <span className="grow">
+              <span className="block text-sm font-medium text-app-ink">
+                {label}
+              </span>
+              <span className="mt-0.5 block text-xs text-app-muted">
+                {description}
+              </span>
+            </span>
+            <span className="flex h-5 w-5 shrink-0 items-center justify-center text-app-primary">
+              {selected ? (
+                <IconCheck className="h-4 w-4" aria-hidden />
+              ) : (
+                <span className="h-4 w-4" aria-hidden />
+              )}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  ) : null;
+
   return (
-    <div ref={rootRef} className="relative">
+    <>
       <button
         ref={triggerRef}
         type="button"
@@ -155,56 +261,9 @@ export function ThemeMenu() {
         <TriggerIcon className="h-5 w-5" aria-hidden />
       </button>
 
-      {open ? (
-        <div
-          id={groupId}
-          role="radiogroup"
-          aria-label="Theme"
-          className="absolute right-0 z-[300] mt-2 min-w-[13.5rem] rounded-xl border border-app-border bg-app-surface py-1 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]"
-          onKeyDown={handleRadiogroupKeyDown}
-        >
-          {OPTIONS.map(({ value, label, description, Icon }, index) => {
-            const selected = preference === value;
-            return (
-              <button
-                key={value}
-                type="button"
-                ref={(el) => {
-                  itemRefs.current[index] = el;
-                }}
-                role="radio"
-                aria-checked={selected}
-                tabIndex={selected ? 0 : -1}
-                className="flex w-full items-start gap-3 px-3 py-2.5 text-left transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-app-ring"
-                onClick={() => {
-                  setPreference(value);
-                  setOpen(false);
-                }}
-              >
-                <Icon
-                  className="mt-0.5 h-5 w-5 shrink-0 text-app-muted"
-                  aria-hidden
-                />
-                <span className="grow">
-                  <span className="block text-sm font-medium text-app-ink">
-                    {label}
-                  </span>
-                  <span className="mt-0.5 block text-xs text-app-muted">
-                    {description}
-                  </span>
-                </span>
-                <span className="flex h-5 w-5 shrink-0 items-center justify-center text-app-primary">
-                  {selected ? (
-                    <IconCheck className="h-4 w-4" aria-hidden />
-                  ) : (
-                    <span className="h-4 w-4" aria-hidden />
-                  )}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
-    </div>
+      {typeof document !== 'undefined' && panel
+        ? createPortal(panel, document.body)
+        : null}
+    </>
   );
 }

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -14,6 +14,7 @@ const nextConfig = {
   transpilePackages: [
     '@abstrack/ui',
     '@abstrack/types',
+    '@abstrack/supabase',
     'react-native',
     'react-native-web',
   ],
@@ -26,6 +27,10 @@ const nextConfig = {
       '@abstrack/types': path.join(
         __dirname,
         '../../packages/types/src/index.ts',
+      ),
+      '@abstrack/supabase': path.join(
+        __dirname,
+        '../../packages/supabase/src/index.ts',
       ),
     };
     return config;

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -19,19 +19,23 @@ const nextConfig = {
     'react-native-web',
   ],
   webpack: (config) => {
+    const supabaseSrc = path.join(__dirname, '../../packages/supabase/src');
     config.resolve.alias = {
       ...config.resolve.alias,
       'react-native$': 'react-native-web',
       // Resolve to source: package `exports` default points at `dist/`, which is easy to forget to
       // rebuild and causes runtime undefined exports (e.g. new helpers not in dist yet).
-      '@abstrack/types': path.join(
+      // Use exact `$` on the root entry so subpath imports (`/browser`, `/server`, …) are not
+      // rewritten to `index.ts/<subpath>`; map subpaths explicitly to match package.json exports.
+      '@abstrack/types$': path.join(
         __dirname,
         '../../packages/types/src/index.ts',
       ),
-      '@abstrack/supabase': path.join(
-        __dirname,
-        '../../packages/supabase/src/index.ts',
-      ),
+      '@abstrack/supabase$': path.join(supabaseSrc, 'index.ts'),
+      '@abstrack/supabase/browser': path.join(supabaseSrc, 'browser.ts'),
+      '@abstrack/supabase/server': path.join(supabaseSrc, 'server.ts'),
+      '@abstrack/supabase/native': path.join(supabaseSrc, 'native.ts'),
+      '@abstrack/supabase/admin': path.join(supabaseSrc, 'admin.ts'),
     };
     return config;
   },

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -8,8 +8,16 @@ import {
 } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import { LiveAnnouncerProvider } from '@abstrack/ui/a11y-web';
-import type { ChartManifestRow, SelectedSeries } from '@abstrack/ui';
+import type {
+  ChartManifestRow,
+  InsightDateRange,
+  SelectedSeries,
+} from '@abstrack/ui';
 import { getChartSeries, getUserChartManifest } from '@abstrack/supabase';
+import {
+  getDefaultInsightDateRange,
+  insightDateRangeToRpcBounds,
+} from '../../../lib/insights/insight-chart-params';
 import { InsightsClient } from './InsightsClient';
 
 const PHI_SUBJECT_A = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
@@ -128,7 +136,25 @@ jest.mock('@abstrack/ui', () => {
         <span data-testid="selected-count">{value.length}</span>
       </div>
     ),
-    InsightDateRangePicker: () => <div data-testid="date-range-picker" />,
+    InsightDateRangePicker: ({
+      onChange,
+    }: {
+      onChange: (next: InsightDateRange) => void;
+    }) => (
+      <div data-testid="date-range-picker">
+        <button
+          type="button"
+          onClick={() =>
+            onChange({
+              from: new Date(2026, 0, 1),
+              to: new Date(2026, 0, 31),
+            })
+          }
+        >
+          Set January 2026 range
+        </button>
+      </div>
+    ),
     InsightComposedChart: ({
       summary,
       loading,
@@ -407,6 +433,54 @@ describe('InsightsClient', () => {
 
     expect(await screen.findByText('Chart RPC failed.')).toBeInTheDocument();
     expect(screen.queryByTestId('composed-chart')).not.toBeInTheDocument();
+  });
+
+  it('refetches chart series when the date range changes', async () => {
+    const updatedRange = {
+      from: new Date(2026, 0, 1),
+      to: new Date(2026, 0, 31),
+    };
+    const defaultBounds = insightDateRangeToRpcBounds(
+      getDefaultInsightDateRange(),
+    );
+    const updatedBounds = insightDateRangeToRpcBounds(updatedRange);
+
+    renderInsights();
+
+    await screen.findByRole('button', { name: 'Select first series' });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Select first series' }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getChartSeriesMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          p_from: defaultBounds.p_from,
+          p_to: defaultBounds.p_to,
+        }),
+      );
+    });
+
+    getChartSeriesMock.mockClear();
+
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Set January 2026 range' }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getChartSeriesMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          p_from: updatedBounds.p_from,
+          p_to: updatedBounds.p_to,
+        }),
+      );
+    });
   });
 
   it('updates chart bucket when the bucket selector changes', async () => {

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -1,0 +1,259 @@
+import '@testing-library/jest-dom';
+import {
+  act,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { LiveAnnouncerProvider } from '@abstrack/ui/a11y-web';
+import type { ChartManifestRow, SelectedSeries } from '@abstrack/ui';
+import { getChartSeries, getUserChartManifest } from '@abstrack/supabase';
+import { InsightsClient } from './InsightsClient';
+
+const PHI_SUBJECT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+const bacManifestRow: ChartManifestRow = {
+  series_id: 'health_marker::bac',
+  series_type: 'health_marker',
+  label: 'BAC',
+  response_type: 'numeric',
+  is_blood_pressure: false,
+  unit: '%',
+  observation_count: 3,
+  first_observed_at: '2026-01-01T00:00:00.000Z',
+  last_observed_at: '2026-02-01T00:00:00.000Z',
+};
+
+const announceMock = jest.fn();
+
+jest.mock('../../../lib/patient/use-web-phi-subject-user-context', () => ({
+  useWebPhiSubjectUserContext: () => ({
+    authUserId: PHI_SUBJECT_ID,
+    phiSubjectUserId: PHI_SUBJECT_ID,
+    profileAppRole: 'patient',
+    loading: false,
+    errorMessage: null,
+    refresh: jest.fn(),
+  }),
+}));
+
+jest.mock('@abstrack/ui/a11y-web', () => ({
+  ...jest.requireActual('@abstrack/ui/a11y-web'),
+  useAnnounce: () => ({ announce: announceMock }),
+}));
+
+jest.mock('../../../lib/supabase/browser-client', () => ({
+  createBrowserClient: () => ({}),
+}));
+
+jest.mock('@abstrack/supabase', () => ({
+  getUserChartManifest: jest.fn(),
+  getChartSeries: jest.fn(),
+}));
+
+jest.mock('@abstrack/ui', () => {
+  const { getInsightDateRangePreset } = jest.requireActual(
+    '../../../../../../packages/ui/src/lib/insight-date-range-picker-utils',
+  );
+  const { pivotChartSeriesBucketRows } = jest.requireActual(
+    '../../../../../../packages/ui/src/lib/insight-composed-chart-utils',
+  );
+  return {
+    getInsightDateRangePreset,
+    pivotChartSeriesBucketRows,
+    Button: ({
+      children,
+      onPress,
+      accessibilityLabel,
+    }: {
+      children: ReactNode;
+      onPress?: () => void;
+      accessibilityLabel?: string;
+    }) => (
+      <button type="button" aria-label={accessibilityLabel} onClick={onPress}>
+        {children}
+      </button>
+    ),
+    InsightSeriesPicker: ({
+      manifest,
+      value,
+      onChange,
+    }: {
+      manifest: ChartManifestRow[];
+      value: unknown[];
+      onChange: (next: unknown[]) => void;
+    }) => (
+      <div>
+        {manifest.map((row) => (
+          <span
+            key={row.series_id}
+            data-testid={`manifest-label-${row.series_id}`}
+          >
+            {row.label}
+          </span>
+        ))}
+        <button
+          type="button"
+          onClick={() => {
+            const row = manifest[0];
+            if (!row) {
+              return;
+            }
+            const selected: SelectedSeries = {
+              seriesId: row.series_id,
+              seriesType: row.series_type,
+              responseType: row.response_type as 'numeric',
+              isBloodPressure: row.is_blood_pressure,
+              label: row.label,
+              unit: row.unit,
+              chartType: 'line',
+              color: '#1d4ed8',
+            };
+            onChange([selected]);
+          }}
+        >
+          Select first series
+        </button>
+        <span data-testid="selected-count">{value.length}</span>
+      </div>
+    ),
+    InsightDateRangePicker: () => <div data-testid="date-range-picker" />,
+    InsightComposedChart: ({
+      summary,
+      loading,
+    }: {
+      summary: string;
+      loading: boolean;
+    }) => (
+      <div data-testid="composed-chart">
+        <p>{summary}</p>
+        {loading ? <p role="status">Chart loading</p> : null}
+      </div>
+    ),
+  };
+});
+
+const getUserChartManifestMock = getUserChartManifest as jest.MockedFunction<
+  typeof getUserChartManifest
+>;
+const getChartSeriesMock = getChartSeries as jest.MockedFunction<
+  typeof getChartSeries
+>;
+
+function renderInsights() {
+  return render(
+    <LiveAnnouncerProvider>
+      <InsightsClient />
+    </LiveAnnouncerProvider>,
+  );
+}
+
+describe('InsightsClient', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getUserChartManifestMock.mockResolvedValue({
+      ok: true,
+      data: [bacManifestRow],
+    });
+    getChartSeriesMock.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          series_id: bacManifestRow.series_id,
+          bucket_start: '2026-01-15T00:00:00.000Z',
+          value_avg: 0.02,
+          value_min: 0.02,
+          value_max: 0.02,
+          systolic_avg: null,
+          diastolic_avg: null,
+          event_count: null,
+        },
+      ],
+    });
+  });
+
+  it('shows the empty state when the manifest is empty', async () => {
+    getUserChartManifestMock.mockResolvedValue({ ok: true, data: [] });
+
+    renderInsights();
+
+    expect(
+      await screen.findByText(
+        'No data to chart yet. Log some episodes or health markers to get started.',
+      ),
+    ).toBeInTheDocument();
+    expect(getChartSeriesMock).not.toHaveBeenCalled();
+  });
+
+  it('does not call getChartSeries until a series is selected', async () => {
+    renderInsights();
+
+    await screen.findByTestId('date-range-picker');
+    expect(getChartSeriesMock).not.toHaveBeenCalled();
+  });
+
+  it('maps raw RPC health marker labels to preset display names', async () => {
+    getUserChartManifestMock.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          ...bacManifestRow,
+          label: 'bac',
+        },
+        {
+          series_id: 'health_marker::blood_glucose',
+          series_type: 'health_marker',
+          label: 'blood_glucose',
+          response_type: 'numeric',
+          is_blood_pressure: false,
+          unit: 'mg/dL',
+          observation_count: 1,
+          first_observed_at: '2026-01-01T00:00:00.000Z',
+          last_observed_at: '2026-02-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    renderInsights();
+
+    expect(
+      await screen.findByTestId('manifest-label-health_marker::bac'),
+    ).toHaveTextContent('BAC');
+    expect(
+      screen.getByTestId('manifest-label-health_marker::blood_glucose'),
+    ).toHaveTextContent('Glucose');
+  });
+
+  it('updates chart bucket when the bucket selector changes', async () => {
+    renderInsights();
+
+    await screen.findByRole('button', { name: 'Select first series' });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Select first series' }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getChartSeriesMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ p_bucket: 'day' }),
+      );
+    });
+
+    getChartSeriesMock.mockClear();
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: 'Week' }));
+    });
+
+    await waitFor(() => {
+      expect(getChartSeriesMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ p_bucket: 'week' }),
+      );
+    });
+  });
+});

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -187,6 +187,23 @@ describe('InsightsClient', () => {
     });
   });
 
+  it('does not show the empty state when PHI scope fails to resolve', async () => {
+    phiContext.phiSubjectUserId = null;
+    phiContext.errorMessage = 'Could not resolve patient context.';
+
+    renderInsights();
+
+    expect(
+      await screen.findByText('Could not resolve patient context.'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(
+        'No data to chart yet. Log some episodes or health markers to get started.',
+      ),
+    ).not.toBeInTheDocument();
+    expect(getUserChartManifestMock).not.toHaveBeenCalled();
+  });
+
   it('shows the empty state when the manifest is empty', async () => {
     getUserChartManifestMock.mockResolvedValue({ ok: true, data: [] });
 
@@ -344,6 +361,25 @@ describe('InsightsClient', () => {
     ).toBeInTheDocument();
     expect(screen.queryByTestId('composed-chart')).not.toBeInTheDocument();
     expect(getChartSeriesMock).not.toHaveBeenCalled();
+  });
+
+  it('does not render the chart when the series RPC fails', async () => {
+    getChartSeriesMock.mockResolvedValue({
+      ok: false,
+      error: { message: 'Chart RPC failed.', code: 'rpc_error' },
+    });
+
+    renderInsights();
+
+    await screen.findByRole('button', { name: 'Select first series' });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Select first series' }),
+      );
+    });
+
+    expect(await screen.findByText('Chart RPC failed.')).toBeInTheDocument();
+    expect(screen.queryByTestId('composed-chart')).not.toBeInTheDocument();
   });
 
   it('updates chart bucket when the bucket selector changes', async () => {

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -297,6 +297,33 @@ describe('InsightsClient', () => {
     expect(screen.queryByText('Chart options loaded.')).not.toBeInTheDocument();
   });
 
+  it('does not announce or apply manifest after unmount when RPC completes late', async () => {
+    let resolveManifest:
+      | ((value: Awaited<ReturnType<typeof getUserChartManifest>>) => void)
+      | undefined;
+    getUserChartManifestMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveManifest = resolve;
+        }),
+    );
+
+    const view = renderInsights();
+
+    expect(
+      await screen.findByText('Loading chart options…'),
+    ).toBeInTheDocument();
+    announceMock.mockClear();
+    view.unmount();
+
+    await act(async () => {
+      resolveManifest?.({ ok: true, data: [bacManifestRow] });
+      await Promise.resolve();
+    });
+
+    expect(announceMock).not.toHaveBeenCalled();
+  });
+
   it('maps raw RPC health marker labels to preset display names', async () => {
     getUserChartManifestMock.mockResolvedValue({
       ok: true,

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -12,7 +12,17 @@ import type { ChartManifestRow, SelectedSeries } from '@abstrack/ui';
 import { getChartSeries, getUserChartManifest } from '@abstrack/supabase';
 import { InsightsClient } from './InsightsClient';
 
-const PHI_SUBJECT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const PHI_SUBJECT_A = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const PHI_SUBJECT_B = 'bbbbbbbb-bbbb-cccc-dddd-ffffffffffff';
+
+const phiContext = {
+  authUserId: PHI_SUBJECT_A,
+  phiSubjectUserId: PHI_SUBJECT_A as string | null,
+  profileAppRole: 'patient' as const,
+  loading: false,
+  errorMessage: null as string | null,
+  refresh: jest.fn(),
+};
 
 const bacManifestRow: ChartManifestRow = {
   series_id: 'health_marker::bac',
@@ -29,14 +39,7 @@ const bacManifestRow: ChartManifestRow = {
 const announceMock = jest.fn();
 
 jest.mock('../../../lib/patient/use-web-phi-subject-user-context', () => ({
-  useWebPhiSubjectUserContext: () => ({
-    authUserId: PHI_SUBJECT_ID,
-    phiSubjectUserId: PHI_SUBJECT_ID,
-    profileAppRole: 'patient',
-    loading: false,
-    errorMessage: null,
-    refresh: jest.fn(),
-  }),
+  useWebPhiSubjectUserContext: () => phiContext,
 }));
 
 jest.mock('@abstrack/ui/a11y-web', () => ({
@@ -54,15 +57,21 @@ jest.mock('@abstrack/supabase', () => ({
 }));
 
 jest.mock('@abstrack/ui', () => {
+  // Six `../` from `apps/web/src/app/(app)/insights` to the repo root, then `packages/ui`.
+  const uiLib = '../../../../../../packages/ui/src/lib';
   const { getInsightDateRangePreset } = jest.requireActual(
-    '../../../../../../packages/ui/src/lib/insight-date-range-picker-utils',
+    `${uiLib}/insight-date-range-picker-utils`,
   );
   const { pivotChartSeriesBucketRows } = jest.requireActual(
-    '../../../../../../packages/ui/src/lib/insight-composed-chart-utils',
+    `${uiLib}/insight-composed-chart-utils`,
   );
+  const { filterChartableManifestRows, reconcileSelectedSeriesWithManifest } =
+    jest.requireActual(`${uiLib}/insight-series-picker-utils`);
   return {
     getInsightDateRangePreset,
     pivotChartSeriesBucketRows,
+    filterChartableManifestRows,
+    reconcileSelectedSeriesWithManifest,
     Button: ({
       children,
       onPress,
@@ -153,6 +162,10 @@ function renderInsights() {
 describe('InsightsClient', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    phiContext.authUserId = PHI_SUBJECT_A;
+    phiContext.phiSubjectUserId = PHI_SUBJECT_A;
+    phiContext.loading = false;
+    phiContext.errorMessage = null;
     getUserChartManifestMock.mockResolvedValue({
       ok: true,
       data: [bacManifestRow],
@@ -187,11 +200,84 @@ describe('InsightsClient', () => {
     expect(getChartSeriesMock).not.toHaveBeenCalled();
   });
 
+  it('shows the empty state when the manifest has only non-chartable rows', async () => {
+    getUserChartManifestMock.mockResolvedValue({
+      ok: true,
+      data: [
+        {
+          series_id: 'symptom::journal::text',
+          series_type: 'symptom',
+          label: 'Journal',
+          response_type: 'text',
+          is_blood_pressure: false,
+          unit: null,
+          observation_count: 2,
+          first_observed_at: '2026-01-01T00:00:00.000Z',
+          last_observed_at: '2026-02-01T00:00:00.000Z',
+        },
+      ],
+    });
+
+    renderInsights();
+
+    expect(
+      await screen.findByText(
+        'No data to chart yet. Log some episodes or health markers to get started.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('date-range-picker')).not.toBeInTheDocument();
+    expect(getChartSeriesMock).not.toHaveBeenCalled();
+  });
+
   it('does not call getChartSeries until a series is selected', async () => {
     renderInsights();
 
     await screen.findByTestId('date-range-picker');
     expect(getChartSeriesMock).not.toHaveBeenCalled();
+  });
+
+  it('discards stale manifest when PHI subject changes before RPC completes', async () => {
+    let resolveManifest:
+      | ((value: Awaited<ReturnType<typeof getUserChartManifest>>) => void)
+      | undefined;
+    getUserChartManifestMock.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveManifest = resolve;
+        }),
+    );
+
+    const view = renderInsights();
+
+    expect(
+      await screen.findByText('Loading chart options…'),
+    ).toBeInTheDocument();
+
+    phiContext.phiSubjectUserId = PHI_SUBJECT_B;
+    phiContext.loading = true;
+    view.rerender(
+      <LiveAnnouncerProvider>
+        <InsightsClient />
+      </LiveAnnouncerProvider>,
+    );
+
+    await act(async () => {
+      resolveManifest?.({
+        ok: true,
+        data: [
+          {
+            ...bacManifestRow,
+            label: 'bac',
+          },
+        ],
+      });
+      await Promise.resolve();
+    });
+
+    expect(
+      screen.queryByTestId('manifest-label-health_marker::bac'),
+    ).not.toBeInTheDocument();
+    expect(screen.queryByText('Chart options loaded.')).not.toBeInTheDocument();
   });
 
   it('maps raw RPC health marker labels to preset display names', async () => {
@@ -224,6 +310,40 @@ describe('InsightsClient', () => {
     expect(
       screen.getByTestId('manifest-label-health_marker::blood_glucose'),
     ).toHaveTextContent('Glucose');
+  });
+
+  it('clears series selection and skips chart fetch after PHI subject switch', async () => {
+    const view = renderInsights();
+
+    await screen.findByRole('button', { name: 'Select first series' });
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Select first series' }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getChartSeriesMock).toHaveBeenCalled();
+    });
+    getChartSeriesMock.mockClear();
+
+    phiContext.phiSubjectUserId = PHI_SUBJECT_B;
+    phiContext.loading = false;
+    getUserChartManifestMock.mockResolvedValue({ ok: true, data: [] });
+
+    view.rerender(
+      <LiveAnnouncerProvider>
+        <InsightsClient />
+      </LiveAnnouncerProvider>,
+    );
+
+    expect(
+      await screen.findByText(
+        'No data to chart yet. Log some episodes or health markers to get started.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByTestId('composed-chart')).not.toBeInTheDocument();
+    expect(getChartSeriesMock).not.toHaveBeenCalled();
   });
 
   it('updates chart bucket when the bucket selector changes', async () => {

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -139,8 +139,14 @@ export function InsightsClient() {
     [manifest],
   );
 
+  const phiScopeReady =
+    !phiScopeLoading && !phiScopeError && phiSubjectUserId != null;
+
   const manifestIsEmpty =
-    !manifestLoading && !manifestError && chartableManifest.length === 0;
+    phiScopeReady &&
+    !manifestLoading &&
+    !manifestError &&
+    chartableManifest.length === 0;
 
   const chartSummary = useMemo(
     () =>
@@ -331,7 +337,10 @@ export function InsightsClient() {
         </p>
       ) : null}
 
-      {!manifestLoading && !manifestError && chartableManifest.length > 0 ? (
+      {phiScopeReady &&
+      !manifestLoading &&
+      !manifestError &&
+      chartableManifest.length > 0 ? (
         <section aria-labelledby={filtersHeadingId} className="space-y-6">
           <h2 id={filtersHeadingId} className="sr-only">
             Chart filters
@@ -402,18 +411,18 @@ export function InsightsClient() {
                 >
                   {chartError}
                 </p>
-              ) : null}
-
-              <InsightComposedChart
-                series={series}
-                data={chartRows}
-                bucket={bucket}
-                loading={chartLoading}
-                summary={chartSummary}
-                patientTimeZone={chartTimeZone}
-                showPatientTimeZoneNote={showPatientTimeZoneNote}
-                patientTimeZoneNoteUsesPatientLocal={false}
-              />
+              ) : (
+                <InsightComposedChart
+                  series={series}
+                  data={chartRows}
+                  bucket={bucket}
+                  loading={chartLoading}
+                  summary={chartSummary}
+                  patientTimeZone={chartTimeZone}
+                  showPatientTimeZoneNote={showPatientTimeZoneNote}
+                  patientTimeZoneNoteUsesPatientLocal={false}
+                />
+              )}
             </section>
           ) : null}
         </section>

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -17,8 +17,10 @@ import {
 import {
   InsightComposedChart,
   InsightDateRangePicker,
+  filterChartableManifestRows,
   InsightSeriesPicker,
   pivotChartSeriesBucketRows,
+  reconcileSelectedSeriesWithManifest,
   type ChartManifestRow,
   type InsightChartBucket,
   type InsightDateRange,
@@ -76,14 +78,16 @@ export function InsightsClient() {
     errorMessage: phiScopeError,
   } = useWebPhiSubjectUserContext();
 
-  const patientTimeZone = useMemo(
+  /** Viewer browser zone for RPC bucketing and labels until patient IANA timezone is stored on profile. */
+  const chartTimeZone = useMemo(
     () => Intl.DateTimeFormat().resolvedOptions().timeZone,
     [],
   );
-  const showPatientTimeZoneNote =
+  const viewingAnotherPhiSubject =
     phiSubjectUserId != null &&
     authUserId != null &&
     phiSubjectUserId !== authUserId;
+  const showPatientTimeZoneNote = viewingAnotherPhiSubject;
 
   const [manifestLoading, setManifestLoading] = useState(true);
   const [manifest, setManifest] = useState<ChartManifestRow[]>([]);
@@ -103,9 +107,40 @@ export function InsightsClient() {
 
   const manifestLoadGenRef = useRef(0);
   const chartLoadGenRef = useRef(0);
+  const phiSubjectUserIdRef = useRef(phiSubjectUserId);
+  phiSubjectUserIdRef.current = phiSubjectUserId;
+  /** PHI subject that owns the current picker selection (null after scope reset). */
+  const selectionOwnerUserIdRef = useRef<string | null>(null);
+
+  /** Drops in-flight manifest/chart loads when PHI scope changes or unmounts. */
+  const invalidateInsightsLoads = useCallback(() => {
+    manifestLoadGenRef.current += 1;
+    chartLoadGenRef.current += 1;
+  }, []);
+
+  const resetInsightsPatientState = useCallback(() => {
+    selectionOwnerUserIdRef.current = null;
+    setSeries([]);
+    setChartLoading(false);
+    setChartRows([]);
+    setChartError(null);
+  }, []);
+
+  const handleSeriesChange = useCallback(
+    (next: SelectedSeries[]) => {
+      selectionOwnerUserIdRef.current = phiSubjectUserId;
+      setSeries(next);
+    },
+    [phiSubjectUserId],
+  );
+
+  const chartableManifest = useMemo(
+    () => filterChartableManifestRows(manifest),
+    [manifest],
+  );
 
   const manifestIsEmpty =
-    !manifestLoading && !manifestError && manifest.length === 0;
+    !manifestLoading && !manifestError && chartableManifest.length === 0;
 
   const chartSummary = useMemo(
     () =>
@@ -121,15 +156,19 @@ export function InsightsClient() {
     if (phiSubjectUserId == null) {
       return;
     }
+    const requestedUserId = phiSubjectUserId;
     const generation = ++manifestLoadGenRef.current;
     setManifestLoading(true);
     setManifestError(null);
     announce('Loading chart options.', { politeness: 'polite' });
 
     const supabase = createBrowserClient();
-    const result = await getUserChartManifest(supabase, phiSubjectUserId);
+    const result = await getUserChartManifest(supabase, requestedUserId);
 
-    if (generation !== manifestLoadGenRef.current) {
+    if (
+      generation !== manifestLoadGenRef.current ||
+      requestedUserId !== phiSubjectUserIdRef.current
+    ) {
       return;
     }
 
@@ -144,27 +183,46 @@ export function InsightsClient() {
       return;
     }
 
-    setManifest(manifestToChartRows(result.data));
+    const chartManifest = manifestToChartRows(result.data);
+    setManifest(chartManifest);
+    setSeries((current) =>
+      reconcileSelectedSeriesWithManifest(chartManifest, current),
+    );
     announce('Chart options loaded.', { politeness: 'polite' });
   }, [announce, phiSubjectUserId]);
 
   useEffect(() => {
+    invalidateInsightsLoads();
+    resetInsightsPatientState();
+
     if (phiScopeLoading) {
+      setManifestLoading(true);
+      setManifest([]);
+      setManifestError(null);
       return;
     }
     if (phiSubjectUserId == null) {
       setManifestLoading(false);
       setManifest([]);
+      setManifestError(null);
       return;
     }
     void loadManifest();
-  }, [loadManifest, phiScopeLoading, phiSubjectUserId]);
+  }, [
+    invalidateInsightsLoads,
+    loadManifest,
+    phiScopeLoading,
+    phiSubjectUserId,
+    resetInsightsPatientState,
+  ]);
 
   const loadChartSeries = useCallback(async () => {
     if (phiSubjectUserId == null || series.length === 0) {
       return;
     }
 
+    const requestedUserId = phiSubjectUserId;
+    const requestedSeries = selectedSeriesToChartSeriesSelection(series);
     const generation = ++chartLoadGenRef.current;
     setChartLoading(true);
     setChartError(null);
@@ -173,15 +231,18 @@ export function InsightsClient() {
     const { p_from, p_to } = insightDateRangeToRpcBounds(dateRange);
     const supabase = createBrowserClient();
     const result = await getChartSeries(supabase, {
-      p_user_id: phiSubjectUserId,
-      p_series: selectedSeriesToChartSeriesSelection(series),
+      p_user_id: requestedUserId,
+      p_series: requestedSeries,
       p_from,
       p_to,
       p_bucket: bucket,
-      p_timezone: patientTimeZone,
+      p_timezone: chartTimeZone,
     });
 
-    if (generation !== chartLoadGenRef.current) {
+    if (
+      generation !== chartLoadGenRef.current ||
+      requestedUserId !== phiSubjectUserIdRef.current
+    ) {
       return;
     }
 
@@ -198,10 +259,25 @@ export function InsightsClient() {
 
     setChartRows(pivotChartSeriesBucketRows(result.data));
     announce('Chart data loaded.', { politeness: 'polite' });
-  }, [announce, bucket, dateRange, patientTimeZone, phiSubjectUserId, series]);
+  }, [announce, bucket, chartTimeZone, dateRange, phiSubjectUserId, series]);
 
   useEffect(() => {
-    if (phiScopeLoading || series.length === 0) {
+    const selectionOwnedByCurrentSubject =
+      selectionOwnerUserIdRef.current === phiSubjectUserId;
+    const selectionMatchesManifest =
+      series.length > 0 &&
+      series.every((item) =>
+        manifest.some((row) => row.series_id === item.seriesId),
+      );
+
+    if (
+      manifestLoading ||
+      phiScopeLoading ||
+      phiSubjectUserId == null ||
+      series.length === 0 ||
+      !selectionOwnedByCurrentSubject ||
+      !selectionMatchesManifest
+    ) {
       chartLoadGenRef.current += 1;
       setChartLoading(false);
       setChartRows([]);
@@ -209,7 +285,14 @@ export function InsightsClient() {
       return;
     }
     void loadChartSeries();
-  }, [loadChartSeries, phiScopeLoading, series]);
+  }, [
+    loadChartSeries,
+    manifest,
+    manifestLoading,
+    phiScopeLoading,
+    phiSubjectUserId,
+    series,
+  ]);
 
   const showChartSection = series.length > 0;
 
@@ -248,7 +331,7 @@ export function InsightsClient() {
         </p>
       ) : null}
 
-      {!manifestLoading && !manifestError && manifest.length > 0 ? (
+      {!manifestLoading && !manifestError && chartableManifest.length > 0 ? (
         <section aria-labelledby={filtersHeadingId} className="space-y-6">
           <h2 id={filtersHeadingId} className="sr-only">
             Chart filters
@@ -267,7 +350,7 @@ export function InsightsClient() {
             <InsightSeriesPicker
               manifest={manifest}
               value={series}
-              onChange={setSeries}
+              onChange={handleSeriesChange}
             />
             <InsightDateRangePicker value={dateRange} onChange={setDateRange} />
           </div>
@@ -327,8 +410,9 @@ export function InsightsClient() {
                 bucket={bucket}
                 loading={chartLoading}
                 summary={chartSummary}
-                patientTimeZone={patientTimeZone}
+                patientTimeZone={chartTimeZone}
                 showPatientTimeZoneNote={showPatientTimeZoneNote}
+                patientTimeZoneNoteUsesPatientLocal={false}
               />
             </section>
           ) : null}

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -1,0 +1,339 @@
+'use client';
+
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { chartManifestSeriesDisplayLabel } from '@abstrack/types';
+import {
+  getChartSeries,
+  getUserChartManifest,
+  type UserChartManifestSeries,
+} from '@abstrack/supabase';
+import {
+  InsightComposedChart,
+  InsightDateRangePicker,
+  InsightSeriesPicker,
+  pivotChartSeriesBucketRows,
+  type ChartManifestRow,
+  type InsightChartBucket,
+  type InsightDateRange,
+  type SelectedSeries,
+} from '@abstrack/ui';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import {
+  formatInsightChartPageSummary,
+  getDefaultInsightDateRange,
+  insightDateRangeToRpcBounds,
+  selectedSeriesToChartSeriesSelection,
+} from '@/lib/insights/insight-chart-params';
+import { useWebPhiSubjectUserContext } from '@/lib/patient/use-web-phi-subject-user-context';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+
+const BUCKET_OPTIONS: ReadonlyArray<{
+  value: InsightChartBucket;
+  label: string;
+}> = [
+  { value: 'day', label: 'Day' },
+  { value: 'week', label: 'Week' },
+  { value: 'month', label: 'Month' },
+];
+
+const EMPTY_MANIFEST_MESSAGE =
+  'No data to chart yet. Log some episodes or health markers to get started.';
+
+function manifestToChartRows(
+  rows: UserChartManifestSeries[],
+): ChartManifestRow[] {
+  return rows.map((row) => ({
+    ...row,
+    label: chartManifestSeriesDisplayLabel(
+      row.series_type,
+      row.series_id,
+      row.label,
+    ),
+  }));
+}
+
+/**
+ * Interactive insights chart builder: manifest, series and date filters, bucket size, and chart.
+ *
+ * @returns Client insights page content.
+ */
+export function InsightsClient() {
+  const { announce } = useAnnounce();
+  const filtersHeadingId = useId();
+  const chartOptionsHeadingId = useId();
+  const bucketGroupId = useId();
+  const {
+    authUserId,
+    phiSubjectUserId,
+    loading: phiScopeLoading,
+    errorMessage: phiScopeError,
+  } = useWebPhiSubjectUserContext();
+
+  const patientTimeZone = useMemo(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone,
+    [],
+  );
+  const showPatientTimeZoneNote =
+    phiSubjectUserId != null &&
+    authUserId != null &&
+    phiSubjectUserId !== authUserId;
+
+  const [manifestLoading, setManifestLoading] = useState(true);
+  const [manifest, setManifest] = useState<ChartManifestRow[]>([]);
+  const [manifestError, setManifestError] = useState<string | null>(null);
+
+  const [series, setSeries] = useState<SelectedSeries[]>([]);
+  const [dateRange, setDateRange] = useState<InsightDateRange>(
+    getDefaultInsightDateRange,
+  );
+  const [bucket, setBucket] = useState<InsightChartBucket>('day');
+
+  const [chartLoading, setChartLoading] = useState(false);
+  const [chartRows, setChartRows] = useState<
+    ReturnType<typeof pivotChartSeriesBucketRows>
+  >([]);
+  const [chartError, setChartError] = useState<string | null>(null);
+
+  const manifestLoadGenRef = useRef(0);
+  const chartLoadGenRef = useRef(0);
+
+  const manifestIsEmpty =
+    !manifestLoading && !manifestError && manifest.length === 0;
+
+  const chartSummary = useMemo(
+    () =>
+      formatInsightChartPageSummary(
+        series.map((item) => item.label),
+        dateRange,
+        bucket,
+      ),
+    [series, dateRange, bucket],
+  );
+
+  const loadManifest = useCallback(async () => {
+    if (phiSubjectUserId == null) {
+      return;
+    }
+    const generation = ++manifestLoadGenRef.current;
+    setManifestLoading(true);
+    setManifestError(null);
+    announce('Loading chart options.', { politeness: 'polite' });
+
+    const supabase = createBrowserClient();
+    const result = await getUserChartManifest(supabase, phiSubjectUserId);
+
+    if (generation !== manifestLoadGenRef.current) {
+      return;
+    }
+
+    setManifestLoading(false);
+
+    if (!result.ok) {
+      setManifest([]);
+      setManifestError(result.error.message);
+      announce(`Could not load chart options. ${result.error.message}`, {
+        politeness: 'assertive',
+      });
+      return;
+    }
+
+    setManifest(manifestToChartRows(result.data));
+    announce('Chart options loaded.', { politeness: 'polite' });
+  }, [announce, phiSubjectUserId]);
+
+  useEffect(() => {
+    if (phiScopeLoading) {
+      return;
+    }
+    if (phiSubjectUserId == null) {
+      setManifestLoading(false);
+      setManifest([]);
+      return;
+    }
+    void loadManifest();
+  }, [loadManifest, phiScopeLoading, phiSubjectUserId]);
+
+  const loadChartSeries = useCallback(async () => {
+    if (phiSubjectUserId == null || series.length === 0) {
+      return;
+    }
+
+    const generation = ++chartLoadGenRef.current;
+    setChartLoading(true);
+    setChartError(null);
+    announce('Loading chart data.', { politeness: 'polite' });
+
+    const { p_from, p_to } = insightDateRangeToRpcBounds(dateRange);
+    const supabase = createBrowserClient();
+    const result = await getChartSeries(supabase, {
+      p_user_id: phiSubjectUserId,
+      p_series: selectedSeriesToChartSeriesSelection(series),
+      p_from,
+      p_to,
+      p_bucket: bucket,
+      p_timezone: patientTimeZone,
+    });
+
+    if (generation !== chartLoadGenRef.current) {
+      return;
+    }
+
+    setChartLoading(false);
+
+    if (!result.ok) {
+      setChartRows([]);
+      setChartError(result.error.message);
+      announce(`Could not load chart data. ${result.error.message}`, {
+        politeness: 'assertive',
+      });
+      return;
+    }
+
+    setChartRows(pivotChartSeriesBucketRows(result.data));
+    announce('Chart data loaded.', { politeness: 'polite' });
+  }, [announce, bucket, dateRange, patientTimeZone, phiSubjectUserId, series]);
+
+  useEffect(() => {
+    if (phiScopeLoading || series.length === 0) {
+      chartLoadGenRef.current += 1;
+      setChartLoading(false);
+      setChartRows([]);
+      setChartError(null);
+      return;
+    }
+    void loadChartSeries();
+  }, [loadChartSeries, phiScopeLoading, series]);
+
+  const showChartSection = series.length > 0;
+
+  return (
+    <div className="w-full space-y-8">
+      <header>
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Insights
+        </h1>
+        <p className="mt-1 text-sm text-app-muted">
+          Explore trends in your health markers and symptoms over time.
+        </p>
+      </header>
+
+      {phiScopeError ? (
+        <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+          {phiScopeError}
+        </p>
+      ) : null}
+
+      {manifestLoading ? (
+        <p className="text-sm text-app-muted" role="status">
+          Loading chart options…
+        </p>
+      ) : null}
+
+      {manifestError ? (
+        <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+          {manifestError}
+        </p>
+      ) : null}
+
+      {manifestIsEmpty ? (
+        <p className="text-sm text-app-muted" role="status">
+          {EMPTY_MANIFEST_MESSAGE}
+        </p>
+      ) : null}
+
+      {!manifestLoading && !manifestError && manifest.length > 0 ? (
+        <section aria-labelledby={filtersHeadingId} className="space-y-6">
+          <h2 id={filtersHeadingId} className="sr-only">
+            Chart filters
+          </h2>
+
+          <div
+            className="space-y-6 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+            aria-labelledby={chartOptionsHeadingId}
+          >
+            <h3
+              id={chartOptionsHeadingId}
+              className="text-lg font-semibold text-app-ink"
+            >
+              What to chart
+            </h3>
+            <InsightSeriesPicker
+              manifest={manifest}
+              value={series}
+              onChange={setSeries}
+            />
+            <InsightDateRangePicker value={dateRange} onChange={setDateRange} />
+          </div>
+
+          {showChartSection ? (
+            <section
+              aria-labelledby="insights-chart-heading"
+              className="space-y-4 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+            >
+              <h3
+                id="insights-chart-heading"
+                className="text-lg font-semibold text-app-ink"
+              >
+                Chart
+              </h3>
+
+              <div
+                role="group"
+                aria-labelledby={bucketGroupId}
+                className="flex flex-wrap gap-2"
+              >
+                <span id={bucketGroupId} className="sr-only">
+                  Time bucket
+                </span>
+                {BUCKET_OPTIONS.map(({ value, label }) => {
+                  const selected = bucket === value;
+                  return (
+                    <button
+                      key={value}
+                      type="button"
+                      aria-pressed={selected}
+                      className={
+                        selected
+                          ? 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-primary px-4 text-base font-semibold text-white shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
+                          : 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
+                      }
+                      onClick={() => setBucket(value)}
+                    >
+                      {label}
+                    </button>
+                  );
+                })}
+              </div>
+
+              {chartError ? (
+                <p
+                  className="text-sm text-red-700 dark:text-red-300"
+                  role="alert"
+                >
+                  {chartError}
+                </p>
+              ) : null}
+
+              <InsightComposedChart
+                series={series}
+                data={chartRows}
+                bucket={bucket}
+                loading={chartLoading}
+                summary={chartSummary}
+                patientTimeZone={patientTimeZone}
+                showPatientTimeZoneNote={showPatientTimeZoneNote}
+              />
+            </section>
+          ) : null}
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -388,7 +388,7 @@ export function InsightsClient() {
                 className="flex flex-wrap gap-2"
               >
                 <span id={bucketGroupId} className="sr-only">
-                  Time bucket
+                  Group chart by
                 </span>
                 {BUCKET_OPTIONS.map(({ value, label }) => {
                   const selected = bucket === value;

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -205,15 +205,17 @@ export function InsightsClient() {
       setManifestLoading(true);
       setManifest([]);
       setManifestError(null);
-      return;
-    }
-    if (phiSubjectUserId == null) {
+    } else if (phiSubjectUserId == null) {
       setManifestLoading(false);
       setManifest([]);
       setManifestError(null);
-      return;
+    } else {
+      void loadManifest();
     }
-    void loadManifest();
+
+    return () => {
+      invalidateInsightsLoads();
+    };
   }, [
     invalidateInsightsLoads,
     loadManifest,
@@ -288,9 +290,13 @@ export function InsightsClient() {
       setChartLoading(false);
       setChartRows([]);
       setChartError(null);
-      return;
+    } else {
+      void loadChartSeries();
     }
-    void loadChartSeries();
+
+    return () => {
+      chartLoadGenRef.current += 1;
+    };
   }, [
     loadChartSeries,
     manifest,

--- a/apps/web/src/app/(app)/insights/page.tsx
+++ b/apps/web/src/app/(app)/insights/page.tsx
@@ -1,0 +1,10 @@
+import { InsightsClient } from './InsightsClient';
+
+/**
+ * Patient insights charts: server wrapper for the interactive chart builder.
+ *
+ * @returns Insights page with client-side data loading and filters.
+ */
+export default function InsightsPage() {
+  return <InsightsClient />;
+}

--- a/apps/web/src/app/global.css
+++ b/apps/web/src/app/global.css
@@ -99,6 +99,16 @@
     }
   }
 
+  /* react-day-picker: map accent colors to semantic app tokens (light + html.dark). */
+  .rdp-root {
+    --rdp-accent-color: rgb(var(--app-primary) / 1);
+    --rdp-accent-background-color: rgb(var(--app-primary-soft) / 1);
+    --rdp-range_middle-color: rgb(var(--app-ink) / 1);
+    --rdp-range_start-color: rgb(var(--app-surface) / 1);
+    --rdp-range_end-color: rgb(var(--app-surface) / 1);
+    color: rgb(var(--app-ink) / 1);
+  }
+
   html {
     -webkit-text-size-adjust: 100%;
     line-height: 1.5;

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -25,6 +25,11 @@ const NAV_ITEMS: {
     match: (path) => path === '/manage' || path.startsWith('/manage/'),
   },
   {
+    href: '/insights',
+    label: 'Insights',
+    match: (path) => path === '/insights' || path.startsWith('/insights/'),
+  },
+  {
     href: '/presets/symptoms',
     label: 'Symptom presets',
     match: (path) =>
@@ -115,7 +120,7 @@ export function AuthenticatedShell({
         }}
         mainStyle={{ backgroundColor: 'transparent', flex: 1 }}
         header={
-          <header className="sticky top-0 z-40 border-b border-[var(--app-header-border)] bg-[var(--app-header-bg)] shadow-header backdrop-blur-md supports-[backdrop-filter]:bg-[var(--app-header-bg)]">
+          <header className="sticky top-0 z-50 overflow-visible border-b border-[var(--app-header-border)] bg-[var(--app-header-bg)] shadow-header backdrop-blur-md supports-[backdrop-filter]:bg-[var(--app-header-bg)]">
             <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-3.5 sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:gap-8 lg:px-8">
               <Link
                 href="/dashboard"

--- a/apps/web/src/components/theme/ThemeMenu.tsx
+++ b/apps/web/src/components/theme/ThemeMenu.tsx
@@ -1,9 +1,20 @@
 'use client';
 
-import { useEffect, useId, useRef, useState } from 'react';
+import {
+  useEffect,
+  useId,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { useTheme } from './ThemeProvider';
 import { IconCheck, IconComputer, IconMoon, IconSun } from './ThemeIcons';
 import type { ThemePreference } from '@/lib/theme-storage';
+
+/** Above app chrome, charts, and Recharts tooltip layers. */
+const THEME_MENU_POPOVER_Z_INDEX = 5000;
 
 const OPTIONS: {
   value: ThemePreference;
@@ -32,18 +43,38 @@ const OPTIONS: {
 ];
 
 /**
+ * Positions the theme radiogroup popover under the trigger using viewport coordinates.
+ *
+ * @param trigger - Theme menu disclosure button.
+ * @returns Fixed-position style for the portaled popover.
+ */
+function getThemeMenuPanelStyle(trigger: HTMLButtonElement): CSSProperties {
+  const rect = trigger.getBoundingClientRect();
+  return {
+    position: 'fixed',
+    top: rect.bottom + 8,
+    right: Math.max(8, window.innerWidth - rect.right),
+    zIndex: THEME_MENU_POPOVER_Z_INDEX,
+  };
+}
+
+/**
  * Theme preference control: disclosure button plus a popup implemented as a **radiogroup**
  * (mutually exclusive options) with arrow / Home / End keyboard navigation per the WAI-ARIA
- * Radio Group pattern—not a full application menu. Closing the popup restores focus to the
- * trigger so focus is not lost when the radios unmount.
+ * Radio Group pattern—not a full application menu. The popover is portaled to `document.body`
+ * so it is not clipped or covered by sticky header stacking contexts or page content.
+ * Closing the popup restores focus to the trigger so focus is not lost when the radios unmount.
  *
  * @returns Theme picker UI.
  */
 export function ThemeMenu() {
   const { preference, setPreference } = useTheme();
   const [open, setOpen] = useState(false);
-  const rootRef = useRef<HTMLDivElement>(null);
+  const [panelStyle, setPanelStyle] = useState<CSSProperties>({
+    visibility: 'hidden',
+  });
   const triggerRef = useRef<HTMLButtonElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
   const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
   const wasOpenRef = useRef(false);
   const groupId = useId();
@@ -54,6 +85,29 @@ export function ThemeMenu() {
       : preference === 'dark'
         ? IconMoon
         : IconComputer;
+
+  useLayoutEffect(() => {
+    if (!open) {
+      return;
+    }
+    const updatePosition = () => {
+      const trigger = triggerRef.current;
+      if (!trigger) {
+        return;
+      }
+      setPanelStyle({
+        ...getThemeMenuPanelStyle(trigger),
+        visibility: 'visible',
+      });
+    };
+    updatePosition();
+    window.addEventListener('resize', updatePosition);
+    window.addEventListener('scroll', updatePosition, true);
+    return () => {
+      window.removeEventListener('resize', updatePosition);
+      window.removeEventListener('scroll', updatePosition, true);
+    };
+  }, [open]);
 
   useEffect(() => {
     if (!open) {
@@ -83,10 +137,14 @@ export function ThemeMenu() {
       return;
     }
     const onPointerDown = (e: MouseEvent | TouchEvent) => {
-      const el = rootRef.current;
-      if (el && !el.contains(e.target as Node)) {
-        setOpen(false);
+      const target = e.target as Node;
+      if (
+        triggerRef.current?.contains(target) ||
+        panelRef.current?.contains(target)
+      ) {
+        return;
       }
+      setOpen(false);
     };
     const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
@@ -136,8 +194,61 @@ export function ThemeMenu() {
     }
   };
 
+  const panel = open ? (
+    <div
+      ref={panelRef}
+      id={groupId}
+      role="radiogroup"
+      aria-label="Theme"
+      style={panelStyle}
+      className="min-w-[13.5rem] rounded-xl border border-app-border bg-app-surface py-1 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]"
+      onKeyDown={handleRadiogroupKeyDown}
+    >
+      {OPTIONS.map(({ value, label, description, Icon }, index) => {
+        const selected = preference === value;
+        return (
+          <button
+            key={value}
+            type="button"
+            ref={(el) => {
+              itemRefs.current[index] = el;
+            }}
+            role="radio"
+            aria-checked={selected}
+            tabIndex={selected ? 0 : -1}
+            className="flex w-full items-start gap-3 px-3 py-2.5 text-left transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-app-ring"
+            onClick={() => {
+              setPreference(value);
+              setOpen(false);
+            }}
+          >
+            <Icon
+              className="mt-0.5 h-5 w-5 shrink-0 text-app-muted"
+              aria-hidden
+            />
+            <span className="grow">
+              <span className="block text-sm font-medium text-app-ink">
+                {label}
+              </span>
+              <span className="mt-0.5 block text-xs text-app-muted">
+                {description}
+              </span>
+            </span>
+            <span className="flex h-5 w-5 shrink-0 items-center justify-center text-app-primary">
+              {selected ? (
+                <IconCheck className="h-4 w-4" aria-hidden />
+              ) : (
+                <span className="h-4 w-4" aria-hidden />
+              )}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  ) : null;
+
   return (
-    <div ref={rootRef} className="relative">
+    <>
       <button
         ref={triggerRef}
         type="button"
@@ -152,56 +263,9 @@ export function ThemeMenu() {
         <TriggerIcon className="h-5 w-5" aria-hidden />
       </button>
 
-      {open ? (
-        <div
-          id={groupId}
-          role="radiogroup"
-          aria-label="Theme"
-          className="absolute right-0 z-[300] mt-2 min-w-[13.5rem] rounded-xl border border-app-border bg-app-surface py-1 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]"
-          onKeyDown={handleRadiogroupKeyDown}
-        >
-          {OPTIONS.map(({ value, label, description, Icon }, index) => {
-            const selected = preference === value;
-            return (
-              <button
-                key={value}
-                type="button"
-                ref={(el) => {
-                  itemRefs.current[index] = el;
-                }}
-                role="radio"
-                aria-checked={selected}
-                tabIndex={selected ? 0 : -1}
-                className="flex w-full items-start gap-3 px-3 py-2.5 text-left transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-app-ring"
-                onClick={() => {
-                  setPreference(value);
-                  setOpen(false);
-                }}
-              >
-                <Icon
-                  className="mt-0.5 h-5 w-5 shrink-0 text-app-muted"
-                  aria-hidden
-                />
-                <span className="grow">
-                  <span className="block text-sm font-medium text-app-ink">
-                    {label}
-                  </span>
-                  <span className="mt-0.5 block text-xs text-app-muted">
-                    {description}
-                  </span>
-                </span>
-                <span className="flex h-5 w-5 shrink-0 items-center justify-center text-app-primary">
-                  {selected ? (
-                    <IconCheck className="h-4 w-4" aria-hidden />
-                  ) : (
-                    <span className="h-4 w-4" aria-hidden />
-                  )}
-                </span>
-              </button>
-            );
-          })}
-        </div>
-      ) : null}
-    </div>
+      {typeof document !== 'undefined' && panel
+        ? createPortal(panel, document.body)
+        : null}
+    </>
   );
 }

--- a/apps/web/src/lib/insights/insight-chart-params.spec.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.spec.ts
@@ -40,9 +40,9 @@ describe('insight-chart-params', () => {
     const fromLabel = dateFormatter.format(range.from);
     const toLabel = dateFormatter.format(range.to);
 
-    expect(
-      formatInsightChartPageSummary(['BAC readings'], range, 'day'),
-    ).toBe(`BAC readings from ${fromLabel} to ${toLabel}, daily buckets`);
+    expect(formatInsightChartPageSummary(['BAC readings'], range, 'day')).toBe(
+      `BAC readings from ${fromLabel} to ${toLabel}, daily buckets`,
+    );
   });
 
   it('maps selected series to RPC selections', () => {

--- a/apps/web/src/lib/insights/insight-chart-params.spec.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.spec.ts
@@ -41,7 +41,7 @@ describe('insight-chart-params', () => {
     const toLabel = dateFormatter.format(range.to);
 
     expect(formatInsightChartPageSummary(['BAC readings'], range, 'day')).toBe(
-      `BAC readings from ${fromLabel} to ${toLabel}, daily buckets`,
+      `BAC readings from ${fromLabel} to ${toLabel}, grouped by day`,
     );
   });
 

--- a/apps/web/src/lib/insights/insight-chart-params.spec.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.spec.ts
@@ -16,15 +16,16 @@ describe('insight-chart-params', () => {
     expect(range.from.getHours()).toBe(0);
   });
 
-  it('builds inclusive local-day RPC bounds', () => {
-    const range = getDefaultInsightDateRange();
+  it('builds local-day RPC bounds with an exclusive next-day p_to', () => {
+    const range = {
+      from: new Date(2026, 3, 1),
+      to: new Date(2026, 3, 30),
+    };
     const { p_from, p_to } = insightDateRangeToRpcBounds(range);
 
-    expect(new Date(p_from).getHours()).toBe(0);
-    expect(new Date(p_to).getHours()).toBe(23);
-    expect(new Date(p_from).getTime()).toBeLessThanOrEqual(
-      new Date(p_to).getTime(),
-    );
+    expect(new Date(p_from)).toEqual(new Date(2026, 3, 1, 0, 0, 0, 0));
+    expect(new Date(p_to)).toEqual(new Date(2026, 4, 1, 0, 0, 0, 0));
+    expect(new Date(p_from).getTime()).toBeLessThan(new Date(p_to).getTime());
   });
 
   it('formats a plain-English chart summary', () => {

--- a/apps/web/src/lib/insights/insight-chart-params.spec.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.spec.ts
@@ -28,14 +28,21 @@ describe('insight-chart-params', () => {
     expect(new Date(p_from).getTime()).toBeLessThan(new Date(p_to).getTime());
   });
 
-  it('formats a plain-English chart summary', () => {
+  it('formats a chart summary with locale-aware date labels', () => {
     const range = {
       from: new Date(2026, 3, 1),
       to: new Date(2026, 3, 30),
     };
+    const dateFormatter = new Intl.DateTimeFormat(undefined, {
+      month: 'long',
+      day: 'numeric',
+    });
+    const fromLabel = dateFormatter.format(range.from);
+    const toLabel = dateFormatter.format(range.to);
+
     expect(
       formatInsightChartPageSummary(['BAC readings'], range, 'day'),
-    ).toMatch(/BAC readings from April 1 to April 30, daily buckets/);
+    ).toBe(`BAC readings from ${fromLabel} to ${toLabel}, daily buckets`);
   });
 
   it('maps selected series to RPC selections', () => {

--- a/apps/web/src/lib/insights/insight-chart-params.spec.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.spec.ts
@@ -1,0 +1,63 @@
+import {
+  formatInsightChartPageSummary,
+  getDefaultInsightDateRange,
+  insightDateRangeToRpcBounds,
+  selectedSeriesToChartSeriesSelection,
+} from './insight-chart-params';
+
+describe('insight-chart-params', () => {
+  it('defaults to a 30-day inclusive local range ending today', () => {
+    const range = getDefaultInsightDateRange();
+    const dayMs = 86_400_000;
+    const spanDays =
+      Math.round((range.to.getTime() - range.from.getTime()) / dayMs) + 1;
+    expect(spanDays).toBe(30);
+    expect(range.to.getHours()).toBe(0);
+    expect(range.from.getHours()).toBe(0);
+  });
+
+  it('builds inclusive local-day RPC bounds', () => {
+    const range = getDefaultInsightDateRange();
+    const { p_from, p_to } = insightDateRangeToRpcBounds(range);
+
+    expect(new Date(p_from).getHours()).toBe(0);
+    expect(new Date(p_to).getHours()).toBe(23);
+    expect(new Date(p_from).getTime()).toBeLessThanOrEqual(
+      new Date(p_to).getTime(),
+    );
+  });
+
+  it('formats a plain-English chart summary', () => {
+    const range = {
+      from: new Date(2026, 3, 1),
+      to: new Date(2026, 3, 30),
+    };
+    expect(
+      formatInsightChartPageSummary(['BAC readings'], range, 'day'),
+    ).toMatch(/BAC readings from April 1 to April 30, daily buckets/);
+  });
+
+  it('maps selected series to RPC selections', () => {
+    expect(
+      selectedSeriesToChartSeriesSelection([
+        {
+          seriesId: 'health_marker::bac',
+          seriesType: 'health_marker',
+          responseType: 'numeric',
+          isBloodPressure: false,
+          label: 'BAC',
+          unit: '%',
+          chartType: 'line',
+          color: '#1d4ed8',
+        },
+      ]),
+    ).toEqual([
+      {
+        series_id: 'health_marker::bac',
+        series_type: 'health_marker',
+        response_type: 'numeric',
+        is_blood_pressure: false,
+      },
+    ]);
+  });
+});

--- a/apps/web/src/lib/insights/insight-chart-params.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.ts
@@ -19,8 +19,10 @@ export function getDefaultInsightDateRange(): InsightDateRange {
 }
 
 /**
- * Inclusive local-calendar-day bounds for `get_chart_series` (`p_from` / `p_to`).
+ * Local-calendar-day bounds for `get_chart_series` (`p_from` inclusive, `p_to` exclusive).
  * Uses the browser's local timezone, matching {@link InsightDateRangePicker} calendar days.
+ * `p_to` is midnight on the day after `range.to` so the RPC can use `recorded_at < p_to` and
+ * include observations with sub-millisecond timestamps on the last selected day.
  *
  * @param range - Selected inclusive chart date range.
  * @returns ISO timestamps for RPC range filters.
@@ -31,11 +33,12 @@ export function insightDateRangeToRpcBounds(range: InsightDateRange): {
 } {
   const from = new Date(range.from);
   from.setHours(0, 0, 0, 0);
-  const to = new Date(range.to);
-  to.setHours(23, 59, 59, 999);
+  const toExclusive = new Date(range.to);
+  toExclusive.setHours(0, 0, 0, 0);
+  toExclusive.setDate(toExclusive.getDate() + 1);
   return {
     p_from: from.toISOString(),
-    p_to: to.toISOString(),
+    p_to: toExclusive.toISOString(),
   };
 }
 

--- a/apps/web/src/lib/insights/insight-chart-params.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.ts
@@ -60,9 +60,9 @@ export function selectedSeriesToChartSeriesSelection(
 }
 
 const BUCKET_SUMMARY_LABEL: Record<InsightChartBucket, string> = {
-  day: 'daily buckets',
-  week: 'weekly buckets',
-  month: 'monthly buckets',
+  day: 'grouped by day',
+  week: 'grouped by week',
+  month: 'grouped by month',
 };
 
 function formatSeriesLabelsForSummary(labels: string[]): string {
@@ -84,8 +84,8 @@ function formatSeriesLabelsForSummary(labels: string[]): string {
  *
  * @param labels - Human-readable series labels from the manifest.
  * @param range - Active inclusive date range.
- * @param bucket - Active time bucket granularity.
- * @returns Summary sentence (e.g. "BAC readings from April 1 to April 30, daily buckets").
+ * @param bucket - Active chart period (day, week, or month).
+ * @returns Summary sentence (e.g. "BAC readings from April 1 to April 30, grouped by day").
  */
 export function formatInsightChartPageSummary(
   labels: string[],

--- a/apps/web/src/lib/insights/insight-chart-params.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.ts
@@ -1,0 +1,100 @@
+import type { ChartSeriesSelection } from '@abstrack/supabase';
+import type {
+  InsightChartBucket,
+  InsightDateRange,
+  SelectedSeries,
+} from '@abstrack/ui';
+
+/**
+ * Default insights date range: last 30 inclusive calendar days ending today (local).
+ *
+ * @returns Preset range for initial chart filters.
+ */
+export function getDefaultInsightDateRange(): InsightDateRange {
+  const to = new Date();
+  to.setHours(0, 0, 0, 0);
+  const from = new Date(to);
+  from.setDate(from.getDate() - 29);
+  return { from, to };
+}
+
+/**
+ * Inclusive local-calendar-day bounds for `get_chart_series` (`p_from` / `p_to`).
+ * Uses the browser's local timezone, matching {@link InsightDateRangePicker} calendar days.
+ *
+ * @param range - Selected inclusive chart date range.
+ * @returns ISO timestamps for RPC range filters.
+ */
+export function insightDateRangeToRpcBounds(range: InsightDateRange): {
+  p_from: string;
+  p_to: string;
+} {
+  const from = new Date(range.from);
+  from.setHours(0, 0, 0, 0);
+  const to = new Date(range.to);
+  to.setHours(23, 59, 59, 999);
+  return {
+    p_from: from.toISOString(),
+    p_to: to.toISOString(),
+  };
+}
+
+/**
+ * Maps UI selected series to `get_chart_series` `p_series` elements.
+ *
+ * @param series - Series chosen in {@link InsightSeriesPicker}.
+ * @returns RPC selection payload.
+ */
+export function selectedSeriesToChartSeriesSelection(
+  series: SelectedSeries[],
+): ChartSeriesSelection[] {
+  return series.map((item) => ({
+    series_id: item.seriesId,
+    series_type: item.seriesType,
+    response_type: item.responseType,
+    is_blood_pressure: item.isBloodPressure,
+  }));
+}
+
+const BUCKET_SUMMARY_LABEL: Record<InsightChartBucket, string> = {
+  day: 'daily buckets',
+  week: 'weekly buckets',
+  month: 'monthly buckets',
+};
+
+function formatSeriesLabelsForSummary(labels: string[]): string {
+  if (labels.length === 0) {
+    return 'Selected series';
+  }
+  if (labels.length === 1) {
+    const [only] = labels;
+    return only ?? 'Selected series';
+  }
+  if (labels.length === 2) {
+    return `${labels[0]} and ${labels[1]}`;
+  }
+  return `${labels.slice(0, -1).join(', ')}, and ${labels[labels.length - 1]}`;
+}
+
+/**
+ * Plain-English chart summary for {@link InsightComposedChart} and screen readers.
+ *
+ * @param labels - Human-readable series labels from the manifest.
+ * @param range - Active inclusive date range.
+ * @param bucket - Active time bucket granularity.
+ * @returns Summary sentence (e.g. "BAC readings from April 1 to April 30, daily buckets").
+ */
+export function formatInsightChartPageSummary(
+  labels: string[],
+  range: InsightDateRange,
+  bucket: InsightChartBucket,
+): string {
+  const dateFormatter = new Intl.DateTimeFormat(undefined, {
+    month: 'long',
+    day: 'numeric',
+  });
+  const seriesPart = formatSeriesLabelsForSummary(labels);
+  const fromLabel = dateFormatter.format(range.from);
+  const toLabel = dateFormatter.format(range.to);
+  return `${seriesPart} from ${fromLabel} to ${toLabel}, ${BUCKET_SUMMARY_LABEL[bucket]}`;
+}

--- a/packages/supabase/src/lib/chart-manifest-query.spec.ts
+++ b/packages/supabase/src/lib/chart-manifest-query.spec.ts
@@ -27,8 +27,19 @@ describe('getUserChartManifest', () => {
     });
   });
 
-  it('returns RPC rows unchanged', async () => {
+  it('maps preset health marker labels to product copy', async () => {
     const rows: UserChartManifestSeries[] = [
+      {
+        series_id: 'health_marker::bac',
+        series_type: 'health_marker',
+        label: 'bac',
+        response_type: 'numeric',
+        is_blood_pressure: false,
+        unit: null,
+        observation_count: 2,
+        first_observed_at: '2026-01-01T00:00:00.000Z',
+        last_observed_at: '2026-03-01T00:00:00.000Z',
+      },
       {
         series_id: 'symptom::fatigue::boolean',
         series_type: 'symptom',
@@ -49,7 +60,8 @@ describe('getUserChartManifest', () => {
       return;
     }
 
-    expect(result.data).toEqual(rows);
+    expect(result.data[0]?.label).toBe('BAC');
+    expect(result.data[1]?.label).toBe('Fatigue');
   });
 
   it('returns ok: false when rpc returns an error', async () => {

--- a/packages/supabase/src/lib/chart-manifest-query.ts
+++ b/packages/supabase/src/lib/chart-manifest-query.ts
@@ -1,4 +1,4 @@
-import type { Uuid } from '@abstrack/types';
+import { chartManifestSeriesDisplayLabel, type Uuid } from '@abstrack/types';
 import { toPresetDataError } from './preset-data-error.js';
 import type { PresetDataResult } from './preset-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
@@ -29,7 +29,7 @@ export interface UserChartManifestSeries {
  *
  * @param client - Supabase client with the caller JWT.
  * @param userId - Subject user id (`p_user_id`).
- * @returns Manifest rows from Postgres on success (`data` is unchanged RPC output).
+ * @returns Manifest rows with preset health-marker labels aligned to {@link PRESET_HEALTH_MARKER_KIND_LABELS}.
  */
 export async function getUserChartManifest(
   client: AbstrackSupabaseClient,
@@ -44,9 +44,18 @@ export async function getUserChartManifest(
       return { ok: false, error: toPresetDataError(error) };
     }
 
+    const rows = (data ?? []) as UserChartManifestSeries[];
+
     return {
       ok: true,
-      data: (data ?? []) as UserChartManifestSeries[],
+      data: rows.map((row) => ({
+        ...row,
+        label: chartManifestSeriesDisplayLabel(
+          row.series_type,
+          row.series_id,
+          row.label,
+        ),
+      })),
     };
   } catch (cause) {
     return { ok: false, error: toPresetDataError(cause) };

--- a/packages/supabase/src/lib/chart-series-query.ts
+++ b/packages/supabase/src/lib/chart-series-query.ts
@@ -37,7 +37,9 @@ export interface ChartSeriesBucketRow {
 export interface GetChartSeriesParams {
   p_user_id: Uuid;
   p_series: ChartSeriesSelection[];
+  /** Inclusive range start (local midnight of the first selected day). */
   p_from: string;
+  /** Exclusive range end (local midnight of the day after the last selected day). */
   p_to: string;
   p_bucket: ChartSeriesBucket;
   /**

--- a/packages/supabase/src/lib/preset-data-error.spec.ts
+++ b/packages/supabase/src/lib/preset-data-error.spec.ts
@@ -25,6 +25,15 @@ describe('mapSupabaseErrorToPresetDataError', () => {
     expect(mapped?.message).toMatch(/conflict/i);
   });
 
+  it('maps get_chart_series validation messages to validation_error', () => {
+    const mapped = mapSupabaseErrorToPresetDataError({
+      code: '22023',
+      message: 'get_chart_series: p_bucket must be day, week, or month',
+    });
+    expect(mapped?.code).toBe('validation_error');
+    expect(mapped?.message).toBe('p_bucket must be day, week, or month');
+  });
+
   it('maps Error instances with PostgREST-shaped fields (no PostgrestError constructor)', () => {
     const err = Object.assign(new Error('duplicate'), {
       code: '23505',

--- a/packages/supabase/src/lib/preset-data-error.ts
+++ b/packages/supabase/src/lib/preset-data-error.ts
@@ -139,6 +139,13 @@ export function mapSupabaseErrorToPresetDataError(
 
   const combined = `${pg.message} ${pg.details ?? ''}`;
 
+  const chartSeriesMessage = pg.message?.includes('get_chart_series:')
+    ? pg.message.replace(/^get_chart_series:\s*/u, '').trim()
+    : null;
+  if (chartSeriesMessage) {
+    return new PresetDataError('validation_error', chartSeriesMessage, error);
+  }
+
   if (
     combined.includes('abstrack_preset_reorder_count_mismatch') ||
     combined.includes('abstrack_preset_reorder_duplicate_id') ||

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -9,3 +9,4 @@ export * from './lib/episode-open-pass.js';
 export * from './lib/episode-bac-suggestion.js';
 export * from './lib/types.js';
 export * from './lib/marker-draft.js';
+export * from './lib/chart-manifest-labels.js';

--- a/packages/types/src/lib/chart-manifest-labels.spec.ts
+++ b/packages/types/src/lib/chart-manifest-labels.spec.ts
@@ -17,8 +17,32 @@ describe('chartManifestHealthMarkerDisplayLabel', () => {
     ).toBe('Glucose');
   });
 
-  it('maps when rpcLabel is the raw marker_kind even if series_id is unexpected', () => {
-    expect(chartManifestHealthMarkerDisplayLabel('bac', 'bac')).toBe('BAC');
+  it('keeps custom marker labels when the custom name matches a preset key', () => {
+    expect(
+      chartManifestHealthMarkerDisplayLabel(
+        'health_marker::custom::bac',
+        'bac',
+      ),
+    ).toBe('bac');
+  });
+
+  it('does not map preset labels from rpcLabel alone when series_id is not a preset key', () => {
+    expect(chartManifestHealthMarkerDisplayLabel('bac', 'bac')).toBe('bac');
+  });
+
+  it('does not treat inherited property names as preset keys', () => {
+    expect(
+      chartManifestHealthMarkerDisplayLabel(
+        'health_marker::toString',
+        'toString',
+      ),
+    ).toBe('toString');
+    expect(
+      chartManifestHealthMarkerDisplayLabel(
+        'health_marker::constructor',
+        'constructor',
+      ),
+    ).toBe('constructor');
   });
 
   it('keeps custom and unknown RPC labels', () => {

--- a/packages/types/src/lib/chart-manifest-labels.spec.ts
+++ b/packages/types/src/lib/chart-manifest-labels.spec.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import {
+  chartManifestHealthMarkerDisplayLabel,
+  chartManifestSeriesDisplayLabel,
+} from './chart-manifest-labels.js';
+
+describe('chartManifestHealthMarkerDisplayLabel', () => {
+  it('maps preset marker_kind keys to PRESET_HEALTH_MARKER_KIND_LABELS', () => {
+    expect(
+      chartManifestHealthMarkerDisplayLabel('health_marker::bac', 'bac'),
+    ).toBe('BAC');
+    expect(
+      chartManifestHealthMarkerDisplayLabel(
+        'health_marker::blood_glucose',
+        'blood_glucose',
+      ),
+    ).toBe('Glucose');
+  });
+
+  it('maps when rpcLabel is the raw marker_kind even if series_id is unexpected', () => {
+    expect(chartManifestHealthMarkerDisplayLabel('bac', 'bac')).toBe('BAC');
+  });
+
+  it('keeps custom and unknown RPC labels', () => {
+    expect(
+      chartManifestHealthMarkerDisplayLabel(
+        'health_marker::custom::steps',
+        'Steps',
+      ),
+    ).toBe('Steps');
+    expect(
+      chartManifestHealthMarkerDisplayLabel(
+        'health_marker::wellness_mood',
+        'wellness_mood',
+      ),
+    ).toBe('wellness_mood');
+  });
+});
+
+describe('chartManifestSeriesDisplayLabel', () => {
+  it('passes symptom labels through unchanged', () => {
+    expect(
+      chartManifestSeriesDisplayLabel(
+        'symptom',
+        'symptom::fatigue::boolean',
+        'Fatigue',
+      ),
+    ).toBe('Fatigue');
+  });
+});

--- a/packages/types/src/lib/chart-manifest-labels.ts
+++ b/packages/types/src/lib/chart-manifest-labels.ts
@@ -1,0 +1,70 @@
+import {
+  PRESET_HEALTH_MARKER_KIND_LABELS,
+  type PresetHealthMarkerKind,
+} from './types.js';
+
+const HEALTH_MARKER_SERIES_PREFIX = 'health_marker::';
+
+/**
+ * Human-readable label for a health-marker row from `get_user_chart_manifest`.
+ *
+ * The RPC uses `coalesce(custom_name, marker_kind)` for `label`, so preset kinds without
+ * a stored custom name surface as snake_case keys (`bac`, `blood_glucose`). This maps those
+ * to {@link PRESET_HEALTH_MARKER_KIND_LABELS} (same copy as the health-marker preset UI).
+ *
+ * @param seriesId - Manifest `series_id` (e.g. `health_marker::bac`).
+ * @param rpcLabel - `label` returned by the RPC.
+ * @returns Display label for chart pickers and summaries.
+ */
+function presetHealthMarkerLabelForKey(markerKey: string): string | undefined {
+  if (
+    markerKey in PRESET_HEALTH_MARKER_KIND_LABELS &&
+    markerKey !== 'custom' &&
+    !markerKey.includes('::')
+  ) {
+    return PRESET_HEALTH_MARKER_KIND_LABELS[
+      markerKey as PresetHealthMarkerKind
+    ];
+  }
+  return undefined;
+}
+
+export function chartManifestHealthMarkerDisplayLabel(
+  seriesId: string,
+  rpcLabel: string,
+): string {
+  if (seriesId.startsWith(HEALTH_MARKER_SERIES_PREFIX)) {
+    const fromSeriesId = presetHealthMarkerLabelForKey(
+      seriesId.slice(HEALTH_MARKER_SERIES_PREFIX.length),
+    );
+    if (fromSeriesId) {
+      return fromSeriesId;
+    }
+  }
+
+  const fromRpcLabel = presetHealthMarkerLabelForKey(rpcLabel);
+  if (fromRpcLabel) {
+    return fromRpcLabel;
+  }
+
+  return rpcLabel;
+}
+
+/**
+ * Human-readable label for any manifest series row.
+ *
+ * @param seriesType - Manifest `series_type`.
+ * @param seriesId - Manifest `series_id`.
+ * @param rpcLabel - `label` from the RPC.
+ * @returns Display label for chart UI.
+ */
+export function chartManifestSeriesDisplayLabel(
+  seriesType: 'health_marker' | 'symptom',
+  seriesId: string,
+  rpcLabel: string,
+): string {
+  if (seriesType === 'health_marker') {
+    return chartManifestHealthMarkerDisplayLabel(seriesId, rpcLabel);
+  }
+  return rpcLabel;
+}

--- a/packages/types/src/lib/chart-manifest-labels.ts
+++ b/packages/types/src/lib/chart-manifest-labels.ts
@@ -6,18 +6,10 @@ import {
 const HEALTH_MARKER_SERIES_PREFIX = 'health_marker::';
 
 /**
- * Human-readable label for a health-marker row from `get_user_chart_manifest`.
+ * Maps a preset `marker_kind` key to {@link PRESET_HEALTH_MARKER_KIND_LABELS}.
  *
- * The RPC uses `coalesce(custom_name, marker_kind)` for `label`, so preset kinds without
- * a stored custom name surface as snake_case keys (`bac`, `blood_glucose`). This maps those
- * to {@link PRESET_HEALTH_MARKER_KIND_LABELS} (same copy as the health-marker preset UI).
- *
- * @param seriesId - Manifest `series_id` (e.g. `health_marker::bac`).
- * Preset kinds use `health_marker::<kind>`; custom markers use `health_marker::custom::<name>`
- * and must keep the RPC label (even when the custom name matches a preset key string).
- *
- * @param rpcLabel - `label` returned by the RPC.
- * @returns Display label for chart pickers and summaries.
+ * @param markerKey - Suffix after `health_marker::` (e.g. `bac`, or `custom::steps`).
+ * @returns Preset display label, or `undefined` when the key is custom or not a preset kind.
  */
 function presetHealthMarkerLabelForKey(markerKey: string): string | undefined {
   if (
@@ -32,6 +24,19 @@ function presetHealthMarkerLabelForKey(markerKey: string): string | undefined {
   return undefined;
 }
 
+/**
+ * Human-readable label for a health-marker row from `get_user_chart_manifest`.
+ *
+ * The RPC uses `coalesce(custom_name, marker_kind)` for `label`, so preset kinds without
+ * a stored custom name surface as snake_case keys (`bac`, `blood_glucose`). Preset kinds
+ * use `health_marker::<kind>` and map through {@link PRESET_HEALTH_MARKER_KIND_LABELS}
+ * (same copy as the health-marker preset UI). Custom markers use `health_marker::custom::<name>`
+ * and keep the RPC label (even when the custom name matches a preset key string).
+ *
+ * @param seriesId - Manifest `series_id` (e.g. `health_marker::bac`).
+ * @param rpcLabel - `label` returned by the RPC.
+ * @returns Display label for chart pickers and summaries.
+ */
 export function chartManifestHealthMarkerDisplayLabel(
   seriesId: string,
   rpcLabel: string,

--- a/packages/types/src/lib/chart-manifest-labels.ts
+++ b/packages/types/src/lib/chart-manifest-labels.ts
@@ -13,12 +13,15 @@ const HEALTH_MARKER_SERIES_PREFIX = 'health_marker::';
  * to {@link PRESET_HEALTH_MARKER_KIND_LABELS} (same copy as the health-marker preset UI).
  *
  * @param seriesId - Manifest `series_id` (e.g. `health_marker::bac`).
+ * Preset kinds use `health_marker::<kind>`; custom markers use `health_marker::custom::<name>`
+ * and must keep the RPC label (even when the custom name matches a preset key string).
+ *
  * @param rpcLabel - `label` returned by the RPC.
  * @returns Display label for chart pickers and summaries.
  */
 function presetHealthMarkerLabelForKey(markerKey: string): string | undefined {
   if (
-    markerKey in PRESET_HEALTH_MARKER_KIND_LABELS &&
+    Object.hasOwn(PRESET_HEALTH_MARKER_KIND_LABELS, markerKey) &&
     markerKey !== 'custom' &&
     !markerKey.includes('::')
   ) {
@@ -40,11 +43,6 @@ export function chartManifestHealthMarkerDisplayLabel(
     if (fromSeriesId) {
       return fromSeriesId;
     }
-  }
-
-  const fromRpcLabel = presetHealthMarkerLabelForKey(rpcLabel);
-  if (fromRpcLabel) {
-    return fromRpcLabel;
   }
 
   return rpcLabel;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -35,3 +35,7 @@ export {
   pivotChartSeriesBucketRows,
   type ChartSeriesBucketRowInput,
 } from './lib/insight-composed-chart-utils.js';
+export {
+  filterChartableManifestRows,
+  reconcileSelectedSeriesWithManifest,
+} from './lib/insight-series-picker-utils.js';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -23,6 +23,7 @@ export {
   type InsightDateRangePickerProps,
   type InsightDateRangePresetId,
 } from './lib/InsightDateRangePicker.js';
+export { getInsightDateRangePreset } from './lib/insight-date-range-picker-utils.js';
 export {
   InsightComposedChart,
   type ChartSeriesBucketMetrics,

--- a/packages/ui/src/lib/InsightComposedChart.spec.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.spec.tsx
@@ -322,6 +322,6 @@ describe('InsightComposedChart', () => {
       />,
     );
 
-    expect(screen.getByText(/patient's local timezone/i)).toBeInTheDocument();
+    expect(screen.getByText(/your browser timezone/i)).toBeInTheDocument();
   });
 });

--- a/packages/ui/src/lib/InsightComposedChart.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.tsx
@@ -237,8 +237,14 @@ export function InsightComposedChart({
   );
   const summaryId = `${useId().replace(/:/g, '')}-summary`;
 
+  const chartTooltipStyle = {
+    backgroundColor: 'rgb(var(--app-surface) / 1)',
+    borderColor: 'rgb(var(--app-border) / 1)',
+    color: 'rgb(var(--app-ink) / 1)',
+  } as const;
+
   return (
-    <div className="space-y-3">
+    <div className="space-y-3 text-app-ink">
       <figure
         aria-busy={loading ? true : undefined}
         aria-labelledby={summaryId}
@@ -327,6 +333,9 @@ export function InsightComposedChart({
                 ) : null}
                 <Tooltip
                   labelFormatter={(label) => bucketTickFormatter(String(label))}
+                  contentStyle={chartTooltipStyle}
+                  labelStyle={{ color: 'rgb(var(--app-ink) / 1)' }}
+                  itemStyle={{ color: 'rgb(var(--app-ink) / 1)' }}
                 />
                 {series.map((item) => {
                   if (item.chartType === 'bp_band') {

--- a/packages/ui/src/lib/InsightComposedChart.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.tsx
@@ -43,6 +43,15 @@ export type {
   InsightComposedChartProps,
 } from './InsightComposedChart.types.js';
 
+const CHART_PERIOD_TABLE_CAPTION: Record<
+  InsightComposedChartProps['bucket'],
+  string
+> = {
+  day: 'day',
+  week: 'week',
+  month: 'month',
+};
+
 const CHART_HEIGHT_PX = 320;
 
 function yAxisLabelForUnit(
@@ -372,7 +381,9 @@ export function InsightComposedChart({
       </figure>
 
       <table className="sr-only">
-        <caption>Detailed chart data by {bucket}</caption>
+        <caption>
+          Detailed chart data grouped by {CHART_PERIOD_TABLE_CAPTION[bucket]}
+        </caption>
         <thead>
           <tr>
             <th scope="col">Period</th>

--- a/packages/ui/src/lib/InsightComposedChart.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.tsx
@@ -204,6 +204,7 @@ export function InsightComposedChart({
   summary,
   patientTimeZone,
   showPatientTimeZoneNote = false,
+  patientTimeZoneNoteUsesPatientLocal = false,
 }: InsightComposedChartProps) {
   const chartData = useMemo(
     () =>
@@ -256,7 +257,9 @@ export function InsightComposedChart({
 
         {showPatientTimeZoneNote ? (
           <p className="mb-3 text-xs text-app-muted">
-            {formatInsightChartPatientTimeZoneNote(patientTimeZone)}
+            {formatInsightChartPatientTimeZoneNote(patientTimeZone, {
+              patientLocal: patientTimeZoneNoteUsesPatientLocal,
+            })}
           </p>
         ) : null}
 

--- a/packages/ui/src/lib/InsightComposedChart.types.ts
+++ b/packages/ui/src/lib/InsightComposedChart.types.ts
@@ -39,17 +39,22 @@ export interface InsightComposedChartProps {
   summary: string;
   /**
    * IANA timezone for bucket axis and table labels (e.g. `America/Chicago`).
-   * Must be the same value as `p_timezone` on {@link getChartSeries} so server
-   * `bucket_start` values and labels stay aligned. Use the **patient's** timezone;
-   * pass the device zone only when the patient views their own chart.
+   * Must match `p_timezone` on {@link getChartSeries}. When the patient's zone is stored,
+   * pass it here; until then the viewer's browser zone is a common fallback for caretaker views.
    */
   patientTimeZone: string;
   /**
-   * When true, shows that period labels use the patient's local timezone.
-   * Enable for practitioner views; omit or set false when the patient views their own chart.
+   * When true, shows a note explaining which timezone buckets and labels use.
+   * Use for caretaker/practitioner views (`patientTimeZoneNoteUsesPatientLocal` should be
+   * false unless `patientTimeZone` is the patient's real IANA zone).
    * @defaultValue false
    */
   showPatientTimeZoneNote?: boolean;
+  /**
+   * When true with {@link showPatientTimeZoneNote}, copy claims patient-local alignment.
+   * @defaultValue false
+   */
+  patientTimeZoneNoteUsesPatientLocal?: boolean;
 }
 
 export type { ChartTypeChoice, SelectedSeries };

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -5,16 +5,10 @@ import {
   useId,
   useMemo,
   useState,
-  type CSSProperties,
-  type SelectHTMLAttributes,
   type ButtonHTMLAttributes,
+  type SelectHTMLAttributes,
 } from 'react';
 import { useFocusRing } from './hooks/useFocusRing.js';
-import {
-  defaultPalette,
-  highContrastPalette,
-  type UiPalette,
-} from './styles/theme.js';
 import {
   canAddAnotherSeries,
   chartTypeChoiceLabel,
@@ -41,107 +35,37 @@ export type {
   SelectedSeries,
 } from './InsightSeriesPicker.types.js';
 
-function insightSeriesPickerStyles(palette: UiPalette) {
-  const field: CSSProperties = {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 6,
-  };
+const pickerSelectClassName = [
+  'min-h-11 w-full rounded-lg border border-app-border bg-app-surface px-3 text-base text-app-ink shadow-inner',
+  'outline-none transition disabled:cursor-not-allowed disabled:text-app-muted disabled:opacity-50',
+  'focus-visible:ring-2 focus-visible:ring-app-ring',
+].join(' ');
 
-  const label: CSSProperties = {
-    fontSize: 16,
-    fontWeight: 600,
-    color: palette.text,
-  };
-
-  const select: CSSProperties = {
-    minHeight: 44,
-    fontSize: 16,
-    padding: '8px 12px',
-    borderRadius: 8,
-    border: `1px solid ${palette.border}`,
-    backgroundColor: palette.surface,
-    color: palette.text,
-  };
-
-  const slot: CSSProperties = {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 12,
-    padding: 12,
-    border: `1px solid ${palette.border}`,
-    borderRadius: 8,
-    backgroundColor: palette.surface,
-  };
-
-  const root: CSSProperties = {
-    display: 'flex',
-    flexDirection: 'column',
-    gap: 16,
-    color: palette.text,
-  };
-
-  const secondaryButton: CSSProperties = {
-    alignSelf: 'flex-start',
-    minHeight: 44,
-    minWidth: 44,
-    padding: '8px 16px',
-    fontSize: 16,
-    borderRadius: 8,
-    border: `1px solid ${palette.border}`,
-    backgroundColor: palette.surface,
-    color: palette.text,
-    cursor: 'pointer',
-  };
-
-  const colorSwatch = (color: string): CSSProperties => ({
-    width: 16,
-    height: 16,
-    borderRadius: 4,
-    backgroundColor: color,
-    border: `1px solid ${palette.mutedText}`,
-    flexShrink: 0,
-  });
-
-  const focusRing = (focused: boolean): CSSProperties =>
-    focused
-      ? {
-          outline: '2px solid',
-          outlineColor: palette.focusRing,
-          outlineOffset: 2,
-        }
-      : {};
-
-  return {
-    field,
-    label,
-    select,
-    slot,
-    root,
-    secondaryButton,
-    colorSwatch,
-    focusRing,
-  };
-}
+const pickerButtonClassName = [
+  'inline-flex min-h-11 min-w-11 items-center justify-center self-start rounded-lg border border-app-border',
+  'bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm',
+  'transition hover:bg-[var(--app-nav-hover-bg)]',
+  'outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg',
+].join(' ');
 
 function PickerSelect({
-  palette,
-  style,
+  className,
   onFocus,
   onBlur,
   ...rest
-}: SelectHTMLAttributes<HTMLSelectElement> & { palette: UiPalette }) {
+}: SelectHTMLAttributes<HTMLSelectElement>) {
   const { focused, onFocus: onFocusRing, onBlur: onBlurRing } = useFocusRing();
-  const styles = insightSeriesPickerStyles(palette);
 
   return (
     <select
       {...rest}
-      style={{
-        ...styles.select,
-        ...style,
-        ...styles.focusRing(focused),
-      }}
+      className={[
+        pickerSelectClassName,
+        focused ? 'ring-2 ring-app-ring ring-offset-2 ring-offset-app-bg' : '',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
       onFocus={(event) => {
         onFocusRing();
         onFocus?.(event);
@@ -155,23 +79,23 @@ function PickerSelect({
 }
 
 function PickerButton({
-  palette,
-  style,
+  className,
   onFocus,
   onBlur,
   ...rest
-}: ButtonHTMLAttributes<HTMLButtonElement> & { palette: UiPalette }) {
+}: ButtonHTMLAttributes<HTMLButtonElement>) {
   const { focused, onFocus: onFocusRing, onBlur: onBlurRing } = useFocusRing();
-  const styles = insightSeriesPickerStyles(palette);
 
   return (
     <button
       {...rest}
-      style={{
-        ...styles.secondaryButton,
-        ...style,
-        ...styles.focusRing(focused),
-      }}
+      className={[
+        pickerButtonClassName,
+        focused ? 'ring-2 ring-app-ring ring-offset-2 ring-offset-app-bg' : '',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
       onFocus={(event) => {
         onFocusRing();
         onFocus?.(event);
@@ -235,6 +159,7 @@ function optionsForSlot(
 /**
  * Series and chart-type picker for the insight chart builder (web only).
  * Supports up to three series with progressive slot disclosure.
+ * Uses semantic `app-*` tokens from the host app `global.css` (light/dark via `html.dark`).
  *
  * @param props - Manifest rows, selected series, and change handler.
  * @returns Accessible form controls for series selection.
@@ -245,9 +170,6 @@ export function InsightSeriesPicker({
   onChange,
   highContrast = false,
 }: InsightSeriesPickerProps) {
-  const palette = highContrast ? highContrastPalette : defaultPalette;
-  const styles = useMemo(() => insightSeriesPickerStyles(palette), [palette]);
-
   const seriesValue = useMemo(() => clampSeriesValue(value), [value]);
   const chartableManifest = useMemo(
     () => filterChartableManifestRows(manifest),
@@ -351,10 +273,17 @@ export function InsightSeriesPicker({
     setRevealedSlotCount(Math.max(1, slotIndex));
   };
 
+  const slotSurfaceClassName = [
+    'mb-3 flex flex-col gap-3 rounded-lg border border-app-border/90 bg-app-surface p-3 shadow-sm ring-1 ring-[color:var(--app-ring-slate)]',
+    highContrast ? 'border-2 border-app-ink ring-2 ring-app-ink' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+
   return (
-    <div style={styles.root}>
-      <fieldset style={{ border: 'none', margin: 0, padding: 0 }}>
-        <legend style={{ ...styles.label, marginBottom: 8 }}>
+    <div className="flex flex-col gap-4 text-app-ink">
+      <fieldset className="m-0 border-0 p-0">
+        <legend className="mb-2 text-base font-semibold text-app-ink">
           Chart series
         </legend>
 
@@ -375,24 +304,19 @@ export function InsightSeriesPicker({
           return (
             <div
               key={slotIndex}
-              style={{ ...styles.slot, marginBottom: 12 }}
+              className={slotSurfaceClassName}
               role="group"
               aria-labelledby={`${baseId}-slot-${slotIndex}-legend`}
             >
               <div
                 id={`${baseId}-slot-${slotIndex}-legend`}
-                style={{
-                  display: 'flex',
-                  alignItems: 'center',
-                  gap: 8,
-                  fontWeight: 600,
-                  fontSize: 16,
-                }}
+                className="flex items-center gap-2 text-base font-semibold text-app-ink"
               >
                 {selected ? (
                   <>
                     <span
-                      style={styles.colorSwatch(selected.color)}
+                      className="h-4 w-4 shrink-0 rounded border border-app-border"
+                      style={{ backgroundColor: selected.color }}
                       aria-hidden
                     />
                     <span>
@@ -404,12 +328,14 @@ export function InsightSeriesPicker({
                 )}
               </div>
 
-              <div style={styles.field}>
-                <label htmlFor={seriesSelectId} style={styles.label}>
+              <div className="flex flex-col gap-1.5">
+                <label
+                  htmlFor={seriesSelectId}
+                  className="text-base font-semibold text-app-ink"
+                >
                   {`Data series ${slotIndex + 1}`}
                 </label>
                 <PickerSelect
-                  palette={palette}
                   id={seriesSelectId}
                   value={selected?.seriesId ?? ''}
                   onChange={(event) =>
@@ -427,12 +353,14 @@ export function InsightSeriesPicker({
               </div>
 
               {!chartTypeHidden && row ? (
-                <div style={styles.field}>
-                  <label htmlFor={chartTypeSelectId} style={styles.label}>
+                <div className="flex flex-col gap-1.5">
+                  <label
+                    htmlFor={chartTypeSelectId}
+                    className="text-base font-semibold text-app-ink"
+                  >
                     {`Chart type for series ${slotIndex + 1}`}
                   </label>
                   <PickerSelect
-                    palette={palette}
                     id={chartTypeSelectId}
                     value={selected?.chartType ?? ''}
                     onChange={(event) =>
@@ -453,7 +381,6 @@ export function InsightSeriesPicker({
 
               <PickerButton
                 type="button"
-                palette={palette}
                 onClick={() => handleRemove(slotIndex)}
               >
                 {seriesSlotActionLabel(slotIndex)}
@@ -464,11 +391,7 @@ export function InsightSeriesPicker({
       </fieldset>
 
       {showAddAnother ? (
-        <PickerButton
-          type="button"
-          palette={palette}
-          onClick={handleAddAnother}
-        >
+        <PickerButton type="button" onClick={handleAddAnother}>
           Add another series
         </PickerButton>
       ) : null}

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -35,33 +35,47 @@ export type {
   SelectedSeries,
 } from './InsightSeriesPicker.types.js';
 
-const pickerSelectClassName = [
-  'min-h-11 w-full rounded-lg border border-app-border bg-app-surface px-3 text-base text-app-ink shadow-inner',
-  'outline-none transition disabled:cursor-not-allowed disabled:text-app-muted disabled:opacity-50',
-  'focus-visible:ring-2 focus-visible:ring-app-ring',
-].join(' ');
+function pickerSelectClassName(highContrast: boolean): string {
+  return [
+    'min-h-11 w-full rounded-lg bg-app-surface px-3 text-base text-app-ink outline-none transition',
+    'disabled:cursor-not-allowed',
+    highContrast
+      ? 'border-2 border-app-ink font-semibold shadow-none disabled:opacity-60 focus-visible:ring-2 focus-visible:ring-app-ink focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
+      : 'border border-app-border shadow-inner disabled:text-app-muted disabled:opacity-50 focus-visible:ring-2 focus-visible:ring-app-ring',
+  ].join(' ');
+}
 
-const pickerButtonClassName = [
-  'inline-flex min-h-11 min-w-11 items-center justify-center self-start rounded-lg border border-app-border',
-  'bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm',
-  'transition hover:bg-[var(--app-nav-hover-bg)]',
-  'outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg',
-].join(' ');
+function pickerButtonClassName(highContrast: boolean): string {
+  return [
+    'inline-flex min-h-11 min-w-11 items-center justify-center self-start rounded-lg bg-app-surface px-4 text-base text-app-ink',
+    'transition hover:bg-[var(--app-nav-hover-bg)] outline-none focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg',
+    highContrast
+      ? 'border-2 border-app-ink font-bold shadow-none focus-visible:ring-2 focus-visible:ring-app-ink'
+      : 'border border-app-border font-semibold shadow-sm focus-visible:ring-2 focus-visible:ring-app-ring',
+  ].join(' ');
+}
+
+function pickerFocusRingClassName(highContrast: boolean): string {
+  return highContrast
+    ? 'ring-2 ring-app-ink ring-offset-2 ring-offset-app-bg'
+    : 'ring-2 ring-app-ring ring-offset-2 ring-offset-app-bg';
+}
 
 function PickerSelect({
   className,
+  highContrast = false,
   onFocus,
   onBlur,
   ...rest
-}: SelectHTMLAttributes<HTMLSelectElement>) {
+}: SelectHTMLAttributes<HTMLSelectElement> & { highContrast?: boolean }) {
   const { focused, onFocus: onFocusRing, onBlur: onBlurRing } = useFocusRing();
 
   return (
     <select
       {...rest}
       className={[
-        pickerSelectClassName,
-        focused ? 'ring-2 ring-app-ring ring-offset-2 ring-offset-app-bg' : '',
+        pickerSelectClassName(highContrast),
+        focused ? pickerFocusRingClassName(highContrast) : '',
         className,
       ]
         .filter(Boolean)
@@ -80,18 +94,19 @@ function PickerSelect({
 
 function PickerButton({
   className,
+  highContrast = false,
   onFocus,
   onBlur,
   ...rest
-}: ButtonHTMLAttributes<HTMLButtonElement>) {
+}: ButtonHTMLAttributes<HTMLButtonElement> & { highContrast?: boolean }) {
   const { focused, onFocus: onFocusRing, onBlur: onBlurRing } = useFocusRing();
 
   return (
     <button
       {...rest}
       className={[
-        pickerButtonClassName,
-        focused ? 'ring-2 ring-app-ring ring-offset-2 ring-offset-app-bg' : '',
+        pickerButtonClassName(highContrast),
+        focused ? pickerFocusRingClassName(highContrast) : '',
         className,
       ]
         .filter(Boolean)
@@ -160,6 +175,8 @@ function optionsForSlot(
  * Series and chart-type picker for the insight chart builder (web only).
  * Supports up to three series with progressive slot disclosure.
  * Uses semantic `app-*` tokens from the host app `global.css` (light/dark via `html.dark`).
+ * When `highContrast` is true, slots, labels, selects, buttons, and focus rings use stronger
+ * `app-ink` borders and rings for the documented high-contrast presentation.
  *
  * @param props - Manifest rows, selected series, and change handler.
  * @returns Accessible form controls for series selection.
@@ -274,18 +291,38 @@ export function InsightSeriesPicker({
   };
 
   const slotSurfaceClassName = [
-    'mb-3 flex flex-col gap-3 rounded-lg border border-app-border/90 bg-app-surface p-3 shadow-sm ring-1 ring-[color:var(--app-ring-slate)]',
-    highContrast ? 'border-2 border-app-ink ring-2 ring-app-ink' : '',
-  ]
-    .filter(Boolean)
-    .join(' ');
+    'mb-3 flex flex-col gap-3 rounded-lg bg-app-surface p-3',
+    highContrast
+      ? 'border-2 border-app-ink shadow-none ring-2 ring-app-ink'
+      : 'border border-app-border/90 shadow-sm ring-1 ring-[color:var(--app-ring-slate)]',
+  ].join(' ');
+
+  const labelClassName = highContrast
+    ? 'text-base font-bold text-app-ink'
+    : 'text-base font-semibold text-app-ink';
+
+  const legendClassName = highContrast
+    ? 'mb-2 text-base font-bold text-app-ink'
+    : 'mb-2 text-base font-semibold text-app-ink';
+
+  const slotTitleClassName = highContrast
+    ? 'flex items-center gap-2 text-base font-bold text-app-ink'
+    : 'flex items-center gap-2 text-base font-semibold text-app-ink';
+
+  const colorSwatchClassName = highContrast
+    ? 'h-4 w-4 shrink-0 rounded border-2 border-app-ink'
+    : 'h-4 w-4 shrink-0 rounded border border-app-border';
 
   return (
-    <div className="flex flex-col gap-4 text-app-ink">
+    <div
+      className={
+        highContrast
+          ? 'flex flex-col gap-4 font-medium text-app-ink'
+          : 'flex flex-col gap-4 text-app-ink'
+      }
+    >
       <fieldset className="m-0 border-0 p-0">
-        <legend className="mb-2 text-base font-semibold text-app-ink">
-          Chart series
-        </legend>
+        <legend className={legendClassName}>Chart series</legend>
 
         {Array.from({ length: visibleSlotCount }, (_, slotIndex) => {
           const selected = seriesValue[slotIndex];
@@ -310,12 +347,12 @@ export function InsightSeriesPicker({
             >
               <div
                 id={`${baseId}-slot-${slotIndex}-legend`}
-                className="flex items-center gap-2 text-base font-semibold text-app-ink"
+                className={slotTitleClassName}
               >
                 {selected ? (
                   <>
                     <span
-                      className="h-4 w-4 shrink-0 rounded border border-app-border"
+                      className={colorSwatchClassName}
                       style={{ backgroundColor: selected.color }}
                       aria-hidden
                     />
@@ -329,14 +366,12 @@ export function InsightSeriesPicker({
               </div>
 
               <div className="flex flex-col gap-1.5">
-                <label
-                  htmlFor={seriesSelectId}
-                  className="text-base font-semibold text-app-ink"
-                >
+                <label htmlFor={seriesSelectId} className={labelClassName}>
                   {`Data series ${slotIndex + 1}`}
                 </label>
                 <PickerSelect
                   id={seriesSelectId}
+                  highContrast={highContrast}
                   value={selected?.seriesId ?? ''}
                   onChange={(event) =>
                     handleSeriesChange(slotIndex, event.target.value)
@@ -354,14 +389,12 @@ export function InsightSeriesPicker({
 
               {!chartTypeHidden && row ? (
                 <div className="flex flex-col gap-1.5">
-                  <label
-                    htmlFor={chartTypeSelectId}
-                    className="text-base font-semibold text-app-ink"
-                  >
+                  <label htmlFor={chartTypeSelectId} className={labelClassName}>
                     {`Chart type for series ${slotIndex + 1}`}
                   </label>
                   <PickerSelect
                     id={chartTypeSelectId}
+                    highContrast={highContrast}
                     value={selected?.chartType ?? ''}
                     onChange={(event) =>
                       handleChartTypeChange(
@@ -381,6 +414,7 @@ export function InsightSeriesPicker({
 
               <PickerButton
                 type="button"
+                highContrast={highContrast}
                 onClick={() => handleRemove(slotIndex)}
               >
                 {seriesSlotActionLabel(slotIndex)}
@@ -391,7 +425,11 @@ export function InsightSeriesPicker({
       </fieldset>
 
       {showAddAnother ? (
-        <PickerButton type="button" onClick={handleAddAnother}>
+        <PickerButton
+          type="button"
+          highContrast={highContrast}
+          onClick={handleAddAnother}
+        >
           Add another series
         </PickerButton>
       ) : null}

--- a/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
@@ -192,9 +192,11 @@ describe('formatInsightChartPatientTimeZoneNote', () => {
   it('describes browser timezone for proxy viewers by default', () => {
     const note = formatInsightChartPatientTimeZoneNote('America/New_York');
     expect(note).toMatch(/your browser timezone/i);
-    expect(note).toMatch(/time buckets are grouped in this timezone/i);
+    expect(note).toMatch(
+      /day, week, and month groupings use this timezone/i,
+    );
     expect(note).not.toMatch(/patient's local timezone/i);
-    expect(note).not.toMatch(/\bday and week\b/i);
+    expect(note).not.toMatch(/\bbuckets\b/i);
   });
 
   it('can state patient-local alignment when the zone is known', () => {

--- a/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
@@ -190,12 +190,11 @@ describe('formatInsightChartBucketLabel', () => {
 
 describe('formatInsightChartPatientTimeZoneNote', () => {
   it('describes browser timezone for proxy viewers by default', () => {
-    expect(formatInsightChartPatientTimeZoneNote('America/New_York')).toMatch(
-      /your browser timezone/i,
-    );
-    expect(
-      formatInsightChartPatientTimeZoneNote('America/New_York'),
-    ).not.toMatch(/patient's local timezone/i);
+    const note = formatInsightChartPatientTimeZoneNote('America/New_York');
+    expect(note).toMatch(/your browser timezone/i);
+    expect(note).toMatch(/time buckets are grouped in this timezone/i);
+    expect(note).not.toMatch(/patient's local timezone/i);
+    expect(note).not.toMatch(/\bday and week\b/i);
   });
 
   it('can state patient-local alignment when the zone is known', () => {

--- a/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
@@ -192,9 +192,7 @@ describe('formatInsightChartPatientTimeZoneNote', () => {
   it('describes browser timezone for proxy viewers by default', () => {
     const note = formatInsightChartPatientTimeZoneNote('America/New_York');
     expect(note).toMatch(/your browser timezone/i);
-    expect(note).toMatch(
-      /day, week, and month groupings use this timezone/i,
-    );
+    expect(note).toMatch(/day, week, and month groupings use this timezone/i);
     expect(note).not.toMatch(/patient's local timezone/i);
     expect(note).not.toMatch(/\bbuckets\b/i);
   });

--- a/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
@@ -189,10 +189,21 @@ describe('formatInsightChartBucketLabel', () => {
 });
 
 describe('formatInsightChartPatientTimeZoneNote', () => {
-  it('mentions the patient local timezone', () => {
+  it('describes browser timezone for proxy viewers by default', () => {
     expect(formatInsightChartPatientTimeZoneNote('America/New_York')).toMatch(
-      /patient's local timezone/i,
+      /your browser timezone/i,
     );
+    expect(
+      formatInsightChartPatientTimeZoneNote('America/New_York'),
+    ).not.toMatch(/patient's local timezone/i);
+  });
+
+  it('can state patient-local alignment when the zone is known', () => {
+    expect(
+      formatInsightChartPatientTimeZoneNote('America/New_York', {
+        patientLocal: true,
+      }),
+    ).toMatch(/patient's local timezone/i);
   });
 });
 

--- a/packages/ui/src/lib/insight-composed-chart-utils.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.ts
@@ -335,7 +335,7 @@ export function formatInsightChartPatientTimeZoneNote(
   if (options?.patientLocal) {
     return `Period labels use the patient's local timezone (${label}).`;
   }
-  return `Period labels use your browser timezone (${label}). Time buckets are grouped in this timezone.`;
+  return `Period labels use your browser timezone (${label}). Day, week, and month groupings use this timezone.`;
 }
 
 /**

--- a/packages/ui/src/lib/insight-composed-chart-utils.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.ts
@@ -335,7 +335,7 @@ export function formatInsightChartPatientTimeZoneNote(
   if (options?.patientLocal) {
     return `Period labels use the patient's local timezone (${label}).`;
   }
-  return `Period labels use your browser timezone (${label}). Day and week buckets are grouped in this timezone.`;
+  return `Period labels use your browser timezone (${label}). Time buckets are grouped in this timezone.`;
 }
 
 /**

--- a/packages/ui/src/lib/insight-composed-chart-utils.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.ts
@@ -320,16 +320,22 @@ export function formatIanaTimeZoneForDisplay(patientTimeZone: string): string {
 }
 
 /**
- * Caption explaining that chart period labels use the patient's timezone.
+ * Caption for chart period timezone alignment.
  *
- * @param patientTimeZone - IANA timezone id.
- * @returns Practitioner-facing note text.
+ * @param chartTimeZone - IANA timezone used for `get_chart_series` bucketing and axis labels.
+ * @param options.patientLocal - When true, copy states patient-local alignment (only when
+ *   `chartTimeZone` is the patient's IANA zone, not the viewer's browser zone).
+ * @returns Note text for the chart figure.
  */
 export function formatInsightChartPatientTimeZoneNote(
-  patientTimeZone: string,
+  chartTimeZone: string,
+  options?: { patientLocal?: boolean },
 ): string {
-  const label = formatIanaTimeZoneForDisplay(patientTimeZone);
-  return `Period labels use the patient's local timezone (${label}).`;
+  const label = formatIanaTimeZoneForDisplay(chartTimeZone);
+  if (options?.patientLocal) {
+    return `Period labels use the patient's local timezone (${label}).`;
+  }
+  return `Period labels use your browser timezone (${label}). Day and week buckets are grouped in this timezone.`;
 }
 
 /**

--- a/packages/ui/src/lib/insight-series-picker-utils.spec.ts
+++ b/packages/ui/src/lib/insight-series-picker-utils.spec.ts
@@ -9,6 +9,7 @@ import {
   isChartTypeSelectorHidden,
   MAX_SERIES_SLOTS,
   mergeSeriesSelectionAtSlot,
+  reconcileSelectedSeriesWithManifest,
 } from './insight-series-picker-utils.js';
 import type {
   ChartableManifestRow,
@@ -172,5 +173,16 @@ describe('insight-series-picker-utils', () => {
     expect(canAddAnotherSeries([], 1)).toBe(false);
     expect(canAddAnotherSeries([selectedFromRow(numericRow)], 1)).toBe(true);
     expect(canAddAnotherSeries([], MAX_SERIES_SLOTS)).toBe(false);
+  });
+
+  it('reconcileSelectedSeriesWithManifest drops rows missing from the manifest', () => {
+    const selected = [
+      selectedFromRow(numericRow, 0),
+      selectedFromRow(severityRow, 1),
+    ];
+
+    expect(reconcileSelectedSeriesWithManifest([numericRow], selected)).toEqual(
+      [expect.objectContaining({ seriesId: numericRow.series_id })],
+    );
   });
 });

--- a/packages/ui/src/lib/insight-series-picker-utils.ts
+++ b/packages/ui/src/lib/insight-series-picker-utils.ts
@@ -227,3 +227,41 @@ export function wouldManifestRowExceedDistinctNonBpValueUnitLimit(
   }
   return wouldExceedDistinctNonBpValueUnitLimit(value, candidate, slotIndex);
 }
+
+/**
+ * Keeps only selections that still exist in the manifest, refreshing labels and metadata.
+ *
+ * @param manifest - Latest chart manifest rows.
+ * @param selected - Current picker selection.
+ * @returns Selection reconciled to the manifest (may be shorter than `selected`).
+ */
+export function reconcileSelectedSeriesWithManifest(
+  manifest: ChartManifestRow[],
+  selected: SelectedSeries[],
+): SelectedSeries[] {
+  const chartableById = new Map(
+    filterChartableManifestRows(manifest).map((row) => [row.series_id, row]),
+  );
+
+  const reconciled: SelectedSeries[] = [];
+  for (let slotIndex = 0; slotIndex < selected.length; slotIndex++) {
+    const item = selected[slotIndex];
+    if (!item) {
+      continue;
+    }
+    const row = chartableById.get(item.seriesId);
+    if (!row) {
+      continue;
+    }
+    const refreshed = createSelectedSeriesFromManifestRow(
+      row,
+      reconciled.length,
+      item.chartType,
+    );
+    if (refreshed) {
+      reconciled.push(refreshed);
+    }
+  }
+
+  return reconciled.slice(0, MAX_SERIES_SLOTS);
+}

--- a/supabase/migrations/20260524120000_fix_get_chart_series_elem_ambiguous.sql
+++ b/supabase/migrations/20260524120000_fix_get_chart_series_elem_ambiguous.sql
@@ -1,0 +1,333 @@
+-- Fix get_chart_series: PL/pgSQL loop variable `elem` conflicted with CTE alias `elem`
+-- (PostgreSQL error 42702: column reference "elem" is ambiguous).
+
+CREATE OR REPLACE FUNCTION public.get_chart_series (
+  p_user_id uuid,
+  p_series jsonb,
+  p_from timestamptz,
+  p_to timestamptz,
+  p_bucket text,
+  p_timezone text
+)
+RETURNS TABLE (
+  series_id text,
+  bucket_start timestamptz,
+  value_avg numeric,
+  value_min numeric,
+  value_max numeric,
+  systolic_avg numeric,
+  diastolic_avg numeric,
+  event_count bigint
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+STABLE
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  series_count int;
+  elem jsonb;
+  sid text;
+  stype text;
+  rtype text;
+  is_bp boolean;
+  seen_series_ids text[] := ARRAY[]::text[];
+  symptom_match text[];
+  hm_suffix text;
+  tz text;
+BEGIN
+  tz := nullif(trim(p_timezone), '');
+
+  IF tz IS NULL THEN
+    RAISE EXCEPTION 'get_chart_series: p_timezone must be a non-empty IANA timezone name'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_timezone_names
+    WHERE name = tz
+  ) THEN
+    RAISE EXCEPTION 'get_chart_series: invalid IANA timezone %', tz
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_bucket NOT IN ('day', 'week', 'month') THEN
+    RAISE EXCEPTION 'get_chart_series: p_bucket must be day, week, or month'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF jsonb_typeof(p_series) IS DISTINCT FROM 'array' THEN
+    RAISE EXCEPTION 'get_chart_series: p_series must be a JSON array'
+      USING ERRCODE = '22023';
+  END IF;
+
+  series_count := jsonb_array_length(p_series);
+
+  IF series_count < 1 OR series_count > 3 THEN
+    RAISE EXCEPTION 'get_chart_series: p_series must contain 1 to 3 series'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_from > p_to THEN
+    RAISE EXCEPTION 'get_chart_series: p_from must be less than or equal to p_to'
+      USING ERRCODE = '22023';
+  END IF;
+
+  FOR elem IN
+    SELECT value
+    FROM jsonb_array_elements(p_series)
+  LOOP
+    IF jsonb_typeof(elem) <> 'object' THEN
+      RAISE EXCEPTION 'get_chart_series: each p_series element must be a JSON object'
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF NOT (
+      elem ? 'series_id'
+      AND elem ? 'series_type'
+      AND elem ? 'response_type'
+      AND elem ? 'is_blood_pressure'
+    ) THEN
+      RAISE EXCEPTION 'get_chart_series: each p_series element must include series_id, series_type, response_type, and is_blood_pressure'
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF jsonb_typeof(elem -> 'is_blood_pressure') <> 'boolean' THEN
+      RAISE EXCEPTION 'get_chart_series: is_blood_pressure must be a JSON boolean'
+        USING ERRCODE = '22023';
+    END IF;
+
+    sid := nullif(trim(elem ->> 'series_id'), '');
+    stype := nullif(trim(elem ->> 'series_type'), '');
+    rtype := nullif(trim(elem ->> 'response_type'), '');
+    is_bp := (elem ->> 'is_blood_pressure')::boolean;
+
+    IF sid IS NULL OR stype IS NULL OR rtype IS NULL THEN
+      RAISE EXCEPTION 'get_chart_series: series_id, series_type, and response_type must be non-empty strings'
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF sid <> lower(sid) THEN
+      RAISE EXCEPTION 'get_chart_series: series_id must be lowercase (manifest format) %', sid
+        USING ERRCODE = '22023';
+    END IF;
+
+    IF sid = ANY (seen_series_ids) THEN
+      RAISE EXCEPTION 'get_chart_series: duplicate series_id %', sid
+        USING ERRCODE = '22023';
+    END IF;
+
+    seen_series_ids := array_append(seen_series_ids, sid);
+
+    IF stype = 'health_marker' THEN
+      IF rtype <> 'numeric' THEN
+        RAISE EXCEPTION 'get_chart_series: health_marker series % requires response_type numeric', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF sid NOT LIKE 'health_marker::%' OR length(sid) <= length('health_marker::') THEN
+        RAISE EXCEPTION 'get_chart_series: invalid health_marker series_id %', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      hm_suffix := substring(sid FROM length('health_marker::') + 1);
+
+      IF is_bp AND hm_suffix <> 'blood_pressure' THEN
+        RAISE EXCEPTION 'get_chart_series: is_blood_pressure true requires series_id health_marker::blood_pressure'
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF NOT is_bp AND hm_suffix = 'blood_pressure' THEN
+        RAISE EXCEPTION 'get_chart_series: health_marker::blood_pressure requires is_blood_pressure true'
+          USING ERRCODE = '22023';
+      END IF;
+    ELSIF stype = 'symptom' THEN
+      IF rtype NOT IN ('boolean', 'severity') THEN
+        RAISE EXCEPTION 'get_chart_series: symptom series % requires response_type boolean or severity', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF is_bp THEN
+        RAISE EXCEPTION 'get_chart_series: symptom series must have is_blood_pressure false'
+          USING ERRCODE = '22023';
+      END IF;
+
+      symptom_match := regexp_match(sid, '^symptom::(.+)::(boolean|severity)$');
+
+      IF symptom_match IS NULL THEN
+        RAISE EXCEPTION 'get_chart_series: invalid symptom series_id % (expected symptom::<name>::boolean|severity)', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF symptom_match[2] <> rtype THEN
+        RAISE EXCEPTION 'get_chart_series: series_id suffix must match response_type for %', sid
+          USING ERRCODE = '22023';
+      END IF;
+
+      IF nullif(trim(symptom_match[1]), '') IS NULL THEN
+        RAISE EXCEPTION 'get_chart_series: symptom series_id must include a non-empty symptom name'
+          USING ERRCODE = '22023';
+      END IF;
+    ELSE
+      RAISE EXCEPTION 'get_chart_series: unsupported series_type %', stype
+        USING ERRCODE = '22023';
+    END IF;
+  END LOOP;
+
+  RETURN QUERY
+  WITH series_defs AS (
+    SELECT
+      series_elem->>'series_id' AS series_id,
+      series_elem->>'series_type' AS series_type,
+      series_elem->>'response_type' AS response_type,
+      COALESCE((series_elem->>'is_blood_pressure')::boolean, false) AS is_blood_pressure
+    FROM jsonb_array_elements(p_series) AS series_elem
+  ),
+  health_marker_defs AS (
+    SELECT
+      sd.series_id,
+      sd.response_type,
+      sd.is_blood_pressure,
+      lower(regexp_replace(sd.series_id, '^health_marker::', '')) AS marker_series_key
+    FROM series_defs sd
+    WHERE sd.series_type = 'health_marker'
+  ),
+  symptom_defs AS (
+    SELECT
+      sd.series_id,
+      sd.response_type,
+      (regexp_match(sd.series_id, '^symptom::(.+)::(boolean|severity)$'))[1] AS symptom_series_key
+    FROM series_defs sd
+    WHERE sd.series_type = 'symptom'
+  ),
+  health_marker_match AS (
+    SELECT
+      hmd.series_id,
+      hmd.is_blood_pressure,
+      hm.recorded_at,
+      hm.value_numeric,
+      hm.systolic_numeric,
+      hm.diastolic_numeric
+    FROM health_marker_defs hmd
+    INNER JOIN public.health_markers hm
+      ON hm.user_id = p_user_id
+      AND hm.recorded_at >= p_from
+      AND hm.recorded_at <= p_to
+      AND (
+        hm.marker_kind <> 'custom'
+        OR nullif(trim(hm.custom_name), '') IS NOT NULL
+      )
+      AND (
+        CASE
+          WHEN hm.marker_kind = 'custom' THEN
+            lower(hm.marker_kind) || '::' || lower(nullif(trim(hm.custom_name), ''))
+          ELSE lower(hm.marker_kind)
+        END
+      ) = hmd.marker_series_key
+  ),
+  health_marker_bucketed AS (
+    SELECT
+      hmm.series_id,
+      hmm.is_blood_pressure,
+      hmm.value_numeric,
+      hmm.systolic_numeric,
+      hmm.diastolic_numeric,
+      (
+        date_trunc(p_bucket, hmm.recorded_at AT TIME ZONE tz)
+        AT TIME ZONE tz
+      ) AS bucket_start
+    FROM health_marker_match hmm
+  ),
+  blood_pressure_buckets AS (
+    SELECT
+      hmb.series_id,
+      hmb.bucket_start,
+      NULL::numeric AS value_avg,
+      NULL::numeric AS value_min,
+      NULL::numeric AS value_max,
+      avg(hmb.systolic_numeric) AS systolic_avg,
+      avg(hmb.diastolic_numeric) AS diastolic_avg,
+      NULL::bigint AS event_count
+    FROM health_marker_bucketed hmb
+    WHERE hmb.is_blood_pressure
+    GROUP BY hmb.series_id, hmb.bucket_start
+  ),
+  numeric_health_marker_buckets AS (
+    SELECT
+      hmb.series_id,
+      hmb.bucket_start,
+      avg(hmb.value_numeric) AS value_avg,
+      min(hmb.value_numeric) AS value_min,
+      max(hmb.value_numeric) AS value_max,
+      NULL::numeric AS systolic_avg,
+      NULL::numeric AS diastolic_avg,
+      NULL::bigint AS event_count
+    FROM health_marker_bucketed hmb
+    WHERE NOT hmb.is_blood_pressure
+      AND hmb.value_numeric IS NOT NULL
+    GROUP BY hmb.series_id, hmb.bucket_start
+  ),
+  symptom_boolean_buckets AS (
+    SELECT
+      sd.series_id,
+      (
+        date_trunc(p_bucket, es.created_at AT TIME ZONE tz)
+        AT TIME ZONE tz
+      ) AS bucket_start,
+      NULL::numeric AS value_avg,
+      NULL::numeric AS value_min,
+      NULL::numeric AS value_max,
+      NULL::numeric AS systolic_avg,
+      NULL::numeric AS diastolic_avg,
+      count(*) FILTER (WHERE es.response_boolean IS TRUE)::bigint AS event_count
+    FROM symptom_defs sd
+    INNER JOIN public.episode_symptoms es
+      ON es.user_id = p_user_id
+      AND es.created_at >= p_from
+      AND es.created_at <= p_to
+      AND lower(nullif(trim(es.symptom_name), '')) = sd.symptom_series_key
+      AND es.response_type = 'yes_no'
+    WHERE sd.response_type = 'boolean'
+    GROUP BY
+      sd.series_id,
+      date_trunc(p_bucket, es.created_at AT TIME ZONE tz) AT TIME ZONE tz
+  ),
+  symptom_severity_buckets AS (
+    SELECT
+      sd.series_id,
+      (
+        date_trunc(p_bucket, es.created_at AT TIME ZONE tz)
+        AT TIME ZONE tz
+      ) AS bucket_start,
+      avg(es.response_severity) AS value_avg,
+      min(es.response_severity) AS value_min,
+      max(es.response_severity) AS value_max,
+      NULL::numeric AS systolic_avg,
+      NULL::numeric AS diastolic_avg,
+      count(*)::bigint AS event_count
+    FROM symptom_defs sd
+    INNER JOIN public.episode_symptoms es
+      ON es.user_id = p_user_id
+      AND es.created_at >= p_from
+      AND es.created_at <= p_to
+      AND lower(nullif(trim(es.symptom_name), '')) = sd.symptom_series_key
+      AND es.response_type = 'severity_scale'
+    WHERE sd.response_type = 'severity'
+    GROUP BY
+      sd.series_id,
+      date_trunc(p_bucket, es.created_at AT TIME ZONE tz) AT TIME ZONE tz
+  )
+  SELECT * FROM blood_pressure_buckets
+  UNION ALL
+  SELECT * FROM numeric_health_marker_buckets
+  UNION ALL
+  SELECT * FROM symptom_boolean_buckets
+  UNION ALL
+  SELECT * FROM symptom_severity_buckets
+  ORDER BY 1, 2;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text, text) IS
+'Returns pre-bucketed chart series for p_user_id and selected manifest series. Buckets use date_trunc in p_timezone (IANA name, validated against pg_timezone_names) so bucket_start aligns with patient-local chart labels. Validates p_bucket (day|week|month), p_series (1–3 series), and p_from <= p_to. Severity: value_* ignores NULL response_severity; event_count is total severity_scale rows per bucket. SECURITY INVOKER.';

--- a/supabase/migrations/20260524120000_fix_get_chart_series_elem_ambiguous.sql
+++ b/supabase/migrations/20260524120000_fix_get_chart_series_elem_ambiguous.sql
@@ -336,7 +336,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text, text) IS
-'Returns pre-bucketed chart series for p_user_id and selected manifest series. Buckets use date_trunc in p_timezone (IANA name, validated against pg_timezone_names) so bucket_start aligns with patient-local chart labels. Validates p_bucket (day|week|month), p_series (1–3 series), and p_from < p_to (p_to exclusive). Severity: value_* ignores NULL response_severity; event_count is total severity_scale rows per bucket. SECURITY INVOKER.';
+'Returns pre-bucketed chart series for p_user_id and selected manifest series. Buckets use date_trunc in p_timezone (IANA name, validated against pg_timezone_names) so bucket_start aligns with chart labels formatted in that same zone (caller-supplied; e.g. patient IANA from profile or viewer browser when no stored patient zone). Validates p_bucket (day|week|month), p_series (1–3 series), and p_from < p_to (p_to exclusive). Severity: value_* ignores NULL response_severity; event_count is total severity_scale rows per bucket. SECURITY INVOKER.';
 
 REVOKE ALL ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text, text) FROM PUBLIC;
 GRANT EXECUTE ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text, text) TO authenticated;

--- a/supabase/migrations/20260524120000_fix_get_chart_series_elem_ambiguous.sql
+++ b/supabase/migrations/20260524120000_fix_get_chart_series_elem_ambiguous.sql
@@ -74,8 +74,8 @@ BEGIN
       USING ERRCODE = '22023';
   END IF;
 
-  IF p_from > p_to THEN
-    RAISE EXCEPTION 'get_chart_series: p_from must be less than or equal to p_to'
+  IF p_from >= p_to THEN
+    RAISE EXCEPTION 'get_chart_series: p_from must be less than p_to (p_to is exclusive)'
       USING ERRCODE = '22023';
   END IF;
 
@@ -219,7 +219,7 @@ BEGIN
     INNER JOIN public.health_markers hm
       ON hm.user_id = p_user_id
       AND hm.recorded_at >= p_from
-      AND hm.recorded_at <= p_to
+      AND hm.recorded_at < p_to
       AND (
         hm.marker_kind <> 'custom'
         OR nullif(trim(hm.custom_name), '') IS NOT NULL
@@ -291,7 +291,7 @@ BEGIN
     INNER JOIN public.episode_symptoms es
       ON es.user_id = p_user_id
       AND es.created_at >= p_from
-      AND es.created_at <= p_to
+      AND es.created_at < p_to
       AND lower(nullif(trim(es.symptom_name), '')) = sd.symptom_series_key
       AND es.response_type = 'yes_no'
     WHERE sd.response_type = 'boolean'
@@ -316,7 +316,7 @@ BEGIN
     INNER JOIN public.episode_symptoms es
       ON es.user_id = p_user_id
       AND es.created_at >= p_from
-      AND es.created_at <= p_to
+      AND es.created_at < p_to
       AND lower(nullif(trim(es.symptom_name), '')) = sd.symptom_series_key
       AND es.response_type = 'severity_scale'
     WHERE sd.response_type = 'severity'
@@ -336,4 +336,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text, text) IS
-'Returns pre-bucketed chart series for p_user_id and selected manifest series. Buckets use date_trunc in p_timezone (IANA name, validated against pg_timezone_names) so bucket_start aligns with patient-local chart labels. Validates p_bucket (day|week|month), p_series (1–3 series), and p_from <= p_to. Severity: value_* ignores NULL response_severity; event_count is total severity_scale rows per bucket. SECURITY INVOKER.';
+'Returns pre-bucketed chart series for p_user_id and selected manifest series. Buckets use date_trunc in p_timezone (IANA name, validated against pg_timezone_names) so bucket_start aligns with patient-local chart labels. Validates p_bucket (day|week|month), p_series (1–3 series), and p_from < p_to (p_to exclusive). Severity: value_* ignores NULL response_severity; event_count is total severity_scale rows per bucket. SECURITY INVOKER.';
+
+REVOKE ALL ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_chart_series (uuid, jsonb, timestamptz, timestamptz, text, text) TO authenticated;

--- a/supabase/migrations/20260524120000_fix_get_chart_series_elem_ambiguous.sql
+++ b/supabase/migrations/20260524120000_fix_get_chart_series_elem_ambiguous.sql
@@ -52,7 +52,7 @@ BEGIN
       USING ERRCODE = '22023';
   END IF;
 
-  IF p_bucket NOT IN ('day', 'week', 'month') THEN
+  IF p_bucket IS NULL OR p_bucket NOT IN ('day', 'week', 'month') THEN
     RAISE EXCEPTION 'get_chart_series: p_bucket must be day, week, or month'
       USING ERRCODE = '22023';
   END IF;
@@ -66,6 +66,11 @@ BEGIN
 
   IF series_count < 1 OR series_count > 3 THEN
     RAISE EXCEPTION 'get_chart_series: p_series must contain 1 to 3 series'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_from IS NULL OR p_to IS NULL THEN
+    RAISE EXCEPTION 'get_chart_series: p_from and p_to must be non-null timestamps'
       USING ERRCODE = '22023';
   END IF;
 
@@ -126,7 +131,8 @@ BEGIN
           USING ERRCODE = '22023';
       END IF;
 
-      IF sid NOT LIKE 'health_marker::%' OR length(sid) <= length('health_marker::') THEN
+      IF NOT starts_with(sid, 'health_marker::')
+        OR length(sid) <= length('health_marker::') THEN
         RAISE EXCEPTION 'get_chart_series: invalid health_marker series_id %', sid
           USING ERRCODE = '22023';
       END IF;


### PR DESCRIPTION
Closes #176

## Summary

- Adds patient **Insights** at `/insights`: manifest-driven series picker, 30-day default date range, day/week/month buckets, and `InsightComposedChart` backed by `get_user_chart_manifest` and `get_chart_series` (browser Supabase client + PHI subject context).
- Fixes **`get_chart_series` 400** on cloud: new migration renames the conflicting CTE alias (`elem` vs PL/pgSQL loop variable) that caused `column reference "elem" is ambiguous`.
- Maps chart manifest health-marker labels to **`PRESET_HEALTH_MARKER_KIND_LABELS`** (e.g. BAC, Glucose) so Insights matches the health-marker preset UI; applies in `getUserChartManifest`, `InsightsClient`, and `@abstrack/types` helpers.
- Styles shared insight UI for **light/dark** (`app-*` tokens, tooltip vars, react-day-picker vars); refactors `InsightSeriesPicker` to web-native controls.
- **Theme menu**: portal popover + z-index so the header theme dropdown is clickable; Insights nav link in `AuthenticatedShell`.
- **Dev ergonomics**: webpack alias `@abstrack/supabase` → source (same pattern as `@abstrack/types`); surfaces `get_chart_series:` validation messages via `preset-data-error`.

## Migration

Sarah must apply before chart data works on cloud (function-only; no `database.types.ts` regen required):

    pnpm dlx supabase db push

Migration file: `supabase/migrations/20260524120000_fix_get_chart_series_elem_ambiguous.sql`

## Test plan

- [ ] Run `pnpm dlx supabase db push` on the linked project, then reload `/insights`
- [ ] Manifest loads; series dropdown shows **BAC** / **Glucose** (not `bac` / `blood_glucose`)
- [ ] Select a health-marker series → chart loads (no 400 on `get_chart_series`)
- [ ] Change date range and day/week/month bucket → chart refetches
- [ ] Empty manifest copy when user has no chartable observations
- [ ] Theme menu opens above page content (web + practitioner shell smoke)
- [ ] Dark mode: insights filters, chart, and date picker use semantic tokens
- [ ] `pnpm exec nx test web` and `pnpm exec nx test ui` / `supabase` / `types` as needed