### PR TITLE
feat(ui-web): add shared side nav shell for web and practitioner apps

### DIFF
--- a/apps/practitioner/next.config.js
+++ b/apps/practitioner/next.config.js
@@ -45,6 +45,7 @@ const nextConfig = {
   ],
   webpack: (config) => {
     const supabaseSrc = path.join(__dirname, '../../packages/supabase/src');
+    const uiWebSrc = path.join(__dirname, '../../packages/ui-web/src');
     config.resolve.alias = {
       ...config.resolve.alias,
       'react-native$': 'react-native-web',
@@ -57,10 +58,8 @@ const nextConfig = {
       '@abstrack/supabase/server': path.join(supabaseSrc, 'server.ts'),
       '@abstrack/supabase/native': path.join(supabaseSrc, 'native.ts'),
       '@abstrack/supabase/admin': path.join(supabaseSrc, 'admin.ts'),
-      '@abstrack/ui-web': path.join(
-        __dirname,
-        '../../packages/ui-web/src/index.ts',
-      ),
+      '@abstrack/ui-web$': path.join(uiWebSrc, 'index.ts'),
+      '@abstrack/ui-web/sidebar': path.join(uiWebSrc, 'components/sidebar.tsx'),
     };
     return config;
   },

--- a/apps/practitioner/next.config.js
+++ b/apps/practitioner/next.config.js
@@ -37,6 +37,7 @@ const nextConfig = {
   nx: {},
   transpilePackages: [
     '@abstrack/ui',
+    '@abstrack/ui-web',
     '@abstrack/types',
     '@abstrack/supabase',
     'react-native',
@@ -56,6 +57,10 @@ const nextConfig = {
       '@abstrack/supabase/server': path.join(supabaseSrc, 'server.ts'),
       '@abstrack/supabase/native': path.join(supabaseSrc, 'native.ts'),
       '@abstrack/supabase/admin': path.join(supabaseSrc, 'admin.ts'),
+      '@abstrack/ui-web': path.join(
+        __dirname,
+        '../../packages/ui-web/src/index.ts',
+      ),
     };
     return config;
   },

--- a/apps/practitioner/package.json
+++ b/apps/practitioner/package.json
@@ -17,6 +17,7 @@
     "recharts": "^3.8.1"
   },
   "devDependencies": {
-    "@types/qrcode": "^1.5.6"
+    "@types/qrcode": "^1.5.6",
+    "tailwindcss-animate": "^1.0.7"
   }
 }

--- a/apps/practitioner/package.json
+++ b/apps/practitioner/package.json
@@ -6,6 +6,7 @@
     "@abstrack/supabase": "workspace:*",
     "@abstrack/types": "workspace:*",
     "@abstrack/ui": "workspace:*",
+    "@abstrack/ui-web": "workspace:*",
     "next": "~16.0.1",
     "qrcode": "^1.5.4",
     "react": "19.1.0",

