### PR TITLE
feat(web): notify patients and surface practitioner-shared chart snapshots on Insights

### DIFF
--- a/apps/practitioner/specs/patient-detail-insights.spec.tsx
+++ b/apps/practitioner/specs/patient-detail-insights.spec.tsx
@@ -253,6 +253,7 @@ describe('PractitionerPatientDetailPage insights tab', () => {
       expect.objectContaining({
         patientUserId: PATIENT_ID,
         bucket: 'day',
+        chartTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         practitionerNote: 'Please review this trend.',
         dateFrom: p_from,
         dateTo: p_to,

--- a/apps/practitioner/src/components/practitioner-patient-insights-panel.tsx
+++ b/apps/practitioner/src/components/practitioner-patient-insights-panel.tsx
@@ -305,6 +305,7 @@ export function PractitionerPatientInsightsPanel({
       dateFrom: p_from,
       dateTo: p_to,
       bucket,
+      chartTimezone: chartTimeZone,
       practitionerNote: shareNote,
     });
 
@@ -318,7 +319,16 @@ export function PractitionerPatientInsightsPanel({
     announce('Chart shared with patient.', { politeness: 'polite' });
     setShareNote('');
     return;
-  }, [announce, bucket, dateRange, patientUserId, series, shareNote, supabase]);
+  }, [
+    announce,
+    bucket,
+    chartTimeZone,
+    dateRange,
+    patientUserId,
+    series,
+    shareNote,
+    supabase,
+  ]);
 
   return (
     <div className="space-y-8">

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -579,6 +579,65 @@ describe('InsightsClient', () => {
     expect(screen.getByText('Please review this trend.')).toBeInTheDocument();
   });
 
+  it('clears the banner when mark returns false because the snapshot was already seen', async () => {
+    listUnseenChartSnapshotsForPatientMock.mockResolvedValue({
+      ok: true,
+      data: [SHARED_SNAPSHOT],
+    });
+    markChartSnapshotSeenMock.mockResolvedValue({ ok: true, data: false });
+
+    renderInsights();
+
+    await screen.findByText('Your practitioner shared a chart with you.');
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: /your practitioner shared a chart with you/i,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(markChartSnapshotSeenMock).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(
+        screen.queryByText('Your practitioner shared a chart with you.'),
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  it('keeps the banner when mark_chart_snapshot_seen fails so the patient can retry', async () => {
+    listUnseenChartSnapshotsForPatientMock.mockResolvedValue({
+      ok: true,
+      data: [SHARED_SNAPSHOT],
+    });
+    markChartSnapshotSeenMock.mockResolvedValue({
+      ok: false,
+      error: { message: 'Network error.', code: 'network_error' },
+    });
+
+    renderInsights();
+
+    await screen.findByText('Your practitioner shared a chart with you.');
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: /your practitioner shared a chart with you/i,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(markChartSnapshotSeenMock).toHaveBeenCalled();
+    });
+
+    expect(
+      screen.getByText('Your practitioner shared a chart with you.'),
+    ).toBeInTheDocument();
+  });
+
   it('does not query unseen snapshots when viewing another PHI subject', async () => {
     phiContext.phiSubjectUserId = PHI_SUBJECT_B;
     phiContext.authUserId = PHI_SUBJECT_A;

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -212,6 +212,7 @@ const SHARED_SNAPSHOT = {
   date_to: '2026-02-01T05:00:00.000Z',
   bucket: 'week' as const,
   practitioner_note: 'Please review this trend.',
+  chart_timezone: 'America/New_York',
   created_at: '2026-05-01T12:00:00.000Z',
   seen_by_patient_at: null,
 };
@@ -564,6 +565,7 @@ describe('InsightsClient', () => {
           p_from: SHARED_SNAPSHOT.date_from,
           p_to: SHARED_SNAPSHOT.date_to,
           p_bucket: 'week',
+          p_timezone: 'America/New_York',
         }),
       );
     });

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -13,7 +13,12 @@ import type {
   InsightDateRange,
   SelectedSeries,
 } from '@abstrack/ui';
-import { getChartSeries, getUserChartManifest } from '@abstrack/supabase';
+import {
+  getChartSeries,
+  getUserChartManifest,
+  listUnseenChartSnapshotsForPatient,
+  markChartSnapshotSeen,
+} from '@abstrack/supabase';
 import {
   getDefaultInsightDateRange,
   insightDateRangeToRpcBounds,
@@ -62,6 +67,8 @@ jest.mock('../../../lib/supabase/browser-client', () => ({
 jest.mock('@abstrack/supabase', () => ({
   getUserChartManifest: jest.fn(),
   getChartSeries: jest.fn(),
+  listUnseenChartSnapshotsForPatient: jest.fn(),
+  markChartSnapshotSeen: jest.fn(),
 }));
 
 jest.mock('@abstrack/ui', () => {
@@ -176,6 +183,38 @@ const getUserChartManifestMock = getUserChartManifest as jest.MockedFunction<
 const getChartSeriesMock = getChartSeries as jest.MockedFunction<
   typeof getChartSeries
 >;
+const listUnseenChartSnapshotsForPatientMock =
+  listUnseenChartSnapshotsForPatient as jest.MockedFunction<
+    typeof listUnseenChartSnapshotsForPatient
+  >;
+const markChartSnapshotSeenMock = markChartSnapshotSeen as jest.MockedFunction<
+  typeof markChartSnapshotSeen
+>;
+
+const SHARED_SNAPSHOT_ID = 'cccccccc-bbbb-cccc-dddd-111111111111';
+const SHARED_SNAPSHOT = {
+  id: SHARED_SNAPSHOT_ID,
+  patient_user_id: PHI_SUBJECT_A,
+  practitioner_user_id: 'dddddddd-bbbb-cccc-dddd-222222222222',
+  series_definition: [
+    {
+      seriesId: 'health_marker::bac',
+      seriesType: 'health_marker' as const,
+      responseType: 'numeric' as const,
+      isBloodPressure: false,
+      label: 'BAC',
+      unit: '%',
+      chartType: 'line' as const,
+      color: '#1d4ed8',
+    },
+  ],
+  date_from: '2026-01-01T05:00:00.000Z',
+  date_to: '2026-02-01T05:00:00.000Z',
+  bucket: 'week' as const,
+  practitioner_note: 'Please review this trend.',
+  created_at: '2026-05-01T12:00:00.000Z',
+  seen_by_patient_at: null,
+};
 
 function renderInsights() {
   return render(
@@ -211,6 +250,11 @@ describe('InsightsClient', () => {
         },
       ],
     });
+    listUnseenChartSnapshotsForPatientMock.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+    markChartSnapshotSeenMock.mockResolvedValue({ ok: true, data: true });
   });
 
   it('does not show the empty state when PHI scope fails to resolve', async () => {
@@ -481,6 +525,71 @@ describe('InsightsClient', () => {
         }),
       );
     });
+  });
+
+  it('shows a banner when unseen practitioner chart snapshots exist', async () => {
+    listUnseenChartSnapshotsForPatientMock.mockResolvedValue({
+      ok: true,
+      data: [SHARED_SNAPSHOT],
+    });
+
+    renderInsights();
+
+    expect(
+      await screen.findByText('Your practitioner shared a chart with you.'),
+    ).toBeInTheDocument();
+  });
+
+  it('loads and marks a shared chart snapshot when the banner is activated', async () => {
+    listUnseenChartSnapshotsForPatientMock.mockResolvedValue({
+      ok: true,
+      data: [SHARED_SNAPSHOT],
+    });
+
+    renderInsights();
+
+    await screen.findByText('Your practitioner shared a chart with you.');
+    await act(async () => {
+      fireEvent.click(
+        screen.getByRole('button', {
+          name: /your practitioner shared a chart with you/i,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(getChartSeriesMock).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          p_from: SHARED_SNAPSHOT.date_from,
+          p_to: SHARED_SNAPSHOT.date_to,
+          p_bucket: 'week',
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(markChartSnapshotSeenMock).toHaveBeenCalledWith(
+        expect.anything(),
+        SHARED_SNAPSHOT_ID,
+      );
+    });
+
+    expect(screen.getByText('Note from your practitioner')).toBeInTheDocument();
+    expect(screen.getByText('Please review this trend.')).toBeInTheDocument();
+  });
+
+  it('does not query unseen snapshots when viewing another PHI subject', async () => {
+    phiContext.phiSubjectUserId = PHI_SUBJECT_B;
+    phiContext.authUserId = PHI_SUBJECT_A;
+
+    renderInsights();
+
+    await screen.findByTestId('date-range-picker');
+    expect(listUnseenChartSnapshotsForPatientMock).not.toHaveBeenCalled();
+    expect(
+      screen.queryByText('Your practitioner shared a chart with you.'),
+    ).not.toBeInTheDocument();
   });
 
   it('updates chart bucket when the bucket selector changes', async () => {

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -351,11 +351,13 @@ export function InsightsClient() {
     if (snapshotId != null) {
       pendingSeenSnapshotIdRef.current = null;
       const markResult = await markChartSnapshotSeen(supabase, snapshotId);
-      if (markResult.ok && markResult.data) {
+      if (markResult.ok) {
         setUnseenSnapshots((current) =>
           current.filter((row) => row.id !== snapshotId),
         );
-        announce('Shared chart marked as viewed.', { politeness: 'polite' });
+        if (markResult.data) {
+          announce('Shared chart marked as viewed.', { politeness: 'polite' });
+        }
       }
     }
   }, [announce, bucket, chartTimeZone, dateRange, phiSubjectUserId, series]);

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -12,6 +12,9 @@ import { chartManifestSeriesDisplayLabel } from '@abstrack/types';
 import {
   getChartSeries,
   getUserChartManifest,
+  listUnseenChartSnapshotsForPatient,
+  markChartSnapshotSeen,
+  type ChartSnapshotRow,
   type UserChartManifestSeries,
 } from '@abstrack/supabase';
 import {
@@ -28,6 +31,8 @@ import {
 } from '@abstrack/ui';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import {
+  chartSnapshotBoundsToInsightDateRange,
+  chartSnapshotDefinitionToSelectedSeries,
   formatInsightChartPageSummary,
   getDefaultInsightDateRange,
   insightDateRangeToRpcBounds,
@@ -87,6 +92,10 @@ export function InsightsClient() {
     phiSubjectUserId != null &&
     authUserId != null &&
     phiSubjectUserId !== authUserId;
+  const viewingOwnInsights =
+    phiSubjectUserId != null &&
+    authUserId != null &&
+    phiSubjectUserId === authUserId;
   const showPatientTimeZoneNote = viewingAnotherPhiSubject;
 
   const [manifestLoading, setManifestLoading] = useState(true);
@@ -105,8 +114,21 @@ export function InsightsClient() {
   >([]);
   const [chartError, setChartError] = useState<string | null>(null);
 
+  const [unseenSnapshots, setUnseenSnapshots] = useState<ChartSnapshotRow[]>(
+    [],
+  );
+  const [sharedSnapshotNote, setSharedSnapshotNote] = useState<string | null>(
+    null,
+  );
+
   const manifestLoadGenRef = useRef(0);
   const chartLoadGenRef = useRef(0);
+  const unseenSnapshotsLoadGenRef = useRef(0);
+  const pendingSeenSnapshotIdRef = useRef<string | null>(null);
+  const chartRpcBoundsOverrideRef = useRef<{
+    p_from: string;
+    p_to: string;
+  } | null>(null);
   const phiSubjectUserIdRef = useRef(phiSubjectUserId);
   phiSubjectUserIdRef.current = phiSubjectUserId;
   /** PHI subject that owns the current picker selection (null after scope reset). */
@@ -120,19 +142,39 @@ export function InsightsClient() {
 
   const resetInsightsPatientState = useCallback(() => {
     selectionOwnerUserIdRef.current = null;
+    pendingSeenSnapshotIdRef.current = null;
+    chartRpcBoundsOverrideRef.current = null;
     setSeries([]);
     setChartLoading(false);
     setChartRows([]);
     setChartError(null);
+    setSharedSnapshotNote(null);
   }, []);
 
   const handleSeriesChange = useCallback(
     (next: SelectedSeries[]) => {
       selectionOwnerUserIdRef.current = phiSubjectUserId;
+      pendingSeenSnapshotIdRef.current = null;
+      chartRpcBoundsOverrideRef.current = null;
+      setSharedSnapshotNote(null);
       setSeries(next);
     },
     [phiSubjectUserId],
   );
+
+  const handleDateRangeChange = useCallback((next: InsightDateRange) => {
+    pendingSeenSnapshotIdRef.current = null;
+    chartRpcBoundsOverrideRef.current = null;
+    setSharedSnapshotNote(null);
+    setDateRange(next);
+  }, []);
+
+  const handleBucketChange = useCallback((next: InsightChartBucket) => {
+    pendingSeenSnapshotIdRef.current = null;
+    chartRpcBoundsOverrideRef.current = null;
+    setSharedSnapshotNote(null);
+    setBucket(next);
+  }, []);
 
   const chartableManifest = useMemo(
     () => filterChartableManifestRows(manifest),
@@ -157,6 +199,28 @@ export function InsightsClient() {
       ),
     [series, dateRange, bucket],
   );
+
+  const loadUnseenSnapshots = useCallback(async () => {
+    if (!viewingOwnInsights) {
+      setUnseenSnapshots([]);
+      return;
+    }
+
+    const generation = ++unseenSnapshotsLoadGenRef.current;
+    const supabase = createBrowserClient();
+    const result = await listUnseenChartSnapshotsForPatient(supabase);
+
+    if (generation !== unseenSnapshotsLoadGenRef.current) {
+      return;
+    }
+
+    if (!result.ok) {
+      setUnseenSnapshots([]);
+      return;
+    }
+
+    setUnseenSnapshots(result.data);
+  }, [viewingOwnInsights]);
 
   const loadManifest = useCallback(async () => {
     if (phiSubjectUserId == null) {
@@ -198,6 +262,19 @@ export function InsightsClient() {
   }, [announce, phiSubjectUserId]);
 
   useEffect(() => {
+    if (viewingOwnInsights && phiScopeReady) {
+      void loadUnseenSnapshots();
+    } else {
+      unseenSnapshotsLoadGenRef.current += 1;
+      setUnseenSnapshots([]);
+    }
+
+    return () => {
+      unseenSnapshotsLoadGenRef.current += 1;
+    };
+  }, [loadUnseenSnapshots, phiScopeReady, viewingOwnInsights]);
+
+  useEffect(() => {
     invalidateInsightsLoads();
     resetInsightsPatientState();
 
@@ -236,7 +313,9 @@ export function InsightsClient() {
     setChartError(null);
     announce('Loading chart data.', { politeness: 'polite' });
 
-    const { p_from, p_to } = insightDateRangeToRpcBounds(dateRange);
+    const { p_from, p_to } =
+      chartRpcBoundsOverrideRef.current ??
+      insightDateRangeToRpcBounds(dateRange);
     const supabase = createBrowserClient();
     const result = await getChartSeries(supabase, {
       p_user_id: requestedUserId,
@@ -267,7 +346,47 @@ export function InsightsClient() {
 
     setChartRows(pivotChartSeriesBucketRows(result.data));
     announce('Chart data loaded.', { politeness: 'polite' });
+
+    const snapshotId = pendingSeenSnapshotIdRef.current;
+    if (snapshotId != null) {
+      pendingSeenSnapshotIdRef.current = null;
+      const markResult = await markChartSnapshotSeen(supabase, snapshotId);
+      if (markResult.ok && markResult.data) {
+        setUnseenSnapshots((current) =>
+          current.filter((row) => row.id !== snapshotId),
+        );
+        announce('Shared chart marked as viewed.', { politeness: 'polite' });
+      }
+    }
   }, [announce, bucket, chartTimeZone, dateRange, phiSubjectUserId, series]);
+
+  const handleViewSharedChart = useCallback(() => {
+    const snapshot = unseenSnapshots[0];
+    if (snapshot == null || phiSubjectUserId == null) {
+      return;
+    }
+
+    selectionOwnerUserIdRef.current = phiSubjectUserId;
+    pendingSeenSnapshotIdRef.current = snapshot.id;
+    chartRpcBoundsOverrideRef.current = {
+      p_from: snapshot.date_from,
+      p_to: snapshot.date_to,
+    };
+    setSharedSnapshotNote(snapshot.practitioner_note);
+    setSeries(
+      chartSnapshotDefinitionToSelectedSeries(snapshot.series_definition),
+    );
+    setDateRange(
+      chartSnapshotBoundsToInsightDateRange(
+        snapshot.date_from,
+        snapshot.date_to,
+      ),
+    );
+    setBucket(snapshot.bucket);
+    announce('Loading your practitioner’s shared chart.', {
+      politeness: 'polite',
+    });
+  }, [announce, phiSubjectUserId, unseenSnapshots]);
 
   useEffect(() => {
     const selectionOwnedByCurrentSubject =
@@ -277,6 +396,7 @@ export function InsightsClient() {
       series.every((item) =>
         manifest.some((row) => row.series_id === item.seriesId),
       );
+    const viewingSharedSnapshot = chartRpcBoundsOverrideRef.current != null;
 
     if (
       manifestLoading ||
@@ -284,7 +404,7 @@ export function InsightsClient() {
       phiSubjectUserId == null ||
       series.length === 0 ||
       !selectionOwnedByCurrentSubject ||
-      !selectionMatchesManifest
+      (!selectionMatchesManifest && !viewingSharedSnapshot)
     ) {
       chartLoadGenRef.current += 1;
       setChartLoading(false);
@@ -323,6 +443,29 @@ export function InsightsClient() {
         <p className="text-sm text-red-700 dark:text-red-300" role="alert">
           {phiScopeError}
         </p>
+      ) : null}
+
+      {viewingOwnInsights && unseenSnapshots.length > 0 ? (
+        <div
+          className="rounded-2xl border border-app-primary/30 bg-app-primary/5 p-4 shadow-soft ring-1 ring-app-primary/20"
+          role="region"
+          aria-label="Shared chart notification"
+        >
+          <button
+            type="button"
+            className="w-full rounded-lg text-left outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+            onClick={handleViewSharedChart}
+          >
+            <p className="text-base font-semibold text-app-ink">
+              Your practitioner shared a chart with you.
+            </p>
+            <p className="mt-1 text-sm text-app-muted">
+              {unseenSnapshots.length === 1
+                ? 'Tap to view the chart they selected.'
+                : `Tap to view the most recent of ${unseenSnapshots.length} shared charts.`}
+            </p>
+          </button>
+        </div>
       ) : null}
 
       {manifestLoading ? (
@@ -367,7 +510,10 @@ export function InsightsClient() {
               value={series}
               onChange={handleSeriesChange}
             />
-            <InsightDateRangePicker value={dateRange} onChange={setDateRange} />
+            <InsightDateRangePicker
+              value={dateRange}
+              onChange={handleDateRangeChange}
+            />
           </div>
 
           {showChartSection ? (
@@ -381,6 +527,20 @@ export function InsightsClient() {
               >
                 Chart
               </h3>
+
+              {sharedSnapshotNote ? (
+                <div
+                  className="rounded-lg border border-app-border bg-app-bg/80 px-4 py-3 text-sm text-app-ink"
+                  role="note"
+                >
+                  <p className="font-medium text-app-ink">
+                    Note from your practitioner
+                  </p>
+                  <p className="mt-1 whitespace-pre-wrap text-app-muted">
+                    {sharedSnapshotNote}
+                  </p>
+                </div>
+              ) : null}
 
               <div
                 role="group"
@@ -402,7 +562,7 @@ export function InsightsClient() {
                           ? 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-primary px-4 text-base font-semibold text-white shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
                           : 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
                       }
-                      onClick={() => setBucket(value)}
+                      onClick={() => handleBucketChange(value)}
                     >
                       {label}
                     </button>

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -489,7 +489,7 @@ export function InsightsClient() {
             </p>
             <p className="mt-1 text-sm text-app-muted">
               {unseenSnapshots.length === 1
-                ? 'Tap to view the chart they selected.'
+                ? 'Tap to view the chart your practitioner selected.'
                 : `Tap to view the most recent of ${unseenSnapshots.length} shared charts.`}
             </p>
           </button>

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -616,7 +616,11 @@ export function InsightsClient() {
                   showPatientTimeZoneNote={
                     showPatientTimeZoneNote || showSharedChartTimeZoneNote
                   }
-                  patientTimeZoneNoteUsesPatientLocal={false}
+                  patientTimeZoneNoteVariant={
+                    showSharedChartTimeZoneNote
+                      ? 'practitionerShared'
+                      : 'browser'
+                  }
                 />
               )}
             </section>

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -120,14 +120,18 @@ export function InsightsClient() {
   const [sharedSnapshotNote, setSharedSnapshotNote] = useState<string | null>(
     null,
   );
+  const [sharedSnapshotChartTimeZone, setSharedSnapshotChartTimeZone] =
+    useState<string | null>(null);
 
   const manifestLoadGenRef = useRef(0);
   const chartLoadGenRef = useRef(0);
   const unseenSnapshotsLoadGenRef = useRef(0);
   const pendingSeenSnapshotIdRef = useRef<string | null>(null);
+  /** Snapshot RPC bounds + timezone; set synchronously before series state updates. */
   const chartRpcBoundsOverrideRef = useRef<{
     p_from: string;
     p_to: string;
+    p_timezone: string;
   } | null>(null);
   const phiSubjectUserIdRef = useRef(phiSubjectUserId);
   phiSubjectUserIdRef.current = phiSubjectUserId;
@@ -149,6 +153,7 @@ export function InsightsClient() {
     setChartRows([]);
     setChartError(null);
     setSharedSnapshotNote(null);
+    setSharedSnapshotChartTimeZone(null);
   }, []);
 
   const handleSeriesChange = useCallback(
@@ -157,6 +162,7 @@ export function InsightsClient() {
       pendingSeenSnapshotIdRef.current = null;
       chartRpcBoundsOverrideRef.current = null;
       setSharedSnapshotNote(null);
+      setSharedSnapshotChartTimeZone(null);
       setSeries(next);
     },
     [phiSubjectUserId],
@@ -166,6 +172,7 @@ export function InsightsClient() {
     pendingSeenSnapshotIdRef.current = null;
     chartRpcBoundsOverrideRef.current = null;
     setSharedSnapshotNote(null);
+    setSharedSnapshotChartTimeZone(null);
     setDateRange(next);
   }, []);
 
@@ -173,8 +180,12 @@ export function InsightsClient() {
     pendingSeenSnapshotIdRef.current = null;
     chartRpcBoundsOverrideRef.current = null;
     setSharedSnapshotNote(null);
+    setSharedSnapshotChartTimeZone(null);
     setBucket(next);
   }, []);
+
+  const activeChartTimeZone = sharedSnapshotChartTimeZone ?? chartTimeZone;
+  const showSharedChartTimeZoneNote = sharedSnapshotChartTimeZone != null;
 
   const chartableManifest = useMemo(
     () => filterChartableManifestRows(manifest),
@@ -313,9 +324,9 @@ export function InsightsClient() {
     setChartError(null);
     announce('Loading chart data.', { politeness: 'polite' });
 
+    const rpcOverride = chartRpcBoundsOverrideRef.current;
     const { p_from, p_to } =
-      chartRpcBoundsOverrideRef.current ??
-      insightDateRangeToRpcBounds(dateRange);
+      rpcOverride ?? insightDateRangeToRpcBounds(dateRange);
     const supabase = createBrowserClient();
     const result = await getChartSeries(supabase, {
       p_user_id: requestedUserId,
@@ -323,7 +334,7 @@ export function InsightsClient() {
       p_from,
       p_to,
       p_bucket: bucket,
-      p_timezone: chartTimeZone,
+      p_timezone: rpcOverride?.p_timezone ?? chartTimeZone,
     });
 
     if (
@@ -370,11 +381,22 @@ export function InsightsClient() {
 
     selectionOwnerUserIdRef.current = phiSubjectUserId;
     pendingSeenSnapshotIdRef.current = snapshot.id;
+    const snapshotTimeZone = snapshot.chart_timezone?.trim() ?? null;
+    const snapshotChartTimeZone =
+      snapshotTimeZone != null && snapshotTimeZone.length > 0
+        ? snapshotTimeZone
+        : chartTimeZone;
     chartRpcBoundsOverrideRef.current = {
       p_from: snapshot.date_from,
       p_to: snapshot.date_to,
+      p_timezone: snapshotChartTimeZone,
     };
     setSharedSnapshotNote(snapshot.practitioner_note);
+    setSharedSnapshotChartTimeZone(
+      snapshotTimeZone != null && snapshotTimeZone.length > 0
+        ? snapshotTimeZone
+        : null,
+    );
     setSeries(
       chartSnapshotDefinitionToSelectedSeries(snapshot.series_definition),
     );
@@ -382,13 +404,14 @@ export function InsightsClient() {
       chartSnapshotBoundsToInsightDateRange(
         snapshot.date_from,
         snapshot.date_to,
+        snapshotTimeZone,
       ),
     );
     setBucket(snapshot.bucket);
     announce('Loading your practitioner’s shared chart.', {
       politeness: 'polite',
     });
-  }, [announce, phiSubjectUserId, unseenSnapshots]);
+  }, [announce, chartTimeZone, phiSubjectUserId, unseenSnapshots]);
 
   useEffect(() => {
     const selectionOwnedByCurrentSubject =
@@ -586,8 +609,10 @@ export function InsightsClient() {
                   bucket={bucket}
                   loading={chartLoading}
                   summary={chartSummary}
-                  patientTimeZone={chartTimeZone}
-                  showPatientTimeZoneNote={showPatientTimeZoneNote}
+                  patientTimeZone={activeChartTimeZone}
+                  showPatientTimeZoneNote={
+                    showPatientTimeZoneNote || showSharedChartTimeZoneNote
+                  }
                   patientTimeZoneNoteUsesPatientLocal={false}
                 />
               )}

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -212,14 +212,17 @@ export function InsightsClient() {
   );
 
   const loadUnseenSnapshots = useCallback(async () => {
-    if (!viewingOwnInsights) {
+    if (!viewingOwnInsights || phiSubjectUserId == null) {
       setUnseenSnapshots([]);
       return;
     }
 
     const generation = ++unseenSnapshotsLoadGenRef.current;
     const supabase = createBrowserClient();
-    const result = await listUnseenChartSnapshotsForPatient(supabase);
+    const result = await listUnseenChartSnapshotsForPatient(
+      supabase,
+      phiSubjectUserId,
+    );
 
     if (generation !== unseenSnapshotsLoadGenRef.current) {
       return;
@@ -231,7 +234,7 @@ export function InsightsClient() {
     }
 
     setUnseenSnapshots(result.data);
-  }, [viewingOwnInsights]);
+  }, [phiSubjectUserId, viewingOwnInsights]);
 
   const loadManifest = useCallback(async () => {
     if (phiSubjectUserId == null) {

--- a/apps/web/src/lib/insights/insight-chart-params.spec.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.spec.ts
@@ -1,4 +1,6 @@
 import {
+  chartSnapshotBoundsToInsightDateRange,
+  chartSnapshotDefinitionToSelectedSeries,
   formatInsightChartPageSummary,
   getDefaultInsightDateRange,
   insightDateRangeToRpcBounds,
@@ -43,6 +45,46 @@ describe('insight-chart-params', () => {
     expect(formatInsightChartPageSummary(['BAC readings'], range, 'day')).toBe(
       `BAC readings from ${fromLabel} to ${toLabel}, grouped by day`,
     );
+  });
+
+  it('round-trips snapshot RPC bounds to an inclusive date range', () => {
+    const range = {
+      from: new Date(2026, 3, 1),
+      to: new Date(2026, 3, 30),
+    };
+    const { p_from, p_to } = insightDateRangeToRpcBounds(range);
+    const restored = chartSnapshotBoundsToInsightDateRange(p_from, p_to);
+
+    expect(restored.from).toEqual(range.from);
+    expect(restored.to).toEqual(range.to);
+  });
+
+  it('maps snapshot series definition to selected series', () => {
+    expect(
+      chartSnapshotDefinitionToSelectedSeries([
+        {
+          seriesId: 'health_marker::bac',
+          seriesType: 'health_marker',
+          responseType: 'numeric',
+          isBloodPressure: false,
+          label: 'BAC',
+          unit: '%',
+          chartType: 'line',
+          color: '#1d4ed8',
+        },
+      ]),
+    ).toEqual([
+      {
+        seriesId: 'health_marker::bac',
+        seriesType: 'health_marker',
+        responseType: 'numeric',
+        isBloodPressure: false,
+        label: 'BAC',
+        unit: '%',
+        chartType: 'line',
+        color: '#1d4ed8',
+      },
+    ]);
   });
 
   it('maps selected series to RPC selections', () => {

--- a/apps/web/src/lib/insights/insight-chart-params.spec.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.spec.ts
@@ -59,6 +59,20 @@ describe('insight-chart-params', () => {
     expect(restored.to).toEqual(range.to);
   });
 
+  it('uses the snapshot chart timezone for calendar days, not the patient browser zone', () => {
+    const dateFrom = '2026-01-01T05:00:00.000Z';
+    const dateTo = '2026-02-01T05:00:00.000Z';
+
+    const restored = chartSnapshotBoundsToInsightDateRange(
+      dateFrom,
+      dateTo,
+      'America/New_York',
+    );
+
+    expect(restored.from).toEqual(new Date(2026, 0, 1, 0, 0, 0, 0));
+    expect(restored.to).toEqual(new Date(2026, 0, 31, 0, 0, 0, 0));
+  });
+
   it('normalizes snapshot bounds to local calendar midnights for the date picker', () => {
     const fromIso = new Date(2026, 3, 15, 14, 30, 0).toISOString();
     const toIso = new Date(2026, 4, 1, 9, 45, 0).toISOString();

--- a/apps/web/src/lib/insights/insight-chart-params.spec.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.spec.ts
@@ -59,6 +59,16 @@ describe('insight-chart-params', () => {
     expect(restored.to).toEqual(range.to);
   });
 
+  it('normalizes snapshot bounds to local calendar midnights for the date picker', () => {
+    const fromIso = new Date(2026, 3, 15, 14, 30, 0).toISOString();
+    const toIso = new Date(2026, 4, 1, 9, 45, 0).toISOString();
+
+    const restored = chartSnapshotBoundsToInsightDateRange(fromIso, toIso);
+
+    expect(restored.from).toEqual(new Date(2026, 3, 15, 0, 0, 0, 0));
+    expect(restored.to).toEqual(new Date(2026, 3, 30, 0, 0, 0, 0));
+  });
+
   it('maps snapshot series definition to selected series', () => {
     expect(
       chartSnapshotDefinitionToSelectedSeries([

--- a/apps/web/src/lib/insights/insight-chart-params.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.ts
@@ -1,4 +1,7 @@
-import type { ChartSeriesSelection } from '@abstrack/supabase';
+import type {
+  ChartSnapshotSeriesDefinition,
+  ChartSeriesSelection,
+} from '@abstrack/supabase';
 import type {
   InsightChartBucket,
   InsightDateRange,
@@ -100,4 +103,44 @@ export function formatInsightChartPageSummary(
   const fromLabel = dateFormatter.format(range.from);
   const toLabel = dateFormatter.format(range.to);
   return `${seriesPart} from ${fromLabel} to ${toLabel}, ${BUCKET_SUMMARY_LABEL[bucket]}`;
+}
+
+/**
+ * Converts stored snapshot bounds (`date_from` inclusive, `date_to` exclusive) to an
+ * {@link InsightDateRange} for the date picker and chart summary.
+ *
+ * @param dateFrom - Snapshot `date_from` (ISO).
+ * @param dateTo - Snapshot `date_to` exclusive end (ISO).
+ * @returns Inclusive local calendar range for the UI.
+ */
+export function chartSnapshotBoundsToInsightDateRange(
+  dateFrom: string,
+  dateTo: string,
+): InsightDateRange {
+  const from = new Date(dateFrom);
+  const toExclusive = new Date(dateTo);
+  const to = new Date(toExclusive);
+  to.setDate(to.getDate() - 1);
+  return { from, to };
+}
+
+/**
+ * Restores practitioner-shared {@link SelectedSeries} from `chart_snapshots.series_definition`.
+ *
+ * @param definition - Stored snapshot series rows.
+ * @returns Series selection for {@link InsightSeriesPicker} and {@link InsightComposedChart}.
+ */
+export function chartSnapshotDefinitionToSelectedSeries(
+  definition: ChartSnapshotSeriesDefinition[],
+): SelectedSeries[] {
+  return definition.map((item) => ({
+    seriesId: item.seriesId,
+    seriesType: item.seriesType,
+    responseType: item.responseType,
+    isBloodPressure: item.isBloodPressure,
+    label: item.label,
+    unit: item.unit,
+    chartType: item.chartType,
+    color: item.color,
+  }));
 }

--- a/apps/web/src/lib/insights/insight-chart-params.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.ts
@@ -106,8 +106,23 @@ export function formatInsightChartPageSummary(
 }
 
 /**
+ * Start of the local calendar day for an instant (matches {@link InsightDateRangePicker}).
+ *
+ * @param date - Input instant.
+ * @returns Local midnight on that calendar day.
+ */
+function toLocalCalendarDay(date: Date): Date {
+  const day = new Date(date);
+  day.setHours(0, 0, 0, 0);
+  return day;
+}
+
+/**
  * Converts stored snapshot bounds (`date_from` inclusive, `date_to` exclusive) to an
  * {@link InsightDateRange} for the date picker and chart summary.
+ *
+ * Returned dates are local midnights so {@link InsightDateRangePicker} normalization does
+ * not call `onChange` and clear an in-flight shared-snapshot restore.
  *
  * @param dateFrom - Snapshot `date_from` (ISO).
  * @param dateTo - Snapshot `date_to` exclusive end (ISO).
@@ -117,8 +132,8 @@ export function chartSnapshotBoundsToInsightDateRange(
   dateFrom: string,
   dateTo: string,
 ): InsightDateRange {
-  const from = new Date(dateFrom);
-  const toExclusive = new Date(dateTo);
+  const from = toLocalCalendarDay(new Date(dateFrom));
+  const toExclusive = toLocalCalendarDay(new Date(dateTo));
   const to = new Date(toExclusive);
   to.setDate(to.getDate() - 1);
   return { from, to };

--- a/apps/web/src/lib/insights/insight-chart-params.ts
+++ b/apps/web/src/lib/insights/insight-chart-params.ts
@@ -105,6 +105,12 @@ export function formatInsightChartPageSummary(
   return `${seriesPart} from ${fromLabel} to ${toLabel}, ${BUCKET_SUMMARY_LABEL[bucket]}`;
 }
 
+type CalendarDayParts = {
+  year: number;
+  month: number;
+  day: number;
+};
+
 /**
  * Start of the local calendar day for an instant (matches {@link InsightDateRangePicker}).
  *
@@ -118,24 +124,88 @@ function toLocalCalendarDay(date: Date): Date {
 }
 
 /**
+ * Calendar day parts for an instant in an IANA timezone.
+ *
+ * @param iso - ISO timestamp.
+ * @param timeZone - IANA timezone name.
+ * @returns Year, month (1–12), and day in that zone.
+ */
+function calendarDayPartsInTimeZone(
+  iso: string,
+  timeZone: string,
+): CalendarDayParts {
+  const formatter = new Intl.DateTimeFormat('en-US', {
+    timeZone,
+    year: 'numeric',
+    month: 'numeric',
+    day: 'numeric',
+  });
+  const parts = formatter.formatToParts(new Date(iso));
+  const year = Number(parts.find((part) => part.type === 'year')?.value);
+  const month = Number(parts.find((part) => part.type === 'month')?.value);
+  const day = Number(parts.find((part) => part.type === 'day')?.value);
+  return { year, month, day };
+}
+
+/**
+ * Builds a {@link Date} at local midnight using calendar components (for the date picker).
+ *
+ * @param parts - Calendar day in the practitioner's chart zone.
+ * @returns Local midnight with those Y/M/D fields.
+ */
+function calendarPartsToLocalDate(parts: CalendarDayParts): Date {
+  return new Date(parts.year, parts.month - 1, parts.day);
+}
+
+/**
+ * Previous calendar day (local date arithmetic on Y/M/D components).
+ *
+ * @param parts - Starting calendar day.
+ * @returns Previous day.
+ */
+function previousCalendarDay(parts: CalendarDayParts): CalendarDayParts {
+  const date = new Date(parts.year, parts.month - 1, parts.day);
+  date.setDate(date.getDate() - 1);
+  return {
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    day: date.getDate(),
+  };
+}
+
+/**
  * Converts stored snapshot bounds (`date_from` inclusive, `date_to` exclusive) to an
  * {@link InsightDateRange} for the date picker and chart summary.
  *
- * Returned dates are local midnights so {@link InsightDateRangePicker} normalization does
- * not call `onChange` and clear an in-flight shared-snapshot restore.
+ * When `chartTimeZone` is set, calendar days match the practitioner's chart zone (not the
+ * patient's current browser zone). Returned dates are local midnights so
+ * {@link InsightDateRangePicker} normalization does not clear an in-flight restore.
  *
  * @param dateFrom - Snapshot `date_from` (ISO).
  * @param dateTo - Snapshot `date_to` exclusive end (ISO).
+ * @param chartTimeZone - IANA zone from `chart_snapshots.chart_timezone`; omit for legacy rows.
  * @returns Inclusive local calendar range for the UI.
  */
 export function chartSnapshotBoundsToInsightDateRange(
   dateFrom: string,
   dateTo: string,
+  chartTimeZone?: string | null,
 ): InsightDateRange {
-  const from = toLocalCalendarDay(new Date(dateFrom));
-  const toExclusive = toLocalCalendarDay(new Date(dateTo));
-  const to = new Date(toExclusive);
-  to.setDate(to.getDate() - 1);
+  const trimmedZone = chartTimeZone?.trim();
+  if (trimmedZone == null || trimmedZone.length === 0) {
+    const from = toLocalCalendarDay(new Date(dateFrom));
+    const toExclusive = toLocalCalendarDay(new Date(dateTo));
+    const to = new Date(toExclusive);
+    to.setDate(to.getDate() - 1);
+    return { from, to };
+  }
+
+  const from = calendarPartsToLocalDate(
+    calendarDayPartsInTimeZone(dateFrom, trimmedZone),
+  );
+  const to = calendarPartsToLocalDate(
+    previousCalendarDay(calendarDayPartsInTimeZone(dateTo, trimmedZone)),
+  );
   return { from, to };
 }
 

--- a/docs/SUPABASE_CLOUD_DEVELOPER.md
+++ b/docs/SUPABASE_CLOUD_DEVELOPER.md
@@ -124,9 +124,12 @@ SELECT public.delete_chart_snapshots_maintenance(
 -- All rows: (NULL, NULL)
 ```
 
-If delete still fails with `chart_snapshots rows cannot be deleted`, the session is not trusted (for example Studio Table Editor as `dashboard_user`). Use **SQL Editor**, not Table Editor.
+If cleanup from an app or Studio session fails, check the exact error from `chart_snapshots_append_only_guard`:
 
-**Before the migration is on cloud:** `chart_snapshots` does not exist yet (or an older trigger blocks all deletes). Finish review on the migration file, then `db push` once before relying on the commands above.
+- **Untrusted `DELETE`:** `chart_snapshots is append-only` (hint: _Use the SQL Editor as postgres, or call delete_chart_snapshots_maintenance from a trusted session._). The session is not trusted—for example Table Editor as `dashboard_user`. Use **SQL Editor** as `postgres`, not Table Editor.
+- **Untrusted `UPDATE`:** `chart_snapshots is append-only except seen_by_patient_at` (patients may only mark seen via `mark_chart_snapshot_seen`).
+
+**Before the migration is on cloud:** `chart_snapshots` does not exist yet (or migration `20260524130000` still blocks all `DELETE` with `chart_snapshots is append-only`). Finish review on the migration file, then `db push` once before relying on the commands above.
 
 ---
 

--- a/docs/SUPABASE_CLOUD_DEVELOPER.md
+++ b/docs/SUPABASE_CLOUD_DEVELOPER.md
@@ -90,6 +90,46 @@ Supabase records **which migration versions** have been applied. **Deleting rows
 
 ---
 
+## Dev cleanup: `chart_snapshots` (cloud SQL Editor)
+
+Migration **`20260524140000_chart_snapshots.sql`** makes shares **append-only for app clients** (`authenticated` has no `DELETE`). During development you will still need to remove test shares on **Supabase Cloud**.
+
+**Use the dashboard SQL Editor** on your linked project (runs as `postgres`, a **trusted** session per `profiles_trusted_session_for_app_role()`). Table Editor may still refuse delete depending on which role Studio uses; SQL Editor is the supported cleanup path.
+
+After that migration is applied to cloud (`db push`), run one of the following in **SQL Editor**:
+
+```sql
+-- One snapshot
+DELETE FROM public.chart_snapshots
+WHERE id = '00000000-0000-0000-0000-000000000000';
+
+-- All shares for one patient
+DELETE FROM public.chart_snapshots
+WHERE patient_user_id = '00000000-0000-0000-0000-000000000000';
+
+-- All rows (throwaway dev only)
+DELETE FROM public.chart_snapshots;
+```
+
+Or use the maintenance helper from the same migration (trusted sessions only; not granted to `authenticated`):
+
+```sql
+-- Returns number of rows deleted
+SELECT public.delete_chart_snapshots_maintenance(
+  '00000000-0000-0000-0000-000000000000'::uuid,  -- p_snapshot_id (or NULL)
+  NULL::uuid                                       -- p_patient_user_id (or NULL)
+);
+
+-- All rows for a patient: (NULL, patient_user_id)
+-- All rows: (NULL, NULL)
+```
+
+If delete still fails with `chart_snapshots rows cannot be deleted`, the session is not trusted (for example Studio Table Editor as `dashboard_user`). Use **SQL Editor**, not Table Editor.
+
+**Before the migration is on cloud:** `chart_snapshots` does not exist yet (or an older trigger blocks all deletes). Finish review on the migration file, then `db push` once before relying on the commands above.
+
+---
+
 ## If you skip local `db push` before merge
 
 Then the migration hits cloud when **CI runs `db push` on `main`** after merge. **`gen types --linked`** only works **after** that. You would need to **regenerate types and commit** in a **follow-up** commit (or PR) unless the [PR types workflow](../.github/workflows/supabase-db-types-pr.yml) already forced an updated file via its Docker-based check.
@@ -427,3 +467,4 @@ Repository secrets are documented under **[DEV_SETUP.md → PowerSync sync confi
 | PowerSync sync YAML on `main` | [`.github/workflows/powersync-sync-config.yml`](../.github/workflows/powersync-sync-config.yml)    |
 | PR types check                | [`.github/workflows/supabase-db-types-pr.yml`](../.github/workflows/supabase-db-types-pr.yml)      |
 | App env vars                  | [`packages/supabase/README.md`](../packages/supabase/README.md), [`.env.example`](../.env.example) |
+| `chart_snapshots` dev cleanup | **Dev cleanup: `chart_snapshots`** (above); migration `20260524140000_chart_snapshots.sql`         |

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -203,11 +203,13 @@ export type {
 } from './lib/chart-series-query.js';
 export { getChartSeries } from './lib/chart-series-query.js';
 export type {
+  ChartSnapshotRow,
   ChartSnapshotSeriesDefinition,
   ShareChartSnapshotParams,
 } from './lib/chart-snapshots-query.js';
 export {
   CHART_SNAPSHOT_PRACTITIONER_NOTE_MAX_LENGTH,
+  listUnseenChartSnapshotsForPatient,
   markChartSnapshotSeen,
   shareChartSnapshot,
 } from './lib/chart-snapshots-query.js';

--- a/packages/supabase/src/lib/chart-snapshots-db-types.ts
+++ b/packages/supabase/src/lib/chart-snapshots-db-types.ts
@@ -1,0 +1,52 @@
+import type { Database } from './database.types.js';
+
+type GeneratedShareChartSnapshotArgs =
+  Database['public']['Functions']['share_chart_snapshot']['Args'];
+
+/**
+ * PostgREST / RPC args for `public.share_chart_snapshot` after migration
+ * `20260524140000_chart_snapshots.sql` (`p_chart_timezone`).
+ *
+ * Until `supabase gen types typescript --linked` includes this arg on the generated
+ * `Database` type, callers should build payloads as this type and pass them through
+ * {@link asGeneratedShareChartSnapshotRpcArgs} at the `client.rpc` boundary.
+ */
+export type ShareChartSnapshotRpcArgs = GeneratedShareChartSnapshotArgs & {
+  p_chart_timezone: string;
+};
+
+type GeneratedChartSnapshotsRow =
+  Database['public']['Tables']['chart_snapshots']['Row'];
+
+/**
+ * `public.chart_snapshots` row including `chart_timezone` (migration `20260524140000`).
+ *
+ * Use for `.from('chart_snapshots').select(...)` results until generated types catch up.
+ */
+export type ChartSnapshotsRowDb = GeneratedChartSnapshotsRow & {
+  chart_timezone: string | null;
+};
+
+/** Column list for patient unseen snapshot queries (includes `chart_timezone`). */
+export const CHART_SNAPSHOT_LIST_SELECT =
+  'id, patient_user_id, practitioner_user_id, series_definition, date_from, date_to, bucket, practitioner_note, chart_timezone, created_at, seen_by_patient_at' as const;
+
+/**
+ * Same columns as {@link CHART_SNAPSHOT_LIST_SELECT}, widened for `.select()` until generated
+ * types include `chart_snapshots.chart_timezone` (avoids `SelectQueryError` at compile time).
+ */
+export const CHART_SNAPSHOT_LIST_SELECT_FOR_QUERY: string =
+  CHART_SNAPSHOT_LIST_SELECT;
+
+/**
+ * Narrows {@link ShareChartSnapshotRpcArgs} for `AbstrackSupabaseClient.rpc` until
+ * `database.types.ts` is regenerated.
+ *
+ * @param args - Full RPC payload including `p_chart_timezone`.
+ * @returns Value typed for the current generated `share_chart_snapshot` Args.
+ */
+export function asGeneratedShareChartSnapshotRpcArgs(
+  args: ShareChartSnapshotRpcArgs,
+): GeneratedShareChartSnapshotArgs {
+  return args as GeneratedShareChartSnapshotArgs;
+}

--- a/packages/supabase/src/lib/chart-snapshots-query.spec.ts
+++ b/packages/supabase/src/lib/chart-snapshots-query.spec.ts
@@ -1,16 +1,20 @@
+import type { Uuid } from '@abstrack/types';
 import { describe, expect, it, vi } from 'vitest';
+import { PresetDataError } from './preset-data-error.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 import {
-  CHART_SNAPSHOT_PRACTITIONER_NOTE_MAX_LENGTH,
   markChartSnapshotSeen,
   shareChartSnapshot,
   type ChartSnapshotSeriesDefinition,
+  type ShareChartSnapshotParams,
 } from './chart-snapshots-query.js';
 
-const PATIENT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
-const SNAPSHOT_ID = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const PATIENT_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' as Uuid;
+const SNAPSHOT_ID = 'bbbbbbbb-bbbb-cccc-dddd-ffffffffffff' as Uuid;
+const DATE_FROM = '2026-01-01T05:00:00.000Z';
+const DATE_TO = '2026-02-01T05:00:00.000Z';
 
-const SERIES: ChartSnapshotSeriesDefinition[] = [
+const SERIES_DEFINITION: ChartSnapshotSeriesDefinition[] = [
   {
     seriesId: 'health_marker::bac',
     seriesType: 'health_marker',
@@ -19,83 +23,97 @@ const SERIES: ChartSnapshotSeriesDefinition[] = [
     label: 'BAC',
     unit: '%',
     chartType: 'line',
-    color: '#2563eb',
+    color: '#1d4ed8',
   },
 ];
 
-function rpcClient(
-  data: unknown,
-  error: { message: string } | null = null,
-): AbstrackSupabaseClient {
-  return {
-    rpc: vi.fn().mockResolvedValue({ data, error }),
-  } as unknown as AbstrackSupabaseClient;
-}
+const SHARE_PARAMS: ShareChartSnapshotParams = {
+  patientUserId: PATIENT_ID,
+  seriesDefinition: SERIES_DEFINITION,
+  dateFrom: DATE_FROM,
+  dateTo: DATE_TO,
+  bucket: 'week',
+  practitionerNote: '  Check this trend  ',
+};
 
 describe('shareChartSnapshot', () => {
-  it('calls share_chart_snapshot RPC with expected payload', async () => {
-    const client = rpcClient(SNAPSHOT_ID);
+  it('calls share_chart_snapshot RPC with snake_case payload', async () => {
+    const rpc = vi.fn(async () => ({ data: SNAPSHOT_ID, error: null }));
+    const client = { rpc } as unknown as AbstrackSupabaseClient;
+
+    await shareChartSnapshot(client, SHARE_PARAMS);
+
+    expect(rpc).toHaveBeenCalledWith('share_chart_snapshot', {
+      p_patient_user_id: PATIENT_ID,
+      p_series_definition: SERIES_DEFINITION,
+      p_date_from: DATE_FROM,
+      p_date_to: DATE_TO,
+      p_bucket: 'week',
+      p_practitioner_note: 'Check this trend',
+    });
+  });
+
+  it('omits practitioner note when blank after trim', async () => {
+    const rpc = vi.fn(async () => ({ data: SNAPSHOT_ID, error: null }));
+    const client = { rpc } as unknown as AbstrackSupabaseClient;
 
     await shareChartSnapshot(client, {
-      patientUserId: PATIENT_ID,
-      seriesDefinition: SERIES,
-      dateFrom: '2026-04-01T00:00:00.000Z',
-      dateTo: '2026-05-01T00:00:00.000Z',
-      bucket: 'day',
-      practitionerNote: '  Trend looks stable.  ',
+      ...SHARE_PARAMS,
+      practitionerNote: '   ',
     });
 
-    expect(client.rpc).toHaveBeenCalledWith('share_chart_snapshot', {
+    expect(rpc).toHaveBeenCalledWith('share_chart_snapshot', {
       p_patient_user_id: PATIENT_ID,
-      p_series_definition: SERIES,
-      p_date_from: '2026-04-01T00:00:00.000Z',
-      p_date_to: '2026-05-01T00:00:00.000Z',
-      p_bucket: 'day',
-      p_practitioner_note: 'Trend looks stable.',
+      p_series_definition: SERIES_DEFINITION,
+      p_date_from: DATE_FROM,
+      p_date_to: DATE_TO,
+      p_bucket: 'week',
+      p_practitioner_note: undefined,
     });
   });
 
-  it('rejects practitioner notes longer than the database limit', async () => {
-    const client = rpcClient(SNAPSHOT_ID);
-    const tooLong = 'x'.repeat(CHART_SNAPSHOT_PRACTITIONER_NOTE_MAX_LENGTH + 1);
+  it('returns ok: false when rpc returns an error', async () => {
+    const rpc = vi.fn(async () => ({
+      data: null,
+      error: { message: 'permission denied for function share_chart_snapshot' },
+    }));
+    const client = { rpc } as unknown as AbstrackSupabaseClient;
 
-    const result = await shareChartSnapshot(client, {
-      patientUserId: PATIENT_ID,
-      seriesDefinition: SERIES,
-      dateFrom: '2026-04-01T00:00:00.000Z',
-      dateTo: '2026-05-01T00:00:00.000Z',
-      bucket: 'day',
-      practitionerNote: tooLong,
-    });
+    const result = await shareChartSnapshot(client, SHARE_PARAMS);
 
     expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error.code).toBe('validation_error');
+    if (result.ok) {
+      return;
     }
-    expect(client.rpc).not.toHaveBeenCalled();
-  });
 
-  it('returns snapshot id on success', async () => {
-    const result = await shareChartSnapshot(rpcClient(SNAPSHOT_ID), {
-      patientUserId: PATIENT_ID,
-      seriesDefinition: SERIES,
-      dateFrom: '2026-04-01T00:00:00.000Z',
-      dateTo: '2026-05-01T00:00:00.000Z',
-      bucket: 'week',
-    });
-
-    expect(result).toEqual({ ok: true, data: SNAPSHOT_ID });
+    expect(result.error).toBeInstanceOf(PresetDataError);
+    expect(result.error.code).toBe('permission_denied');
   });
 });
 
 describe('markChartSnapshotSeen', () => {
   it('calls mark_chart_snapshot_seen RPC with snapshot id', async () => {
-    const client = rpcClient(true);
+    const rpc = vi.fn(async () => ({ data: true, error: null }));
+    const client = { rpc } as unknown as AbstrackSupabaseClient;
 
     await markChartSnapshotSeen(client, SNAPSHOT_ID);
 
-    expect(client.rpc).toHaveBeenCalledWith('mark_chart_snapshot_seen', {
+    expect(rpc).toHaveBeenCalledWith('mark_chart_snapshot_seen', {
       p_snapshot_id: SNAPSHOT_ID,
     });
+  });
+
+  it('returns boolean from RPC data', async () => {
+    const rpc = vi.fn(async () => ({ data: false, error: null }));
+    const client = { rpc } as unknown as AbstrackSupabaseClient;
+
+    const result = await markChartSnapshotSeen(client, SNAPSHOT_ID);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.data).toBe(false);
   });
 });

--- a/packages/supabase/src/lib/chart-snapshots-query.spec.ts
+++ b/packages/supabase/src/lib/chart-snapshots-query.spec.ts
@@ -35,11 +35,12 @@ const SHARE_PARAMS: ShareChartSnapshotParams = {
   dateFrom: DATE_FROM,
   dateTo: DATE_TO,
   bucket: 'week',
+  chartTimezone: 'America/New_York',
   practitionerNote: '  Check this trend  ',
 };
 
 const CHART_SNAPSHOTS_SELECT =
-  'id, patient_user_id, practitioner_user_id, series_definition, date_from, date_to, bucket, practitioner_note, created_at, seen_by_patient_at';
+  'id, patient_user_id, practitioner_user_id, series_definition, date_from, date_to, bucket, practitioner_note, chart_timezone, created_at, seen_by_patient_at';
 
 const UNSEEN_SNAPSHOT_ROW: ChartSnapshotRow = {
   id: SNAPSHOT_ID,
@@ -50,6 +51,7 @@ const UNSEEN_SNAPSHOT_ROW: ChartSnapshotRow = {
   date_to: DATE_TO,
   bucket: 'week',
   practitioner_note: 'Check this trend',
+  chart_timezone: 'America/New_York',
   created_at: '2026-05-01T12:00:00.000Z',
   seen_by_patient_at: null,
 };
@@ -143,6 +145,7 @@ describe('shareChartSnapshot', () => {
       p_date_to: DATE_TO,
       p_bucket: 'week',
       p_practitioner_note: 'Check this trend',
+      p_chart_timezone: 'America/New_York',
     });
   });
 
@@ -162,6 +165,7 @@ describe('shareChartSnapshot', () => {
       p_date_to: DATE_TO,
       p_bucket: 'week',
       p_practitioner_note: undefined,
+      p_chart_timezone: 'America/New_York',
     });
   });
 

--- a/packages/supabase/src/lib/chart-snapshots-query.spec.ts
+++ b/packages/supabase/src/lib/chart-snapshots-query.spec.ts
@@ -3,8 +3,10 @@ import { describe, expect, it, vi } from 'vitest';
 import { PresetDataError } from './preset-data-error.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 import {
+  listUnseenChartSnapshotsForPatient,
   markChartSnapshotSeen,
   shareChartSnapshot,
+  type ChartSnapshotRow,
   type ChartSnapshotSeriesDefinition,
   type ShareChartSnapshotParams,
 } from './chart-snapshots-query.js';
@@ -35,6 +37,97 @@ const SHARE_PARAMS: ShareChartSnapshotParams = {
   bucket: 'week',
   practitionerNote: '  Check this trend  ',
 };
+
+const CHART_SNAPSHOTS_SELECT =
+  'id, patient_user_id, practitioner_user_id, series_definition, date_from, date_to, bucket, practitioner_note, created_at, seen_by_patient_at';
+
+const UNSEEN_SNAPSHOT_ROW: ChartSnapshotRow = {
+  id: SNAPSHOT_ID,
+  patient_user_id: PATIENT_ID,
+  practitioner_user_id: 'cccccccc-bbbb-cccc-dddd-111111111111',
+  series_definition: SERIES_DEFINITION,
+  date_from: DATE_FROM,
+  date_to: DATE_TO,
+  bucket: 'week',
+  practitioner_note: 'Check this trend',
+  created_at: '2026-05-01T12:00:00.000Z',
+  seen_by_patient_at: null,
+};
+
+function chartSnapshotsQueryClient(
+  rows: ChartSnapshotRow[] | null,
+  error: { message: string } | null = null,
+) {
+  const order = vi.fn(async () => ({ data: rows, error }));
+  const is = vi.fn(() => ({ order }));
+  const select = vi.fn(() => ({ is }));
+  const from = vi.fn(() => ({ select }));
+
+  return {
+    client: { from } as unknown as AbstrackSupabaseClient,
+    from,
+    select,
+    is,
+    order,
+  };
+}
+
+describe('listUnseenChartSnapshotsForPatient', () => {
+  it('queries chart_snapshots for unseen rows newest first', async () => {
+    const { client, from, select, is, order } = chartSnapshotsQueryClient([
+      UNSEEN_SNAPSHOT_ROW,
+    ]);
+
+    await listUnseenChartSnapshotsForPatient(client);
+
+    expect(from).toHaveBeenCalledWith('chart_snapshots');
+    expect(select).toHaveBeenCalledWith(CHART_SNAPSHOTS_SELECT);
+    expect(is).toHaveBeenCalledWith('seen_by_patient_at', null);
+    expect(order).toHaveBeenCalledWith('created_at', { ascending: false });
+  });
+
+  it('returns query rows on success', async () => {
+    const { client } = chartSnapshotsQueryClient([UNSEEN_SNAPSHOT_ROW]);
+
+    const result = await listUnseenChartSnapshotsForPatient(client);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.data).toEqual([UNSEEN_SNAPSHOT_ROW]);
+  });
+
+  it('returns an empty array when data is null', async () => {
+    const { client } = chartSnapshotsQueryClient(null);
+
+    const result = await listUnseenChartSnapshotsForPatient(client);
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) {
+      return;
+    }
+
+    expect(result.data).toEqual([]);
+  });
+
+  it('returns ok: false when the query returns an error', async () => {
+    const { client } = chartSnapshotsQueryClient(null, {
+      message: 'permission denied for table chart_snapshots',
+    });
+
+    const result = await listUnseenChartSnapshotsForPatient(client);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error).toBeInstanceOf(PresetDataError);
+    expect(result.error.code).toBe('permission_denied');
+  });
+});
 
 describe('shareChartSnapshot', () => {
   it('calls share_chart_snapshot RPC with snake_case payload', async () => {

--- a/packages/supabase/src/lib/chart-snapshots-query.spec.ts
+++ b/packages/supabase/src/lib/chart-snapshots-query.spec.ts
@@ -62,13 +62,15 @@ function chartSnapshotsQueryClient(
 ) {
   const order = vi.fn(async () => ({ data: rows, error }));
   const is = vi.fn(() => ({ order }));
-  const select = vi.fn(() => ({ is }));
+  const eq = vi.fn(() => ({ is }));
+  const select = vi.fn(() => ({ eq }));
   const from = vi.fn(() => ({ select }));
 
   return {
     client: { from } as unknown as AbstrackSupabaseClient,
     from,
     select,
+    eq,
     is,
     order,
   };
@@ -76,14 +78,15 @@ function chartSnapshotsQueryClient(
 
 describe('listUnseenChartSnapshotsForPatient', () => {
   it('queries chart_snapshots for unseen rows newest first', async () => {
-    const { client, from, select, is, order } = chartSnapshotsQueryClient([
+    const { client, from, select, eq, is, order } = chartSnapshotsQueryClient([
       UNSEEN_SNAPSHOT_ROW,
     ]);
 
-    await listUnseenChartSnapshotsForPatient(client);
+    await listUnseenChartSnapshotsForPatient(client, PATIENT_ID);
 
     expect(from).toHaveBeenCalledWith('chart_snapshots');
     expect(select).toHaveBeenCalledWith(CHART_SNAPSHOTS_SELECT);
+    expect(eq).toHaveBeenCalledWith('patient_user_id', PATIENT_ID);
     expect(is).toHaveBeenCalledWith('seen_by_patient_at', null);
     expect(order).toHaveBeenCalledWith('created_at', { ascending: false });
   });
@@ -91,7 +94,7 @@ describe('listUnseenChartSnapshotsForPatient', () => {
   it('returns query rows on success', async () => {
     const { client } = chartSnapshotsQueryClient([UNSEEN_SNAPSHOT_ROW]);
 
-    const result = await listUnseenChartSnapshotsForPatient(client);
+    const result = await listUnseenChartSnapshotsForPatient(client, PATIENT_ID);
 
     expect(result.ok).toBe(true);
     if (!result.ok) {
@@ -104,7 +107,7 @@ describe('listUnseenChartSnapshotsForPatient', () => {
   it('returns an empty array when data is null', async () => {
     const { client } = chartSnapshotsQueryClient(null);
 
-    const result = await listUnseenChartSnapshotsForPatient(client);
+    const result = await listUnseenChartSnapshotsForPatient(client, PATIENT_ID);
 
     expect(result.ok).toBe(true);
     if (!result.ok) {
@@ -119,7 +122,7 @@ describe('listUnseenChartSnapshotsForPatient', () => {
       message: 'permission denied for table chart_snapshots',
     });
 
-    const result = await listUnseenChartSnapshotsForPatient(client);
+    const result = await listUnseenChartSnapshotsForPatient(client, PATIENT_ID);
 
     expect(result.ok).toBe(false);
     if (result.ok) {

--- a/packages/supabase/src/lib/chart-snapshots-query.ts
+++ b/packages/supabase/src/lib/chart-snapshots-query.ts
@@ -21,7 +21,7 @@ export interface ChartSnapshotRow {
   date_to: string;
   bucket: ChartSeriesBucket;
   practitioner_note: string | null;
-  /** IANA zone from the practitioner chart builder; null on legacy rows. */
+  /** IANA zone from the practitioner chart builder; null only if stored before timezone was required. */
   chart_timezone: string | null;
   created_at: string;
   seen_by_patient_at: string | null;

--- a/packages/supabase/src/lib/chart-snapshots-query.ts
+++ b/packages/supabase/src/lib/chart-snapshots-query.ts
@@ -5,6 +5,20 @@ import { PresetDataError, toPresetDataError } from './preset-data-error.js';
 import type { PresetDataResult } from './preset-data.js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
+/** One `chart_snapshots` row (patient or practitioner SELECT via RLS). */
+export interface ChartSnapshotRow {
+  id: Uuid;
+  patient_user_id: Uuid;
+  practitioner_user_id: Uuid;
+  series_definition: ChartSnapshotSeriesDefinition[];
+  date_from: string;
+  date_to: string;
+  bucket: ChartSeriesBucket;
+  practitioner_note: string | null;
+  created_at: string;
+  seen_by_patient_at: string | null;
+}
+
 /** Matches `chart_snapshots_practitioner_note_len` (`char_length(practitioner_note) <= 16000`). */
 export const CHART_SNAPSHOT_PRACTITIONER_NOTE_MAX_LENGTH = 16_000;
 
@@ -97,6 +111,37 @@ export async function shareChartSnapshot(
     }
 
     return { ok: true, data };
+  } catch (cause) {
+    return { ok: false, error: toPresetDataError(cause) };
+  }
+}
+
+/**
+ * Lists unseen chart snapshots for the signed-in patient (`seen_by_patient_at IS NULL`).
+ *
+ * @param client - Supabase client with the patient JWT.
+ * @returns Newest-first unseen rows (RLS limits to `patient_user_id = auth.uid()`).
+ */
+export async function listUnseenChartSnapshotsForPatient(
+  client: AbstrackSupabaseClient,
+): Promise<PresetDataResult<ChartSnapshotRow[]>> {
+  try {
+    const { data, error } = await client
+      .from('chart_snapshots')
+      .select(
+        'id, patient_user_id, practitioner_user_id, series_definition, date_from, date_to, bucket, practitioner_note, created_at, seen_by_patient_at',
+      )
+      .is('seen_by_patient_at', null)
+      .order('created_at', { ascending: false });
+
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+
+    return {
+      ok: true,
+      data: (data ?? []) as unknown as ChartSnapshotRow[],
+    };
   } catch (cause) {
     return { ok: false, error: toPresetDataError(cause) };
   }

--- a/packages/supabase/src/lib/chart-snapshots-query.ts
+++ b/packages/supabase/src/lib/chart-snapshots-query.ts
@@ -1,5 +1,11 @@
 import type { Uuid } from '@abstrack/types';
 import type { Json } from './database.types.js';
+import {
+  asGeneratedShareChartSnapshotRpcArgs,
+  CHART_SNAPSHOT_LIST_SELECT_FOR_QUERY,
+  type ChartSnapshotsRowDb,
+  type ShareChartSnapshotRpcArgs,
+} from './chart-snapshots-db-types.js';
 import type { ChartSeriesBucket } from './chart-series-query.js';
 import { PresetDataError, toPresetDataError } from './preset-data-error.js';
 import type { PresetDataResult } from './preset-data.js';
@@ -92,7 +98,7 @@ export async function shareChartSnapshot(
   }
 
   try {
-    const { data, error } = await client.rpc('share_chart_snapshot', {
+    const rpcArgs: ShareChartSnapshotRpcArgs = {
       p_patient_user_id: params.patientUserId,
       p_series_definition: params.seriesDefinition as unknown as Json,
       p_date_from: params.dateFrom,
@@ -100,7 +106,11 @@ export async function shareChartSnapshot(
       p_bucket: params.bucket,
       p_practitioner_note: practitionerNote ?? undefined,
       p_chart_timezone: params.chartTimezone,
-    });
+    };
+    const { data, error } = await client.rpc(
+      'share_chart_snapshot',
+      asGeneratedShareChartSnapshotRpcArgs(rpcArgs),
+    );
 
     if (error) {
       return { ok: false, error: toPresetDataError(error) };
@@ -122,20 +132,24 @@ export async function shareChartSnapshot(
 }
 
 /**
- * Lists unseen chart snapshots for the signed-in patient (`seen_by_patient_at IS NULL`).
+ * Lists unseen chart snapshots for a patient (`seen_by_patient_at IS NULL`).
+ *
+ * Filters explicitly on `patient_user_id` because RLS also allows practitioners to
+ * select snapshots they created.
  *
  * @param client - Supabase client with the patient JWT.
- * @returns Newest-first unseen rows (RLS limits to `patient_user_id = auth.uid()`).
+ * @param patientUserId - Patient subject id (`chart_snapshots.patient_user_id`).
+ * @returns Newest-first unseen rows for that patient.
  */
 export async function listUnseenChartSnapshotsForPatient(
   client: AbstrackSupabaseClient,
+  patientUserId: Uuid,
 ): Promise<PresetDataResult<ChartSnapshotRow[]>> {
   try {
     const { data, error } = await client
       .from('chart_snapshots')
-      .select(
-        'id, patient_user_id, practitioner_user_id, series_definition, date_from, date_to, bucket, practitioner_note, chart_timezone, created_at, seen_by_patient_at',
-      )
+      .select(CHART_SNAPSHOT_LIST_SELECT_FOR_QUERY)
+      .eq('patient_user_id', patientUserId)
       .is('seen_by_patient_at', null)
       .order('created_at', { ascending: false });
 
@@ -143,9 +157,11 @@ export async function listUnseenChartSnapshotsForPatient(
       return { ok: false, error: toPresetDataError(error) };
     }
 
+    const rows = (data ?? []) as unknown as ChartSnapshotsRowDb[];
+
     return {
       ok: true,
-      data: (data ?? []) as unknown as ChartSnapshotRow[],
+      data: rows as unknown as ChartSnapshotRow[],
     };
   } catch (cause) {
     return { ok: false, error: toPresetDataError(cause) };

--- a/packages/supabase/src/lib/chart-snapshots-query.ts
+++ b/packages/supabase/src/lib/chart-snapshots-query.ts
@@ -21,7 +21,7 @@ export interface ChartSnapshotRow {
   date_to: string;
   bucket: ChartSeriesBucket;
   practitioner_note: string | null;
-  /** IANA zone from the practitioner chart builder; null only if stored before timezone was required. */
+  /** IANA zone from the practitioner chart builder; null only on rows created before chart_timezone was required. */
   chart_timezone: string | null;
   created_at: string;
   seen_by_patient_at: string | null;

--- a/packages/supabase/src/lib/chart-snapshots-query.ts
+++ b/packages/supabase/src/lib/chart-snapshots-query.ts
@@ -15,6 +15,8 @@ export interface ChartSnapshotRow {
   date_to: string;
   bucket: ChartSeriesBucket;
   practitioner_note: string | null;
+  /** IANA zone from the practitioner chart builder; null on legacy rows. */
+  chart_timezone: string | null;
   created_at: string;
   seen_by_patient_at: string | null;
 }
@@ -56,6 +58,8 @@ export interface ShareChartSnapshotParams {
   /** Exclusive range end (ISO timestamp). */
   dateTo: string;
   bucket: ChartSeriesBucket;
+  /** IANA timezone used for date range and get_chart_series bucketing. */
+  chartTimezone: string;
   practitionerNote?: string | null;
 }
 
@@ -95,6 +99,7 @@ export async function shareChartSnapshot(
       p_date_to: params.dateTo,
       p_bucket: params.bucket,
       p_practitioner_note: practitionerNote ?? undefined,
+      p_chart_timezone: params.chartTimezone,
     });
 
     if (error) {
@@ -129,7 +134,7 @@ export async function listUnseenChartSnapshotsForPatient(
     const { data, error } = await client
       .from('chart_snapshots')
       .select(
-        'id, patient_user_id, practitioner_user_id, series_definition, date_from, date_to, bucket, practitioner_note, created_at, seen_by_patient_at',
+        'id, patient_user_id, practitioner_user_id, series_definition, date_from, date_to, bucket, practitioner_note, chart_timezone, created_at, seen_by_patient_at',
       )
       .is('seen_by_patient_at', null)
       .order('created_at', { ascending: false });

--- a/packages/supabase/src/lib/database.types.ts
+++ b/packages/supabase/src/lib/database.types.ts
@@ -113,6 +113,7 @@ export type Database = {
       chart_snapshots: {
         Row: {
           bucket: string
+          chart_timezone: string | null
           created_at: string
           date_from: string
           date_to: string
@@ -125,6 +126,7 @@ export type Database = {
         }
         Insert: {
           bucket: string
+          chart_timezone?: string | null
           created_at?: string
           date_from: string
           date_to: string
@@ -137,6 +139,7 @@ export type Database = {
         }
         Update: {
           bucket?: string
+          chart_timezone?: string | null
           created_at?: string
           date_from?: string
           date_to?: string
@@ -744,6 +747,14 @@ export type Database = {
       [_ in never]: never
     }
     Functions: {
+      chart_snapshots_normalize_chart_timezone: {
+        Args: { p_chart_timezone: string }
+        Returns: string
+      }
+      delete_chart_snapshots_maintenance: {
+        Args: { p_patient_user_id?: string; p_snapshot_id?: string }
+        Returns: number
+      }
       episode_media_storage_can_select: {
         Args: { p_object_name: string }
         Returns: boolean
@@ -817,6 +828,7 @@ export type Database = {
       share_chart_snapshot: {
         Args: {
           p_bucket: string
+          p_chart_timezone: string
           p_date_from: string
           p_date_to: string
           p_patient_user_id: string

--- a/packages/ui/src/lib/InsightComposedChart.tsx
+++ b/packages/ui/src/lib/InsightComposedChart.tsx
@@ -214,6 +214,7 @@ export function InsightComposedChart({
   patientTimeZone,
   showPatientTimeZoneNote = false,
   patientTimeZoneNoteUsesPatientLocal = false,
+  patientTimeZoneNoteVariant,
 }: InsightComposedChartProps) {
   const chartData = useMemo(
     () =>
@@ -267,7 +268,11 @@ export function InsightComposedChart({
         {showPatientTimeZoneNote ? (
           <p className="mb-3 text-xs text-app-muted">
             {formatInsightChartPatientTimeZoneNote(patientTimeZone, {
-              patientLocal: patientTimeZoneNoteUsesPatientLocal,
+              variant:
+                patientTimeZoneNoteVariant ??
+                (patientTimeZoneNoteUsesPatientLocal
+                  ? 'patientLocal'
+                  : 'browser'),
             })}
           </p>
         ) : null}

--- a/packages/ui/src/lib/InsightComposedChart.types.ts
+++ b/packages/ui/src/lib/InsightComposedChart.types.ts
@@ -2,6 +2,7 @@ import type {
   ChartTypeChoice,
   SelectedSeries,
 } from './InsightSeriesPicker.types.js';
+import type { InsightChartTimeZoneNoteVariant } from './insight-composed-chart-utils.js';
 
 /** Time bucket granularity for insight charts (matches `get_chart_series`). */
 export type InsightChartBucket = 'day' | 'week' | 'month';
@@ -52,9 +53,15 @@ export interface InsightComposedChartProps {
   showPatientTimeZoneNote?: boolean;
   /**
    * When true with {@link showPatientTimeZoneNote}, copy claims patient-local alignment.
+   * Ignored when {@link patientTimeZoneNoteVariant} is set.
    * @defaultValue false
    */
   patientTimeZoneNoteUsesPatientLocal?: boolean;
+  /**
+   * Which timezone source the period note describes. Use `practitionerShared` when restoring
+   * a practitioner chart snapshot (`chart_snapshots.chart_timezone`).
+   */
+  patientTimeZoneNoteVariant?: InsightChartTimeZoneNoteVariant;
 }
 
 export type { ChartTypeChoice, SelectedSeries };

--- a/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.spec.ts
@@ -204,6 +204,15 @@ describe('formatInsightChartPatientTimeZoneNote', () => {
       }),
     ).toMatch(/patient's local timezone/i);
   });
+
+  it('describes practitioner chart timezone for shared snapshots', () => {
+    const note = formatInsightChartPatientTimeZoneNote('America/New_York', {
+      variant: 'practitionerShared',
+    });
+    expect(note).toMatch(/practitioner's chart timezone/i);
+    expect(note).not.toMatch(/your browser timezone/i);
+    expect(note).toMatch(/day, week, and month groupings use this timezone/i);
+  });
 });
 
 describe('pivotChartSeriesBucketRows', () => {

--- a/packages/ui/src/lib/insight-composed-chart-utils.ts
+++ b/packages/ui/src/lib/insight-composed-chart-utils.ts
@@ -319,23 +319,40 @@ export function formatIanaTimeZoneForDisplay(patientTimeZone: string): string {
   return parts.find((part) => part.type === 'timeZoneName')?.value ?? zone;
 }
 
+/** Which timezone source the chart period note should describe. */
+export type InsightChartTimeZoneNoteVariant =
+  | 'browser'
+  | 'patientLocal'
+  | 'practitionerShared';
+
 /**
  * Caption for chart period timezone alignment.
  *
  * @param chartTimeZone - IANA timezone used for `get_chart_series` bucketing and axis labels.
- * @param options.patientLocal - When true, copy states patient-local alignment (only when
- *   `chartTimeZone` is the patient's IANA zone, not the viewer's browser zone).
+ * @param options.variant - Copy source; defaults to `browser`, or `patientLocal` when
+ *   `patientLocal: true` is passed without `variant`.
+ * @param options.patientLocal - Deprecated shorthand for `variant: 'patientLocal'`.
  * @returns Note text for the chart figure.
  */
 export function formatInsightChartPatientTimeZoneNote(
   chartTimeZone: string,
-  options?: { patientLocal?: boolean },
+  options?: {
+    patientLocal?: boolean;
+    variant?: InsightChartTimeZoneNoteVariant;
+  },
 ): string {
   const label = formatIanaTimeZoneForDisplay(chartTimeZone);
-  if (options?.patientLocal) {
-    return `Period labels use the patient's local timezone (${label}).`;
+  const variant: InsightChartTimeZoneNoteVariant =
+    options?.variant ?? (options?.patientLocal ? 'patientLocal' : 'browser');
+
+  switch (variant) {
+    case 'patientLocal':
+      return `Period labels use the patient's local timezone (${label}).`;
+    case 'practitionerShared':
+      return `Period labels use your practitioner's chart timezone (${label}). Day, week, and month groupings use this timezone.`;
+    default:
+      return `Period labels use your browser timezone (${label}). Day, week, and month groupings use this timezone.`;
   }
-  return `Period labels use your browser timezone (${label}). Day, week, and month groupings use this timezone.`;
 }
 
 /**

--- a/supabase/migrations/20260524140000_chart_snapshots.sql
+++ b/supabase/migrations/20260524140000_chart_snapshots.sql
@@ -8,6 +8,106 @@ COMMENT ON COLUMN public.chart_snapshots.date_to IS 'Exclusive chart range end (
 ALTER TABLE public.chart_snapshots
   ADD CONSTRAINT chart_snapshots_date_range_chk CHECK (date_from < date_to);
 
+ALTER TABLE public.chart_snapshots
+  ADD COLUMN chart_timezone text;
+
+COMMENT ON COLUMN public.chart_snapshots.chart_timezone IS 'IANA timezone used when the practitioner built the chart (matches get_chart_series p_timezone). Nullable for rows created before this column existed.';
+
+-- ---------------------------------------------------------------------------
+-- share_chart_snapshot: persist chart_timezone (new parameter; drop prior overload)
+-- ---------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text);
+
+CREATE OR REPLACE FUNCTION public.share_chart_snapshot (
+  p_patient_user_id uuid,
+  p_series_definition jsonb,
+  p_date_from timestamptz,
+  p_date_to timestamptz,
+  p_bucket text,
+  p_practitioner_note text DEFAULT NULL,
+  p_chart_timezone text DEFAULT NULL
+)
+  RETURNS uuid
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+  SET search_path = pg_catalog, public
+  AS $$
+DECLARE
+  v_id uuid;
+  v_tz text;
+BEGIN
+  IF NOT public.user_has_practitioner_access (p_patient_user_id) THEN
+    RAISE EXCEPTION 'permission denied'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_bucket IS NULL
+    OR p_bucket NOT IN ('day', 'week', 'month') THEN
+    RAISE EXCEPTION 'p_bucket must be day, week, or month';
+  END IF;
+
+  IF p_series_definition IS NULL
+    OR jsonb_typeof (p_series_definition) <> 'array'
+    OR jsonb_array_length (p_series_definition) < 1 THEN
+    RAISE EXCEPTION 'p_series_definition must be a non-empty JSON array';
+  END IF;
+
+  IF p_date_from IS NULL
+    OR p_date_to IS NULL
+    OR p_date_from >= p_date_to THEN
+    RAISE EXCEPTION 'p_date_from must be before p_date_to';
+  END IF;
+
+  v_tz := nullif(trim(p_chart_timezone), '');
+
+  IF v_tz IS NULL THEN
+    RAISE EXCEPTION 'p_chart_timezone must be a non-empty IANA timezone name'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT
+      1
+    FROM
+      pg_catalog.pg_timezone_names
+    WHERE
+      name = v_tz) THEN
+    RAISE EXCEPTION 'share_chart_snapshot: invalid IANA timezone %', v_tz
+      USING ERRCODE = '22023';
+  END IF;
+
+  INSERT INTO public.chart_snapshots (
+    patient_user_id,
+    practitioner_user_id,
+    series_definition,
+    date_from,
+    date_to,
+    bucket,
+    practitioner_note,
+    chart_timezone)
+  VALUES (
+    p_patient_user_id,
+    (SELECT auth.uid ()),
+    p_series_definition,
+    p_date_from,
+    p_date_to,
+    p_bucket,
+    NULLIF (trim(p_practitioner_note), ''),
+    v_tz)
+  RETURNING
+    id INTO v_id;
+
+  RETURN v_id;
+END;
+$$;
+
+COMMENT ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text) IS 'Practitioner shares a chart snapshot with a linked patient. Stores chart_timezone (IANA) so patients see the same calendar range and bucket labels as the practitioner chart.';
+
+REVOKE ALL ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text)
+FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text) TO authenticated;
+
 CREATE OR REPLACE FUNCTION public.chart_snapshots_append_only_guard ()
   RETURNS TRIGGER
   LANGUAGE plpgsql
@@ -72,3 +172,5 @@ COMMENT ON FUNCTION public.delete_chart_snapshots_maintenance (uuid, uuid) IS 'T
 
 REVOKE ALL ON FUNCTION public.delete_chart_snapshots_maintenance (uuid, uuid)
 FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.delete_chart_snapshots_maintenance (uuid, uuid) TO service_role;

--- a/supabase/migrations/20260524140000_chart_snapshots.sql
+++ b/supabase/migrations/20260524140000_chart_snapshots.sql
@@ -67,16 +67,18 @@ CREATE TRIGGER chart_snapshots_chart_timezone
   EXECUTE FUNCTION public.chart_snapshots_chart_timezone_guard ();
 
 -- ---------------------------------------------------------------------------
--- share_chart_snapshot: persist chart_timezone (7-arg); keep 6-arg for older clients
+-- share_chart_snapshot: replace six-arg RPC with chart_timezone (seven-arg)
 -- ---------------------------------------------------------------------------
+DROP FUNCTION IF EXISTS public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text);
+
 CREATE OR REPLACE FUNCTION public.share_chart_snapshot (
   p_patient_user_id uuid,
   p_series_definition jsonb,
   p_date_from timestamptz,
   p_date_to timestamptz,
   p_bucket text,
-  p_practitioner_note text DEFAULT NULL,
-  p_chart_timezone text
+  p_chart_timezone text,
+  p_practitioner_note text DEFAULT NULL
 )
   RETURNS uuid
   LANGUAGE plpgsql
@@ -136,45 +138,12 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text) IS 'Practitioner shares a chart snapshot with a linked patient. Requires p_chart_timezone (no default) so six- and seven-argument overloads do not collide. Non-empty IANA values are validated; null or blank stores chart_timezone null.';
+COMMENT ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text) IS 'Practitioner shares a chart snapshot with a linked patient. Args: bucket, chart_timezone (IANA, required), optional note. Replaces the six-argument function from 20260524130000.';
 
 REVOKE ALL ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text)
 FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text) TO authenticated;
-
--- Six-argument overload: same RPC name/signature as 20260524130000 (no p_chart_timezone).
-CREATE OR REPLACE FUNCTION public.share_chart_snapshot (
-  p_patient_user_id uuid,
-  p_series_definition jsonb,
-  p_date_from timestamptz,
-  p_date_to timestamptz,
-  p_bucket text,
-  p_practitioner_note text DEFAULT NULL
-)
-  RETURNS uuid
-  LANGUAGE plpgsql
-  SECURITY INVOKER
-  SET search_path = pg_catalog, public
-  AS $$
-BEGIN
-  RETURN public.share_chart_snapshot (
-    p_patient_user_id,
-    p_series_definition,
-    p_date_from,
-    p_date_to,
-    p_bucket,
-    p_practitioner_note,
-    NULL::text);
-END;
-$$;
-
-COMMENT ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text) IS 'Backward-compatible overload without p_chart_timezone; delegates to the seven-argument function with chart_timezone null until clients are updated.';
-
-REVOKE ALL ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text)
-FROM PUBLIC;
-
-GRANT EXECUTE ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text) TO authenticated;
 
 CREATE OR REPLACE FUNCTION public.chart_snapshots_append_only_guard ()
   RETURNS TRIGGER

--- a/supabase/migrations/20260524140000_chart_snapshots.sql
+++ b/supabase/migrations/20260524140000_chart_snapshots.sql
@@ -14,10 +14,8 @@ ALTER TABLE public.chart_snapshots
 COMMENT ON COLUMN public.chart_snapshots.chart_timezone IS 'IANA timezone used when the practitioner built the chart (matches get_chart_series p_timezone). Nullable for rows created before this column existed.';
 
 -- ---------------------------------------------------------------------------
--- share_chart_snapshot: persist chart_timezone (new parameter; drop prior overload)
+-- share_chart_snapshot: persist chart_timezone (7-arg); keep 6-arg for older clients
 -- ---------------------------------------------------------------------------
-DROP FUNCTION IF EXISTS public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text);
-
 CREATE OR REPLACE FUNCTION public.share_chart_snapshot (
   p_patient_user_id uuid,
   p_series_definition jsonb,
@@ -60,18 +58,14 @@ BEGIN
 
   v_tz := nullif(trim(p_chart_timezone), '');
 
-  IF v_tz IS NULL THEN
-    RAISE EXCEPTION 'p_chart_timezone must be a non-empty IANA timezone name'
-      USING ERRCODE = '22023';
-  END IF;
-
-  IF NOT EXISTS (
-    SELECT
-      1
-    FROM
-      pg_catalog.pg_timezone_names
-    WHERE
-      name = v_tz) THEN
+  IF v_tz IS NOT NULL
+    AND NOT EXISTS (
+      SELECT
+        1
+      FROM
+        pg_catalog.pg_timezone_names
+      WHERE
+        name = v_tz) THEN
     RAISE EXCEPTION 'share_chart_snapshot: invalid IANA timezone %', v_tz
       USING ERRCODE = '22023';
   END IF;
@@ -101,12 +95,45 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text) IS 'Practitioner shares a chart snapshot with a linked patient. Stores chart_timezone (IANA) so patients see the same calendar range and bucket labels as the practitioner chart.';
+COMMENT ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text) IS 'Practitioner shares a chart snapshot with a linked patient. When p_chart_timezone is set, stores IANA zone so patients see the same calendar range and bucket labels as the practitioner chart; when omitted or null, chart_timezone is stored null (legacy-compatible).';
 
 REVOKE ALL ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text)
 FROM PUBLIC;
 
 GRANT EXECUTE ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text) TO authenticated;
+
+-- Six-argument overload: same RPC name/signature as 20260524130000 (no p_chart_timezone).
+CREATE OR REPLACE FUNCTION public.share_chart_snapshot (
+  p_patient_user_id uuid,
+  p_series_definition jsonb,
+  p_date_from timestamptz,
+  p_date_to timestamptz,
+  p_bucket text,
+  p_practitioner_note text DEFAULT NULL
+)
+  RETURNS uuid
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+  SET search_path = pg_catalog, public
+  AS $$
+BEGIN
+  RETURN public.share_chart_snapshot (
+    p_patient_user_id,
+    p_series_definition,
+    p_date_from,
+    p_date_to,
+    p_bucket,
+    p_practitioner_note,
+    NULL::text);
+END;
+$$;
+
+COMMENT ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text) IS 'Backward-compatible overload without p_chart_timezone; delegates to the seven-argument function with chart_timezone null until clients are updated.';
+
+REVOKE ALL ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text)
+FROM PUBLIC;
+
+GRANT EXECUTE ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text) TO authenticated;
 
 CREATE OR REPLACE FUNCTION public.chart_snapshots_append_only_guard ()
   RETURNS TRIGGER

--- a/supabase/migrations/20260524140000_chart_snapshots.sql
+++ b/supabase/migrations/20260524140000_chart_snapshots.sql
@@ -1,0 +1,74 @@
+-- Follow-up to 20260524130000_chart_snapshots.sql (already applied on main/cloud).
+-- Trusted-session DELETE for dev cleanup; app clients remain append-only.
+
+COMMENT ON COLUMN public.chart_snapshots.date_from IS 'Inclusive chart range start (ISO timestamptz; matches get_chart_series p_from).';
+
+COMMENT ON COLUMN public.chart_snapshots.date_to IS 'Exclusive chart range end (ISO timestamptz; matches get_chart_series p_to).';
+
+ALTER TABLE public.chart_snapshots
+  ADD CONSTRAINT chart_snapshots_date_range_chk CHECK (date_from < date_to);
+
+CREATE OR REPLACE FUNCTION public.chart_snapshots_append_only_guard ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    IF public.profiles_trusted_session_for_app_role () THEN
+      RETURN OLD;
+    END IF;
+
+    RAISE EXCEPTION 'chart_snapshots is append-only'
+      USING HINT = 'Use the SQL Editor as postgres, or call delete_chart_snapshots_maintenance from a trusted session.';
+  END IF;
+
+  IF TG_OP = 'UPDATE'
+    AND (to_jsonb(OLD) - 'seen_by_patient_at') = (to_jsonb(NEW) - 'seen_by_patient_at')
+    AND OLD.seen_by_patient_at IS NULL
+    AND NEW.seen_by_patient_at IS NOT NULL THEN
+    RETURN NEW;
+  END IF;
+
+  RAISE EXCEPTION 'chart_snapshots is append-only except seen_by_patient_at';
+END;
+$$;
+
+COMMENT ON FUNCTION public.chart_snapshots_append_only_guard () IS 'Blocks DELETE for app sessions; allows DELETE when profiles_trusted_session_for_app_role() (postgres SQL Editor or service_role). UPDATE only for one-time seen_by_patient_at.';
+
+CREATE OR REPLACE FUNCTION public.delete_chart_snapshots_maintenance (
+  p_snapshot_id uuid DEFAULT NULL,
+  p_patient_user_id uuid DEFAULT NULL
+)
+  RETURNS bigint
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = pg_catalog, public
+  AS $$
+DECLARE
+  v_deleted bigint;
+BEGIN
+  IF NOT public.profiles_trusted_session_for_app_role () THEN
+    RAISE EXCEPTION 'delete_chart_snapshots_maintenance requires a trusted session (postgres or service_role)'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF p_snapshot_id IS NOT NULL THEN
+    DELETE FROM public.chart_snapshots
+    WHERE id = p_snapshot_id;
+  ELSIF p_patient_user_id IS NOT NULL THEN
+    DELETE FROM public.chart_snapshots
+    WHERE patient_user_id = p_patient_user_id;
+  ELSE
+    DELETE FROM public.chart_snapshots;
+  END IF;
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+
+  RETURN v_deleted;
+END;
+$$;
+
+COMMENT ON FUNCTION public.delete_chart_snapshots_maintenance (uuid, uuid) IS 'Trusted-session maintenance only: delete one snapshot, all for a patient, or all rows when both args are NULL. Not granted to authenticated.';
+
+REVOKE ALL ON FUNCTION public.delete_chart_snapshots_maintenance (uuid, uuid)
+FROM PUBLIC;

--- a/supabase/migrations/20260524140000_chart_snapshots.sql
+++ b/supabase/migrations/20260524140000_chart_snapshots.sql
@@ -14,6 +14,59 @@ ALTER TABLE public.chart_snapshots
 COMMENT ON COLUMN public.chart_snapshots.chart_timezone IS 'IANA timezone used when the practitioner built the chart (matches get_chart_series p_timezone). Nullable for rows created before this column existed.';
 
 -- ---------------------------------------------------------------------------
+-- chart_timezone: table-level IANA validation (direct INSERT and RPC)
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.chart_snapshots_normalize_chart_timezone (p_chart_timezone text)
+  RETURNS text
+  LANGUAGE plpgsql
+  STABLE
+  SET search_path = pg_catalog, public
+  AS $$
+DECLARE
+  v_tz text;
+BEGIN
+  v_tz := nullif(trim(p_chart_timezone), '');
+
+  IF v_tz IS NULL THEN
+    RETURN NULL;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT
+      1
+    FROM
+      pg_catalog.pg_timezone_names
+    WHERE
+      name = v_tz) THEN
+    RAISE EXCEPTION 'chart_snapshots.chart_timezone: invalid IANA timezone %', v_tz
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN v_tz;
+END;
+$$;
+
+COMMENT ON FUNCTION public.chart_snapshots_normalize_chart_timezone (text) IS 'Trims chart_snapshots.chart_timezone; null/blank → NULL; non-empty values must exist in pg_timezone_names.';
+
+CREATE OR REPLACE FUNCTION public.chart_snapshots_chart_timezone_guard ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  AS $$
+BEGIN
+  NEW.chart_timezone := public.chart_snapshots_normalize_chart_timezone (NEW.chart_timezone);
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.chart_snapshots_chart_timezone_guard () IS 'BEFORE INSERT/UPDATE: enforce valid IANA chart_timezone on all writes (RPC and direct INSERT).';
+
+CREATE TRIGGER chart_snapshots_chart_timezone
+  BEFORE INSERT OR UPDATE ON public.chart_snapshots
+  FOR EACH ROW
+  EXECUTE FUNCTION public.chart_snapshots_chart_timezone_guard ();
+
+-- ---------------------------------------------------------------------------
 -- share_chart_snapshot: persist chart_timezone (7-arg); keep 6-arg for older clients
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.share_chart_snapshot (
@@ -23,7 +76,7 @@ CREATE OR REPLACE FUNCTION public.share_chart_snapshot (
   p_date_to timestamptz,
   p_bucket text,
   p_practitioner_note text DEFAULT NULL,
-  p_chart_timezone text DEFAULT NULL
+  p_chart_timezone text
 )
   RETURNS uuid
   LANGUAGE plpgsql
@@ -56,19 +109,7 @@ BEGIN
     RAISE EXCEPTION 'p_date_from must be before p_date_to';
   END IF;
 
-  v_tz := nullif(trim(p_chart_timezone), '');
-
-  IF v_tz IS NOT NULL
-    AND NOT EXISTS (
-      SELECT
-        1
-      FROM
-        pg_catalog.pg_timezone_names
-      WHERE
-        name = v_tz) THEN
-    RAISE EXCEPTION 'share_chart_snapshot: invalid IANA timezone %', v_tz
-      USING ERRCODE = '22023';
-  END IF;
+  v_tz := public.chart_snapshots_normalize_chart_timezone (p_chart_timezone);
 
   INSERT INTO public.chart_snapshots (
     patient_user_id,
@@ -95,7 +136,7 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text) IS 'Practitioner shares a chart snapshot with a linked patient. When p_chart_timezone is set, stores IANA zone so patients see the same calendar range and bucket labels as the practitioner chart; when omitted or null, chart_timezone is stored null (legacy-compatible).';
+COMMENT ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text) IS 'Practitioner shares a chart snapshot with a linked patient. Requires p_chart_timezone (no default) so six- and seven-argument overloads do not collide. Non-empty IANA values are validated; null or blank stores chart_timezone null.';
 
 REVOKE ALL ON FUNCTION public.share_chart_snapshot (uuid, jsonb, timestamptz, timestamptz, text, text, text)
 FROM PUBLIC;

--- a/supabase/migrations/20260524140000_chart_snapshots.sql
+++ b/supabase/migrations/20260524140000_chart_snapshots.sql
@@ -55,11 +55,17 @@ CREATE OR REPLACE FUNCTION public.chart_snapshots_chart_timezone_guard ()
 BEGIN
   NEW.chart_timezone := public.chart_snapshots_normalize_chart_timezone (NEW.chart_timezone);
 
+  IF TG_OP = 'INSERT'
+    AND NEW.chart_timezone IS NULL THEN
+    RAISE EXCEPTION 'chart_snapshots.chart_timezone is required on insert'
+      USING ERRCODE = '22023';
+  END IF;
+
   RETURN NEW;
 END;
 $$;
 
-COMMENT ON FUNCTION public.chart_snapshots_chart_timezone_guard () IS 'BEFORE INSERT/UPDATE: enforce valid IANA chart_timezone on all writes (RPC and direct INSERT).';
+COMMENT ON FUNCTION public.chart_snapshots_chart_timezone_guard () IS 'BEFORE INSERT/UPDATE: valid IANA when set; INSERT requires non-null chart_timezone (legacy rows may keep null on UPDATE).';
 
 CREATE TRIGGER chart_snapshots_chart_timezone
   BEFORE INSERT OR UPDATE ON public.chart_snapshots
@@ -112,6 +118,11 @@ BEGIN
   END IF;
 
   v_tz := public.chart_snapshots_normalize_chart_timezone (p_chart_timezone);
+
+  IF v_tz IS NULL THEN
+    RAISE EXCEPTION 'p_chart_timezone must be a non-empty IANA timezone name'
+      USING ERRCODE = '22023';
+  END IF;
 
   INSERT INTO public.chart_snapshots (
     patient_user_id,


### PR DESCRIPTION
Closes #178

## Summary

- Adds the **patient web Insights** flow for practitioner-shared charts: query unseen `chart_snapshots`, show a banner (“Your practitioner shared a chart with you”), load the stored series/range/bucket into `InsightComposedChart`, and call `mark_chart_snapshot_seen` after the chart loads.
- Extends `@abstrack/supabase` with `listUnseenChartSnapshotsForPatient`, `ChartSnapshotRow`, and tests for chart-snapshot RPC wrappers.
- Adds web helpers to map snapshot `series_definition` and date bounds back into the Insights UI.
- Follow-up migration `20260524140000_chart_snapshots.sql` (builds on `20260524130000`, already on main/cloud): trusted-session `DELETE` for dev cleanup via SQL Editor (`postgres`), plus `delete_chart_snapshots_maintenance`.
- Documents cloud dev cleanup for `chart_snapshots` in `docs/SUPABASE_CLOUD_DEVELOPER.md`.

Practitioner **share** UI and initial schema/RPCs landed in #189 (`20260524130000_chart_snapshots.sql`).

## Test plan

- [ ] After `db push` + `gen types --linked` (see below), practitioner shares a chart from patient Insights tab → patient opens **web** Insights as that patient → banner appears → tap loads chart with correct series/range → banner clears after view.
- [ ] Caretaker viewing another patient’s Insights does **not** show the share banner or query unseen snapshots.
- [ ] `pnpm exec nx run @abstrack/supabase:test -- chart-snapshots-query`
- [ ] `pnpm exec nx run @abstrack/web:test -- InsightsClient`
- [ ] SQL Editor cleanup: `DELETE FROM public.chart_snapshots WHERE …` works as `postgres` (optional: `SELECT delete_chart_snapshots_maintenance(...)`).

## Database (Sarah)

When migration SQL is stable:

```bash
pnpm dlx supabase db push
pnpm dlx supabase gen types typescript --linked --schema public > packages/supabase/src/lib/database.types.ts
pnpm exec prettier --write packages/supabase/src/lib/database.types.ts