--- a/apps/practitioner/src/app/auth/callback/fragment/page.tsx
+++ b/apps/practitioner/src/app/auth/callback/fragment/page.tsx
@@ -34,6 +34,7 @@ export default function PractitionerAuthCallbackFragmentPage() {
     <Suspense
       fallback={
         <main
+          id="main-content"
           aria-live="polite"
           className="mx-auto max-w-lg p-6 text-base text-neutral-700"
         >
@@ -153,6 +154,7 @@ function PractitionerAuthCallbackFragmentContent() {
   if (surfaceError) {
     return (
       <main
+        id="main-content"
         role="alert"
         className="mx-auto max-w-lg p-6 text-base text-red-700"
       >
@@ -163,6 +165,7 @@ function PractitionerAuthCallbackFragmentContent() {
 
   return (
     <main
+      id="main-content"
       aria-live="polite"
       className="mx-auto max-w-lg p-6 text-base text-neutral-700"
     >

--- a/apps/practitioner/src/app/global.css
+++ b/apps/practitioner/src/app/global.css
@@ -16,6 +16,7 @@
     --app-primary-soft: 219 234 254;
     --app-ring: 37 99 235;
     --app-header-bg: rgba(255, 255, 255, 0.92);
+    --app-sidebar-bg: rgba(255, 255, 255, 0.94);
     --app-header-border: rgba(226, 232, 240, 0.95);
     --app-nav-hover-bg: #f1f5f9;
     --app-ring-slate: rgba(15, 23, 42, 0.06);
@@ -28,6 +29,7 @@
     --app-shadow-soft:
       0 1px 2px rgba(15, 23, 42, 0.04), 0 8px 24px -4px rgba(15, 23, 42, 0.08);
     --app-shadow-header: 0 1px 0 rgba(15, 23, 42, 0.06);
+    --app-shadow-sidebar-edge: 1px 0 0 rgba(15, 23, 42, 0.06);
   }
 
   html.dark {
@@ -40,6 +42,7 @@
     --app-primary-soft: 37 99 235;
     --app-ring: 147 197 253;
     --app-header-bg: rgba(15, 23, 42, 0.92);
+    --app-sidebar-bg: rgba(15, 23, 42, 0.94);
     --app-header-border: rgba(51, 65, 85, 0.95);
     --app-nav-hover-bg: #334155;
     --app-ring-slate: rgba(241, 245, 249, 0.08);
@@ -52,6 +55,50 @@
     --app-shadow-soft:
       0 1px 2px rgba(0, 0, 0, 0.25), 0 8px 24px -4px rgba(0, 0, 0, 0.35);
     --app-shadow-header: 0 1px 0 rgba(0, 0, 0, 0.35);
+    --app-shadow-sidebar-edge: 1px 0 0 rgba(0, 0, 0, 0.35);
+  }
+
+  /* OS-level higher contrast: align with user web (`apps/web/src/app/global.css`). */
+  @media (prefers-contrast: more) {
+    :root {
+      --app-bg: 255 255 255;
+      --app-surface: 255 255 255;
+      --app-border: 15 23 42;
+      --app-muted: 15 23 42;
+      --app-ink: 2 6 23;
+      --app-primary: 30 64 175;
+      --app-primary-soft: 219 234 254;
+      --app-ring: 30 64 175;
+      --app-header-bg: rgba(255, 255, 255, 1);
+      --app-sidebar-bg: rgba(255, 255, 255, 1);
+      --app-header-border: rgba(15, 23, 42, 0.85);
+      --app-nav-hover-bg: #dbeafe;
+      --app-ring-slate: rgba(15, 23, 42, 0.2);
+      --app-gradient: none;
+      --app-shadow-soft: 0 0 0 transparent;
+      --app-shadow-header: 0 0 0 transparent;
+      --app-shadow-sidebar-edge: 0 0 0 transparent;
+    }
+
+    html.dark {
+      --app-bg: 0 0 0;
+      --app-surface: 0 0 0;
+      --app-border: 255 255 255;
+      --app-muted: 255 255 255;
+      --app-ink: 255 255 255;
+      --app-primary: 147 197 253;
+      --app-primary-soft: 30 64 175;
+      --app-ring: 250 204 21;
+      --app-header-bg: rgba(0, 0, 0, 1);
+      --app-sidebar-bg: rgba(0, 0, 0, 1);
+      --app-header-border: rgba(255, 255, 255, 0.9);
+      --app-nav-hover-bg: #1e3a8a;
+      --app-ring-slate: rgba(255, 255, 255, 0.22);
+      --app-gradient: none;
+      --app-shadow-soft: 0 0 0 transparent;
+      --app-shadow-header: 0 0 0 transparent;
+      --app-shadow-sidebar-edge: 0 0 0 transparent;
+    }
   }
 
   /* react-day-picker: map accent colors to semantic app tokens (light + html.dark). */
@@ -63,13 +110,33 @@
     --rdp-range_end-color: rgb(var(--app-surface) / 1);
     color: rgb(var(--app-ink) / 1);
   }
+}
 
-  body {
-    color: rgb(var(--app-ink) / 1);
-    background-color: rgb(var(--app-bg) / 1);
-    background-image: var(--app-gradient);
-    min-height: 100vh;
-  }
+/* Grid-paper viewport background (body + app shell main column). Outside @layer so it
+ * wins over Tailwind utilities such as bg-background on layout wrappers. */
+body,
+.app-grid-background {
+  background-color: rgb(var(--app-bg) / 1);
+  background-image:
+    linear-gradient(to right, #80808012 1px, transparent 1px),
+    linear-gradient(to bottom, #80808012 1px, transparent 1px),
+    var(--app-gradient);
+  background-size:
+    14px 24px,
+    14px 24px,
+    100% 100%;
+}
+
+html.dark body,
+html.dark .app-grid-background {
+  background-image:
+    linear-gradient(to right, #ffffff0a 1px, transparent 1px),
+    linear-gradient(to bottom, #ffffff0a 1px, transparent 1px),
+    var(--app-gradient);
+  background-size:
+    14px 24px,
+    14px 24px,
+    100% 100%;
 }
 
 html {
@@ -95,9 +162,12 @@ html {
   scroll-behavior: smooth;
 }
 body {
+  color: rgb(var(--app-ink) / 1);
   font-family: inherit;
   line-height: inherit;
   margin: 0;
+  min-height: 100vh;
+  text-rendering: optimizeLegibility;
 }
 h1,
 h2,

--- a/apps/practitioner/src/app/invite/join/page.tsx
+++ b/apps/practitioner/src/app/invite/join/page.tsx
@@ -181,7 +181,10 @@ export default function PractitionerInviteJoinPage() {
   const donePasswordSet = state.kind === 'done' && state.passwordSignInEnabled;
 
   return (
-    <div className="mx-auto flex w-full max-w-lg flex-col gap-6 px-4 py-12 sm:px-6">
+    <main
+      id="main-content"
+      className="mx-auto flex w-full max-w-lg flex-col gap-6 px-4 py-12 sm:px-6"
+    >
       <h1 className="text-2xl font-bold tracking-tight text-app-ink">
         Welcome to ABStrack Practitioner
       </h1>
@@ -261,6 +264,6 @@ export default function PractitionerInviteJoinPage() {
           Go to patient workspace
         </Link>
       ) : null}
-    </div>
+    </main>
   );
 }

--- a/apps/practitioner/src/app/layout.tsx
+++ b/apps/practitioner/src/app/layout.tsx
@@ -2,8 +2,9 @@ import './global.css';
 import type { ReactNode } from 'react';
 import { Plus_Jakarta_Sans } from 'next/font/google';
 import Script from 'next/script';
+import { PractitionerAppShell } from '../components/app-shell/PractitionerAppShell';
+import { PractitionerPublicThemeBar } from '../components/app-shell/PractitionerPublicThemeBar';
 import { LiveAnnouncerRoot } from '../components/a11y/LiveAnnouncerRoot';
-import { ThemeMenu } from '../components/theme/ThemeMenu';
 import { ThemeProvider } from '../components/theme/ThemeProvider';
 import { AuthProvider } from '../lib/auth-provider';
 import { THEME_INIT_SCRIPT } from '../lib/theme-init-script';
@@ -30,14 +31,10 @@ export default function RootLayout({ children }: { children: ReactNode }) {
           {THEME_INIT_SCRIPT}
         </Script>
         <ThemeProvider>
-          <div className="pointer-events-none fixed right-3 top-3 z-[200] sm:right-4 sm:top-4">
-            <div className="pointer-events-auto">
-              <ThemeMenu />
-            </div>
-          </div>
           <AuthProvider>
             <LiveAnnouncerRoot>
-              <main>{children}</main>
+              <PractitionerPublicThemeBar />
+              <PractitionerAppShell>{children}</PractitionerAppShell>
             </LiveAnnouncerRoot>
           </AuthProvider>
         </ThemeProvider>

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -579,7 +579,10 @@ export default function LoginPage() {
   const showCredentialsStep = step === 'credentials';
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-app-bg bg-app-gradient px-4">
+    <main
+      id="main-content"
+      className="flex min-h-screen items-center justify-center bg-app-bg bg-app-gradient px-4"
+    >
       <div className="w-full max-w-md rounded-2xl border border-app-border/90 bg-app-surface p-8 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
         <h1 className="mb-2 text-center text-2xl font-bold text-app-ink">
           Practitioner login
@@ -765,6 +768,6 @@ export default function LoginPage() {
           </form>
         )}
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/practitioner/src/app/update-password/page.tsx
+++ b/apps/practitioner/src/app/update-password/page.tsx
@@ -170,7 +170,10 @@ export default function PractitionerUpdatePasswordPage() {
   };
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-app-bg bg-app-gradient px-4 py-12">
+    <main
+      id="main-content"
+      className="flex min-h-screen items-center justify-center bg-app-bg bg-app-gradient px-4 py-12"
+    >
       <div className="w-full max-w-md rounded-2xl border border-app-border/90 bg-app-surface p-8 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
         <h1 className="mb-6 text-center text-2xl font-bold text-app-ink">
           {isInvitePassword ? 'Create your password' : 'Set new password'}
@@ -277,6 +280,6 @@ export default function PractitionerUpdatePasswordPage() {
           </p>
         )}
       </div>
-    </div>
+    </main>
   );
 }

--- a/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
+++ b/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
@@ -12,19 +12,7 @@ import { forwardRef, type ReactNode } from 'react';
 import { ThemeMenu } from '@/components/theme/ThemeMenu';
 import { useAuth } from '@/lib/auth-provider';
 import { PRACTITIONER_APP_NAV_ITEMS } from '@/lib/practitioner-nav-items';
-
-const PUBLIC_PATH_PREFIXES = [
-  '/login',
-  '/invite',
-  '/update-password',
-  '/auth',
-] as const;
-
-function isPublicPractitionerPath(pathname: string): boolean {
-  return PUBLIC_PATH_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
-  );
-}
+import { isPublicPractitionerPath } from '@/lib/practitioner-public-paths';
 
 const PractitionerNavLink = forwardRef<HTMLAnchorElement, AppSideNavLinkProps>(
   ({ href, children, ...rest }, ref) => (

--- a/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
+++ b/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
@@ -32,14 +32,15 @@ export type PractitionerAppShellProps = {
  * public (login, invite, password reset, auth callback). Uses shadcn/ui sidebar with themed tokens.
  *
  * @param props - Layout children.
- * @returns Shell or bare children for public/unauthenticated views.
+ * @returns Shell or unwrapped children for public/unauthenticated views (each public page
+ * supplies its own single `<main>` landmark where needed).
  */
 export function PractitionerAppShell({ children }: PractitionerAppShellProps) {
   const pathname = usePathname() ?? '/';
   const { session, loading } = useAuth();
 
   if (loading || !session || isPublicPractitionerPath(pathname)) {
-    return <main>{children}</main>;
+    return <>{children}</>;
   }
 
   const email = session.user.email;

--- a/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
+++ b/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import {
+  AppShellWithSideNav,
+  AppSideNav,
+  type AppSideNavLinkProps,
+} from '@abstrack/ui-web';
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import type { ComponentType, ReactNode } from 'react';
+
+import { ThemeMenu } from '@/components/theme/ThemeMenu';
+import { useAuth } from '@/lib/auth-provider';
+import { PRACTITIONER_APP_NAV_ITEMS } from '@/lib/practitioner-nav-items';
+
+const PUBLIC_PATH_PREFIXES = [
+  '/login',
+  '/invite',
+  '/update-password',
+  '/auth',
+] as const;
+
+function isPublicPractitionerPath(pathname: string): boolean {
+  return PUBLIC_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+const PractitionerNavLink: ComponentType<AppSideNavLinkProps> = ({
+  href,
+  children,
+  className,
+  'aria-current': ariaCurrent,
+}) => (
+  <Link href={href} className={className} aria-current={ariaCurrent}>
+    {children}
+  </Link>
+);
+
+export type PractitionerAppShellProps = {
+  children: ReactNode;
+};
+
+/**
+ * Practitioner chrome with side navigation when the user has a session and the route is not
+ * public (login, invite, password reset, auth callback). Uses shadcn/ui sidebar with themed tokens.
+ *
+ * @param props - Layout children.
+ * @returns Shell or bare children for public/unauthenticated views.
+ */
+export function PractitionerAppShell({ children }: PractitionerAppShellProps) {
+  const pathname = usePathname() ?? '/';
+  const { session, loading } = useAuth();
+
+  if (loading || !session || isPublicPractitionerPath(pathname)) {
+    return <main>{children}</main>;
+  }
+
+  const email = session.user.email;
+
+  return (
+    <AppShellWithSideNav
+      skipLink={
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[60] focus:rounded-lg focus:bg-app-surface focus:px-4 focus:py-2.5 focus:text-sm focus:font-medium focus:text-app-ink focus:shadow-soft focus:outline-none focus:ring-2 focus:ring-app-ring focus:ring-offset-2 focus:ring-offset-app-bg"
+        >
+          Skip to main content
+        </a>
+      }
+      sideNav={
+        <AppSideNav
+          pathname={pathname}
+          items={PRACTITIONER_APP_NAV_ITEMS}
+          LinkComponent={PractitionerNavLink}
+          accessibilityLabel="Practitioner application"
+          brand={
+            <Link
+              href="/"
+              className="block rounded-lg outline-none ring-offset-2 ring-offset-app-bg transition hover:text-app-primary focus-visible:ring-2 focus-visible:ring-app-ring"
+            >
+              <span className="block text-lg font-bold tracking-tight text-sidebar-foreground">
+                ABStrack
+              </span>
+              <span className="mt-0.5 block text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-muted-foreground">
+                Practitioner
+              </span>
+            </Link>
+          }
+          footer={
+            <div className="flex flex-col gap-3">
+              {email ? (
+                <p
+                  className="truncate text-xs text-muted-foreground"
+                  title={email}
+                  aria-label={`Signed in as ${email}`}
+                >
+                  {email}
+                </p>
+              ) : null}
+              <ThemeMenu />
+            </div>
+          }
+        />
+      }
+      mainClassName="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 lg:px-8"
+      mobileMenuTriggerLabel="Open practitioner navigation menu"
+    >
+      {children}
+    </AppShellWithSideNav>
+  );
+}

--- a/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
+++ b/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
@@ -7,7 +7,7 @@ import {
 } from '@abstrack/ui-web';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import type { ComponentType, ReactNode } from 'react';
+import { forwardRef, type ReactNode } from 'react';
 
 import { ThemeMenu } from '@/components/theme/ThemeMenu';
 import { useAuth } from '@/lib/auth-provider';
@@ -26,16 +26,14 @@ function isPublicPractitionerPath(pathname: string): boolean {
   );
 }
 
-const PractitionerNavLink: ComponentType<AppSideNavLinkProps> = ({
-  href,
-  children,
-  className,
-  'aria-current': ariaCurrent,
-}) => (
-  <Link href={href} className={className} aria-current={ariaCurrent}>
-    {children}
-  </Link>
+const PractitionerNavLink = forwardRef<HTMLAnchorElement, AppSideNavLinkProps>(
+  ({ href, children, ...rest }, ref) => (
+    <Link href={href} ref={ref} {...rest}>
+      {children}
+    </Link>
+  ),
 );
+PractitionerNavLink.displayName = 'PractitionerNavLink';
 
 export type PractitionerAppShellProps = {
   children: ReactNode;

--- a/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
+++ b/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
@@ -32,15 +32,19 @@ export type PractitionerAppShellProps = {
  * public (login, invite, password reset, auth callback). Uses shadcn/ui sidebar with themed tokens.
  *
  * @param props - Layout children.
- * @returns Shell or unwrapped children for public/unauthenticated views (each public page
- * supplies its own single `<main>` landmark where needed).
+ * @returns Shell, a layout `<main>` while auth is resolving on private routes, or unwrapped
+ * children on public routes (each public page supplies its own single `<main>` landmark).
  */
 export function PractitionerAppShell({ children }: PractitionerAppShellProps) {
   const pathname = usePathname() ?? '/';
   const { session, loading } = useAuth();
 
-  if (loading || !session || isPublicPractitionerPath(pathname)) {
+  if (isPublicPractitionerPath(pathname)) {
     return <>{children}</>;
+  }
+
+  if (loading || !session) {
+    return <main id="main-content">{children}</main>;
   }
 
   const email = session.user.email;

--- a/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
+++ b/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
@@ -46,6 +46,7 @@ export function PractitionerAppShell({ children }: PractitionerAppShellProps) {
 
   return (
     <AppShellWithSideNav
+      sidebarCookieName="abstrack_practitioner_sidebar_state"
       skipLink={
         <a
           href="#main-content"

--- a/apps/practitioner/src/components/app-shell/PractitionerPublicThemeBar.tsx
+++ b/apps/practitioner/src/components/app-shell/PractitionerPublicThemeBar.tsx
@@ -8,20 +8,17 @@ import { isPublicPractitionerPath } from '@/lib/practitioner-public-paths';
 
 /**
  * Fixed theme control when the authenticated app shell (sidebar footer) is not shown.
+ * Always renders on public routes (including while auth is loading) so login/invite pages
+ * never flash without a theme toggle.
  *
  * @returns Theme menu portal or null.
  */
 export function PractitionerPublicThemeBar() {
   const pathname = usePathname() ?? '/';
   const { session, loading } = useAuth();
+  const isPublic = isPublicPractitionerPath(pathname);
 
-  if (loading) {
-    return null;
-  }
-
-  const usesAppShell = !!session && !isPublicPractitionerPath(pathname);
-
-  if (usesAppShell) {
+  if (!isPublic && !loading && session) {
     return null;
   }
 

--- a/apps/practitioner/src/components/app-shell/PractitionerPublicThemeBar.tsx
+++ b/apps/practitioner/src/components/app-shell/PractitionerPublicThemeBar.tsx
@@ -4,19 +4,7 @@ import { usePathname } from 'next/navigation';
 
 import { ThemeMenu } from '@/components/theme/ThemeMenu';
 import { useAuth } from '@/lib/auth-provider';
-
-const PUBLIC_PATH_PREFIXES = [
-  '/login',
-  '/invite',
-  '/update-password',
-  '/auth',
-] as const;
-
-function isPublicPractitionerPath(pathname: string): boolean {
-  return PUBLIC_PATH_PREFIXES.some(
-    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
-  );
-}
+import { isPublicPractitionerPath } from '@/lib/practitioner-public-paths';
 
 /**
  * Fixed theme control when the authenticated app shell (sidebar footer) is not shown.

--- a/apps/practitioner/src/components/app-shell/PractitionerPublicThemeBar.tsx
+++ b/apps/practitioner/src/components/app-shell/PractitionerPublicThemeBar.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+
+import { ThemeMenu } from '@/components/theme/ThemeMenu';
+import { useAuth } from '@/lib/auth-provider';
+
+const PUBLIC_PATH_PREFIXES = [
+  '/login',
+  '/invite',
+  '/update-password',
+  '/auth',
+] as const;
+
+function isPublicPractitionerPath(pathname: string): boolean {
+  return PUBLIC_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+/**
+ * Fixed theme control when the authenticated app shell (sidebar footer) is not shown.
+ *
+ * @returns Theme menu portal or null.
+ */
+export function PractitionerPublicThemeBar() {
+  const pathname = usePathname() ?? '/';
+  const { session, loading } = useAuth();
+
+  if (loading) {
+    return null;
+  }
+
+  const usesAppShell = !!session && !isPublicPractitionerPath(pathname);
+
+  if (usesAppShell) {
+    return null;
+  }
+
+  return (
+    <div className="pointer-events-none fixed right-3 top-3 z-[200] sm:right-4 sm:top-4">
+      <div className="pointer-events-auto">
+        <ThemeMenu />
+      </div>
+    </div>
+  );
+}

--- a/apps/practitioner/src/lib/practitioner-nav-items.ts
+++ b/apps/practitioner/src/lib/practitioner-nav-items.ts
@@ -1,0 +1,17 @@
+import type { AppSideNavItem } from '@abstrack/ui-web';
+
+/**
+ * Primary practitioner app routes for the side navigation.
+ */
+export const PRACTITIONER_APP_NAV_ITEMS: AppSideNavItem[] = [
+  {
+    href: '/',
+    label: 'Home',
+    match: (path) => path === '/',
+  },
+  {
+    href: '/patients',
+    label: 'Patients',
+    match: (path) => path === '/patients' || path.startsWith('/patients/'),
+  },
+];

--- a/apps/practitioner/src/lib/practitioner-public-paths.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-public-paths.spec.ts
@@ -1,0 +1,21 @@
+import { isPublicPractitionerPath } from './practitioner-public-paths';
+
+describe('isPublicPractitionerPath', () => {
+  it('matches exact public prefixes', () => {
+    expect(isPublicPractitionerPath('/login')).toBe(true);
+    expect(isPublicPractitionerPath('/invite')).toBe(true);
+    expect(isPublicPractitionerPath('/update-password')).toBe(true);
+    expect(isPublicPractitionerPath('/auth')).toBe(true);
+  });
+
+  it('matches nested paths under public prefixes', () => {
+    expect(isPublicPractitionerPath('/invite/join')).toBe(true);
+    expect(isPublicPractitionerPath('/auth/callback')).toBe(true);
+  });
+
+  it('returns false for authenticated app routes', () => {
+    expect(isPublicPractitionerPath('/')).toBe(false);
+    expect(isPublicPractitionerPath('/patients')).toBe(false);
+    expect(isPublicPractitionerPath('/patients/abc')).toBe(false);
+  });
+});

--- a/apps/practitioner/src/lib/practitioner-public-paths.ts
+++ b/apps/practitioner/src/lib/practitioner-public-paths.ts
@@ -1,0 +1,22 @@
+/**
+ * Route prefixes where practitioner chrome (sidebar shell, etc.) is not shown.
+ * Used by the practitioner app shell and public theme bar components.
+ */
+export const PRACTITIONER_PUBLIC_PATH_PREFIXES = [
+  '/login',
+  '/invite',
+  '/update-password',
+  '/auth',
+] as const;
+
+/**
+ * Whether `pathname` is a public practitioner route (exact match or nested under a prefix).
+ *
+ * @param pathname - Current path from the router (e.g. `usePathname()`), without query/hash.
+ * @returns `true` when the app shell should not wrap the page.
+ */
+export function isPublicPractitionerPath(pathname: string): boolean {
+  return PRACTITIONER_PUBLIC_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}

--- a/apps/practitioner/tailwind.config.js
+++ b/apps/practitioner/tailwind.config.js
@@ -9,14 +9,19 @@
 // If you are **not** using `--turbo` you can uncomment both lines 1 & 19.
 // A discussion of the issue can be found: https://github.com/nrwl/nx/issues/26510
 
+const shadcnPreset = require('../../packages/ui-web/tailwind-shadcn-preset.js');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: 'class',
+  presets: [shadcnPreset],
   content: [
     './{src,pages,components,app}/**/*.{ts,tsx,js,jsx,html}',
     '!./{src,pages,components,app}/**/*.{stories,spec}.{ts,tsx,js,jsx,html}',
     '../../packages/ui/src/**/*.{ts,tsx}',
     '!../../packages/ui/src/**/*.{stories,spec}.{ts,tsx}',
+    '../../packages/ui-web/src/**/*.{ts,tsx}',
+    '!../../packages/ui-web/src/**/*.{stories,spec}.{ts,tsx}',
     //     ...createGlobPatternsForDependencies(__dirname)
   ],
   theme: {
@@ -53,11 +58,12 @@ module.exports = {
       boxShadow: {
         soft: 'var(--app-shadow-soft)',
         header: 'var(--app-shadow-header)',
+        'sidebar-edge': 'var(--app-shadow-sidebar-edge)',
       },
       backgroundImage: {
         'app-gradient': 'var(--app-gradient)',
       },
     },
   },
-  plugins: [],
+  plugins: [require('tailwindcss-animate')],
 };

--- a/apps/practitioner/tailwind.config.js
+++ b/apps/practitioner/tailwind.config.js
@@ -9,7 +9,7 @@
 // If you are **not** using `--turbo` you can uncomment both lines 1 & 19.
 // A discussion of the issue can be found: https://github.com/nrwl/nx/issues/26510
 
-const shadcnPreset = require('../../packages/ui-web/tailwind-shadcn-preset.js');
+const shadcnPreset = require('../../packages/ui-web/tailwind-shadcn-preset.cjs');
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {

--- a/apps/practitioner/tsconfig.json
+++ b/apps/practitioner/tsconfig.json
@@ -56,6 +56,9 @@
       "path": "../../packages/ui"
     },
     {
+      "path": "../../packages/ui-web"
+    },
+    {
       "path": "../../packages/supabase"
     }
   ]

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -13,6 +13,7 @@ const nextConfig = {
   // so the dev server does not bundle a stale `packages/types/dist` (see webpack alias below).
   transpilePackages: [
     '@abstrack/ui',
+    '@abstrack/ui-web',
     '@abstrack/types',
     '@abstrack/supabase',
     'react-native',
@@ -36,6 +37,10 @@ const nextConfig = {
       '@abstrack/supabase/server': path.join(supabaseSrc, 'server.ts'),
       '@abstrack/supabase/native': path.join(supabaseSrc, 'native.ts'),
       '@abstrack/supabase/admin': path.join(supabaseSrc, 'admin.ts'),
+      '@abstrack/ui-web': path.join(
+        __dirname,
+        '../../packages/ui-web/src/index.ts',
+      ),
     };
     return config;
   },

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -21,6 +21,7 @@ const nextConfig = {
   ],
   webpack: (config) => {
     const supabaseSrc = path.join(__dirname, '../../packages/supabase/src');
+    const uiWebSrc = path.join(__dirname, '../../packages/ui-web/src');
     config.resolve.alias = {
       ...config.resolve.alias,
       'react-native$': 'react-native-web',
@@ -37,10 +38,8 @@ const nextConfig = {
       '@abstrack/supabase/server': path.join(supabaseSrc, 'server.ts'),
       '@abstrack/supabase/native': path.join(supabaseSrc, 'native.ts'),
       '@abstrack/supabase/admin': path.join(supabaseSrc, 'admin.ts'),
-      '@abstrack/ui-web': path.join(
-        __dirname,
-        '../../packages/ui-web/src/index.ts',
-      ),
+      '@abstrack/ui-web$': path.join(uiWebSrc, 'index.ts'),
+      '@abstrack/ui-web/sidebar': path.join(uiWebSrc, 'components/sidebar.tsx'),
     };
     return config;
   },

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,5 +16,8 @@
     "react-native": "0.81.5",
     "react-native-web": "~0.21.0",
     "recharts": "^3.8.1"
+  },
+  "devDependencies": {
+    "tailwindcss-animate": "^1.0.7"
   }
 }

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,6 +6,7 @@
     "@abstrack/supabase": "workspace:*",
     "@abstrack/types": "workspace:*",
     "@abstrack/ui": "workspace:*",
+    "@abstrack/ui-web": "workspace:*",
     "@supabase/ssr": "^0.6.1",
     "chart.js": "^4.5.1",
     "next": "~16.0.1",

--- a/apps/web/src/app/global.css
+++ b/apps/web/src/app/global.css
@@ -19,6 +19,7 @@
     --app-primary-soft: 219 234 254;
     --app-ring: 37 99 235;
     --app-header-bg: rgba(255, 255, 255, 0.92);
+    --app-sidebar-bg: rgba(255, 255, 255, 0.94);
     --app-header-border: rgba(226, 232, 240, 0.95);
     --app-nav-hover-bg: #f1f5f9;
     --app-ring-slate: rgba(15, 23, 42, 0.06);
@@ -31,6 +32,7 @@
     --app-shadow-soft:
       0 1px 2px rgba(15, 23, 42, 0.04), 0 8px 24px -4px rgba(15, 23, 42, 0.08);
     --app-shadow-header: 0 1px 0 rgba(15, 23, 42, 0.06);
+    --app-shadow-sidebar-edge: 1px 0 0 rgba(15, 23, 42, 0.06);
   }
 
   /* Scope to document root only; `class="dark"` on descendants must not override tokens. */
@@ -45,6 +47,7 @@
     --app-primary-soft: 37 99 235;
     --app-ring: 147 197 253;
     --app-header-bg: rgba(15, 23, 42, 0.92);
+    --app-sidebar-bg: rgba(15, 23, 42, 0.94);
     --app-header-border: rgba(51, 65, 85, 0.95);
     --app-nav-hover-bg: #334155;
     --app-ring-slate: rgba(241, 245, 249, 0.08);
@@ -57,6 +60,7 @@
     --app-shadow-soft:
       0 1px 2px rgba(0, 0, 0, 0.25), 0 8px 24px -4px rgba(0, 0, 0, 0.35);
     --app-shadow-header: 0 1px 0 rgba(0, 0, 0, 0.35);
+    --app-shadow-sidebar-edge: 1px 0 0 rgba(0, 0, 0, 0.35);
   }
 
   /* OS-level higher contrast preference: keep brand hue but increase contrast
@@ -72,12 +76,14 @@
       --app-primary-soft: 219 234 254;
       --app-ring: 30 64 175;
       --app-header-bg: rgba(255, 255, 255, 1);
+      --app-sidebar-bg: rgba(255, 255, 255, 1);
       --app-header-border: rgba(15, 23, 42, 0.85);
       --app-nav-hover-bg: #dbeafe;
       --app-ring-slate: rgba(15, 23, 42, 0.2);
       --app-gradient: none;
       --app-shadow-soft: 0 0 0 transparent;
       --app-shadow-header: 0 0 0 transparent;
+      --app-shadow-sidebar-edge: 0 0 0 transparent;
     }
 
     html.dark {
@@ -90,12 +96,14 @@
       --app-primary-soft: 30 64 175;
       --app-ring: 250 204 21;
       --app-header-bg: rgba(0, 0, 0, 1);
+      --app-sidebar-bg: rgba(0, 0, 0, 1);
       --app-header-border: rgba(255, 255, 255, 0.9);
       --app-nav-hover-bg: #1e3a8a;
       --app-ring-slate: rgba(255, 255, 255, 0.22);
       --app-gradient: none;
       --app-shadow-soft: 0 0 0 transparent;
       --app-shadow-header: 0 0 0 transparent;
+      --app-shadow-sidebar-edge: 0 0 0 transparent;
     }
   }
 
@@ -123,12 +131,10 @@
   }
 }
 
-/* Body rules outside @layer so they win over Tailwind utility overrides */
-body {
-  margin: 0;
-  font-family: inherit;
-  line-height: inherit;
-  color: rgb(var(--app-ink) / 1);
+/* Grid-paper viewport background (body + app shell main column). Outside @layer so it
+ * wins over Tailwind utilities such as bg-background on layout wrappers. */
+body,
+.app-grid-background {
   background-color: rgb(var(--app-bg) / 1);
   background-image:
     linear-gradient(to right, #80808012 1px, transparent 1px),
@@ -138,11 +144,10 @@ body {
     14px 24px,
     14px 24px,
     100% 100%;
-  min-height: 100vh;
-  text-rendering: optimizeLegibility;
 }
 
-html.dark body {
+html.dark body,
+html.dark .app-grid-background {
   background-image:
     linear-gradient(to right, #ffffff0a 1px, transparent 1px),
     linear-gradient(to bottom, #ffffff0a 1px, transparent 1px),
@@ -151,6 +156,16 @@ html.dark body {
     14px 24px,
     14px 24px,
     100% 100%;
+}
+
+/* Body rules outside @layer so they win over Tailwind utility overrides */
+body {
+  margin: 0;
+  font-family: inherit;
+  line-height: inherit;
+  color: rgb(var(--app-ink) / 1);
+  min-height: 100vh;
+  text-rendering: optimizeLegibility;
 }
 
 /* Do not style `body` with `prefers-color-scheme`: theme is class-based (`html.dark`) only.

--- a/apps/web/src/components/app-shell/AuthenticatedShell.spec.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.spec.tsx
@@ -41,19 +41,36 @@ jest.mock('../theme/ThemeMenu', () => ({
   ThemeMenu: () => <button type="button">Theme</button>,
 }));
 
-jest.mock('@abstrack/ui', () => ({
-  NavigationShell: ({
+jest.mock('@abstrack/ui-web', () => ({
+  AppShellWithSideNav: ({
     children,
-    header,
+    topHeader,
+    sideNav,
   }: {
     children: ReactNode;
-    header?: ReactNode;
+    topHeader?: ReactNode;
+    sideNav?: ReactNode;
   }) => (
     <div>
-      <div data-testid="nav-shell-header">{header}</div>
-      <div data-testid="nav-shell-main">{children}</div>
+      <div data-testid="app-shell-top-header">{topHeader}</div>
+      <div data-testid="app-side-nav">{sideNav}</div>
+      <div data-testid="app-shell-main">{children}</div>
     </div>
   ),
+  AppSideNav: ({
+    items,
+  }: {
+    items: Array<{ href: string; label: string }>;
+  }) => (
+    <nav aria-label="ABStrack application">
+      {items.map((item) => (
+        <a key={item.href} href={item.href}>
+          {item.label}
+        </a>
+      ))}
+    </nav>
+  ),
+  SidebarTrigger: () => <button type="button">Menu</button>,
 }));
 
 import { AuthenticatedShell } from './AuthenticatedShell';

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -8,8 +8,7 @@ import {
 } from '@abstrack/ui-web';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { forwardRef, type ReactNode } from 'react';
-import { useMemo } from 'react';
+import { forwardRef, useMemo, type CSSProperties, type ReactNode } from 'react';
 
 import { ThemeMenu } from '@/components/theme/ThemeMenu';
 import { WEB_APP_NAV_ITEMS } from '@/lib/app-nav-items';
@@ -69,9 +68,7 @@ export function AuthenticatedShell({
       topHeader={
         <header
           className="sticky top-0 z-50 w-full shrink-0 overflow-visible border-b border-[var(--app-header-border)] bg-[var(--app-header-bg)] shadow-header backdrop-blur-md supports-[backdrop-filter]:bg-[var(--app-header-bg)]"
-          style={
-            { '--app-shell-header-height': '4.5rem' } as React.CSSProperties
-          }
+          style={{ '--app-shell-header-height': '4.5rem' } as CSSProperties}
         >
           <div className="mx-auto flex max-w-6xl items-center gap-3 px-4 py-3.5 sm:px-6 lg:px-8">
             <SidebarTrigger

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -61,7 +61,7 @@ export function AuthenticatedShell({
       skipLink={
         <a
           href="#main-content"
-          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[60] focus:rounded-lg focus:bg-app-surface focus:px-4 focus:py-2.5 focus:text-sm focus:font-medium text-app-ink focus:shadow-soft focus:outline-none focus:ring-2 focus:ring-app-ring focus:ring-offset-2 focus:ring-offset-app-bg"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[60] focus:rounded-lg focus:bg-app-surface focus:px-4 focus:py-2.5 focus:text-sm focus:font-medium focus:text-app-ink focus:shadow-soft focus:outline-none focus:ring-2 focus:ring-app-ring focus:ring-offset-2 focus:ring-offset-app-bg"
         >
           Skip to main content
         </a>

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -1,72 +1,30 @@
 'use client';
 
+import {
+  AppShellWithSideNav,
+  AppSideNav,
+  SidebarTrigger,
+  type AppSideNavLinkProps,
+} from '@abstrack/ui-web';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import type { ReactNode } from 'react';
+import type { ComponentType, ReactNode } from 'react';
 import { useMemo } from 'react';
-import { NavigationShell } from '@abstrack/ui';
 
 import { ThemeMenu } from '@/components/theme/ThemeMenu';
+import { WEB_APP_NAV_ITEMS } from '@/lib/app-nav-items';
 import { useWebPhiSubjectUserContext } from '@/lib/patient/use-web-phi-subject-user-context';
 
-const NAV_ITEMS: {
-  href: string;
-  label: string;
-  match: (path: string) => boolean;
-}[] = [
-  {
-    href: '/dashboard',
-    label: 'Dashboard',
-    match: (path) => path === '/dashboard' || path.startsWith('/dashboard/'),
-  },
-  {
-    href: '/manage',
-    label: 'Manage',
-    match: (path) => path === '/manage' || path.startsWith('/manage/'),
-  },
-  {
-    href: '/insights',
-    label: 'Insights',
-    match: (path) => path === '/insights' || path.startsWith('/insights/'),
-  },
-  {
-    href: '/presets/symptoms',
-    label: 'Symptom presets',
-    match: (path) =>
-      path === '/presets/symptoms' || path.startsWith('/presets/symptoms/'),
-  },
-  {
-    href: '/presets/health-markers',
-    label: 'Health marker presets',
-    match: (path) =>
-      path === '/presets/health-markers' ||
-      path.startsWith('/presets/health-markers/'),
-  },
-  {
-    href: '/presets/episode-templates',
-    label: 'Episode templates',
-    match: (path) =>
-      path === '/presets/episode-templates' ||
-      path.startsWith('/presets/episode-templates/'),
-  },
-  {
-    href: '/settings/caretaker',
-    label: 'Caretaker',
-    match: (path) =>
-      path === '/settings/caretaker' || path.startsWith('/settings/caretaker/'),
-  },
-  {
-    href: '/settings/practitioner',
-    label: 'Practitioner',
-    match: (path) =>
-      path === '/settings/practitioner' ||
-      path.startsWith('/settings/practitioner/'),
-  },
-];
-
-function isNavActive(pathname: string, match: (path: string) => boolean) {
-  return match(pathname);
-}
+const WebNavLink: ComponentType<AppSideNavLinkProps> = ({
+  href,
+  children,
+  className,
+  'aria-current': ariaCurrent,
+}) => (
+  <Link href={href} className={className} aria-current={ariaCurrent}>
+    {children}
+  </Link>
+);
 
 export type AuthenticatedShellProps = {
   children: ReactNode;
@@ -75,11 +33,10 @@ export type AuthenticatedShellProps = {
 };
 
 /**
- * Authenticated app chrome: skip link, {@link NavigationShell} with primary nav, sign-out, and a
- * centered main column. Surfaces use CSS variables so light/dark tracks the theme toggle.
- * Primary nav shows the patient-only Caretaker and Practitioner settings links only when
- * {@link useWebPhiSubjectUserContext} reports `profileAppRole === 'patient'`, so caretakers,
- * practitioners, and unresolved roles do not see dead-end routes (Edge returns 403).
+ * Authenticated app chrome: skip link, full-width top bar, side navigation (shadcn/ui sidebar),
+ * and a centered main column. Surfaces use CSS variables so light/dark tracks the theme toggle.
+ * Patient-only Caretaker and Practitioner settings links follow
+ * {@link useWebPhiSubjectUserContext} (`profileAppRole === 'patient'`).
  *
  * @param props - Props.
  * @returns Shell layout wrapping page content.
@@ -92,102 +49,82 @@ export function AuthenticatedShell({
   const { profileAppRole } = useWebPhiSubjectUserContext();
   const navItems = useMemo(() => {
     if (profileAppRole !== 'patient') {
-      return NAV_ITEMS.filter(
+      return WEB_APP_NAV_ITEMS.filter(
         (item) =>
           item.href !== '/settings/caretaker' &&
           item.href !== '/settings/practitioner',
       );
     }
-    return NAV_ITEMS;
+    return WEB_APP_NAV_ITEMS;
   }, [profileAppRole]);
 
   return (
-    <div className="flex min-h-screen flex-col">
-      <a
-        href="#main-content"
-        className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[60] focus:rounded-lg focus:bg-app-surface focus:px-4 focus:py-2.5 focus:text-sm focus:font-medium focus:text-app-ink focus:shadow-soft focus:outline-none focus:ring-2 focus:ring-app-ring focus:ring-offset-2 focus:ring-offset-app-bg"
-      >
-        Skip to main content
-      </a>
-      <NavigationShell
-        accessibilityLabel="ABStrack application"
-        style={{ backgroundColor: 'transparent' }}
-        headerStyle={{
-          backgroundColor: 'transparent',
-          borderBottomWidth: 0,
-          paddingHorizontal: 0,
-          paddingVertical: 0,
-        }}
-        mainStyle={{ backgroundColor: 'transparent', flex: 1 }}
-        header={
-          <header className="sticky top-0 z-50 overflow-visible border-b border-[var(--app-header-border)] bg-[var(--app-header-bg)] shadow-header backdrop-blur-md supports-[backdrop-filter]:bg-[var(--app-header-bg)]">
-            <div className="mx-auto flex max-w-6xl flex-col gap-4 px-4 py-3.5 sm:px-6 lg:flex-row lg:items-center lg:justify-between lg:gap-8 lg:px-8">
-              <Link
-                href="/dashboard"
-                className="shrink-0 rounded-lg outline-none ring-offset-2 ring-offset-app-bg transition hover:text-app-primary focus-visible:ring-2 focus-visible:ring-app-ring"
-              >
-                <span className="block text-lg font-bold tracking-tight text-app-ink">
-                  ABStrack
-                </span>
-                <span className="mt-0.5 block text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-app-muted">
-                  Health tracking
-                </span>
-              </Link>
-
-              <nav
-                aria-label="Primary"
-                className="flex flex-1 flex-wrap items-center justify-center gap-1.5 sm:justify-start lg:justify-center"
-              >
-                {navItems.map(({ href, label, match }) => {
-                  const active = isNavActive(pathname, match);
-                  return (
-                    <Link
-                      key={href}
-                      href={href}
-                      aria-current={active ? 'page' : undefined}
-                      className={
-                        active
-                          ? 'inline-flex min-h-[44px] items-center rounded-full bg-app-primary-soft px-4 py-2 text-sm font-semibold text-app-primary shadow-sm ring-1 ring-app-primary/25 transition outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-app-primary-soft/28'
-                          : 'inline-flex min-h-[44px] items-center rounded-full px-4 py-2 text-sm font-medium text-app-muted transition outline-none hover:bg-[var(--app-nav-hover-bg)] hover:text-app-ink focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
-                      }
-                    >
-                      {label}
-                    </Link>
-                  );
-                })}
-              </nav>
-
-              <div className="flex flex-wrap items-center justify-end gap-3 border-t border-app-border/60 pt-3 sm:border-t-0 sm:pt-0 lg:shrink-0">
-                {email ? (
-                  <p
-                    className="max-w-[min(100%,14rem)] truncate text-right text-xs text-app-muted"
-                    title={email}
-                    aria-label={`Signed in as ${email}`}
-                  >
-                    {email}
-                  </p>
-                ) : null}
-                <form action="/api/auth/logout" method="POST">
-                  <button
-                    type="submit"
-                    className="min-h-[44px] rounded-full border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-                  >
-                    Log out
-                  </button>
-                </form>
-                <ThemeMenu />
-              </div>
-            </div>
-          </header>
-        }
-      >
-        <main
-          id="main-content"
-          className="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 lg:px-8"
+    <AppShellWithSideNav
+      skipLink={
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:absolute focus:left-4 focus:top-4 focus:z-[60] focus:rounded-lg focus:bg-app-surface focus:px-4 focus:py-2.5 focus:text-sm focus:font-medium text-app-ink focus:shadow-soft focus:outline-none focus:ring-2 focus:ring-app-ring focus:ring-offset-2 focus:ring-offset-app-bg"
         >
-          {children}
-        </main>
-      </NavigationShell>
-    </div>
+          Skip to main content
+        </a>
+      }
+      topHeader={
+        <header
+          className="sticky top-0 z-50 w-full shrink-0 overflow-visible border-b border-[var(--app-header-border)] bg-[var(--app-header-bg)] shadow-header backdrop-blur-md supports-[backdrop-filter]:bg-[var(--app-header-bg)]"
+          style={
+            { '--app-shell-header-height': '4.5rem' } as React.CSSProperties
+          }
+        >
+          <div className="mx-auto flex max-w-6xl items-center gap-3 px-4 py-3.5 sm:px-6 lg:px-8">
+            <SidebarTrigger
+              className="min-h-11 min-w-11 shrink-0 text-app-ink md:hidden"
+              aria-label="Open navigation menu"
+            />
+            <Link
+              href="/dashboard"
+              className="shrink-0 rounded-lg outline-none ring-offset-2 ring-offset-app-bg transition hover:text-app-primary focus-visible:ring-2 focus-visible:ring-app-ring"
+            >
+              <span className="block text-lg font-bold tracking-tight text-app-ink">
+                ABStrack
+              </span>
+              <span className="mt-0.5 block text-[0.65rem] font-semibold uppercase tracking-[0.18em] text-app-muted">
+                Health tracking
+              </span>
+            </Link>
+            <div className="flex flex-1 flex-wrap items-center justify-end gap-3">
+              {email ? (
+                <p
+                  className="max-w-[min(100%,14rem)] truncate text-right text-xs text-app-muted"
+                  title={email}
+                  aria-label={`Signed in as ${email}`}
+                >
+                  {email}
+                </p>
+              ) : null}
+              <form action="/api/auth/logout" method="POST">
+                <button
+                  type="submit"
+                  className="min-h-[44px] rounded-full border border-app-border bg-app-surface px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                >
+                  Log out
+                </button>
+              </form>
+              <ThemeMenu />
+            </div>
+          </div>
+        </header>
+      }
+      sideNav={
+        <AppSideNav
+          pathname={pathname}
+          items={navItems}
+          LinkComponent={WebNavLink}
+          accessibilityLabel="ABStrack application"
+        />
+      }
+      mainClassName="mx-auto w-full max-w-3xl flex-1 px-4 py-8 sm:px-6 lg:px-8"
+    >
+      {children}
+    </AppShellWithSideNav>
   );
 }

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -8,7 +8,7 @@ import {
 } from '@abstrack/ui-web';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { forwardRef, useMemo, type CSSProperties, type ReactNode } from 'react';
+import { forwardRef, useMemo, type ReactNode } from 'react';
 
 import { ThemeMenu } from '@/components/theme/ThemeMenu';
 import { WEB_APP_NAV_ITEMS } from '@/lib/app-nav-items';
@@ -57,6 +57,7 @@ export function AuthenticatedShell({
 
   return (
     <AppShellWithSideNav
+      sidebarTopOffset="4.5rem"
       skipLink={
         <a
           href="#main-content"
@@ -66,10 +67,7 @@ export function AuthenticatedShell({
         </a>
       }
       topHeader={
-        <header
-          className="sticky top-0 z-50 w-full shrink-0 overflow-visible border-b border-[var(--app-header-border)] bg-[var(--app-header-bg)] shadow-header backdrop-blur-md supports-[backdrop-filter]:bg-[var(--app-header-bg)]"
-          style={{ '--app-shell-header-height': '4.5rem' } as CSSProperties}
-        >
+        <header className="sticky top-0 z-50 w-full shrink-0 overflow-visible border-b border-[var(--app-header-border)] bg-[var(--app-header-bg)] shadow-header backdrop-blur-md supports-[backdrop-filter]:bg-[var(--app-header-bg)]">
           <div className="mx-auto flex max-w-6xl items-center gap-3 px-4 py-3.5 sm:px-6 lg:px-8">
             <SidebarTrigger
               className="min-h-11 min-w-11 shrink-0 text-app-ink md:hidden"

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -58,6 +58,7 @@ export function AuthenticatedShell({
   return (
     <AppShellWithSideNav
       sidebarTopOffset="4.5rem"
+      sidebarCookieName="abstrack_web_sidebar_state"
       skipLink={
         <a
           href="#main-content"

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -8,23 +8,21 @@ import {
 } from '@abstrack/ui-web';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import type { ComponentType, ReactNode } from 'react';
+import { forwardRef, type ReactNode } from 'react';
 import { useMemo } from 'react';
 
 import { ThemeMenu } from '@/components/theme/ThemeMenu';
 import { WEB_APP_NAV_ITEMS } from '@/lib/app-nav-items';
 import { useWebPhiSubjectUserContext } from '@/lib/patient/use-web-phi-subject-user-context';
 
-const WebNavLink: ComponentType<AppSideNavLinkProps> = ({
-  href,
-  children,
-  className,
-  'aria-current': ariaCurrent,
-}) => (
-  <Link href={href} className={className} aria-current={ariaCurrent}>
-    {children}
-  </Link>
+const WebNavLink = forwardRef<HTMLAnchorElement, AppSideNavLinkProps>(
+  ({ href, children, ...rest }, ref) => (
+    <Link href={href} ref={ref} {...rest}>
+      {children}
+    </Link>
+  ),
 );
+WebNavLink.displayName = 'WebNavLink';
 
 export type AuthenticatedShellProps = {
   children: ReactNode;

--- a/apps/web/src/lib/app-nav-items.ts
+++ b/apps/web/src/lib/app-nav-items.ts
@@ -1,0 +1,55 @@
+import type { AppSideNavItem } from '@abstrack/ui-web';
+
+/**
+ * Primary authenticated routes for the user web app side navigation.
+ */
+export const WEB_APP_NAV_ITEMS: AppSideNavItem[] = [
+  {
+    href: '/dashboard',
+    label: 'Dashboard',
+    match: (path) => path === '/dashboard' || path.startsWith('/dashboard/'),
+  },
+  {
+    href: '/manage',
+    label: 'Manage',
+    match: (path) => path === '/manage' || path.startsWith('/manage/'),
+  },
+  {
+    href: '/insights',
+    label: 'Insights',
+    match: (path) => path === '/insights' || path.startsWith('/insights/'),
+  },
+  {
+    href: '/presets/symptoms',
+    label: 'Symptom presets',
+    match: (path) =>
+      path === '/presets/symptoms' || path.startsWith('/presets/symptoms/'),
+  },
+  {
+    href: '/presets/health-markers',
+    label: 'Health marker presets',
+    match: (path) =>
+      path === '/presets/health-markers' ||
+      path.startsWith('/presets/health-markers/'),
+  },
+  {
+    href: '/presets/episode-templates',
+    label: 'Episode templates',
+    match: (path) =>
+      path === '/presets/episode-templates' ||
+      path.startsWith('/presets/episode-templates/'),
+  },
+  {
+    href: '/settings/caretaker',
+    label: 'Caretaker',
+    match: (path) =>
+      path === '/settings/caretaker' || path.startsWith('/settings/caretaker/'),
+  },
+  {
+    href: '/settings/practitioner',
+    label: 'Practitioner',
+    match: (path) =>
+      path === '/settings/practitioner' ||
+      path.startsWith('/settings/practitioner/'),
+  },
+];

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -9,14 +9,19 @@
 // If you are **not** using `--turbo` you can uncomment both lines 1 & 19.
 // A discussion of the issue can be found: https://github.com/nrwl/nx/issues/26510
 
+const shadcnPreset = require('../../packages/ui-web/tailwind-shadcn-preset.js');
+
 /** @type {import('tailwindcss').Config} */
 module.exports = {
   darkMode: 'class',
+  presets: [shadcnPreset],
   content: [
     './{src,pages,components,app}/**/*.{ts,tsx,js,jsx,html}',
     '!./{src,pages,components,app}/**/*.{stories,spec}.{ts,tsx,js,jsx,html}',
     '../../packages/ui/src/**/*.{ts,tsx}',
     '!../../packages/ui/src/**/*.{stories,spec}.{ts,tsx}',
+    '../../packages/ui-web/src/**/*.{ts,tsx}',
+    '!../../packages/ui-web/src/**/*.{stories,spec}.{ts,tsx}',
     //     ...createGlobPatternsForDependencies(__dirname)
   ],
   theme: {
@@ -55,11 +60,12 @@ module.exports = {
       boxShadow: {
         soft: 'var(--app-shadow-soft)',
         header: 'var(--app-shadow-header)',
+        'sidebar-edge': 'var(--app-shadow-sidebar-edge)',
       },
       backgroundImage: {
         'app-gradient': 'var(--app-gradient)',
       },
     },
   },
-  plugins: [],
+  plugins: [require('tailwindcss-animate')],
 };

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -9,7 +9,7 @@
 // If you are **not** using `--turbo` you can uncomment both lines 1 & 19.
 // A discussion of the issue can be found: https://github.com/nrwl/nx/issues/26510
 
-const shadcnPreset = require('../../packages/ui-web/tailwind-shadcn-preset.js');
+const shadcnPreset = require('../../packages/ui-web/tailwind-shadcn-preset.cjs');
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -57,6 +57,9 @@
     },
     {
       "path": "../../packages/ui"
+    },
+    {
+      "path": "../../packages/ui-web"
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -97,6 +97,7 @@
     "prettier": "~3.6.2",
     "react-test-renderer": "19.1.0",
     "tailwindcss": "3.4.3",
+    "tailwindcss-animate": "^1.0.7",
     "ts-jest": "^29.4.0",
     "ts-node": "10.9.1",
     "tslib": "^2.3.0",
@@ -118,8 +119,7 @@
     "react-native": "0.81.5",
     "react-native-svg": "15.12.1",
     "react-native-svg-transformer": "~1.5.1",
-    "react-native-web": "~0.21.0",
-    "tailwindcss-animate": "^1.0.7"
+    "react-native-web": "~0.21.0"
   },
   "pnpm": {
     "overrides": {

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "prettier": "~3.6.2",
     "react-test-renderer": "19.1.0",
     "tailwindcss": "3.4.3",
-    "tailwindcss-animate": "^1.0.7",
     "ts-jest": "^29.4.0",
     "ts-node": "10.9.1",
     "tslib": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "supabase:test": "nx test @abstrack/supabase",
     "supabase:typecheck": "nx run @abstrack/supabase:typecheck",
     "supabase:validate": "nx run-many -t lint test typecheck -p @abstrack/supabase",
-    "packages:validate": "nx run-many -t lint test typecheck -p @abstrack/types,@abstrack/ui,@abstrack/supabase,@abstrack/powersync",
+    "packages:validate": "nx run-many -t lint test typecheck -p @abstrack/types,@abstrack/ui,@abstrack/ui-web,@abstrack/supabase,@abstrack/powersync",
     "lint": "nx run-many -t lint",
     "test": "nx run-many -t test",
     "build": "nx run-many -t build -p web,practitioner && pnpm mobile:typecheck && pnpm supabase:typecheck",
@@ -118,7 +118,8 @@
     "react-native": "0.81.5",
     "react-native-svg": "15.12.1",
     "react-native-svg-transformer": "~1.5.1",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "tailwindcss-animate": "^1.0.7"
   },
   "pnpm": {
     "overrides": {

--- a/packages/ui-web/README.md
+++ b/packages/ui-web/README.md
@@ -1,0 +1,43 @@
+# @abstrack/ui-web
+
+Shared **web-only** UI built on [shadcn/ui](https://ui.shadcn.com/docs/components/radix/sidebar) (Radix + Tailwind). Used by `@abstrack/web` and `@abstrack/practitioner`.
+
+## Theming
+
+Semantic Tailwind tokens (`bg-sidebar`, `text-foreground`, etc.) map to ABStrack `--app-*` CSS variables via `tailwind-shadcn-preset.js`. Each Next app must:
+
+1. `presets: [require('../../packages/ui-web/tailwind-shadcn-preset')]`
+2. `plugins: [require('tailwindcss-animate')]`
+3. Include `packages/ui-web/src/**/*` in `content`
+
+Dark mode follows `html.dark` (same as the apps’ theme toggle).
+
+**Chrome tokens** (keep in sync in `apps/web/src/app/global.css` and `apps/practitioner/src/app/global.css`):
+
+| Token                 | Light                    | Dark                  |
+| --------------------- | ------------------------ | --------------------- |
+| `--app-header-bg`     | `rgba(255,255,255,0.92)` | `rgba(15,23,42,0.92)` |
+| `--app-sidebar-bg`    | `rgba(255,255,255,0.94)` | `rgba(15,23,42,0.94)` |
+| `--app-header-border` | `rgba(226,232,240,0.95)` | `rgba(51,65,85,0.95)` |
+
+The main column uses the `app-grid-background` class (defined in each app’s `global.css`) so the grid-paper viewport pattern is not covered by shadcn `bg-background` utilities.
+
+The sidebar panel uses `--app-sidebar-bg` with `backdrop-blur-sm`. Grid lines are very faint in light mode (`#80808012`), so only a subtle hint shows through even at 94% opacity — that is expected, not a broken token.
+
+## App side navigation
+
+- `AppSideNav` — menu items + brand + optional footer
+- `AppShellWithSideNav` — `SidebarProvider` + inset main column
+
+Pass the host app’s `Link` component so routing stays in Next.js.
+
+## Adding shadcn components
+
+From the repo root (adjust style if the registry changes):
+
+```bash
+cd packages/ui-web
+pnpm dlx shadcn@latest add <component> -y
+```
+
+Fix imports to use `.js` extensions and `../lib/utils.js` paths for NodeNext resolution, then export from `src/index.ts` if needed.

--- a/packages/ui-web/README.md
+++ b/packages/ui-web/README.md
@@ -7,7 +7,7 @@ Shared **web-only** UI built on [shadcn/ui](https://ui.shadcn.com/docs/component
 Semantic Tailwind tokens (`bg-sidebar`, `text-foreground`, etc.) map to ABStrack `--app-*` CSS variables via `tailwind-shadcn-preset.cjs` (CommonJS; this package is ESM). Each Next app must:
 
 1. `presets: [require('../../packages/ui-web/tailwind-shadcn-preset.cjs')]`
-2. `plugins: [require('tailwindcss-animate')]`
+2. `plugins: [require('tailwindcss-animate')]` (add `tailwindcss-animate` as a **devDependency** of the app)
 3. Include `packages/ui-web/src/**/*` in `content`
 
 Dark mode follows `html.dark` (same as the apps’ theme toggle).

--- a/packages/ui-web/README.md
+++ b/packages/ui-web/README.md
@@ -4,9 +4,9 @@ Shared **web-only** UI built on [shadcn/ui](https://ui.shadcn.com/docs/component
 
 ## Theming
 
-Semantic Tailwind tokens (`bg-sidebar`, `text-foreground`, etc.) map to ABStrack `--app-*` CSS variables via `tailwind-shadcn-preset.js`. Each Next app must:
+Semantic Tailwind tokens (`bg-sidebar`, `text-foreground`, etc.) map to ABStrack `--app-*` CSS variables via `tailwind-shadcn-preset.cjs` (CommonJS; this package is ESM). Each Next app must:
 
-1. `presets: [require('../../packages/ui-web/tailwind-shadcn-preset')]`
+1. `presets: [require('../../packages/ui-web/tailwind-shadcn-preset.cjs')]`
 2. `plugins: [require('tailwindcss-animate')]`
 3. Include `packages/ui-web/src/**/*` in `content`
 

--- a/packages/ui-web/eslint.config.mjs
+++ b/packages/ui-web/eslint.config.mjs
@@ -10,9 +10,10 @@ export default [
         {
           ignoredDependencies: [
             'vitest',
-            'react-dom',
             '@testing-library/react',
             '@testing-library/jest-dom',
+            // Peer for host apps (Next.js); not imported in package source — nx obsolete-deps false positive.
+            'react-dom',
           ],
           ignoredFiles: [
             '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',

--- a/packages/ui-web/eslint.config.mjs
+++ b/packages/ui-web/eslint.config.mjs
@@ -8,7 +8,12 @@ export default [
       '@nx/dependency-checks': [
         'error',
         {
-          ignoredDependencies: ['vitest', 'react-dom'],
+          ignoredDependencies: [
+            'vitest',
+            'react-dom',
+            '@testing-library/react',
+            '@testing-library/jest-dom',
+          ],
           ignoredFiles: [
             '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
             '{projectRoot}/vite.config.{js,ts,mjs,mts}',

--- a/packages/ui-web/eslint.config.mjs
+++ b/packages/ui-web/eslint.config.mjs
@@ -1,0 +1,26 @@
+import baseConfig from '../../eslint.config.mjs';
+
+export default [
+  ...baseConfig,
+  {
+    files: ['**/*.json'],
+    rules: {
+      '@nx/dependency-checks': [
+        'error',
+        {
+          ignoredDependencies: ['vitest', 'react-dom'],
+          ignoredFiles: [
+            '{projectRoot}/eslint.config.{js,cjs,mjs,ts,cts,mts}',
+            '{projectRoot}/vite.config.{js,ts,mjs,mts}',
+          ],
+        },
+      ],
+    },
+    languageOptions: {
+      parser: await import('jsonc-eslint-parser'),
+    },
+  },
+  {
+    ignores: ['**/out-tsc'],
+  },
+];

--- a/packages/ui-web/package.json
+++ b/packages/ui-web/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@abstrack/ui-web",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "@abstrack/source": "./src/index.ts",
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
+      "default": "./dist/index.js"
+    },
+    "./sidebar": {
+      "@abstrack/source": "./src/components/sidebar.tsx",
+      "types": "./dist/components/sidebar.d.ts",
+      "import": "./dist/components/sidebar.js",
+      "default": "./dist/components/sidebar.js"
+    }
+  },
+  "peerDependencies": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0"
+  },
+  "dependencies": {
+    "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-separator": "^1.1.7",
+    "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tooltip": "^1.2.8",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.544.0",
+    "tailwind-merge": "^3.3.1",
+    "tslib": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/react": "~19.1.0",
+    "@types/react-dom": "~19.1.0",
+    "react": "19.1.0",
+    "react-dom": "19.1.0"
+  }
+}

--- a/packages/ui-web/package.json
+++ b/packages/ui-web/package.json
@@ -37,6 +37,8 @@
     "tslib": "^2.3.0"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "16.3.0",
     "@types/react": "~19.1.0",
     "@types/react-dom": "~19.1.0",
     "react": "19.1.0",

--- a/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
+++ b/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
@@ -28,7 +28,10 @@ export type AppShellWithSideNavProps = {
   skipLink?: ReactNode;
   /** `id` on the `<main>` landmark (skip-link target); receives `tabIndex={-1}` for focus. */
   mainId?: string;
-  /** Classes on the `<main>` landmark (`SidebarInset`). */
+  /**
+   * Layout classes for page content below {@link header} and the built-in mobile menu row
+   * (not applied to `<main>` itself, so mobile chrome stays full-width).
+   */
   mainClassName?: string;
   /** Accessible label for the mobile menu trigger. */
   mobileMenuTriggerLabel?: string;
@@ -92,10 +95,7 @@ export function AppShellWithSideNav({
         <SidebarInset
           id={mainId}
           tabIndex={-1}
-          className={cn(
-            'app-grid-background flex min-h-0 min-w-0 flex-1 flex-col',
-            mainClassName,
-          )}
+          className="app-grid-background flex min-h-0 min-w-0 flex-1 flex-col"
         >
           {header}
           {showMobileTrigger ? (
@@ -107,7 +107,9 @@ export function AppShellWithSideNav({
               <span className="text-sm font-semibold text-app-ink">Menu</span>
             </div>
           ) : null}
-          {children}
+          <div className={cn('flex min-h-0 flex-1 flex-col', mainClassName)}>
+            {children}
+          </div>
         </SidebarInset>
       </div>
     </SidebarProvider>

--- a/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
+++ b/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
@@ -33,6 +33,12 @@ export type AppShellWithSideNavProps = {
   /** Accessible label for the mobile menu trigger. */
   mobileMenuTriggerLabel?: string;
   /**
+   * Built-in mobile {@link SidebarTrigger} row inside the main column. Defaults to `false` when
+   * {@link topHeader} is set (the header should include a trigger); defaults to `true` otherwise,
+   * including when only the legacy {@link header} prop is used.
+   */
+  showMobileMenuTrigger?: boolean;
+  /**
    * Cookie for desktop sidebar open state (uncontrolled). Use a distinct name per app on shared
    * hosts (e.g. `abstrack_web_sidebar_state` vs `abstrack_practitioner_sidebar_state`).
    */
@@ -41,7 +47,8 @@ export type AppShellWithSideNavProps = {
 
 /**
  * Layout shell: optional full-width top header, then side navigation and main column under
- * {@link SidebarProvider}. Exposes {@link SidebarTrigger} on small screens when no header is passed.
+ * {@link SidebarProvider}. Exposes a built-in {@link SidebarTrigger} on small screens unless
+ * {@link topHeader} supplies one (override with {@link showMobileMenuTrigger}).
  *
  * @param props - Shell layout props.
  * @returns Provider-wrapped page chrome.
@@ -56,9 +63,10 @@ export function AppShellWithSideNav({
   mainId = 'main-content',
   mainClassName,
   mobileMenuTriggerLabel = 'Open navigation menu',
+  showMobileMenuTrigger,
   sidebarCookieName,
 }: AppShellWithSideNavProps) {
-  const showMobileTrigger = !header && !topHeader;
+  const showMobileTrigger = showMobileMenuTrigger ?? !topHeader;
 
   const providerStyle: CSSProperties = {
     '--sidebar-width': '16rem',

--- a/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
+++ b/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
@@ -6,6 +6,7 @@ import {
   SidebarProvider,
   SidebarTrigger,
 } from '../components/sidebar.js';
+import { cn } from '../lib/utils.js';
 
 export type AppShellWithSideNavProps = {
   children: ReactNode;
@@ -14,16 +15,20 @@ export type AppShellWithSideNavProps = {
   /**
    * Full-width top chrome above the sidebar + main row (e.g. user web top bar).
    * Must render inside {@link SidebarProvider} (e.g. for {@link SidebarTrigger}).
-   * Set `--app-shell-header-height` on the header element so the desktop sidebar stops below it.
    */
   topHeader?: ReactNode;
+  /**
+   * Height of {@link topHeader} for desktop sidebar positioning. Sets `--app-shell-header-height`
+   * and `--sidebar-top-offset` on {@link SidebarProvider} (defaults to `4.5rem` when `topHeader` is set).
+   */
+  sidebarTopOffset?: string;
   /** Top chrome inside the main column only (legacy; prefer {@link topHeader}). */
   header?: ReactNode;
   /** Optional skip link rendered before main content. */
   skipLink?: ReactNode;
-  /** `id` for the scrollable main region (skip-link target). */
+  /** `id` on the `<main>` landmark (skip-link target); receives `tabIndex={-1}` for focus. */
   mainId?: string;
-  /** Classes on the inner main content wrapper. */
+  /** Classes on the `<main>` landmark (`SidebarInset`). */
   mainClassName?: string;
   /** Accessible label for the mobile menu trigger. */
   mobileMenuTriggerLabel?: string;
@@ -40,6 +45,7 @@ export function AppShellWithSideNav({
   children,
   sideNav,
   topHeader,
+  sidebarTopOffset = '4.5rem',
   header,
   skipLink,
   mainId = 'main-content',
@@ -53,7 +59,8 @@ export function AppShellWithSideNav({
     '--sidebar-width-mobile': '18rem',
     ...(topHeader
       ? {
-          '--sidebar-top-offset': 'var(--app-shell-header-height, 4.5rem)',
+          '--app-shell-header-height': sidebarTopOffset,
+          '--sidebar-top-offset': sidebarTopOffset,
         }
       : {}),
   } as CSSProperties;
@@ -67,7 +74,14 @@ export function AppShellWithSideNav({
       {topHeader}
       <div className="flex min-h-0 w-full flex-1">
         {sideNav}
-        <SidebarInset className="app-grid-background flex min-h-0 min-w-0 flex-1 flex-col">
+        <SidebarInset
+          id={mainId}
+          tabIndex={-1}
+          className={cn(
+            'app-grid-background flex min-h-0 min-w-0 flex-1 flex-col',
+            mainClassName,
+          )}
+        >
           {header}
           {showMobileTrigger ? (
             <div className="flex h-14 shrink-0 items-center gap-2 border-b border-app-border bg-[var(--app-header-bg)] px-4 shadow-header backdrop-blur-md md:hidden">
@@ -78,9 +92,7 @@ export function AppShellWithSideNav({
               <span className="text-sm font-semibold text-app-ink">Menu</span>
             </div>
           ) : null}
-          <div id={mainId} className={mainClassName}>
-            {children}
-          </div>
+          {children}
         </SidebarInset>
       </div>
     </SidebarProvider>

--- a/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
+++ b/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
@@ -32,6 +32,11 @@ export type AppShellWithSideNavProps = {
   mainClassName?: string;
   /** Accessible label for the mobile menu trigger. */
   mobileMenuTriggerLabel?: string;
+  /**
+   * Cookie for desktop sidebar open state (uncontrolled). Use a distinct name per app on shared
+   * hosts (e.g. `abstrack_web_sidebar_state` vs `abstrack_practitioner_sidebar_state`).
+   */
+  sidebarCookieName?: string;
 };
 
 /**
@@ -51,6 +56,7 @@ export function AppShellWithSideNav({
   mainId = 'main-content',
   mainClassName,
   mobileMenuTriggerLabel = 'Open navigation menu',
+  sidebarCookieName,
 }: AppShellWithSideNavProps) {
   const showMobileTrigger = !header && !topHeader;
 
@@ -69,6 +75,7 @@ export function AppShellWithSideNav({
     <SidebarProvider
       className="flex min-h-svh w-full flex-col"
       style={providerStyle}
+      sidebarCookieName={sidebarCookieName}
     >
       {skipLink}
       {topHeader}

--- a/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
+++ b/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import type { CSSProperties, ReactNode } from 'react';
+import {
+  SidebarInset,
+  SidebarProvider,
+  SidebarTrigger,
+} from '../components/sidebar.js';
+
+export type AppShellWithSideNavProps = {
+  children: ReactNode;
+  /** Side navigation tree (typically {@link AppSideNav}). */
+  sideNav: ReactNode;
+  /**
+   * Full-width top chrome above the sidebar + main row (e.g. user web top bar).
+   * Must render inside {@link SidebarProvider} (e.g. for {@link SidebarTrigger}).
+   * Set `--app-shell-header-height` on the header element so the desktop sidebar stops below it.
+   */
+  topHeader?: ReactNode;
+  /** Top chrome inside the main column only (legacy; prefer {@link topHeader}). */
+  header?: ReactNode;
+  /** Optional skip link rendered before main content. */
+  skipLink?: ReactNode;
+  /** `id` for the scrollable main region (skip-link target). */
+  mainId?: string;
+  /** Classes on the inner main content wrapper. */
+  mainClassName?: string;
+  /** Accessible label for the mobile menu trigger. */
+  mobileMenuTriggerLabel?: string;
+};
+
+/**
+ * Layout shell: optional full-width top header, then side navigation and main column under
+ * {@link SidebarProvider}. Exposes {@link SidebarTrigger} on small screens when no header is passed.
+ *
+ * @param props - Shell layout props.
+ * @returns Provider-wrapped page chrome.
+ */
+export function AppShellWithSideNav({
+  children,
+  sideNav,
+  topHeader,
+  header,
+  skipLink,
+  mainId = 'main-content',
+  mainClassName,
+  mobileMenuTriggerLabel = 'Open navigation menu',
+}: AppShellWithSideNavProps) {
+  const showMobileTrigger = !header && !topHeader;
+
+  const providerStyle: CSSProperties = {
+    '--sidebar-width': '16rem',
+    '--sidebar-width-mobile': '18rem',
+    ...(topHeader
+      ? {
+          '--sidebar-top-offset': 'var(--app-shell-header-height, 4.5rem)',
+        }
+      : {}),
+  } as CSSProperties;
+
+  return (
+    <SidebarProvider
+      className={
+        topHeader
+          ? 'flex min-h-svh w-full flex-col'
+          : 'flex min-h-svh w-full flex-col'
+      }
+      style={providerStyle}
+    >
+      {skipLink}
+      {topHeader}
+      <div
+        className={
+          topHeader
+            ? 'flex min-h-0 w-full flex-1'
+            : 'flex min-h-0 w-full flex-1'
+        }
+      >
+        {sideNav}
+        <SidebarInset className="app-grid-background flex min-h-0 min-w-0 flex-1 flex-col">
+          {header}
+          {showMobileTrigger ? (
+            <div className="flex h-14 shrink-0 items-center gap-2 border-b border-app-border bg-[var(--app-header-bg)] px-4 shadow-header backdrop-blur-md md:hidden">
+              <SidebarTrigger
+                className="min-h-11 min-w-11 text-app-ink"
+                aria-label={mobileMenuTriggerLabel}
+              />
+              <span className="text-sm font-semibold text-app-ink">Menu</span>
+            </div>
+          ) : null}
+          <div id={mainId} className={mainClassName}>
+            {children}
+          </div>
+        </SidebarInset>
+      </div>
+    </SidebarProvider>
+  );
+}

--- a/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
+++ b/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
@@ -71,16 +71,12 @@ export function AppShellWithSideNav({
 }: AppShellWithSideNavProps) {
   const showMobileTrigger = showMobileMenuTrigger ?? !topHeader;
 
-  const providerStyle: CSSProperties = {
-    '--sidebar-width': '16rem',
-    '--sidebar-width-mobile': '18rem',
-    ...(topHeader
-      ? {
-          '--app-shell-header-height': sidebarTopOffset,
-          '--sidebar-top-offset': sidebarTopOffset,
-        }
-      : {}),
-  } as CSSProperties;
+  const providerStyle: CSSProperties | undefined = topHeader
+    ? ({
+        '--app-shell-header-height': sidebarTopOffset,
+        '--sidebar-top-offset': sidebarTopOffset,
+      } as CSSProperties)
+    : undefined;
 
   return (
     <SidebarProvider

--- a/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
+++ b/packages/ui-web/src/app-side-nav/AppShellWithSideNav.tsx
@@ -60,22 +60,12 @@ export function AppShellWithSideNav({
 
   return (
     <SidebarProvider
-      className={
-        topHeader
-          ? 'flex min-h-svh w-full flex-col'
-          : 'flex min-h-svh w-full flex-col'
-      }
+      className="flex min-h-svh w-full flex-col"
       style={providerStyle}
     >
       {skipLink}
       {topHeader}
-      <div
-        className={
-          topHeader
-            ? 'flex min-h-0 w-full flex-1'
-            : 'flex min-h-0 w-full flex-1'
-        }
-      >
+      <div className="flex min-h-0 w-full flex-1">
         {sideNav}
         <SidebarInset className="app-grid-background flex min-h-0 min-w-0 flex-1 flex-col">
           {header}

--- a/packages/ui-web/src/app-side-nav/AppSideNav.tsx
+++ b/packages/ui-web/src/app-side-nav/AppSideNav.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import type { ReactNode } from 'react';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarRail,
+} from '../components/sidebar.js';
+import { cn } from '../lib/utils.js';
+import type { AppSideNavItem, AppSideNavLinkComponent } from './types.js';
+
+/**
+ * Sidebar nav link styles (legacy user-web top nav). Uses explicit active/inactive classes
+ * because shadcn `data-[active=true]:bg-sidebar-accent` wins in the stylesheet over merged Tailwind.
+ *
+ * @param active - Whether this item matches the current route.
+ * @returns Class string for {@link SidebarMenuButton} (with `isActive` left false).
+ */
+function sideNavItemClassName(active: boolean): string {
+  return cn(
+    'min-h-11 w-full !rounded-full px-3 text-base font-medium md:min-h-9 md:text-sm',
+    'focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg',
+    active
+      ? '!bg-app-primary-soft !font-semibold !text-app-primary shadow-sm ring-1 ring-app-primary/25 hover:!bg-app-primary-soft hover:!text-app-primary dark:!bg-app-primary-soft/28 dark:!text-app-ink dark:hover:!bg-app-primary-soft/28 dark:hover:!text-app-ink'
+      : '!bg-transparent !text-app-muted hover:!bg-[var(--app-nav-hover-bg)] hover:!text-app-ink',
+  );
+}
+
+export type AppSideNavProps = {
+  /** Current pathname from the host router (e.g. `usePathname()`). */
+  pathname: string;
+  /** Primary navigation entries. */
+  items: AppSideNavItem[];
+  /** App link component (e.g. Next.js `Link`). */
+  LinkComponent: AppSideNavLinkComponent;
+  /** Brand block in the sidebar header (logo, product name). Omit when the app has a top bar brand. */
+  brand?: ReactNode;
+  /** Optional footer (account actions, theme toggle). */
+  footer?: ReactNode;
+  /** Accessible name for the navigation landmark. */
+  accessibilityLabel?: string;
+};
+
+/**
+ * Application side navigation built on the shadcn/ui {@link Sidebar} primitives.
+ * On narrow viewports the same menu is shown in a slide-over sheet; on `md+` it is a fixed rail.
+ *
+ * @param props - Side nav configuration.
+ * @returns Sidebar panel (desktop) and mobile sheet (via parent {@link SidebarProvider}).
+ */
+export function AppSideNav({
+  pathname,
+  items,
+  LinkComponent,
+  brand,
+  footer,
+  accessibilityLabel = 'Application',
+}: AppSideNavProps) {
+  return (
+    <Sidebar
+      collapsible="offcanvas"
+      variant="sidebar"
+      className="border-[color:var(--app-header-border)] shadow-sidebar-edge"
+    >
+      {brand ? (
+        <SidebarHeader className="border-b border-[color:var(--app-header-border)] px-3 py-4">
+          {brand}
+        </SidebarHeader>
+      ) : null}
+      <SidebarContent className={brand ? undefined : 'pt-3'}>
+        <SidebarGroup>
+          <SidebarGroupLabel className="sr-only">
+            Primary navigation
+          </SidebarGroupLabel>
+          <SidebarGroupContent>
+            <nav aria-label={accessibilityLabel}>
+              <SidebarMenu>
+                {items.map(({ href, label, match }) => {
+                  const active = match(pathname);
+                  return (
+                    <SidebarMenuItem key={href}>
+                      <SidebarMenuButton
+                        asChild
+                        isActive={false}
+                        tooltip={label}
+                        className={sideNavItemClassName(active)}
+                      >
+                        <LinkComponent
+                          href={href}
+                          aria-current={active ? 'page' : undefined}
+                        >
+                          <span>{label}</span>
+                        </LinkComponent>
+                      </SidebarMenuButton>
+                    </SidebarMenuItem>
+                  );
+                })}
+              </SidebarMenu>
+            </nav>
+          </SidebarGroupContent>
+        </SidebarGroup>
+      </SidebarContent>
+      {footer ? (
+        <SidebarFooter className="border-t border-[color:var(--app-header-border)] p-3">
+          {footer}
+        </SidebarFooter>
+      ) : null}
+      <SidebarRail />
+    </Sidebar>
+  );
+}

--- a/packages/ui-web/src/app-side-nav/app-shell.smoke.spec.tsx
+++ b/packages/ui-web/src/app-side-nav/app-shell.smoke.spec.tsx
@@ -78,6 +78,35 @@ describe('@abstrack/ui-web shell smoke', () => {
     ).toBeInTheDocument();
   });
 
+  it('applies mainClassName to page content, not the mobile menu row', () => {
+    render(
+      <AppShellWithSideNav
+        mainClassName="test-main-content-layout"
+        sideNav={
+          <AppSideNav
+            pathname="/dashboard"
+            items={navItems}
+            LinkComponent={TestNavLink}
+            accessibilityLabel="Test app"
+          />
+        }
+      >
+        <p>Page body</p>
+      </AppShellWithSideNav>,
+    );
+
+    const main = screen.getByRole('main');
+    expect(main).not.toHaveClass('test-main-content-layout');
+    expect(screen.getByText('Page body').parentElement).toHaveClass(
+      'test-main-content-layout',
+    );
+    expect(
+      screen
+        .getByRole('button', { name: 'Open navigation menu' })
+        .closest('.border-b'),
+    ).not.toHaveClass('test-main-content-layout');
+  });
+
   it('hides built-in mobile trigger when topHeader is provided', () => {
     render(
       <AppShellWithSideNav

--- a/packages/ui-web/src/app-side-nav/app-shell.smoke.spec.tsx
+++ b/packages/ui-web/src/app-side-nav/app-shell.smoke.spec.tsx
@@ -55,4 +55,48 @@ describe('@abstrack/ui-web shell smoke', () => {
       '/dashboard',
     );
   });
+
+  it('shows built-in mobile trigger with legacy header when topHeader is absent', () => {
+    render(
+      <AppShellWithSideNav
+        header={<div>Legacy header</div>}
+        sideNav={
+          <AppSideNav
+            pathname="/dashboard"
+            items={navItems}
+            LinkComponent={TestNavLink}
+            accessibilityLabel="Test app"
+          />
+        }
+      >
+        <p>Page body</p>
+      </AppShellWithSideNav>,
+    );
+
+    expect(
+      screen.getByRole('button', { name: 'Open navigation menu' }),
+    ).toBeInTheDocument();
+  });
+
+  it('hides built-in mobile trigger when topHeader is provided', () => {
+    render(
+      <AppShellWithSideNav
+        topHeader={<div>Top chrome</div>}
+        sideNav={
+          <AppSideNav
+            pathname="/dashboard"
+            items={navItems}
+            LinkComponent={TestNavLink}
+            accessibilityLabel="Test app"
+          />
+        }
+      >
+        <p>Page body</p>
+      </AppShellWithSideNav>,
+    );
+
+    expect(
+      screen.queryByRole('button', { name: 'Open navigation menu' }),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/packages/ui-web/src/app-side-nav/app-shell.smoke.spec.tsx
+++ b/packages/ui-web/src/app-side-nav/app-shell.smoke.spec.tsx
@@ -1,0 +1,58 @@
+import { render, screen } from '@testing-library/react';
+import { forwardRef } from 'react';
+import { describe, expect, it } from 'vitest';
+
+import {
+  AppShellWithSideNav,
+  AppSideNav,
+  type AppSideNavItem,
+  type AppSideNavLinkProps,
+} from '../index.js';
+
+const TestNavLink = forwardRef<HTMLAnchorElement, AppSideNavLinkProps>(
+  ({ href, children, ...rest }, ref) => (
+    <a href={href} ref={ref} {...rest}>
+      {children}
+    </a>
+  ),
+);
+TestNavLink.displayName = 'TestNavLink';
+
+const navItems: AppSideNavItem[] = [
+  {
+    href: '/dashboard',
+    label: 'Dashboard',
+    match: (pathname) => pathname === '/dashboard',
+  },
+];
+
+describe('@abstrack/ui-web shell smoke', () => {
+  it('renders AppShellWithSideNav with main landmark and side nav', () => {
+    render(
+      <AppShellWithSideNav
+        sideNav={
+          <AppSideNav
+            pathname="/dashboard"
+            items={navItems}
+            LinkComponent={TestNavLink}
+            accessibilityLabel="Test app"
+          />
+        }
+      >
+        <p>Page body</p>
+      </AppShellWithSideNav>,
+    );
+
+    const main = screen.getByRole('main');
+    expect(main).toHaveAttribute('id', 'main-content');
+    expect(main).toHaveAttribute('tabindex', '-1');
+    expect(screen.getByText('Page body')).toBeInTheDocument();
+    expect(
+      screen.getByRole('navigation', { name: 'Test app' }),
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: 'Dashboard' })).toHaveAttribute(
+      'href',
+      '/dashboard',
+    );
+  });
+});

--- a/packages/ui-web/src/app-side-nav/index.ts
+++ b/packages/ui-web/src/app-side-nav/index.ts
@@ -1,0 +1,10 @@
+export { AppSideNav, type AppSideNavProps } from './AppSideNav.js';
+export {
+  AppShellWithSideNav,
+  type AppShellWithSideNavProps,
+} from './AppShellWithSideNav.js';
+export type {
+  AppSideNavItem,
+  AppSideNavLinkComponent,
+  AppSideNavLinkProps,
+} from './types.js';

--- a/packages/ui-web/src/app-side-nav/types.ts
+++ b/packages/ui-web/src/app-side-nav/types.ts
@@ -1,4 +1,4 @@
-import type { ComponentType, ReactNode } from 'react';
+import type { ComponentPropsWithoutRef, ComponentType, ReactNode } from 'react';
 
 /**
  * One primary navigation entry for {@link AppSideNav}.
@@ -14,15 +14,19 @@ export type AppSideNavItem = {
 
 /**
  * Props passed to the app-supplied link component (e.g. Next.js `Link`).
+ * Matches anchor semantics so Radix `Slot` / `asChild` can merge `data-*`, handlers, and `ref`
+ * from {@link SidebarMenuButton} and tooltip triggers.
  */
-export type AppSideNavLinkProps = {
+export type AppSideNavLinkProps = Omit<
+  ComponentPropsWithoutRef<'a'>,
+  'href'
+> & {
   href: string;
-  children: ReactNode;
-  className?: string;
-  'aria-current'?: 'page' | undefined;
+  children?: ReactNode;
 };
 
 /**
- * Link component type used by {@link AppSideNav} (`asChild` menu buttons).
+ * Link component type used by {@link AppSideNav} (`asChild` menu buttons). Implement with
+ * `forwardRef` and spread remaining props onto the underlying anchor (or Next.js `Link`).
  */
 export type AppSideNavLinkComponent = ComponentType<AppSideNavLinkProps>;

--- a/packages/ui-web/src/app-side-nav/types.ts
+++ b/packages/ui-web/src/app-side-nav/types.ts
@@ -1,4 +1,9 @@
-import type { ComponentPropsWithoutRef, ComponentType, ReactNode } from 'react';
+import type {
+  ComponentPropsWithoutRef,
+  ForwardRefExoticComponent,
+  ReactNode,
+  RefAttributes,
+} from 'react';
 
 /**
  * One primary navigation entry for {@link AppSideNav}.
@@ -26,7 +31,10 @@ export type AppSideNavLinkProps = Omit<
 };
 
 /**
- * Link component type used by {@link AppSideNav} (`asChild` menu buttons). Implement with
- * `forwardRef` and spread remaining props onto the underlying anchor (or Next.js `Link`).
+ * Link component used by {@link AppSideNav} (`asChild` menu buttons). Must use `forwardRef` and
+ * spread remaining props onto the underlying anchor (or Next.js `Link`) so Radix `Slot` can merge
+ * refs and `data-*` attributes.
  */
-export type AppSideNavLinkComponent = ComponentType<AppSideNavLinkProps>;
+export type AppSideNavLinkComponent = ForwardRefExoticComponent<
+  AppSideNavLinkProps & RefAttributes<HTMLAnchorElement>
+>;

--- a/packages/ui-web/src/app-side-nav/types.ts
+++ b/packages/ui-web/src/app-side-nav/types.ts
@@ -1,0 +1,28 @@
+import type { ComponentType, ReactNode } from 'react';
+
+/**
+ * One primary navigation entry for {@link AppSideNav}.
+ */
+export type AppSideNavItem = {
+  /** Route path (app-specific base path). */
+  href: string;
+  /** Visible label and accessible name for the link. */
+  label: string;
+  /** Returns whether `pathname` should mark this item active. */
+  match: (pathname: string) => boolean;
+};
+
+/**
+ * Props passed to the app-supplied link component (e.g. Next.js `Link`).
+ */
+export type AppSideNavLinkProps = {
+  href: string;
+  children: ReactNode;
+  className?: string;
+  'aria-current'?: 'page' | undefined;
+};
+
+/**
+ * Link component type used by {@link AppSideNav} (`asChild` menu buttons).
+ */
+export type AppSideNavLinkComponent = ComponentType<AppSideNavLinkProps>;

--- a/packages/ui-web/src/components/button.tsx
+++ b/packages/ui-web/src/components/button.tsx
@@ -1,0 +1,57 @@
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+
+import { cn } from '../lib/utils.js';
+
+const buttonVariants = cva(
+  'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default:
+          'bg-primary text-primary-foreground shadow hover:bg-primary/90',
+        destructive:
+          'bg-destructive text-destructive-foreground shadow-sm hover:bg-destructive/90',
+        outline:
+          'border border-input bg-background shadow-sm hover:bg-accent hover:text-accent-foreground',
+        secondary:
+          'bg-secondary text-secondary-foreground shadow-sm hover:bg-secondary/80',
+        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        link: 'text-primary underline-offset-4 hover:underline',
+      },
+      size: {
+        default: 'h-9 px-4 py-2',
+        sm: 'h-8 rounded-md px-3 text-xs',
+        lg: 'h-10 rounded-md px-8',
+        icon: 'h-9 w-9',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
+    VariantProps<typeof buttonVariants> {
+  asChild?: boolean;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant, size, asChild = false, ...props }, ref) => {
+    const Comp = asChild ? Slot : 'button';
+    return (
+      <Comp
+        className={cn(buttonVariants({ variant, size, className }))}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Button.displayName = 'Button';
+
+export { Button, buttonVariants };

--- a/packages/ui-web/src/components/button.tsx
+++ b/packages/ui-web/src/components/button.tsx
@@ -41,13 +41,16 @@ export interface ButtonProps
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
+  (
+    { className, variant, size, asChild = false, type = 'button', ...props },
+    ref,
+  ) => {
     const Comp = asChild ? Slot : 'button';
     return (
       <Comp
         className={cn(buttonVariants({ variant, size, className }))}
         ref={ref}
-        {...props}
+        {...(asChild ? props : { type, ...props })}
       />
     );
   },

--- a/packages/ui-web/src/components/input.tsx
+++ b/packages/ui-web/src/components/input.tsx
@@ -1,0 +1,22 @@
+import * as React from 'react';
+
+import { cn } from '../lib/utils.js';
+
+const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<'input'>>(
+  ({ className, type, ...props }, ref) => {
+    return (
+      <input
+        type={type}
+        className={cn(
+          'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Input.displayName = 'Input';
+
+export { Input };

--- a/packages/ui-web/src/components/separator.tsx
+++ b/packages/ui-web/src/components/separator.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import * as React from 'react';
+import * as SeparatorPrimitive from '@radix-ui/react-separator';
+
+import { cn } from '../lib/utils.js';
+
+const Separator = React.forwardRef<
+  React.ElementRef<typeof SeparatorPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+>(
+  (
+    { className, orientation = 'horizontal', decorative = true, ...props },
+    ref,
+  ) => (
+    <SeparatorPrimitive.Root
+      ref={ref}
+      decorative={decorative}
+      orientation={orientation}
+      className={cn(
+        'shrink-0 bg-border',
+        orientation === 'horizontal' ? 'h-[1px] w-full' : 'h-full w-[1px]',
+        className,
+      )}
+      {...props}
+    />
+  ),
+);
+Separator.displayName = SeparatorPrimitive.Root.displayName;
+
+export { Separator };

--- a/packages/ui-web/src/components/sheet.tsx
+++ b/packages/ui-web/src/components/sheet.tsx
@@ -21,7 +21,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className,
     )}
     {...props}

--- a/packages/ui-web/src/components/sheet.tsx
+++ b/packages/ui-web/src/components/sheet.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import * as React from 'react';
+import * as SheetPrimitive from '@radix-ui/react-dialog';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { X } from 'lucide-react';
+
+import { cn } from '../lib/utils.js';
+
+const Sheet = SheetPrimitive.Root;
+
+const SheetTrigger = SheetPrimitive.Trigger;
+
+const SheetClose = SheetPrimitive.Close;
+
+const SheetPortal = SheetPrimitive.Portal;
+
+const SheetOverlay = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Overlay
+    className={cn(
+      'fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      className,
+    )}
+    {...props}
+    ref={ref}
+  />
+));
+SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
+
+const sheetVariants = cva(
+  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=closed]:duration-300 data-[state=open]:duration-500 data-[state=open]:animate-in data-[state=closed]:animate-out',
+  {
+    variants: {
+      side: {
+        top: 'inset-x-0 top-0 border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top',
+        bottom:
+          'inset-x-0 bottom-0 border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom',
+        left: 'inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm',
+        right:
+          'inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm',
+      },
+    },
+    defaultVariants: {
+      side: 'right',
+    },
+  },
+);
+
+interface SheetContentProps
+  extends React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
+    VariantProps<typeof sheetVariants> {}
+
+const SheetContent = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Content>,
+  SheetContentProps
+>(({ side = 'right', className, children, ...props }, ref) => (
+  <SheetPortal>
+    <SheetOverlay />
+    <SheetPrimitive.Content
+      ref={ref}
+      className={cn(sheetVariants({ side }), className)}
+      {...props}
+    >
+      <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </SheetPrimitive.Close>
+      {children}
+    </SheetPrimitive.Content>
+  </SheetPortal>
+));
+SheetContent.displayName = SheetPrimitive.Content.displayName;
+
+const SheetHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col space-y-2 text-center sm:text-left',
+      className,
+    )}
+    {...props}
+  />
+);
+SheetHeader.displayName = 'SheetHeader';
+
+const SheetFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      'flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2',
+      className,
+    )}
+    {...props}
+  />
+);
+SheetFooter.displayName = 'SheetFooter';
+
+const SheetTitle = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Title
+    ref={ref}
+    className={cn('text-lg font-semibold text-foreground', className)}
+    {...props}
+  />
+));
+SheetTitle.displayName = SheetPrimitive.Title.displayName;
+
+const SheetDescription = React.forwardRef<
+  React.ElementRef<typeof SheetPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <SheetPrimitive.Description
+    ref={ref}
+    className={cn('text-sm text-muted-foreground', className)}
+    {...props}
+  />
+));
+SheetDescription.displayName = SheetPrimitive.Description.displayName;
+
+export {
+  Sheet,
+  SheetPortal,
+  SheetOverlay,
+  SheetTrigger,
+  SheetClose,
+  SheetContent,
+  SheetHeader,
+  SheetFooter,
+  SheetTitle,
+  SheetDescription,
+};

--- a/packages/ui-web/src/components/sidebar-provider.spec.tsx
+++ b/packages/ui-web/src/components/sidebar-provider.spec.tsx
@@ -21,6 +21,7 @@ function OpenStateProbe() {
 describe('SidebarProvider cookie persistence', () => {
   afterEach(() => {
     clearCookie(COOKIE);
+    vi.unstubAllGlobals();
   });
 
   it('restores collapsed state from cookie after mount', async () => {
@@ -38,6 +39,11 @@ describe('SidebarProvider cookie persistence', () => {
   });
 
   it('writes cookie when toggled via keyboard shortcut', async () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Win32',
+      userAgent: 'Windows',
+    });
+
     render(
       <SidebarProvider sidebarCookieName={COOKIE} defaultOpen>
         <OpenStateProbe />

--- a/packages/ui-web/src/components/sidebar-provider.spec.tsx
+++ b/packages/ui-web/src/components/sidebar-provider.spec.tsx
@@ -7,6 +7,12 @@ import {
 } from '../lib/sidebar-provider-behavior.js';
 import { SidebarProvider, useSidebar } from './sidebar.js';
 
+const useIsMobileMock = vi.hoisted(() => vi.fn(() => false));
+
+vi.mock('../hooks/use-mobile.js', () => ({
+  useIsMobile: () => useIsMobileMock(),
+}));
+
 const COOKIE = 'abstrack_test_sidebar_provider';
 
 function clearCookie(name: string): void {
@@ -18,9 +24,22 @@ function OpenStateProbe() {
   return <div data-testid="sidebar-open">{open ? 'open' : 'closed'}</div>;
 }
 
+function MobileOpenProbe() {
+  const { openMobile, setOpenMobile } = useSidebar();
+  return (
+    <>
+      <div data-testid="open-mobile">{openMobile ? 'open' : 'closed'}</div>
+      <button type="button" onClick={() => setOpenMobile(true)}>
+        Open sheet
+      </button>
+    </>
+  );
+}
+
 describe('SidebarProvider cookie persistence', () => {
   afterEach(() => {
     clearCookie(COOKIE);
+    useIsMobileMock.mockReturnValue(false);
     vi.unstubAllGlobals();
   });
 
@@ -87,5 +106,37 @@ describe('SidebarProvider cookie persistence', () => {
 
     expect(readSidebarOpenCookie(COOKIE)).toBe(false);
     expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});
+
+describe('SidebarProvider mobile sheet state', () => {
+  afterEach(() => {
+    useIsMobileMock.mockReturnValue(false);
+  });
+
+  it('clears openMobile when the viewport leaves mobile', async () => {
+    useIsMobileMock.mockReturnValue(true);
+
+    const { rerender } = render(
+      <SidebarProvider>
+        <MobileOpenProbe />
+      </SidebarProvider>,
+    );
+
+    await act(async () => {
+      screen.getByRole('button', { name: 'Open sheet' }).click();
+    });
+    expect(screen.getByTestId('open-mobile')).toHaveTextContent('open');
+
+    useIsMobileMock.mockReturnValue(false);
+    rerender(
+      <SidebarProvider>
+        <MobileOpenProbe />
+      </SidebarProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('open-mobile')).toHaveTextContent('closed');
+    });
   });
 });

--- a/packages/ui-web/src/components/sidebar-provider.spec.tsx
+++ b/packages/ui-web/src/components/sidebar-provider.spec.tsx
@@ -1,0 +1,85 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  readSidebarOpenCookie,
+  writeSidebarOpenCookie,
+} from '../lib/sidebar-provider-behavior.js';
+import { SidebarProvider, useSidebar } from './sidebar.js';
+
+const COOKIE = 'abstrack_test_sidebar_provider';
+
+function clearCookie(name: string): void {
+  document.cookie = `${name}=; path=/; max-age=0`;
+}
+
+function OpenStateProbe() {
+  const { open } = useSidebar();
+  return <div data-testid="sidebar-open">{open ? 'open' : 'closed'}</div>;
+}
+
+describe('SidebarProvider cookie persistence', () => {
+  afterEach(() => {
+    clearCookie(COOKIE);
+  });
+
+  it('restores collapsed state from cookie after mount', async () => {
+    writeSidebarOpenCookie(COOKIE, false);
+
+    render(
+      <SidebarProvider sidebarCookieName={COOKIE} defaultOpen>
+        <OpenStateProbe />
+      </SidebarProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-open')).toHaveTextContent('closed');
+    });
+  });
+
+  it('writes cookie when toggled via keyboard shortcut', async () => {
+    render(
+      <SidebarProvider sidebarCookieName={COOKIE} defaultOpen>
+        <OpenStateProbe />
+      </SidebarProvider>,
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'b',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-open')).toHaveTextContent('closed');
+      expect(readSidebarOpenCookie(COOKIE)).toBe(false);
+    });
+  });
+
+  it('does not restore from cookie in controlled mode', async () => {
+    writeSidebarOpenCookie(COOKIE, false);
+    const onOpenChange = vi.fn();
+
+    render(
+      <SidebarProvider
+        sidebarCookieName={COOKIE}
+        open
+        onOpenChange={onOpenChange}
+      >
+        <OpenStateProbe />
+      </SidebarProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('sidebar-open')).toHaveTextContent('open');
+    });
+
+    expect(readSidebarOpenCookie(COOKIE)).toBe(false);
+    expect(onOpenChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -85,9 +85,9 @@ function partitionSidebarChildren(children: React.ReactNode): {
 type SidebarContextProps = {
   state: 'expanded' | 'collapsed';
   open: boolean;
-  setOpen: (open: boolean) => void;
+  setOpen: React.Dispatch<React.SetStateAction<boolean>>;
   openMobile: boolean;
-  setOpenMobile: (open: boolean) => void;
+  setOpenMobile: React.Dispatch<React.SetStateAction<boolean>>;
   isMobile: boolean;
   toggleSidebar: () => void;
 };

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -25,7 +25,8 @@ import {
   TooltipTrigger,
 } from './tooltip.js';
 
-const SIDEBAR_COOKIE_NAME = 'sidebar_state';
+/** Default cookie for uncontrolled desktop sidebar state; override per app on shared hosts. */
+export const DEFAULT_SIDEBAR_COOKIE_NAME = 'abstrack_sidebar_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = '16rem';
 
@@ -34,11 +35,11 @@ const SIDEBAR_WIDTH = '16rem';
  *
  * @returns `true` / `false` when set, otherwise `null`.
  */
-function readSidebarOpenCookie(): boolean | null {
+function readSidebarOpenCookie(cookieName: string): boolean | null {
   if (typeof document === 'undefined') {
     return null;
   }
-  const prefix = `${SIDEBAR_COOKIE_NAME}=`;
+  const prefix = `${cookieName}=`;
   for (const entry of document.cookie.split(';')) {
     const trimmed = entry.trim();
     if (!trimmed.startsWith(prefix)) {
@@ -61,7 +62,7 @@ function readSidebarOpenCookie(): boolean | null {
  *
  * @param open - Whether the desktop sidebar rail is expanded.
  */
-function writeSidebarOpenCookie(open: boolean): void {
+function writeSidebarOpenCookie(cookieName: string, open: boolean): void {
   if (typeof document === 'undefined') {
     return;
   }
@@ -69,7 +70,7 @@ function writeSidebarOpenCookie(open: boolean): void {
     typeof window !== 'undefined' && window.location.protocol === 'https:'
       ? '; Secure'
       : '';
-  document.cookie = `${SIDEBAR_COOKIE_NAME}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; SameSite=Lax${secure}`;
+  document.cookie = `${cookieName}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; SameSite=Lax${secure}`;
 }
 const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
@@ -108,6 +109,11 @@ const SidebarProvider = React.forwardRef<
     open?: boolean;
     /** Controlled setter; must be paired with {@link open}. */
     onOpenChange?: (open: boolean) => void;
+    /**
+     * Cookie name for persisting desktop open state (uncontrolled mode). Use a distinct value per
+     * app when multiple ABStrack apps share a host (e.g. `abstrack_web_sidebar_state`).
+     */
+    sidebarCookieName?: string;
   }
 >(
   (
@@ -115,6 +121,7 @@ const SidebarProvider = React.forwardRef<
       defaultOpen = true,
       open: openProp,
       onOpenChange: setOpenProp,
+      sidebarCookieName = DEFAULT_SIDEBAR_COOKIE_NAME,
       className,
       style,
       children,
@@ -153,11 +160,11 @@ const SidebarProvider = React.forwardRef<
       if (isControlled) {
         return;
       }
-      const stored = readSidebarOpenCookie();
+      const stored = readSidebarOpenCookie(sidebarCookieName);
       if (stored !== null) {
         _setOpen(stored);
       }
-    }, [isControlled]);
+    }, [isControlled, sidebarCookieName]);
 
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
@@ -167,9 +174,9 @@ const SidebarProvider = React.forwardRef<
           return;
         }
         _setOpen(openState);
-        writeSidebarOpenCookie(openState);
+        writeSidebarOpenCookie(sidebarCookieName, openState);
       },
-      [isControlled, setOpenProp, open],
+      [isControlled, setOpenProp, open, sidebarCookieName],
     );
 
     // Helper to toggle the sidebar.

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -133,13 +133,18 @@ const SidebarProvider = React.forwardRef<
     const open = isControlled ? openProp : _open;
 
     React.useEffect(() => {
-      if (
-        process.env.NODE_ENV !== 'production' &&
-        openProp !== undefined &&
-        setOpenProp === undefined
-      ) {
+      if (process.env.NODE_ENV === 'production') {
+        return;
+      }
+      const hasOpen = openProp !== undefined;
+      const hasOnOpenChange = setOpenProp !== undefined;
+      if (hasOpen && !hasOnOpenChange) {
         console.warn(
           'SidebarProvider: `open` without `onOpenChange` is ignored. Pass both props for controlled mode.',
+        );
+      } else if (!hasOpen && hasOnOpenChange) {
+        console.warn(
+          'SidebarProvider: `onOpenChange` without `open` is ignored. Pass both props for controlled mode.',
         );
       }
     }, [openProp, setOpenProp]);

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -60,8 +60,8 @@ function isSidebarRailElement(child: React.ReactNode): boolean {
 }
 
 /**
- * Splits {@link SidebarRail} from other sidebar children so the rail stays focusable when the
- * offcanvas panel is collapsed and inert.
+ * Splits {@link SidebarRail} from other sidebar children so the rail renders outside the inert
+ * offcanvas panel when collapsed (see {@link SidebarRail} for keyboard focus).
  *
  * @param children - {@link Sidebar} children.
  * @returns Rails vs main panel content.
@@ -426,15 +426,22 @@ const SidebarTrigger = React.forwardRef<
 });
 SidebarTrigger.displayName = 'SidebarTrigger';
 
+/**
+ * Desktop edge control to expand/collapse the sidebar. Tabbable when {@link SidebarProvider}
+ * state is `collapsed` (including offcanvas); removed from tab order when expanded so nav links
+ * are not preceded by an extra stop. Cmd/Ctrl+B also toggles the sidebar.
+ */
 const SidebarRail = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<'button'>
->(({ className, type = 'button', ...props }, ref) => {
-  const { toggleSidebar, isMobile } = useSidebar();
+>(({ className, type = 'button', tabIndex, ...props }, ref) => {
+  const { toggleSidebar, isMobile, state } = useSidebar();
 
   if (isMobile) {
     return null;
   }
+
+  const resolvedTabIndex = tabIndex ?? (state === 'collapsed' ? 0 : -1);
 
   return (
     <button
@@ -442,11 +449,11 @@ const SidebarRail = React.forwardRef<
       type={type}
       data-sidebar="rail"
       aria-label="Toggle Sidebar"
-      tabIndex={-1}
+      tabIndex={resolvedTabIndex}
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 md:flex',
+        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sidebar-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg group-data-[side=left]:-right-4 group-data-[side=right]:left-0 md:flex',
         '[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize',
         '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
         'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar',

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -611,12 +611,13 @@ SidebarGroupLabel.displayName = 'SidebarGroupLabel';
 const SidebarGroupAction = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<'button'> & { asChild?: boolean }
->(({ className, asChild = false, ...props }, ref) => {
+>(({ className, asChild = false, type = 'button', ...props }, ref) => {
   const Comp = asChild ? Slot : 'button';
 
   return (
     <Comp
       ref={ref}
+      {...(asChild ? props : { type, ...props })}
       data-sidebar="group-action"
       className={cn(
         'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
@@ -625,7 +626,6 @@ const SidebarGroupAction = React.forwardRef<
         'group-data-[collapsible=icon]:hidden',
         className,
       )}
-      {...props}
     />
   );
 });
@@ -708,6 +708,7 @@ const SidebarMenuButton = React.forwardRef<
       size = 'default',
       tooltip,
       className,
+      type = 'button',
       ...props
     },
     ref,
@@ -718,11 +719,11 @@ const SidebarMenuButton = React.forwardRef<
     const button = (
       <Comp
         ref={ref}
+        {...(asChild ? props : { type, ...props })}
         data-sidebar="menu-button"
         data-size={size}
         data-active={isActive}
         className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
-        {...props}
       />
     );
 
@@ -757,29 +758,40 @@ const SidebarMenuAction = React.forwardRef<
     asChild?: boolean;
     showOnHover?: boolean;
   }
->(({ className, asChild = false, showOnHover = false, ...props }, ref) => {
-  const Comp = asChild ? Slot : 'button';
+>(
+  (
+    {
+      className,
+      asChild = false,
+      showOnHover = false,
+      type = 'button',
+      ...props
+    },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot : 'button';
 
-  return (
-    <Comp
-      ref={ref}
-      data-sidebar="menu-action"
-      className={cn(
-        'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0',
-        // Increases the hit area of the button on mobile.
-        'after:absolute after:-inset-2 after:md:hidden',
-        'peer-data-[size=sm]/menu-button:top-1',
-        'peer-data-[size=default]/menu-button:top-1.5',
-        'peer-data-[size=lg]/menu-button:top-2.5',
-        'group-data-[collapsible=icon]:hidden',
-        showOnHover &&
-          'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
-        className,
-      )}
-      {...props}
-    />
-  );
-});
+    return (
+      <Comp
+        ref={ref}
+        {...(asChild ? props : { type, ...props })}
+        data-sidebar="menu-action"
+        className={cn(
+          'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0',
+          // Increases the hit area of the button on mobile.
+          'after:absolute after:-inset-2 after:md:hidden',
+          'peer-data-[size=sm]/menu-button:top-1',
+          'peer-data-[size=default]/menu-button:top-1.5',
+          'peer-data-[size=lg]/menu-button:top-2.5',
+          'group-data-[collapsible=icon]:hidden',
+          showOnHover &&
+            'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
+          className,
+        )}
+      />
+    );
+  },
+);
 SidebarMenuAction.displayName = 'SidebarMenuAction';
 
 const SidebarMenuBadge = React.forwardRef<

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -767,7 +767,8 @@ const SIDEBAR_MENU_SKELETON_WIDTHS = [
  */
 function sidebarMenuSkeletonWidth(index: number): string {
   const widths = SIDEBAR_MENU_SKELETON_WIDTHS;
-  return widths[((index % widths.length) + widths.length) % widths.length]!;
+  const slot = ((index % widths.length) + widths.length) % widths.length;
+  return widths[slot] ?? widths[0];
 }
 
 const SidebarMenuSkeleton = React.forwardRef<

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -3,7 +3,7 @@
 import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { PanelLeft } from 'lucide-react';
+import { PanelLeft, X } from 'lucide-react';
 
 import { useIsMobile } from '../hooks/use-mobile.js';
 import {
@@ -17,6 +17,7 @@ import { Input } from './input.js';
 import { Separator } from './separator.js';
 import {
   Sheet,
+  SheetClose,
   SheetContent,
   SheetDescription,
   SheetHeader,
@@ -317,10 +318,30 @@ const Sidebar = React.forwardRef<
             {...props}
           >
             <SheetHeader className="sr-only">
-              <SheetTitle>Sidebar</SheetTitle>
-              <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+              <SheetTitle>Navigation menu</SheetTitle>
+              <SheetDescription>Application navigation links.</SheetDescription>
             </SheetHeader>
-            <div className="flex h-full w-full flex-col">{children}</div>
+            <div className="flex h-full w-full flex-col">
+              <div
+                className={cn(
+                  'flex shrink-0 border-b border-sidebar-border p-2',
+                  side === 'left' ? 'justify-end' : 'justify-start',
+                )}
+              >
+                <SheetClose asChild>
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="min-h-11 min-w-11 text-sidebar-foreground"
+                    aria-label="Close navigation menu"
+                  >
+                    <X className="h-4 w-4" aria-hidden />
+                  </Button>
+                </SheetClose>
+              </div>
+              {children}
+            </div>
           </SheetContent>
         </Sheet>
       );

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -28,6 +28,48 @@ import {
 const SIDEBAR_COOKIE_NAME = 'sidebar_state';
 const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = '16rem';
+
+/**
+ * Reads persisted desktop sidebar open state from `document.cookie`.
+ *
+ * @returns `true` / `false` when set, otherwise `null`.
+ */
+function readSidebarOpenCookie(): boolean | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const prefix = `${SIDEBAR_COOKIE_NAME}=`;
+  for (const entry of document.cookie.split('; ')) {
+    if (!entry.startsWith(prefix)) {
+      continue;
+    }
+    const value = entry.slice(prefix.length);
+    if (value === 'true') {
+      return true;
+    }
+    if (value === 'false') {
+      return false;
+    }
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Persists desktop sidebar open state (uncontrolled {@link SidebarProvider} only).
+ *
+ * @param open - Whether the desktop sidebar rail is expanded.
+ */
+function writeSidebarOpenCookie(open: boolean): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const secure =
+    typeof window !== 'undefined' && window.location.protocol === 'https:'
+      ? '; Secure'
+      : '';
+  document.cookie = `${SIDEBAR_COOKIE_NAME}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; SameSite=Lax${secure}`;
+}
 const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
@@ -79,11 +121,28 @@ const SidebarProvider = React.forwardRef<
   ) => {
     const isMobile = useIsMobile();
     const [openMobile, setOpenMobile] = React.useState(false);
+    const isControlled = openProp !== undefined;
 
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
-    const [_open, _setOpen] = React.useState(defaultOpen);
+    const [_open, _setOpen] = React.useState(() => {
+      if (isControlled) {
+        return defaultOpen;
+      }
+      return readSidebarOpenCookie() ?? defaultOpen;
+    });
     const open = openProp ?? _open;
+
+    React.useEffect(() => {
+      if (isControlled) {
+        return;
+      }
+      const stored = readSidebarOpenCookie();
+      if (stored !== null) {
+        _setOpen(stored);
+      }
+    }, [isControlled]);
+
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
         const openState = typeof value === 'function' ? value(open) : value;
@@ -91,10 +150,8 @@ const SidebarProvider = React.forwardRef<
           setOpenProp(openState);
         } else {
           _setOpen(openState);
+          writeSidebarOpenCookie(openState);
         }
-
-        // This sets the cookie to keep the sidebar state.
-        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
       },
       [setOpenProp, open],
     );
@@ -344,7 +401,7 @@ const SidebarRail = React.forwardRef<
 SidebarRail.displayName = 'SidebarRail';
 
 const SidebarInset = React.forwardRef<
-  HTMLDivElement,
+  React.ElementRef<'main'>,
   React.ComponentProps<'main'>
 >(({ className, ...props }, ref) => {
   return (

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -170,6 +170,12 @@ const SidebarProvider = React.forwardRef<
       }
     }, [isControlled, sidebarCookieName]);
 
+    React.useEffect(() => {
+      if (!isMobile) {
+        setOpenMobile(false);
+      }
+    }, [isMobile]);
+
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
         if (controlledOpen !== null && setOpenProp !== undefined) {

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -168,15 +168,17 @@ const SidebarProvider = React.forwardRef<
 
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
-        const openState = typeof value === 'function' ? value(open) : value;
         if (isControlled) {
-          setOpenProp(openState);
+          setOpenProp(typeof value === 'function' ? value(openProp) : value);
           return;
         }
-        _setOpen(openState);
-        writeSidebarOpenCookie(sidebarCookieName, openState);
+        _setOpen((prev) => {
+          const next = typeof value === 'function' ? value(prev) : value;
+          writeSidebarOpenCookie(sidebarCookieName, next);
+          return next;
+        });
       },
-      [isControlled, setOpenProp, open, sidebarCookieName],
+      [isControlled, setOpenProp, openProp, sidebarCookieName],
     );
 
     // Helper to toggle the sidebar.

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -125,12 +125,8 @@ const SidebarProvider = React.forwardRef<
 
     // This is the internal state of the sidebar.
     // We use openProp and setOpenProp for control from outside the component.
-    const [_open, _setOpen] = React.useState(() => {
-      if (isControlled) {
-        return defaultOpen;
-      }
-      return readSidebarOpenCookie() ?? defaultOpen;
-    });
+    // Initialize from defaultOpen only; restore cookie after mount to avoid SSR/client mismatch.
+    const [_open, _setOpen] = React.useState(defaultOpen);
     const open = openProp ?? _open;
 
     React.useEffect(() => {
@@ -278,6 +274,7 @@ const Sidebar = React.forwardRef<
             className={cn(
               'w-[--sidebar-width-mobile] p-0 [&>button]:hidden',
               SIDEBAR_PANEL_SURFACE,
+              className,
             )}
             side={side}
           >
@@ -726,16 +723,36 @@ const SidebarMenuBadge = React.forwardRef<
 ));
 SidebarMenuBadge.displayName = 'SidebarMenuBadge';
 
+/** Deterministic label widths (50–90%) for {@link SidebarMenuSkeleton} — avoids SSR hydration mismatch. */
+const SIDEBAR_MENU_SKELETON_WIDTHS = [
+  '65%',
+  '78%',
+  '55%',
+  '82%',
+  '70%',
+  '60%',
+  '88%',
+  '52%',
+] as const;
+
+/**
+ * @param index - Row index; cycles through {@link SIDEBAR_MENU_SKELETON_WIDTHS}.
+ * @returns CSS width percentage for the skeleton label bar.
+ */
+function sidebarMenuSkeletonWidth(index: number): string {
+  const widths = SIDEBAR_MENU_SKELETON_WIDTHS;
+  return widths[((index % widths.length) + widths.length) % widths.length]!;
+}
+
 const SidebarMenuSkeleton = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<'div'> & {
     showIcon?: boolean;
+    /** Row index for varied, SSR-stable skeleton label width (default `0`). */
+    index?: number;
   }
->(({ className, showIcon = false, ...props }, ref) => {
-  // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+>(({ className, showIcon = false, index = 0, ...props }, ref) => {
+  const width = sidebarMenuSkeletonWidth(index);
 
   return (
     <div

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -39,11 +39,12 @@ function readSidebarOpenCookie(): boolean | null {
     return null;
   }
   const prefix = `${SIDEBAR_COOKIE_NAME}=`;
-  for (const entry of document.cookie.split('; ')) {
-    if (!entry.startsWith(prefix)) {
+  for (const entry of document.cookie.split(';')) {
+    const trimmed = entry.trim();
+    if (!trimmed.startsWith(prefix)) {
       continue;
     }
-    const value = entry.slice(prefix.length);
+    const value = trimmed.slice(prefix.length);
     if (value === 'true') {
       return true;
     }
@@ -267,8 +268,9 @@ const Sidebar = React.forwardRef<
 
     if (isMobile) {
       return (
-        <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+        <Sheet open={openMobile} onOpenChange={setOpenMobile}>
           <SheetContent
+            ref={ref}
             data-sidebar="sidebar"
             data-mobile="true"
             className={cn(
@@ -277,6 +279,7 @@ const Sidebar = React.forwardRef<
               className,
             )}
             side={side}
+            {...props}
           >
             <SheetHeader className="sr-only">
               <SheetTitle>Sidebar</SheetTitle>
@@ -290,7 +293,6 @@ const Sidebar = React.forwardRef<
 
     return (
       <div
-        ref={ref}
         className="group peer hidden text-sidebar-foreground md:block"
         data-state={state}
         data-collapsible={state === 'collapsed' ? collapsible : ''}
@@ -309,6 +311,7 @@ const Sidebar = React.forwardRef<
           )}
         />
         <div
+          ref={ref}
           className={cn(
             'fixed top-[var(--sidebar-top-offset,0px)] z-10 hidden h-[calc(100svh-var(--sidebar-top-offset,0px))] w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex',
             side === 'left'

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -104,7 +104,9 @@ const SidebarProvider = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<'div'> & {
     defaultOpen?: boolean;
+    /** Controlled open state; must be paired with {@link onOpenChange}. */
     open?: boolean;
+    /** Controlled setter; must be paired with {@link open}. */
     onOpenChange?: (open: boolean) => void;
   }
 >(
@@ -122,13 +124,25 @@ const SidebarProvider = React.forwardRef<
   ) => {
     const isMobile = useIsMobile();
     const [openMobile, setOpenMobile] = React.useState(false);
-    const isControlled = openProp !== undefined;
+    const isControlled = openProp !== undefined && setOpenProp !== undefined;
 
     // This is the internal state of the sidebar.
-    // We use openProp and setOpenProp for control from outside the component.
+    // Controlled only when both `open` and `onOpenChange` are provided.
     // Initialize from defaultOpen only; restore cookie after mount to avoid SSR/client mismatch.
     const [_open, _setOpen] = React.useState(defaultOpen);
-    const open = openProp ?? _open;
+    const open = isControlled ? openProp : _open;
+
+    React.useEffect(() => {
+      if (
+        process.env.NODE_ENV !== 'production' &&
+        openProp !== undefined &&
+        setOpenProp === undefined
+      ) {
+        console.warn(
+          'SidebarProvider: `open` without `onOpenChange` is ignored. Pass both props for controlled mode.',
+        );
+      }
+    }, [openProp, setOpenProp]);
 
     React.useEffect(() => {
       if (isControlled) {
@@ -143,14 +157,14 @@ const SidebarProvider = React.forwardRef<
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
         const openState = typeof value === 'function' ? value(open) : value;
-        if (setOpenProp) {
+        if (isControlled) {
           setOpenProp(openState);
-        } else {
-          _setOpen(openState);
-          writeSidebarOpenCookie(openState);
+          return;
         }
+        _setOpen(openState);
+        writeSidebarOpenCookie(openState);
       },
-      [setOpenProp, open],
+      [isControlled, setOpenProp, open],
     );
 
     // Helper to toggle the sidebar.
@@ -371,7 +385,11 @@ const SidebarRail = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<'button'>
 >(({ className, ...props }, ref) => {
-  const { toggleSidebar } = useSidebar();
+  const { toggleSidebar, isMobile } = useSidebar();
+
+  if (isMobile) {
+    return null;
+  }
 
   return (
     <button
@@ -382,7 +400,7 @@ const SidebarRail = React.forwardRef<
       onClick={toggleSidebar}
       title="Toggle Sidebar"
       className={cn(
-        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
+        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 md:flex',
         '[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize',
         '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
         'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar',

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -849,7 +849,7 @@ const SidebarMenuSkeleton = React.forwardRef<
         />
       )}
       <Skeleton
-        className="h-4 max-w-[--skeleton-width] flex-1"
+        className="h-4 max-w-[var(--skeleton-width)] flex-1"
         data-sidebar="menu-skeleton-text"
         style={
           {

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -211,6 +211,7 @@ const SidebarProvider = React.forwardRef<
             style={
               {
                 '--sidebar-width': SIDEBAR_WIDTH,
+                '--sidebar-width-mobile': SIDEBAR_WIDTH_MOBILE,
                 '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
                 ...style,
               } as React.CSSProperties
@@ -275,14 +276,9 @@ const Sidebar = React.forwardRef<
             data-sidebar="sidebar"
             data-mobile="true"
             className={cn(
-              'w-[--sidebar-width] p-0 [&>button]:hidden',
+              'w-[--sidebar-width-mobile] p-0 [&>button]:hidden',
               SIDEBAR_PANEL_SURFACE,
             )}
-            style={
-              {
-                '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
-              } as React.CSSProperties
-            }
             side={side}
           >
             <SheetHeader className="sr-only">
@@ -604,7 +600,7 @@ const sidebarMenuButtonVariants = cva(
       variant: {
         default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
         outline:
-          'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
+          'bg-background shadow-[0_0_0_1px] shadow-sidebar-border hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px] hover:shadow-sidebar-accent',
       },
       size: {
         default: 'h-8 text-sm',

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -156,6 +156,47 @@ function shouldToggleSidebarFromKeyboard(event: KeyboardEvent): boolean {
 const SIDEBAR_PANEL_SURFACE =
   'bg-[var(--app-sidebar-bg,rgb(var(--app-surface)/0.88))] text-sidebar-foreground backdrop-blur-sm supports-[backdrop-filter]:bg-[var(--app-sidebar-bg,rgb(var(--app-surface)/0.88))]';
 
+/**
+ * Whether `child` is a {@link SidebarRail} element (matched by `displayName`).
+ *
+ * @param child - A child of {@link Sidebar}.
+ * @returns `true` when the child should render outside the offcanvas inert panel.
+ */
+function isSidebarRailElement(child: React.ReactNode): boolean {
+  if (!React.isValidElement(child)) {
+    return false;
+  }
+  const type = child.type as { displayName?: string; name?: string };
+  const name =
+    typeof type === 'function' || typeof type === 'object'
+      ? (type.displayName ?? type.name)
+      : undefined;
+  return name === 'SidebarRail';
+}
+
+/**
+ * Splits {@link SidebarRail} from other sidebar children so the rail stays focusable when the
+ * offcanvas panel is collapsed and inert.
+ *
+ * @param children - {@link Sidebar} children.
+ * @returns Rails vs main panel content.
+ */
+function partitionSidebarChildren(children: React.ReactNode): {
+  rails: React.ReactNode[];
+  content: React.ReactNode[];
+} {
+  const rails: React.ReactNode[] = [];
+  const content: React.ReactNode[] = [];
+  React.Children.forEach(children, (child) => {
+    if (isSidebarRailElement(child)) {
+      rails.push(child);
+    } else {
+      content.push(child);
+    }
+  });
+  return { rails, content };
+}
+
 type SidebarContextProps = {
   state: 'expanded' | 'collapsed';
   open: boolean;
@@ -368,6 +409,10 @@ const Sidebar = React.forwardRef<
       );
     }
 
+    const isOffcanvasHidden =
+      collapsible === 'offcanvas' && state === 'collapsed';
+    const { rails, content } = partitionSidebarChildren(children);
+
     if (isMobile) {
       return (
         <Sheet open={openMobile} onOpenChange={setOpenMobile}>
@@ -433,9 +478,11 @@ const Sidebar = React.forwardRef<
               'flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow',
               SIDEBAR_PANEL_SURFACE,
             )}
+            {...(isOffcanvasHidden ? { inert: true, 'aria-hidden': true } : {})}
           >
-            {children}
+            {content}
           </div>
+          {rails}
         </div>
       </div>
     );

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -76,6 +76,82 @@ const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
 const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
 
+/**
+ * Whether `target` is a field where modifier+B is used for text editing (not sidebar chrome).
+ *
+ * @param target - `keydown` event target.
+ * @returns `true` when the shortcut should not toggle the sidebar.
+ */
+function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  if (target.isContentEditable) {
+    return true;
+  }
+  const tag = target.tagName;
+  if (tag === 'TEXTAREA' || tag === 'SELECT') {
+    return true;
+  }
+  if (tag === 'INPUT') {
+    const type = (target as HTMLInputElement).type;
+    if (
+      type === 'button' ||
+      type === 'submit' ||
+      type === 'reset' ||
+      type === 'checkbox' ||
+      type === 'radio' ||
+      type === 'file' ||
+      type === 'hidden' ||
+      type === 'image'
+    ) {
+      return false;
+    }
+    return true;
+  }
+  return (
+    target.closest(
+      '[contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"]',
+    ) != null
+  );
+}
+
+/**
+ * macOS / iOS: Cmd+B only — leave Ctrl+B for editor navigation (e.g. move backward).
+ *
+ * @returns `true` on Apple desktop/mobile platforms.
+ */
+function isMacLikePlatform(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  const platform = navigator.platform ?? '';
+  if (/Mac|iPhone|iPad|iPod/i.test(platform)) {
+    return true;
+  }
+  return /Mac OS X|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+/**
+ * Whether a `keydown` should toggle the sidebar (Cmd/Ctrl+B), respecting editable focus and platform.
+ *
+ * @param event - Window `keydown` event.
+ * @returns `true` when the handler should toggle the sidebar.
+ */
+function shouldToggleSidebarFromKeyboard(event: KeyboardEvent): boolean {
+  if (event.key.toLowerCase() !== SIDEBAR_KEYBOARD_SHORTCUT) {
+    return false;
+  }
+  const isMac = isMacLikePlatform();
+  const hasShortcutModifier = isMac
+    ? event.metaKey
+    : event.metaKey || event.ctrlKey;
+  if (!hasShortcutModifier) {
+    return false;
+  }
+  return !isEditableKeyboardTarget(event.target);
+}
+
 /** Frosted panel fill; uses `--app-sidebar-bg` from app `global.css` (alpha must be below 1). */
 const SIDEBAR_PANEL_SURFACE =
   'bg-[var(--app-sidebar-bg,rgb(var(--app-surface)/0.88))] text-sidebar-foreground backdrop-blur-sm supports-[backdrop-filter]:bg-[var(--app-sidebar-bg,rgb(var(--app-surface)/0.88))]';
@@ -188,16 +264,14 @@ const SidebarProvider = React.forwardRef<
         : setOpen((open) => !open);
     }, [isMobile, setOpen, setOpenMobile]);
 
-    // Adds a keyboard shortcut to toggle the sidebar.
+    // Cmd/Ctrl+B toggles the sidebar; skip editable targets and Ctrl+B on macOS.
     React.useEffect(() => {
       const handleKeyDown = (event: KeyboardEvent) => {
-        if (
-          event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
-          (event.metaKey || event.ctrlKey)
-        ) {
-          event.preventDefault();
-          toggleSidebar();
+        if (!shouldToggleSidebarFromKeyboard(event)) {
+          return;
         }
+        event.preventDefault();
+        toggleSidebar();
       };
 
       window.addEventListener('keydown', handleKeyDown);
@@ -372,12 +446,13 @@ Sidebar.displayName = 'Sidebar';
 const SidebarTrigger = React.forwardRef<
   React.ElementRef<typeof Button>,
   React.ComponentProps<typeof Button>
->(({ className, onClick, ...props }, ref) => {
+>(({ className, onClick, type = 'button', ...props }, ref) => {
   const { toggleSidebar } = useSidebar();
 
   return (
     <Button
       ref={ref}
+      type={type}
       data-sidebar="trigger"
       variant="ghost"
       size="icon"
@@ -398,7 +473,7 @@ SidebarTrigger.displayName = 'SidebarTrigger';
 const SidebarRail = React.forwardRef<
   HTMLButtonElement,
   React.ComponentProps<'button'>
->(({ className, ...props }, ref) => {
+>(({ className, type = 'button', ...props }, ref) => {
   const { toggleSidebar, isMobile } = useSidebar();
 
   if (isMobile) {
@@ -408,6 +483,7 @@ const SidebarRail = React.forwardRef<
   return (
     <button
       ref={ref}
+      type={type}
       data-sidebar="rail"
       aria-label="Toggle Sidebar"
       tabIndex={-1}

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -6,6 +6,11 @@ import { cva, type VariantProps } from 'class-variance-authority';
 import { PanelLeft } from 'lucide-react';
 
 import { useIsMobile } from '../hooks/use-mobile.js';
+import {
+  readSidebarOpenCookie,
+  shouldToggleSidebarFromKeyboard,
+  writeSidebarOpenCookie,
+} from '../lib/sidebar-provider-behavior.js';
 import { cn } from '../lib/utils.js';
 import { Button } from './button.js';
 import { Input } from './input.js';
@@ -27,130 +32,9 @@ import {
 
 /** Default cookie for uncontrolled desktop sidebar state; override per app on shared hosts. */
 export const DEFAULT_SIDEBAR_COOKIE_NAME = 'abstrack_sidebar_state';
-const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
 const SIDEBAR_WIDTH = '16rem';
-
-/**
- * Reads persisted desktop sidebar open state from `document.cookie`.
- *
- * @returns `true` / `false` when set, otherwise `null`.
- */
-function readSidebarOpenCookie(cookieName: string): boolean | null {
-  if (typeof document === 'undefined') {
-    return null;
-  }
-  const prefix = `${cookieName}=`;
-  for (const entry of document.cookie.split(';')) {
-    const trimmed = entry.trim();
-    if (!trimmed.startsWith(prefix)) {
-      continue;
-    }
-    const value = trimmed.slice(prefix.length);
-    if (value === 'true') {
-      return true;
-    }
-    if (value === 'false') {
-      return false;
-    }
-    return null;
-  }
-  return null;
-}
-
-/**
- * Persists desktop sidebar open state (uncontrolled {@link SidebarProvider} only).
- *
- * @param open - Whether the desktop sidebar rail is expanded.
- */
-function writeSidebarOpenCookie(cookieName: string, open: boolean): void {
-  if (typeof document === 'undefined') {
-    return;
-  }
-  const secure =
-    typeof window !== 'undefined' && window.location.protocol === 'https:'
-      ? '; Secure'
-      : '';
-  document.cookie = `${cookieName}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; SameSite=Lax${secure}`;
-}
 const SIDEBAR_WIDTH_MOBILE = '18rem';
 const SIDEBAR_WIDTH_ICON = '3rem';
-const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
-
-/**
- * Whether `target` is a field where modifier+B is used for text editing (not sidebar chrome).
- *
- * @param target - `keydown` event target.
- * @returns `true` when the shortcut should not toggle the sidebar.
- */
-function isEditableKeyboardTarget(target: EventTarget | null): boolean {
-  if (!(target instanceof HTMLElement)) {
-    return false;
-  }
-  if (target.isContentEditable) {
-    return true;
-  }
-  const tag = target.tagName;
-  if (tag === 'TEXTAREA' || tag === 'SELECT') {
-    return true;
-  }
-  if (tag === 'INPUT') {
-    const type = (target as HTMLInputElement).type;
-    if (
-      type === 'button' ||
-      type === 'submit' ||
-      type === 'reset' ||
-      type === 'checkbox' ||
-      type === 'radio' ||
-      type === 'file' ||
-      type === 'hidden' ||
-      type === 'image'
-    ) {
-      return false;
-    }
-    return true;
-  }
-  return (
-    target.closest(
-      '[contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"]',
-    ) != null
-  );
-}
-
-/**
- * macOS / iOS: Cmd+B only — leave Ctrl+B for editor navigation (e.g. move backward).
- *
- * @returns `true` on Apple desktop/mobile platforms.
- */
-function isMacLikePlatform(): boolean {
-  if (typeof navigator === 'undefined') {
-    return false;
-  }
-  const platform = navigator.platform ?? '';
-  if (/Mac|iPhone|iPad|iPod/i.test(platform)) {
-    return true;
-  }
-  return /Mac OS X|iPhone|iPad|iPod/i.test(navigator.userAgent);
-}
-
-/**
- * Whether a `keydown` should toggle the sidebar (Cmd/Ctrl+B), respecting editable focus and platform.
- *
- * @param event - Window `keydown` event.
- * @returns `true` when the handler should toggle the sidebar.
- */
-function shouldToggleSidebarFromKeyboard(event: KeyboardEvent): boolean {
-  if (event.key.toLowerCase() !== SIDEBAR_KEYBOARD_SHORTCUT) {
-    return false;
-  }
-  const isMac = isMacLikePlatform();
-  const hasShortcutModifier = isMac
-    ? event.metaKey
-    : event.metaKey || event.ctrlKey;
-  if (!hasShortcutModifier) {
-    return false;
-  }
-  return !isEditableKeyboardTarget(event.target);
-}
 
 /** Frosted panel fill; uses `--app-sidebar-bg` from app `global.css` (alpha must be below 1). */
 const SIDEBAR_PANEL_SURFACE =
@@ -249,12 +133,14 @@ const SidebarProvider = React.forwardRef<
     const isMobile = useIsMobile();
     const [openMobile, setOpenMobile] = React.useState(false);
     const isControlled = openProp !== undefined && setOpenProp !== undefined;
+    const controlledOpen: boolean | null =
+      openProp !== undefined && setOpenProp !== undefined ? openProp : null;
 
     // This is the internal state of the sidebar.
     // Controlled only when both `open` and `onOpenChange` are provided.
     // Initialize from defaultOpen only; restore cookie after mount to avoid SSR/client mismatch.
     const [_open, _setOpen] = React.useState(defaultOpen);
-    const open = isControlled ? openProp : _open;
+    const open = controlledOpen ?? _open;
 
     React.useEffect(() => {
       if (process.env.NODE_ENV === 'production') {
@@ -285,8 +171,10 @@ const SidebarProvider = React.forwardRef<
 
     const setOpen = React.useCallback(
       (value: boolean | ((value: boolean) => boolean)) => {
-        if (isControlled) {
-          setOpenProp(typeof value === 'function' ? value(openProp) : value);
+        if (controlledOpen !== null && setOpenProp !== undefined) {
+          setOpenProp(
+            typeof value === 'function' ? value(controlledOpen) : value,
+          );
           return;
         }
         _setOpen((prev) => {
@@ -295,7 +183,7 @@ const SidebarProvider = React.forwardRef<
           return next;
         });
       },
-      [isControlled, setOpenProp, openProp, sidebarCookieName],
+      [controlledOpen, setOpenProp, sidebarCookieName],
     );
 
     // Helper to toggle the sidebar.

--- a/packages/ui-web/src/components/sidebar.tsx
+++ b/packages/ui-web/src/components/sidebar.tsx
@@ -1,0 +1,792 @@
+'use client';
+
+import * as React from 'react';
+import { Slot } from '@radix-ui/react-slot';
+import { cva, type VariantProps } from 'class-variance-authority';
+import { PanelLeft } from 'lucide-react';
+
+import { useIsMobile } from '../hooks/use-mobile.js';
+import { cn } from '../lib/utils.js';
+import { Button } from './button.js';
+import { Input } from './input.js';
+import { Separator } from './separator.js';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from './sheet.js';
+import { Skeleton } from './skeleton.js';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from './tooltip.js';
+
+const SIDEBAR_COOKIE_NAME = 'sidebar_state';
+const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+const SIDEBAR_WIDTH = '16rem';
+const SIDEBAR_WIDTH_MOBILE = '18rem';
+const SIDEBAR_WIDTH_ICON = '3rem';
+const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
+
+/** Frosted panel fill; uses `--app-sidebar-bg` from app `global.css` (alpha must be below 1). */
+const SIDEBAR_PANEL_SURFACE =
+  'bg-[var(--app-sidebar-bg,rgb(var(--app-surface)/0.88))] text-sidebar-foreground backdrop-blur-sm supports-[backdrop-filter]:bg-[var(--app-sidebar-bg,rgb(var(--app-surface)/0.88))]';
+
+type SidebarContextProps = {
+  state: 'expanded' | 'collapsed';
+  open: boolean;
+  setOpen: (open: boolean) => void;
+  openMobile: boolean;
+  setOpenMobile: (open: boolean) => void;
+  isMobile: boolean;
+  toggleSidebar: () => void;
+};
+
+const SidebarContext = React.createContext<SidebarContextProps | null>(null);
+
+function useSidebar() {
+  const context = React.useContext(SidebarContext);
+  if (!context) {
+    throw new Error('useSidebar must be used within a SidebarProvider.');
+  }
+
+  return context;
+}
+
+const SidebarProvider = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'> & {
+    defaultOpen?: boolean;
+    open?: boolean;
+    onOpenChange?: (open: boolean) => void;
+  }
+>(
+  (
+    {
+      defaultOpen = true,
+      open: openProp,
+      onOpenChange: setOpenProp,
+      className,
+      style,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const isMobile = useIsMobile();
+    const [openMobile, setOpenMobile] = React.useState(false);
+
+    // This is the internal state of the sidebar.
+    // We use openProp and setOpenProp for control from outside the component.
+    const [_open, _setOpen] = React.useState(defaultOpen);
+    const open = openProp ?? _open;
+    const setOpen = React.useCallback(
+      (value: boolean | ((value: boolean) => boolean)) => {
+        const openState = typeof value === 'function' ? value(open) : value;
+        if (setOpenProp) {
+          setOpenProp(openState);
+        } else {
+          _setOpen(openState);
+        }
+
+        // This sets the cookie to keep the sidebar state.
+        document.cookie = `${SIDEBAR_COOKIE_NAME}=${openState}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}`;
+      },
+      [setOpenProp, open],
+    );
+
+    // Helper to toggle the sidebar.
+    const toggleSidebar = React.useCallback(() => {
+      return isMobile
+        ? setOpenMobile((open) => !open)
+        : setOpen((open) => !open);
+    }, [isMobile, setOpen, setOpenMobile]);
+
+    // Adds a keyboard shortcut to toggle the sidebar.
+    React.useEffect(() => {
+      const handleKeyDown = (event: KeyboardEvent) => {
+        if (
+          event.key === SIDEBAR_KEYBOARD_SHORTCUT &&
+          (event.metaKey || event.ctrlKey)
+        ) {
+          event.preventDefault();
+          toggleSidebar();
+        }
+      };
+
+      window.addEventListener('keydown', handleKeyDown);
+      return () => window.removeEventListener('keydown', handleKeyDown);
+    }, [toggleSidebar]);
+
+    // We add a state so that we can do data-state="expanded" or "collapsed".
+    // This makes it easier to style the sidebar with Tailwind classes.
+    const state = open ? 'expanded' : 'collapsed';
+
+    const contextValue = React.useMemo<SidebarContextProps>(
+      () => ({
+        state,
+        open,
+        setOpen,
+        isMobile,
+        openMobile,
+        setOpenMobile,
+        toggleSidebar,
+      }),
+      [
+        state,
+        open,
+        setOpen,
+        isMobile,
+        openMobile,
+        setOpenMobile,
+        toggleSidebar,
+      ],
+    );
+
+    return (
+      <SidebarContext.Provider value={contextValue}>
+        <TooltipProvider delayDuration={0}>
+          <div
+            style={
+              {
+                '--sidebar-width': SIDEBAR_WIDTH,
+                '--sidebar-width-icon': SIDEBAR_WIDTH_ICON,
+                ...style,
+              } as React.CSSProperties
+            }
+            className={cn(
+              'group/sidebar-wrapper flex min-h-svh w-full has-[[data-variant=inset]]:bg-sidebar',
+              className,
+            )}
+            ref={ref}
+            {...props}
+          >
+            {children}
+          </div>
+        </TooltipProvider>
+      </SidebarContext.Provider>
+    );
+  },
+);
+SidebarProvider.displayName = 'SidebarProvider';
+
+const Sidebar = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'> & {
+    side?: 'left' | 'right';
+    variant?: 'sidebar' | 'floating' | 'inset';
+    collapsible?: 'offcanvas' | 'icon' | 'none';
+  }
+>(
+  (
+    {
+      side = 'left',
+      variant = 'sidebar',
+      collapsible = 'offcanvas',
+      className,
+      children,
+      ...props
+    },
+    ref,
+  ) => {
+    const { isMobile, state, openMobile, setOpenMobile } = useSidebar();
+
+    if (collapsible === 'none') {
+      return (
+        <div
+          className={cn(
+            'flex h-full w-[--sidebar-width] flex-col',
+            SIDEBAR_PANEL_SURFACE,
+            className,
+          )}
+          ref={ref}
+          {...props}
+        >
+          {children}
+        </div>
+      );
+    }
+
+    if (isMobile) {
+      return (
+        <Sheet open={openMobile} onOpenChange={setOpenMobile} {...props}>
+          <SheetContent
+            data-sidebar="sidebar"
+            data-mobile="true"
+            className={cn(
+              'w-[--sidebar-width] p-0 [&>button]:hidden',
+              SIDEBAR_PANEL_SURFACE,
+            )}
+            style={
+              {
+                '--sidebar-width': SIDEBAR_WIDTH_MOBILE,
+              } as React.CSSProperties
+            }
+            side={side}
+          >
+            <SheetHeader className="sr-only">
+              <SheetTitle>Sidebar</SheetTitle>
+              <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+            </SheetHeader>
+            <div className="flex h-full w-full flex-col">{children}</div>
+          </SheetContent>
+        </Sheet>
+      );
+    }
+
+    return (
+      <div
+        ref={ref}
+        className="group peer hidden text-sidebar-foreground md:block"
+        data-state={state}
+        data-collapsible={state === 'collapsed' ? collapsible : ''}
+        data-variant={variant}
+        data-side={side}
+      >
+        {/* This is what handles the sidebar gap on desktop */}
+        <div
+          className={cn(
+            'relative w-[--sidebar-width] bg-transparent transition-[width] duration-200 ease-linear',
+            'group-data-[collapsible=offcanvas]:w-0',
+            'group-data-[side=right]:rotate-180',
+            variant === 'floating' || variant === 'inset'
+              ? 'group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4))]'
+              : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon]',
+          )}
+        />
+        <div
+          className={cn(
+            'fixed top-[var(--sidebar-top-offset,0px)] z-10 hidden h-[calc(100svh-var(--sidebar-top-offset,0px))] w-[--sidebar-width] transition-[left,right,width] duration-200 ease-linear md:flex',
+            side === 'left'
+              ? 'left-0 group-data-[collapsible=offcanvas]:left-[calc(var(--sidebar-width)*-1)]'
+              : 'right-0 group-data-[collapsible=offcanvas]:right-[calc(var(--sidebar-width)*-1)]',
+            // Adjust the padding for floating and inset variants.
+            variant === 'floating' || variant === 'inset'
+              ? 'p-2 group-data-[collapsible=icon]:w-[calc(var(--sidebar-width-icon)_+_theme(spacing.4)_+2px)]'
+              : 'group-data-[collapsible=icon]:w-[--sidebar-width-icon] group-data-[side=left]:border-r group-data-[side=right]:border-l',
+            className,
+          )}
+          {...props}
+        >
+          <div
+            data-sidebar="sidebar"
+            className={cn(
+              'flex h-full w-full flex-col group-data-[variant=floating]:rounded-lg group-data-[variant=floating]:border group-data-[variant=floating]:border-sidebar-border group-data-[variant=floating]:shadow',
+              SIDEBAR_PANEL_SURFACE,
+            )}
+          >
+            {children}
+          </div>
+        </div>
+      </div>
+    );
+  },
+);
+Sidebar.displayName = 'Sidebar';
+
+const SidebarTrigger = React.forwardRef<
+  React.ElementRef<typeof Button>,
+  React.ComponentProps<typeof Button>
+>(({ className, onClick, ...props }, ref) => {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <Button
+      ref={ref}
+      data-sidebar="trigger"
+      variant="ghost"
+      size="icon"
+      className={cn('h-7 w-7', className)}
+      onClick={(event: React.MouseEvent<HTMLButtonElement>) => {
+        onClick?.(event);
+        toggleSidebar();
+      }}
+      {...props}
+    >
+      <PanelLeft />
+      <span className="sr-only">Toggle Sidebar</span>
+    </Button>
+  );
+});
+SidebarTrigger.displayName = 'SidebarTrigger';
+
+const SidebarRail = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<'button'>
+>(({ className, ...props }, ref) => {
+  const { toggleSidebar } = useSidebar();
+
+  return (
+    <button
+      ref={ref}
+      data-sidebar="rail"
+      aria-label="Toggle Sidebar"
+      tabIndex={-1}
+      onClick={toggleSidebar}
+      title="Toggle Sidebar"
+      className={cn(
+        'absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex',
+        '[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize',
+        '[[data-side=left][data-state=collapsed]_&]:cursor-e-resize [[data-side=right][data-state=collapsed]_&]:cursor-w-resize',
+        'group-data-[collapsible=offcanvas]:translate-x-0 group-data-[collapsible=offcanvas]:after:left-full group-data-[collapsible=offcanvas]:hover:bg-sidebar',
+        '[[data-side=left][data-collapsible=offcanvas]_&]:-right-2',
+        '[[data-side=right][data-collapsible=offcanvas]_&]:-left-2',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+SidebarRail.displayName = 'SidebarRail';
+
+const SidebarInset = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'main'>
+>(({ className, ...props }, ref) => {
+  return (
+    <main
+      ref={ref}
+      className={cn(
+        'relative flex w-full flex-1 flex-col',
+        'md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+SidebarInset.displayName = 'SidebarInset';
+
+const SidebarInput = React.forwardRef<
+  React.ElementRef<typeof Input>,
+  React.ComponentProps<typeof Input>
+>(({ className, ...props }, ref) => {
+  return (
+    <Input
+      ref={ref}
+      data-sidebar="input"
+      className={cn(
+        'h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+SidebarInput.displayName = 'SidebarInput';
+
+const SidebarHeader = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'>
+>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="header"
+      className={cn('flex flex-col gap-2 p-2', className)}
+      {...props}
+    />
+  );
+});
+SidebarHeader.displayName = 'SidebarHeader';
+
+const SidebarFooter = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'>
+>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="footer"
+      className={cn('flex flex-col gap-2 p-2', className)}
+      {...props}
+    />
+  );
+});
+SidebarFooter.displayName = 'SidebarFooter';
+
+const SidebarSeparator = React.forwardRef<
+  React.ElementRef<typeof Separator>,
+  React.ComponentProps<typeof Separator>
+>(({ className, ...props }, ref) => {
+  return (
+    <Separator
+      ref={ref}
+      data-sidebar="separator"
+      className={cn('mx-2 w-auto bg-sidebar-border', className)}
+      {...props}
+    />
+  );
+});
+SidebarSeparator.displayName = 'SidebarSeparator';
+
+const SidebarContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'>
+>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="content"
+      className={cn(
+        'flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+SidebarContent.displayName = 'SidebarContent';
+
+const SidebarGroup = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'>
+>(({ className, ...props }, ref) => {
+  return (
+    <div
+      ref={ref}
+      data-sidebar="group"
+      className={cn('relative flex w-full min-w-0 flex-col p-2', className)}
+      {...props}
+    />
+  );
+});
+SidebarGroup.displayName = 'SidebarGroup';
+
+const SidebarGroupLabel = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'> & { asChild?: boolean }
+>(({ className, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'div';
+
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="group-label"
+      className={cn(
+        'flex h-8 shrink-0 items-center rounded-md px-2 text-xs font-medium text-sidebar-foreground/70 outline-none ring-sidebar-ring transition-[margin,opacity] duration-200 ease-linear focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        'group-data-[collapsible=icon]:-mt-8 group-data-[collapsible=icon]:opacity-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+SidebarGroupLabel.displayName = 'SidebarGroupLabel';
+
+const SidebarGroupAction = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<'button'> & { asChild?: boolean }
+>(({ className, asChild = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'button';
+
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="group-action"
+      className={cn(
+        'absolute right-3 top-3.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 [&>svg]:size-4 [&>svg]:shrink-0',
+        // Increases the hit area of the button on mobile.
+        'after:absolute after:-inset-2 after:md:hidden',
+        'group-data-[collapsible=icon]:hidden',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+SidebarGroupAction.displayName = 'SidebarGroupAction';
+
+const SidebarGroupContent = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-sidebar="group-content"
+    className={cn('w-full text-sm', className)}
+    {...props}
+  />
+));
+SidebarGroupContent.displayName = 'SidebarGroupContent';
+
+const SidebarMenu = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<'ul'>
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    data-sidebar="menu"
+    className={cn('flex w-full min-w-0 flex-col gap-1', className)}
+    {...props}
+  />
+));
+SidebarMenu.displayName = 'SidebarMenu';
+
+const SidebarMenuItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<'li'>
+>(({ className, ...props }, ref) => (
+  <li
+    ref={ref}
+    data-sidebar="menu-item"
+    className={cn('group/menu-item relative', className)}
+    {...props}
+  />
+));
+SidebarMenuItem.displayName = 'SidebarMenuItem';
+
+const sidebarMenuButtonVariants = cva(
+  'peer/menu-button flex w-full items-center gap-2 overflow-hidden rounded-md p-2 text-left text-sm outline-none ring-sidebar-ring transition-[width,height,padding] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 group-has-[[data-sidebar=menu-action]]/menu-item:pr-8 aria-disabled:pointer-events-none aria-disabled:opacity-50 data-[active=true]:bg-sidebar-accent data-[active=true]:font-medium data-[active=true]:text-sidebar-accent-foreground data-[state=open]:hover:bg-sidebar-accent data-[state=open]:hover:text-sidebar-accent-foreground group-data-[collapsible=icon]:!size-8 group-data-[collapsible=icon]:!p-2 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0',
+  {
+    variants: {
+      variant: {
+        default: 'hover:bg-sidebar-accent hover:text-sidebar-accent-foreground',
+        outline:
+          'bg-background shadow-[0_0_0_1px_hsl(var(--sidebar-border))] hover:bg-sidebar-accent hover:text-sidebar-accent-foreground hover:shadow-[0_0_0_1px_hsl(var(--sidebar-accent))]',
+      },
+      size: {
+        default: 'h-8 text-sm',
+        sm: 'h-7 text-xs',
+        lg: 'h-12 text-sm group-data-[collapsible=icon]:!p-0',
+      },
+    },
+    defaultVariants: {
+      variant: 'default',
+      size: 'default',
+    },
+  },
+);
+
+const SidebarMenuButton = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<'button'> & {
+    asChild?: boolean;
+    isActive?: boolean;
+    tooltip?: string | React.ComponentProps<typeof TooltipContent>;
+  } & VariantProps<typeof sidebarMenuButtonVariants>
+>(
+  (
+    {
+      asChild = false,
+      isActive = false,
+      variant = 'default',
+      size = 'default',
+      tooltip,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    const Comp = asChild ? Slot : 'button';
+    const { isMobile, state } = useSidebar();
+
+    const button = (
+      <Comp
+        ref={ref}
+        data-sidebar="menu-button"
+        data-size={size}
+        data-active={isActive}
+        className={cn(sidebarMenuButtonVariants({ variant, size }), className)}
+        {...props}
+      />
+    );
+
+    if (!tooltip) {
+      return button;
+    }
+
+    if (typeof tooltip === 'string') {
+      tooltip = {
+        children: tooltip,
+      };
+    }
+
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent
+          side="right"
+          align="center"
+          hidden={state !== 'collapsed' || isMobile}
+          {...tooltip}
+        />
+      </Tooltip>
+    );
+  },
+);
+SidebarMenuButton.displayName = 'SidebarMenuButton';
+
+const SidebarMenuAction = React.forwardRef<
+  HTMLButtonElement,
+  React.ComponentProps<'button'> & {
+    asChild?: boolean;
+    showOnHover?: boolean;
+  }
+>(({ className, asChild = false, showOnHover = false, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'button';
+
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="menu-action"
+      className={cn(
+        'absolute right-1 top-1.5 flex aspect-square w-5 items-center justify-center rounded-md p-0 text-sidebar-foreground outline-none ring-sidebar-ring transition-transform hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 peer-hover/menu-button:text-sidebar-accent-foreground [&>svg]:size-4 [&>svg]:shrink-0',
+        // Increases the hit area of the button on mobile.
+        'after:absolute after:-inset-2 after:md:hidden',
+        'peer-data-[size=sm]/menu-button:top-1',
+        'peer-data-[size=default]/menu-button:top-1.5',
+        'peer-data-[size=lg]/menu-button:top-2.5',
+        'group-data-[collapsible=icon]:hidden',
+        showOnHover &&
+          'group-focus-within/menu-item:opacity-100 group-hover/menu-item:opacity-100 data-[state=open]:opacity-100 peer-data-[active=true]/menu-button:text-sidebar-accent-foreground md:opacity-0',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+SidebarMenuAction.displayName = 'SidebarMenuAction';
+
+const SidebarMenuBadge = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-sidebar="menu-badge"
+    className={cn(
+      'pointer-events-none absolute right-1 flex h-5 min-w-5 select-none items-center justify-center rounded-md px-1 text-xs font-medium tabular-nums text-sidebar-foreground',
+      'peer-hover/menu-button:text-sidebar-accent-foreground peer-data-[active=true]/menu-button:text-sidebar-accent-foreground',
+      'peer-data-[size=sm]/menu-button:top-1',
+      'peer-data-[size=default]/menu-button:top-1.5',
+      'peer-data-[size=lg]/menu-button:top-2.5',
+      'group-data-[collapsible=icon]:hidden',
+      className,
+    )}
+    {...props}
+  />
+));
+SidebarMenuBadge.displayName = 'SidebarMenuBadge';
+
+const SidebarMenuSkeleton = React.forwardRef<
+  HTMLDivElement,
+  React.ComponentProps<'div'> & {
+    showIcon?: boolean;
+  }
+>(({ className, showIcon = false, ...props }, ref) => {
+  // Random width between 50 to 90%.
+  const width = React.useMemo(() => {
+    return `${Math.floor(Math.random() * 40) + 50}%`;
+  }, []);
+
+  return (
+    <div
+      ref={ref}
+      data-sidebar="menu-skeleton"
+      className={cn('flex h-8 items-center gap-2 rounded-md px-2', className)}
+      {...props}
+    >
+      {showIcon && (
+        <Skeleton
+          className="size-4 rounded-md"
+          data-sidebar="menu-skeleton-icon"
+        />
+      )}
+      <Skeleton
+        className="h-4 max-w-[--skeleton-width] flex-1"
+        data-sidebar="menu-skeleton-text"
+        style={
+          {
+            '--skeleton-width': width,
+          } as React.CSSProperties
+        }
+      />
+    </div>
+  );
+});
+SidebarMenuSkeleton.displayName = 'SidebarMenuSkeleton';
+
+const SidebarMenuSub = React.forwardRef<
+  HTMLUListElement,
+  React.ComponentProps<'ul'>
+>(({ className, ...props }, ref) => (
+  <ul
+    ref={ref}
+    data-sidebar="menu-sub"
+    className={cn(
+      'mx-3.5 flex min-w-0 translate-x-px flex-col gap-1 border-l border-sidebar-border px-2.5 py-0.5',
+      'group-data-[collapsible=icon]:hidden',
+      className,
+    )}
+    {...props}
+  />
+));
+SidebarMenuSub.displayName = 'SidebarMenuSub';
+
+const SidebarMenuSubItem = React.forwardRef<
+  HTMLLIElement,
+  React.ComponentProps<'li'>
+>(({ ...props }, ref) => <li ref={ref} {...props} />);
+SidebarMenuSubItem.displayName = 'SidebarMenuSubItem';
+
+const SidebarMenuSubButton = React.forwardRef<
+  HTMLAnchorElement,
+  React.ComponentProps<'a'> & {
+    asChild?: boolean;
+    size?: 'sm' | 'md';
+    isActive?: boolean;
+  }
+>(({ asChild = false, size = 'md', isActive, className, ...props }, ref) => {
+  const Comp = asChild ? Slot : 'a';
+
+  return (
+    <Comp
+      ref={ref}
+      data-sidebar="menu-sub-button"
+      data-size={size}
+      data-active={isActive}
+      className={cn(
+        'flex h-7 min-w-0 -translate-x-px items-center gap-2 overflow-hidden rounded-md px-2 text-sidebar-foreground outline-none ring-sidebar-ring hover:bg-sidebar-accent hover:text-sidebar-accent-foreground focus-visible:ring-2 active:bg-sidebar-accent active:text-sidebar-accent-foreground disabled:pointer-events-none disabled:opacity-50 aria-disabled:pointer-events-none aria-disabled:opacity-50 [&>span:last-child]:truncate [&>svg]:size-4 [&>svg]:shrink-0 [&>svg]:text-sidebar-accent-foreground',
+        'data-[active=true]:bg-sidebar-accent data-[active=true]:text-sidebar-accent-foreground',
+        size === 'sm' && 'text-xs',
+        size === 'md' && 'text-sm',
+        'group-data-[collapsible=icon]:hidden',
+        className,
+      )}
+      {...props}
+    />
+  );
+});
+SidebarMenuSubButton.displayName = 'SidebarMenuSubButton';
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupAction,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInput,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuAction,
+  SidebarMenuBadge,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarMenuSkeleton,
+  SidebarMenuSub,
+  SidebarMenuSubButton,
+  SidebarMenuSubItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarSeparator,
+  SidebarTrigger,
+  useSidebar,
+};

--- a/packages/ui-web/src/components/skeleton.tsx
+++ b/packages/ui-web/src/components/skeleton.tsx
@@ -1,0 +1,15 @@
+import { cn } from '../lib/utils.js';
+
+function Skeleton({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn('animate-pulse rounded-md bg-primary/10', className)}
+      {...props}
+    />
+  );
+}
+
+export { Skeleton };

--- a/packages/ui-web/src/components/skeleton.tsx
+++ b/packages/ui-web/src/components/skeleton.tsx
@@ -1,9 +1,8 @@
+import type { HTMLAttributes } from 'react';
+
 import { cn } from '../lib/utils.js';
 
-function Skeleton({
-  className,
-  ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
+function Skeleton({ className, ...props }: HTMLAttributes<HTMLDivElement>) {
   return (
     <div
       className={cn('animate-pulse rounded-md bg-primary/10', className)}

--- a/packages/ui-web/src/components/tooltip.tsx
+++ b/packages/ui-web/src/components/tooltip.tsx
@@ -1,0 +1,32 @@
+'use client';
+
+import * as React from 'react';
+import * as TooltipPrimitive from '@radix-ui/react-tooltip';
+
+import { cn } from '../lib/utils.js';
+
+const TooltipProvider = TooltipPrimitive.Provider;
+
+const Tooltip = TooltipPrimitive.Root;
+
+const TooltipTrigger = TooltipPrimitive.Trigger;
+
+const TooltipContent = React.forwardRef<
+  React.ElementRef<typeof TooltipPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
+    <TooltipPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        'z-50 overflow-hidden rounded-md bg-primary px-3 py-1.5 text-xs text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-tooltip-content-transform-origin]',
+        className,
+      )}
+      {...props}
+    />
+  </TooltipPrimitive.Portal>
+));
+TooltipContent.displayName = TooltipPrimitive.Content.displayName;
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider };

--- a/packages/ui-web/src/hooks/use-mobile.spec.tsx
+++ b/packages/ui-web/src/hooks/use-mobile.spec.tsx
@@ -1,0 +1,81 @@
+import { act, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useIsMobile } from './use-mobile.js';
+
+function ViewportProbe() {
+  const isMobile = useIsMobile();
+  return <div data-testid="is-mobile">{isMobile ? 'mobile' : 'desktop'}</div>;
+}
+
+describe('useIsMobile', () => {
+  const originalMatchMedia = window.matchMedia;
+  const originalInnerWidth = Object.getOwnPropertyDescriptor(
+    window,
+    'innerWidth',
+  );
+
+  beforeEach(() => {
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      writable: true,
+      value: originalMatchMedia,
+    });
+    if (originalInnerWidth) {
+      Object.defineProperty(window, 'innerWidth', originalInnerWidth);
+    } else {
+      delete (window as { innerWidth?: number }).innerWidth;
+    }
+    vi.restoreAllMocks();
+  });
+
+  it('uses innerWidth when matchMedia is unavailable', () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 360,
+    });
+
+    render(<ViewportProbe />);
+
+    expect(screen.getByTestId('is-mobile')).toHaveTextContent('mobile');
+  });
+
+  it('updates when the viewport resizes without matchMedia', async () => {
+    Object.defineProperty(window, 'matchMedia', {
+      configurable: true,
+      value: undefined,
+    });
+    Object.defineProperty(window, 'innerWidth', {
+      configurable: true,
+      writable: true,
+      value: 1024,
+    });
+
+    render(<ViewportProbe />);
+    expect(screen.getByTestId('is-mobile')).toHaveTextContent('desktop');
+
+    await act(async () => {
+      Object.defineProperty(window, 'innerWidth', {
+        configurable: true,
+        writable: true,
+        value: 360,
+      });
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(screen.getByTestId('is-mobile')).toHaveTextContent('mobile');
+  });
+});

--- a/packages/ui-web/src/hooks/use-mobile.tsx
+++ b/packages/ui-web/src/hooks/use-mobile.tsx
@@ -1,0 +1,21 @@
+import * as React from 'react';
+
+const MOBILE_BREAKPOINT = 768;
+
+export function useIsMobile() {
+  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
+    undefined,
+  );
+
+  React.useEffect(() => {
+    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
+    const onChange = () => {
+      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    };
+    mql.addEventListener('change', onChange);
+    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    return () => mql.removeEventListener('change', onChange);
+  }, []);
+
+  return !!isMobile;
+}

--- a/packages/ui-web/src/hooks/use-mobile.tsx
+++ b/packages/ui-web/src/hooks/use-mobile.tsx
@@ -2,20 +2,37 @@ import * as React from 'react';
 
 const MOBILE_BREAKPOINT = 768;
 
-export function useIsMobile() {
-  const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
-    undefined,
+const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
+
+function getMobileMediaQueryList(): MediaQueryList {
+  return window.matchMedia(MOBILE_MEDIA_QUERY);
+}
+
+function subscribeMobile(onStoreChange: () => void): () => void {
+  const mql = getMobileMediaQueryList();
+  mql.addEventListener('change', onStoreChange);
+  return () => mql.removeEventListener('change', onStoreChange);
+}
+
+function getMobileSnapshot(): boolean {
+  return getMobileMediaQueryList().matches;
+}
+
+/** SSR / pre-hydration: assume desktop layout until the client subscribes. */
+function getMobileServerSnapshot(): boolean {
+  return false;
+}
+
+/**
+ * Whether the viewport is below the Tailwind `md` breakpoint ({@link MOBILE_BREAKPOINT}px).
+ * Uses `matchMedia` so the first client snapshot and subsequent updates stay consistent.
+ *
+ * @returns `true` when width is under 768px.
+ */
+export function useIsMobile(): boolean {
+  return React.useSyncExternalStore(
+    subscribeMobile,
+    getMobileSnapshot,
+    getMobileServerSnapshot,
   );
-
-  React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    };
-    mql.addEventListener('change', onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener('change', onChange);
-  }, []);
-
-  return !!isMobile;
 }

--- a/packages/ui-web/src/hooks/use-mobile.tsx
+++ b/packages/ui-web/src/hooks/use-mobile.tsx
@@ -10,8 +10,24 @@ function getMobileMediaQueryList(): MediaQueryList {
 
 function subscribeMobile(onStoreChange: () => void): () => void {
   const mql = getMobileMediaQueryList();
-  mql.addEventListener('change', onStoreChange);
-  return () => mql.removeEventListener('change', onStoreChange);
+
+  if ('addEventListener' in mql && typeof mql.addEventListener === 'function') {
+    mql.addEventListener('change', onStoreChange);
+    return () => {
+      mql.removeEventListener('change', onStoreChange);
+    };
+  }
+
+  if ('addListener' in mql && typeof mql.addListener === 'function') {
+    mql.addListener(onStoreChange);
+    return () => {
+      if ('removeListener' in mql && typeof mql.removeListener === 'function') {
+        mql.removeListener(onStoreChange);
+      }
+    };
+  }
+
+  return () => undefined;
 }
 
 function getMobileSnapshot(): boolean {
@@ -26,6 +42,7 @@ function getMobileServerSnapshot(): boolean {
 /**
  * Whether the viewport is below the Tailwind `md` breakpoint ({@link MOBILE_BREAKPOINT}px).
  * Uses `matchMedia` so the first client snapshot and subsequent updates stay consistent.
+ * Subscribes via `change` when supported, otherwise legacy `addListener` / `removeListener`.
  *
  * @returns `true` when width is under 768px.
  */

--- a/packages/ui-web/src/hooks/use-mobile.tsx
+++ b/packages/ui-web/src/hooks/use-mobile.tsx
@@ -4,33 +4,29 @@ const MOBILE_BREAKPOINT = 768;
 
 const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
 
-/** Desktop layout when `matchMedia` is unavailable (SSR, tests, older engines). */
-function createFallbackMediaQueryList(): MediaQueryList {
-  const noop = () => undefined;
-  return {
-    matches: false,
-    media: MOBILE_MEDIA_QUERY,
-    onchange: null,
-    addListener: noop,
-    removeListener: noop,
-    addEventListener: noop,
-    removeEventListener: noop,
-    dispatchEvent: () => false,
-  } as MediaQueryList;
+function canUseMatchMedia(): boolean {
+  return (
+    typeof window !== 'undefined' && typeof window.matchMedia === 'function'
+  );
 }
 
-function getMobileMediaQueryList(): MediaQueryList {
-  if (
-    typeof window === 'undefined' ||
-    typeof window.matchMedia !== 'function'
-  ) {
-    return createFallbackMediaQueryList();
+/**
+ * Client-only mobile check: `matchMedia` when available, otherwise `innerWidth`.
+ *
+ * @returns `true` when the viewport is below {@link MOBILE_BREAKPOINT}.
+ */
+function getViewportIsMobile(): boolean {
+  if (typeof window === 'undefined') {
+    return false;
   }
-  return window.matchMedia(MOBILE_MEDIA_QUERY);
+  if (canUseMatchMedia()) {
+    return window.matchMedia(MOBILE_MEDIA_QUERY).matches;
+  }
+  return window.innerWidth < MOBILE_BREAKPOINT;
 }
 
-function subscribeMobile(onStoreChange: () => void): () => void {
-  const mql = getMobileMediaQueryList();
+function subscribeMatchMedia(onStoreChange: () => void): () => void {
+  const mql = window.matchMedia(MOBILE_MEDIA_QUERY);
 
   if ('addEventListener' in mql && typeof mql.addEventListener === 'function') {
     mql.addEventListener('change', onStoreChange);
@@ -51,8 +47,23 @@ function subscribeMobile(onStoreChange: () => void): () => void {
   return () => undefined;
 }
 
+function subscribeMobile(onStoreChange: () => void): () => void {
+  if (typeof window === 'undefined') {
+    return () => undefined;
+  }
+
+  if (canUseMatchMedia()) {
+    return subscribeMatchMedia(onStoreChange);
+  }
+
+  window.addEventListener('resize', onStoreChange);
+  return () => {
+    window.removeEventListener('resize', onStoreChange);
+  };
+}
+
 function getMobileSnapshot(): boolean {
-  return getMobileMediaQueryList().matches;
+  return getViewportIsMobile();
 }
 
 /** SSR / pre-hydration: assume desktop layout until the client subscribes. */
@@ -62,9 +73,7 @@ function getMobileServerSnapshot(): boolean {
 
 /**
  * Whether the viewport is below the Tailwind `md` breakpoint ({@link MOBILE_BREAKPOINT}px).
- * Uses `matchMedia` so the first client snapshot and subsequent updates stay consistent.
- * Subscribes via `change` when supported, otherwise legacy `addListener` / `removeListener`.
- * Falls back to desktop (`false`) when `matchMedia` is missing.
+ * Uses `matchMedia` when available; otherwise derives from `window.innerWidth` and `resize`.
  *
  * @returns `true` when width is under 768px.
  */

--- a/packages/ui-web/src/hooks/use-mobile.tsx
+++ b/packages/ui-web/src/hooks/use-mobile.tsx
@@ -4,7 +4,28 @@ const MOBILE_BREAKPOINT = 768;
 
 const MOBILE_MEDIA_QUERY = `(max-width: ${MOBILE_BREAKPOINT - 1}px)`;
 
+/** Desktop layout when `matchMedia` is unavailable (SSR, tests, older engines). */
+function createFallbackMediaQueryList(): MediaQueryList {
+  const noop = () => undefined;
+  return {
+    matches: false,
+    media: MOBILE_MEDIA_QUERY,
+    onchange: null,
+    addListener: noop,
+    removeListener: noop,
+    addEventListener: noop,
+    removeEventListener: noop,
+    dispatchEvent: () => false,
+  } as MediaQueryList;
+}
+
 function getMobileMediaQueryList(): MediaQueryList {
+  if (
+    typeof window === 'undefined' ||
+    typeof window.matchMedia !== 'function'
+  ) {
+    return createFallbackMediaQueryList();
+  }
   return window.matchMedia(MOBILE_MEDIA_QUERY);
 }
 
@@ -43,6 +64,7 @@ function getMobileServerSnapshot(): boolean {
  * Whether the viewport is below the Tailwind `md` breakpoint ({@link MOBILE_BREAKPOINT}px).
  * Uses `matchMedia` so the first client snapshot and subsequent updates stay consistent.
  * Subscribes via `change` when supported, otherwise legacy `addListener` / `removeListener`.
+ * Falls back to desktop (`false`) when `matchMedia` is missing.
  *
  * @returns `true` when width is under 768px.
  */

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -9,6 +9,7 @@ export {
 } from './app-side-nav/index.js';
 
 export {
+  DEFAULT_SIDEBAR_COOKIE_NAME,
   Sidebar,
   SidebarContent,
   SidebarFooter,

--- a/packages/ui-web/src/index.ts
+++ b/packages/ui-web/src/index.ts
@@ -1,0 +1,29 @@
+export {
+  AppSideNav,
+  AppShellWithSideNav,
+  type AppSideNavItem,
+  type AppSideNavLinkComponent,
+  type AppSideNavLinkProps,
+  type AppSideNavProps,
+  type AppShellWithSideNavProps,
+} from './app-side-nav/index.js';
+
+export {
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarGroupLabel,
+  SidebarHeader,
+  SidebarInset,
+  SidebarMenu,
+  SidebarMenuButton,
+  SidebarMenuItem,
+  SidebarProvider,
+  SidebarRail,
+  SidebarTrigger,
+  useSidebar,
+} from './components/sidebar.js';
+
+export { cn } from './lib/utils.js';

--- a/packages/ui-web/src/lib/sidebar-provider-behavior.spec.ts
+++ b/packages/ui-web/src/lib/sidebar-provider-behavior.spec.ts
@@ -102,6 +102,15 @@ describe('shouldToggleSidebarFromKeyboard', () => {
     expect(shouldToggleSidebarFromKeyboard(event)).toBe(false);
   });
 
+  it('ignores repeated keydown while the shortcut is held', () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Win32',
+      userAgent: 'Windows',
+    });
+    const event = dispatchKey({ key: 'b', ctrlKey: true, repeat: true });
+    expect(shouldToggleSidebarFromKeyboard(event)).toBe(false);
+  });
+
   it('ignores the shortcut when focus is in a text input', () => {
     const input = document.createElement('input');
     document.body.append(input);

--- a/packages/ui-web/src/lib/sidebar-provider-behavior.spec.ts
+++ b/packages/ui-web/src/lib/sidebar-provider-behavior.spec.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  readSidebarOpenCookie,
+  shouldToggleSidebarFromKeyboard,
+  writeSidebarOpenCookie,
+} from './sidebar-provider-behavior.js';
+
+const COOKIE = 'abstrack_test_sidebar_state';
+
+function clearCookie(name: string): void {
+  document.cookie = `${name}=; path=/; max-age=0`;
+}
+
+function dispatchKey(
+  init: KeyboardEventInit & { target?: EventTarget | null },
+): KeyboardEvent {
+  const { target = document.body, ...rest } = init;
+  const event = new KeyboardEvent('keydown', {
+    bubbles: true,
+    cancelable: true,
+    ...rest,
+  });
+  Object.defineProperty(event, 'target', {
+    configurable: true,
+    value: target,
+  });
+  return event;
+}
+
+describe('readSidebarOpenCookie', () => {
+  afterEach(() => {
+    clearCookie(COOKIE);
+  });
+
+  it('returns null when the cookie is absent', () => {
+    expect(readSidebarOpenCookie(COOKIE)).toBeNull();
+  });
+
+  it('parses true and false from document.cookie', () => {
+    document.cookie = `${COOKIE}=true; path=/`;
+    expect(readSidebarOpenCookie(COOKIE)).toBe(true);
+
+    document.cookie = `${COOKIE}=false; path=/`;
+    expect(readSidebarOpenCookie(COOKIE)).toBe(false);
+  });
+
+  it('returns null for invalid values', () => {
+    document.cookie = `${COOKIE}=maybe; path=/`;
+    expect(readSidebarOpenCookie(COOKIE)).toBeNull();
+  });
+});
+
+describe('writeSidebarOpenCookie', () => {
+  afterEach(() => {
+    clearCookie(COOKIE);
+  });
+
+  it('persists open state readable by readSidebarOpenCookie', () => {
+    writeSidebarOpenCookie(COOKIE, false);
+    expect(readSidebarOpenCookie(COOKIE)).toBe(false);
+
+    writeSidebarOpenCookie(COOKIE, true);
+    expect(readSidebarOpenCookie(COOKIE)).toBe(true);
+  });
+});
+
+describe('shouldToggleSidebarFromKeyboard', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('accepts Ctrl+B on non-mac platforms', () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Win32',
+      userAgent: 'Windows',
+    });
+    const event = dispatchKey({ key: 'b', ctrlKey: true });
+    expect(shouldToggleSidebarFromKeyboard(event)).toBe(true);
+  });
+
+  it('accepts Meta+B on mac-like platforms', () => {
+    vi.stubGlobal('navigator', {
+      platform: 'MacIntel',
+      userAgent: 'Mozilla/5.0 (Macintosh)',
+    });
+    const event = dispatchKey({ key: 'B', metaKey: true });
+    expect(shouldToggleSidebarFromKeyboard(event)).toBe(true);
+  });
+
+  it('ignores Ctrl+B on mac-like platforms', () => {
+    vi.stubGlobal('navigator', {
+      platform: 'MacIntel',
+      userAgent: 'Mozilla/5.0 (Macintosh)',
+    });
+    const event = dispatchKey({ key: 'b', ctrlKey: true });
+    expect(shouldToggleSidebarFromKeyboard(event)).toBe(false);
+  });
+
+  it('ignores the shortcut without a modifier', () => {
+    const event = dispatchKey({ key: 'b' });
+    expect(shouldToggleSidebarFromKeyboard(event)).toBe(false);
+  });
+
+  it('ignores the shortcut when focus is in a text input', () => {
+    const input = document.createElement('input');
+    document.body.append(input);
+    const event = dispatchKey({ key: 'b', ctrlKey: true, target: input });
+    expect(shouldToggleSidebarFromKeyboard(event)).toBe(false);
+    input.remove();
+  });
+
+  it('allows the shortcut when focus is on a button input', () => {
+    const input = document.createElement('input');
+    input.type = 'button';
+    document.body.append(input);
+    const event = dispatchKey({ key: 'b', ctrlKey: true, target: input });
+    expect(shouldToggleSidebarFromKeyboard(event)).toBe(true);
+    input.remove();
+  });
+});

--- a/packages/ui-web/src/lib/sidebar-provider-behavior.ts
+++ b/packages/ui-web/src/lib/sidebar-provider-behavior.ts
@@ -1,0 +1,129 @@
+/** Desktop sidebar open-state cookie lifetime (seconds). */
+export const SIDEBAR_COOKIE_MAX_AGE = 60 * 60 * 24 * 7;
+
+/** Key used with Cmd/Ctrl for global sidebar toggle. */
+export const SIDEBAR_KEYBOARD_SHORTCUT = 'b';
+
+/**
+ * Reads persisted desktop sidebar open state from `document.cookie`.
+ *
+ * @param cookieName - Cookie name (e.g. {@link DEFAULT_SIDEBAR_COOKIE_NAME}).
+ * @returns `true` / `false` when set, otherwise `null`.
+ */
+export function readSidebarOpenCookie(cookieName: string): boolean | null {
+  if (typeof document === 'undefined') {
+    return null;
+  }
+  const prefix = `${cookieName}=`;
+  for (const entry of document.cookie.split(';')) {
+    const trimmed = entry.trim();
+    if (!trimmed.startsWith(prefix)) {
+      continue;
+    }
+    const value = trimmed.slice(prefix.length);
+    if (value === 'true') {
+      return true;
+    }
+    if (value === 'false') {
+      return false;
+    }
+    return null;
+  }
+  return null;
+}
+
+/**
+ * Persists desktop sidebar open state (uncontrolled sidebar provider only).
+ *
+ * @param cookieName - Cookie name.
+ * @param open - Whether the desktop sidebar rail is expanded.
+ */
+export function writeSidebarOpenCookie(
+  cookieName: string,
+  open: boolean,
+): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const secure =
+    typeof window !== 'undefined' && window.location.protocol === 'https:'
+      ? '; Secure'
+      : '';
+  document.cookie = `${cookieName}=${open}; path=/; max-age=${SIDEBAR_COOKIE_MAX_AGE}; SameSite=Lax${secure}`;
+}
+
+/**
+ * Whether `target` is a field where modifier+B is used for text editing (not sidebar chrome).
+ *
+ * @param target - `keydown` event target.
+ * @returns `true` when the shortcut should not toggle the sidebar.
+ */
+export function isEditableKeyboardTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) {
+    return false;
+  }
+  if (target.isContentEditable) {
+    return true;
+  }
+  const tag = target.tagName;
+  if (tag === 'TEXTAREA' || tag === 'SELECT') {
+    return true;
+  }
+  if (tag === 'INPUT') {
+    const type = (target as HTMLInputElement).type;
+    if (
+      type === 'button' ||
+      type === 'submit' ||
+      type === 'reset' ||
+      type === 'checkbox' ||
+      type === 'radio' ||
+      type === 'file' ||
+      type === 'hidden' ||
+      type === 'image'
+    ) {
+      return false;
+    }
+    return true;
+  }
+  return (
+    target.closest(
+      '[contenteditable=""], [contenteditable="true"], [contenteditable="plaintext-only"]',
+    ) != null
+  );
+}
+
+/**
+ * macOS / iOS: Cmd+B only — leave Ctrl+B for editor navigation (e.g. move backward).
+ *
+ * @returns `true` on Apple desktop/mobile platforms.
+ */
+export function isMacLikePlatform(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false;
+  }
+  const platform = navigator.platform ?? '';
+  if (/Mac|iPhone|iPad|iPod/i.test(platform)) {
+    return true;
+  }
+  return /Mac OS X|iPhone|iPad|iPod/i.test(navigator.userAgent);
+}
+
+/**
+ * Whether a `keydown` should toggle the sidebar (Cmd/Ctrl+B), respecting editable focus and platform.
+ *
+ * @param event - Window `keydown` event.
+ * @returns `true` when the handler should toggle the sidebar.
+ */
+export function shouldToggleSidebarFromKeyboard(event: KeyboardEvent): boolean {
+  if (event.key.toLowerCase() !== SIDEBAR_KEYBOARD_SHORTCUT) {
+    return false;
+  }
+  const isMac = isMacLikePlatform();
+  const hasShortcutModifier = isMac
+    ? event.metaKey
+    : event.metaKey || event.ctrlKey;
+  if (!hasShortcutModifier) {
+    return false;
+  }
+  return !isEditableKeyboardTarget(event.target);
+}

--- a/packages/ui-web/src/lib/sidebar-provider-behavior.ts
+++ b/packages/ui-web/src/lib/sidebar-provider-behavior.ts
@@ -115,6 +115,9 @@ export function isMacLikePlatform(): boolean {
  * @returns `true` when the handler should toggle the sidebar.
  */
 export function shouldToggleSidebarFromKeyboard(event: KeyboardEvent): boolean {
+  if (event.repeat) {
+    return false;
+  }
   if (event.key.toLowerCase() !== SIDEBAR_KEYBOARD_SHORTCUT) {
     return false;
   }

--- a/packages/ui-web/src/lib/utils.spec.ts
+++ b/packages/ui-web/src/lib/utils.spec.ts
@@ -1,0 +1,9 @@
+import { describe, expect, it } from 'vitest';
+
+import { cn } from './utils.js';
+
+describe('cn', () => {
+  it('merges tailwind classes', () => {
+    expect(cn('px-2', 'px-4')).toBe('px-4');
+  });
+});

--- a/packages/ui-web/src/lib/utils.ts
+++ b/packages/ui-web/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/packages/ui-web/src/test-setup.ts
+++ b/packages/ui-web/src/test-setup.ts
@@ -6,7 +6,10 @@ afterEach(() => {
   cleanup();
 });
 
-/** jsdom has no `matchMedia`; {@link useIsMobile} and sidebar layout depend on it. */
+/**
+ * jsdom has no `matchMedia`; provide a stub for tests. {@link useIsMobile} falls back to
+ * `innerWidth` + `resize` when `matchMedia` is missing (see `use-mobile.spec.tsx`).
+ */
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   configurable: true,

--- a/packages/ui-web/src/test-setup.ts
+++ b/packages/ui-web/src/test-setup.ts
@@ -1,0 +1,23 @@
+import '@testing-library/jest-dom/vitest';
+import { cleanup } from '@testing-library/react';
+import { afterEach, vi } from 'vitest';
+
+afterEach(() => {
+  cleanup();
+});
+
+/** jsdom has no `matchMedia`; {@link useIsMobile} and sidebar layout depend on it. */
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  configurable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+});

--- a/packages/ui-web/tailwind-shadcn-preset.cjs
+++ b/packages/ui-web/tailwind-shadcn-preset.cjs
@@ -2,6 +2,9 @@
  * Maps shadcn/ui semantic Tailwind tokens to ABStrack `--app-*` theme channels.
  * Import in app `tailwind.config.js` via `presets` and add `tailwindcss-animate` to `plugins`.
  *
+ * CommonJS (`.cjs`) because this package is `"type": "module"` and Next app Tailwind
+ * configs load the preset with `require()`.
+ *
  * @type {import('tailwindcss').Config}
  */
 module.exports = {

--- a/packages/ui-web/tailwind-shadcn-preset.js
+++ b/packages/ui-web/tailwind-shadcn-preset.js
@@ -1,0 +1,58 @@
+/**
+ * Maps shadcn/ui semantic Tailwind tokens to ABStrack `--app-*` theme channels.
+ * Import in app `tailwind.config.js` via `presets` and add `tailwindcss-animate` to `plugins`.
+ *
+ * @type {import('tailwindcss').Config}
+ */
+module.exports = {
+  theme: {
+    extend: {
+      colors: {
+        border: 'rgb(var(--app-border) / <alpha-value>)',
+        input: 'rgb(var(--app-border) / <alpha-value>)',
+        ring: 'rgb(var(--app-ring) / <alpha-value>)',
+        background: 'rgb(var(--app-bg) / <alpha-value>)',
+        foreground: 'rgb(var(--app-ink) / <alpha-value>)',
+        primary: {
+          DEFAULT: 'rgb(var(--app-primary) / <alpha-value>)',
+          foreground: 'rgb(var(--app-surface) / <alpha-value>)',
+        },
+        secondary: {
+          DEFAULT: 'rgb(var(--app-surface) / <alpha-value>)',
+          foreground: 'rgb(var(--app-ink) / <alpha-value>)',
+        },
+        destructive: {
+          DEFAULT: 'rgb(220 38 38 / <alpha-value>)',
+          foreground: 'rgb(255 255 255 / <alpha-value>)',
+        },
+        muted: {
+          DEFAULT: 'rgb(var(--app-muted) / <alpha-value>)',
+          foreground: 'rgb(var(--app-ink) / <alpha-value>)',
+        },
+        accent: {
+          DEFAULT: 'rgb(var(--app-primary-soft) / <alpha-value>)',
+          foreground: 'rgb(var(--app-ink) / <alpha-value>)',
+        },
+        popover: {
+          DEFAULT: 'rgb(var(--app-surface) / <alpha-value>)',
+          foreground: 'rgb(var(--app-ink) / <alpha-value>)',
+        },
+        card: {
+          DEFAULT: 'rgb(var(--app-surface) / <alpha-value>)',
+          foreground: 'rgb(var(--app-ink) / <alpha-value>)',
+        },
+        sidebar: {
+          DEFAULT:
+            'var(--app-sidebar-bg, rgb(var(--app-surface) / <alpha-value>))',
+          foreground: 'rgb(var(--app-ink) / <alpha-value>)',
+          primary: 'rgb(var(--app-primary) / <alpha-value>)',
+          'primary-foreground': 'rgb(var(--app-surface) / <alpha-value>)',
+          accent: 'rgb(var(--app-primary-soft) / <alpha-value>)',
+          'accent-foreground': 'rgb(var(--app-ink) / <alpha-value>)',
+          border: 'rgb(var(--app-border) / <alpha-value>)',
+          ring: 'rgb(var(--app-ring) / <alpha-value>)',
+        },
+      },
+    },
+  },
+};

--- a/packages/ui-web/tsconfig.json
+++ b/packages/ui-web/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/ui-web/tsconfig.json
+++ b/packages/ui-web/tsconfig.json
@@ -5,6 +5,9 @@
   "references": [
     {
       "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
     }
   ]
 }

--- a/packages/ui-web/tsconfig.lib.json
+++ b/packages/ui-web/tsconfig.lib.json
@@ -1,0 +1,22 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": "src",
+    "outDir": "dist",
+    "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
+    "emitDeclarationOnly": false,
+    "forceConsistentCasingInFileNames": true,
+    "jsx": "react-jsx",
+    "lib": ["es2022", "dom"],
+    "types": ["node"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx"],
+  "references": [],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
+}

--- a/packages/ui-web/tsconfig.lib.json
+++ b/packages/ui-web/tsconfig.lib.json
@@ -14,9 +14,27 @@
   "include": ["src/**/*.ts", "src/**/*.tsx"],
   "references": [],
   "exclude": [
-    "src/**/*.spec.ts",
-    "src/**/*.spec.tsx",
+    "src/test-setup.ts",
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/__tests__/**",
     "src/**/*.test.ts",
-    "src/**/*.test.tsx"
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.mts",
+    "src/**/*.spec.mts",
+    "src/**/*.test.cts",
+    "src/**/*.spec.cts",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.test.mjs",
+    "src/**/*.spec.mjs",
+    "src/**/*.test.cjs",
+    "src/**/*.spec.cjs"
   ]
 }

--- a/packages/ui-web/tsconfig.spec.json
+++ b/packages/ui-web/tsconfig.spec.json
@@ -26,7 +26,8 @@
     "src/**/*.spec.js",
     "src/**/*.test.jsx",
     "src/**/*.spec.jsx",
-    "src/**/*.d.ts"
+    "src/**/*.d.ts",
+    "src/test-setup.ts"
   ],
   "references": [
     {

--- a/packages/ui-web/tsconfig.spec.json
+++ b/packages/ui-web/tsconfig.spec.json
@@ -1,0 +1,36 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/vitest",
+    "jsx": "react-jsx",
+    "lib": ["es2022", "dom"],
+    "types": [
+      "vitest/globals",
+      "vitest/importMeta",
+      "vite/client",
+      "node",
+      "vitest"
+    ],
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": [
+    "vite.config.ts",
+    "vite.config.mts",
+    "vitest.config.ts",
+    "vitest.config.mts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.test.tsx",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.js",
+    "src/**/*.spec.js",
+    "src/**/*.test.jsx",
+    "src/**/*.spec.jsx",
+    "src/**/*.d.ts"
+  ],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    }
+  ]
+}

--- a/packages/ui-web/vitest.config.mts
+++ b/packages/ui-web/vitest.config.mts
@@ -5,7 +5,7 @@ export default defineConfig(() => ({
   cacheDir: '../../node_modules/.vite/packages/ui-web',
   test: {
     name: '@abstrack/ui-web',
-    passWithNoTests: true,
+    setupFiles: ['./src/test-setup.ts'],
     watch: false,
     globals: true,
     environment: 'jsdom',

--- a/packages/ui-web/vitest.config.mts
+++ b/packages/ui-web/vitest.config.mts
@@ -1,0 +1,19 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig(() => ({
+  root: __dirname,
+  cacheDir: '../../node_modules/.vite/packages/ui-web',
+  test: {
+    name: '@abstrack/ui-web',
+    passWithNoTests: true,
+    watch: false,
+    globals: true,
+    environment: 'jsdom',
+    include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    reporters: ['default'],
+    coverage: {
+      reportsDirectory: './test-output/vitest/coverage',
+      provider: 'v8' as const,
+    },
+  },
+}));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       react-native-web:
         specifier: ~0.21.0
         version: 0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)))
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.11.1
@@ -401,6 +404,9 @@ importers:
       '@abstrack/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@abstrack/ui-web':
+        specifier: workspace:*
+        version: link:../../packages/ui-web
       next:
         specifier: ~16.0.1
         version: 16.0.11(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.97.3)
@@ -443,6 +449,9 @@ importers:
       '@abstrack/ui':
         specifier: workspace:*
         version: link:../../packages/ui
+      '@abstrack/ui-web':
+        specifier: workspace:*
+        version: link:../../packages/ui-web
       '@supabase/ssr':
         specifier: ^0.6.1
         version: 0.6.1(@supabase/supabase-js@2.100.1)
@@ -533,6 +542,49 @@ importers:
       react-native-web:
         specifier: ~0.21.0
         version: 0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+
+  packages/ui-web:
+    dependencies:
+      '@radix-ui/react-dialog':
+        specifier: ^1.1.15
+        version: 1.1.15(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-separator':
+        specifier: ^1.1.7
+        version: 1.1.8(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot':
+        specifier: ^1.2.3
+        version: 1.2.4(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-tooltip':
+        specifier: ^1.2.8
+        version: 1.2.8(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.544.0
+        version: 0.544.0(react@19.1.0)
+      tailwind-merge:
+        specifier: ^3.3.1
+        version: 3.6.0
+      tslib:
+        specifier: ^2.3.0
+        version: 2.8.1
+    devDependencies:
+      '@types/react':
+        specifier: ~19.1.0
+        version: 19.1.17
+      '@types/react-dom':
+        specifier: ~19.1.0
+        version: 19.1.11(@types/react@19.1.17)
+      react:
+        specifier: 19.1.0
+        version: 19.1.0
+      react-dom:
+        specifier: 19.1.0
+        version: 19.1.0(react@19.1.0)
 
 packages:
   '@0no-co/graphql.web@1.2.0':
@@ -2303,6 +2355,33 @@ packages:
     resolution:
       {
         integrity: sha512-o4emRDDvGdkwX18BSVSXH8q27qAL7Z2WDHSN75C8xyRSE4A8UOkig0mWSGoT5M5KaTHZxoLmalFwOTQmbRusUg==,
+      }
+
+  '@floating-ui/core@1.7.5':
+    resolution:
+      {
+        integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==,
+      }
+
+  '@floating-ui/dom@1.7.6':
+    resolution:
+      {
+        integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==,
+      }
+
+  '@floating-ui/react-dom@2.1.8':
+    resolution:
+      {
+        integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==,
+      }
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@floating-ui/utils@0.2.11':
+    resolution:
+      {
+        integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==,
       }
 
   '@humanfs/core@0.19.1':
@@ -4345,6 +4424,366 @@ packages:
     peerDependencies:
       '@powersync/common': 1.52.0
       react: '*'
+
+  '@radix-ui/primitive@1.1.3':
+    resolution:
+      {
+        integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==,
+      }
+
+  '@radix-ui/react-arrow@1.1.7':
+    resolution:
+      {
+        integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-compose-refs@1.1.2':
+    resolution:
+      {
+        integrity: sha512-z4eqJvfiNnFMHIIvXP3CY57y2WJs5g2v3X0zm9mEJkrkNv4rDxu+sg9Jh8EkXyeqBkB7SOcboo9dMVqhyrACIg==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-context@1.1.2':
+    resolution:
+      {
+        integrity: sha512-jCi/QKUM2r1Ju5a3J64TH2A5SpKAgh0LpknyqdQ4m6DCV0xJ2HG1xARRwNGPQfi1SLdLWZ1OJz6F4OMBBNiGJA==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-dialog@1.1.15':
+    resolution:
+      {
+        integrity: sha512-TCglVRtzlffRNxRMEyR36DGBLJpeusFcgMVD9PZEzAKnUs1lKCgX5u9BmC2Yg+LL9MgZDugFFs1Vl+Jp4t/PGw==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-dismissable-layer@1.1.11':
+    resolution:
+      {
+        integrity: sha512-Nqcp+t5cTB8BinFkZgXiMJniQH0PsUt2k51FUhbdfeKvc4ACcG2uQniY/8+h1Yv6Kza4Q7lD7PQV0z0oicE0Mg==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-focus-guards@1.1.3':
+    resolution:
+      {
+        integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-focus-scope@1.1.7':
+    resolution:
+      {
+        integrity: sha512-t2ODlkXBQyn7jkl6TNaw/MtVEVvIGelJDCG41Okq/KwUsJBwQ4XVZsHAVUkK4mBv3ewiAS3PGuUWuY2BoK4ZUw==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-id@1.1.1':
+    resolution:
+      {
+        integrity: sha512-kGkGegYIdQsOb4XjsfM97rXsiHaBwco+hFI66oO4s9LU+PLAC5oJ7khdOVFxkhsmlbpUqDAvXw11CluXP+jkHg==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-popper@1.2.8':
+    resolution:
+      {
+        integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-portal@1.1.9':
+    resolution:
+      {
+        integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-presence@1.1.5':
+    resolution:
+      {
+        integrity: sha512-/jfEwNDdQVBCNvjkGit4h6pMOzq8bHkopq458dPt2lMjx+eBQUohZNG9A7DtO/O5ukSbxuaNGXMjHicgwy6rQQ==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.3':
+    resolution:
+      {
+        integrity: sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-primitive@2.1.4':
+    resolution:
+      {
+        integrity: sha512-9hQc4+GNVtJAIEPEqlYqW5RiYdrr8ea5XQ0ZOnD6fgru+83kqT15mq2OCcbe8KnjRZl5vF3ks69AKz3kh1jrhg==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-separator@1.1.8':
+    resolution:
+      {
+        integrity: sha512-sDvqVY4itsKwwSMEe0jtKgfTh+72Sy3gPmQpjqcQneqQ4PFmr/1I0YA+2/puilhggCe2gJcx5EBAYFkWkdpa5g==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.3':
+    resolution:
+      {
+        integrity: sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-slot@1.2.4':
+    resolution:
+      {
+        integrity: sha512-Jl+bCv8HxKnlTLVrcDE8zTMJ09R9/ukw4qBs/oZClOfoQk/cOTbDn+NceXfV7j09YPVQUryJPHurafcSg6EVKA==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-tooltip@1.2.8':
+    resolution:
+      {
+        integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-use-callback-ref@1.1.1':
+    resolution:
+      {
+        integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-controllable-state@1.2.2':
+    resolution:
+      {
+        integrity: sha512-BjasUjixPFdS+NKkypcyyN5Pmg83Olst0+c6vGov0diwTEo6mgdqVR6hxcEgFuh4QrAs7Rc+9KuGJ9TVCj0Zzg==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-effect-event@0.0.2':
+    resolution:
+      {
+        integrity: sha512-Qp8WbZOBe+blgpuUT+lw2xheLP8q0oatc9UpmiemEICxGvFLYmHm9QowVZGHtJlGbS6A6yJ3iViad/2cVjnOiA==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-escape-keydown@1.1.1':
+    resolution:
+      {
+        integrity: sha512-Il0+boE7w/XebUHyBjroE+DbByORGR9KKmITzbR7MyQ4akpORYP/ZmbhAr0DG7RmmBqoOnZdy2QlvajJ2QA59g==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-layout-effect@1.1.1':
+    resolution:
+      {
+        integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-rect@1.1.1':
+    resolution:
+      {
+        integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution:
+      {
+        integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-visually-hidden@1.2.3':
+    resolution:
+      {
+        integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==,
+      }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      '@types/react-dom': ~19.1.0
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/rect@1.1.1':
+    resolution:
+      {
+        integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==,
+      }
 
   '@react-native-community/datetimepicker@8.4.4':
     resolution:
@@ -6718,6 +7157,13 @@ packages:
         integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==,
       }
 
+  aria-hidden@1.2.6:
+    resolution:
+      {
+        integrity: sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==,
+      }
+    engines: { node: '>=10' }
+
   aria-query@5.3.0:
     resolution:
       {
@@ -7637,6 +8083,12 @@ packages:
     resolution:
       {
         integrity: sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ==,
+      }
+
+  class-variance-authority@0.7.1:
+    resolution:
+      {
+        integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==,
       }
 
   cli-cursor@2.1.0:
@@ -8588,6 +9040,12 @@ packages:
         integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==,
       }
     engines: { node: '>=8' }
+
+  detect-node-es@1.1.0:
+    resolution:
+      {
+        integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==,
+      }
 
   detect-node@2.1.0:
     resolution:
@@ -10095,6 +10553,13 @@ packages:
         integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==,
       }
     engines: { node: '>= 0.4' }
+
+  get-nonce@1.0.1:
+    resolution:
+      {
+        integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==,
+      }
+    engines: { node: '>=6' }
 
   get-package-type@0.1.0:
     resolution:
@@ -12311,6 +12776,14 @@ packages:
       {
         integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
       }
+
+  lucide-react@0.544.0:
+    resolution:
+      {
+        integrity: sha512-t5tS44bqd825zAW45UQxpG2CvcC4urOwn2TrwSH8u+MjeE+1NnWl6QqeQ/6NdjMqdOygyiT9p3Ev0p1NJykxjw==,
+      }
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   luxon@3.7.2:
     resolution:
@@ -14622,6 +15095,45 @@ packages:
       }
     engines: { node: '>=0.10.0' }
 
+  react-remove-scroll-bar@2.3.8:
+    resolution:
+      {
+        integrity: sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-remove-scroll@2.7.2:
+    resolution:
+      {
+        integrity: sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  react-style-singleton@2.2.3:
+    resolution:
+      {
+        integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   react-test-renderer@19.1.0:
     resolution:
       {
@@ -16112,6 +16624,20 @@ packages:
       }
     engines: { node: ^14.18.0 || >=16.0.0 }
 
+  tailwind-merge@3.6.0:
+    resolution:
+      {
+        integrity: sha512-uxL7qAVQriqRQPAyK3pj66VqskWqoZ37PW94jwOTwNfq/z9oyu1V+eqrZqtR2+fCiXdYOZe/Modt8GtvqNzu+w==,
+      }
+
+  tailwindcss-animate@1.0.7:
+    resolution:
+      {
+        integrity: sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA==,
+      }
+    peerDependencies:
+      tailwindcss: '>=3.0.0 || insiders'
+
   tailwindcss@3.4.3:
     resolution:
       {
@@ -16779,6 +17305,19 @@ packages:
         integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==,
       }
 
+  use-callback-ref@1.3.3:
+    resolution:
+      {
+        integrity: sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
   use-latest-callback@0.2.6:
     resolution:
       {
@@ -16786,6 +17325,19 @@ packages:
       }
     peerDependencies:
       react: '>=16.8'
+
+  use-sidecar@1.1.3:
+    resolution:
+      {
+        integrity: sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==,
+      }
+    engines: { node: '>=10' }
+    peerDependencies:
+      '@types/react': ~19.1.0
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   use-sync-external-store@1.6.0:
     resolution:
@@ -19048,6 +19600,23 @@ snapshots:
   '@flatten-js/interval-tree@1.1.4':
     optional: true
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/react-dom@2.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@floating-ui/dom': 1.7.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+
+  '@floating-ui/utils@0.2.11': {}
+
   '@humanfs/core@0.19.1': {}
 
   '@humanfs/node@0.16.7':
@@ -20970,6 +21539,246 @@ snapshots:
       '@powersync/common': 1.52.0
       react: 19.1.0
 
+  '@radix-ui/primitive@1.1.3': {}
+
+  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/react-compose-refs@1.1.2(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-context@1.1.2(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-dialog@1.1.15(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.17)(react@19.1.0)
+      aria-hidden: 1.2.6
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+      react-remove-scroll: 2.7.2(@types/react@19.1.17)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/react-dismissable-layer@1.1.11(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-escape-keydown': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/react-focus-guards@1.1.3(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-focus-scope@1.1.7(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/react-id@1.1.1(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@floating-ui/react-dom': 2.1.8(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/react-portal@1.1.9(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/react-presence@1.1.5(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/react-primitive@2.1.3(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/react-primitive@2.1.4(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-slot': 1.2.4(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/react-separator@1.1.8(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/react-slot@1.2.3(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-slot@1.2.4(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-id': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      '@radix-ui/react-slot': 1.2.3(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-controllable-state@1.2.2(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-effect-event': 0.0.2(@types/react@19.1.17)(react@19.1.0)
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-effect-event@0.0.2(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-escape-keydown@1.1.1(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-layout-effect@1.1.1(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-rect@1.1.1(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/rect': 1.1.1
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@19.1.17)(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.1.17)(react@19.1.0)
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+      '@types/react-dom': 19.1.11(@types/react@19.1.17)
+
+  '@radix-ui/rect@1.1.1': {}
+
   '@react-native-community/datetimepicker@8.4.4(expo@54.0.34)(react-native@0.81.5(@babel/core@7.29.0)(@react-native/metro-config@0.85.0(@babel/core@7.29.0))(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
     dependencies:
       invariant: 2.2.4
@@ -22576,6 +23385,10 @@ snapshots:
 
   argparse@2.0.1: {}
 
+  aria-hidden@1.2.6:
+    dependencies:
+      tslib: 2.8.1
+
   aria-query@5.3.0:
     dependencies:
       dequal: 2.0.3
@@ -23247,6 +24060,10 @@ snapshots:
 
   cjs-module-lexer@2.2.0: {}
 
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
   cli-cursor@2.1.0:
     dependencies:
       restore-cursor: 2.0.0
@@ -23761,6 +24578,8 @@ snapshots:
   detect-libc@2.1.2: {}
 
   detect-newline@3.1.0: {}
+
+  detect-node-es@1.1.0: {}
 
   detect-node@2.1.0: {}
 
@@ -24976,6 +25795,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-nonce@1.0.1: {}
 
   get-package-type@0.1.0: {}
 
@@ -26600,6 +27421,10 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  lucide-react@0.544.0(react@19.1.0):
+    dependencies:
+      react: 19.1.0
 
   luxon@3.7.2: {}
 
@@ -28413,6 +29238,33 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
+  react-remove-scroll-bar@2.3.8(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-style-singleton: 2.2.3(@types/react@19.1.17)(react@19.1.0)
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  react-remove-scroll@2.7.2(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.17)(react@19.1.0)
+      react-style-singleton: 2.2.3(@types/react@19.1.17)(react@19.1.0)
+      tslib: 2.8.1
+      use-callback-ref: 1.3.3(@types/react@19.1.17)(react@19.1.0)
+      use-sidecar: 1.1.3(@types/react@19.1.17)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.17
+
+  react-style-singleton@2.2.3(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      get-nonce: 1.0.1
+      react: 19.1.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.17
+
   react-test-renderer@19.1.0(react@19.1.0):
     dependencies:
       react: 19.1.0
@@ -29380,6 +30232,12 @@ snapshots:
     dependencies:
       '@pkgr/core': 0.2.9
 
+  tailwind-merge@3.6.0: {}
+
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3))):
+    dependencies:
+      tailwindcss: 3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3))
+
   tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -29826,9 +30684,24 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
+  use-callback-ref@1.3.3(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.17
+
   use-latest-callback@0.2.6(react@19.1.0):
     dependencies:
       react: 19.1.0
+
+  use-sidecar@1.1.3(@types/react@19.1.17)(react@19.1.0):
+    dependencies:
+      detect-node-es: 1.1.0
+      react: 19.1.0
+      tslib: 2.8.1
+    optionalDependencies:
+      '@types/react': 19.1.17
 
   use-sync-external-store@1.6.0(react@19.1.0):
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -214,9 +214,6 @@ importers:
       tailwindcss:
         specifier: 3.4.3
         version: 3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3))
-      tailwindcss-animate:
-        specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)))
       ts-jest:
         specifier: ^29.4.0
         version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.0))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3)
@@ -435,6 +432,9 @@ importers:
       '@types/qrcode':
         specifier: ^1.5.6
         version: 1.5.6
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)))
 
   apps/practitioner-e2e: {}
 
@@ -479,6 +479,10 @@ importers:
       recharts:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react-is@19.2.4)(react@19.1.0)(redux@5.0.1)
+    devDependencies:
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)))
 
   apps/web-e2e: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,6 +573,12 @@ importers:
         specifier: ^2.3.0
         version: 2.8.1
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.9.1
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: 16.3.0
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.1.11(@types/react@19.1.17))(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       '@types/react':
         specifier: ~19.1.0
         version: 19.1.17

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -51,9 +51,6 @@ importers:
       react-native-web:
         specifier: ~0.21.0
         version: 0.21.2(encoding@0.1.13)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      tailwindcss-animate:
-        specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)))
     devDependencies:
       '@axe-core/playwright':
         specifier: ^4.11.1
@@ -217,6 +214,9 @@ importers:
       tailwindcss:
         specifier: 3.4.3
         version: 3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3))
+      tailwindcss-animate:
+        specifier: ^1.0.7
+        version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)))
       ts-jest:
         specifier: ^29.4.0
         version: 29.4.6(@babel/core@7.29.0)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.29.0))(jest-util@30.2.0)(jest@30.2.0(@types/node@20.19.9)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)))(typescript@5.9.3)

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -29,6 +29,9 @@
     },
     {
       "path": "./packages/powersync"
+    },
+    {
+      "path": "./packages/ui-web"
     }
   ]
 }


### PR DESCRIPTION
Closes #196

## Summary

- Add `@abstrack/ui-web` with shadcn/ui sidebar primitives, `AppSideNav`, and `AppShellWithSideNav`, themed via a shared Tailwind preset mapped to `--app-*` tokens.
- Refactor user web `AuthenticatedShell` to keep the top bar (wordmark, email, theme, logout) and move primary navigation into a collapsible side nav (mobile sheet); nav items live in `app-nav-items.ts` with existing patient-only Caretaker/Practitioner filtering.
- Add practitioner `PractitionerAppShell` with sidebar nav (Home, Patients) for authenticated routes; public routes keep a standalone theme bar.
- Align web and practitioner `global.css` chrome tokens (header/sidebar surfaces, borders) and restore grid-paper background on the main column without opaque shadcn backgrounds covering it.

## Test plan

- [ ] User web (`pnpm web`): sign in as patient — sidebar shows Dashboard, Manage, Insights, presets, templates, Caretaker, Practitioner; active route styling in light and dark.
- [ ] User web: sign in as caretaker — Caretaker and Practitioner settings links are absent.
- [ ] User web: narrow viewport — `SidebarTrigger` opens sheet nav; skip link and top bar unchanged.
- [ ] Practitioner app: authenticated session — sidebar Home/Patients; public auth pages — no sidebar, theme toggle still works.
- [ ] `pnpm exec jest apps/web/src/components/app-shell/AuthenticatedShell.spec.tsx`
- [ ] `nx build @abstrack/ui-web` (or full affected build if you prefer)