### PR TITLE
feat(web): redesign dashboard with logging CTAs and recent episodes preview

### DIFF
--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -10,10 +10,15 @@ import App from './App';
 import { completeCaretakerInviteAfterAuth } from '../lib/caretaker-invite-complete';
 import {
   createMobileSupabaseClient,
+  getMobileAuthSessionSafe,
   getMobileSupabaseClient,
 } from '../lib/supabase-wiring';
 import * as mobilePhiHook from '../lib/auth/use-mobile-phi-subject-user-context';
 import * as mobileNetinfo from '../lib/network/mobile-device-netinfo';
+
+type MobileAuthGetSessionResult = Awaited<
+  ReturnType<typeof getMobileAuthSessionSafe>
+>;
 
 jest.mock('@abstrack/supabase', () => {
   const actual =
@@ -34,6 +39,14 @@ jest.mock('../lib/supabase-wiring-core', () => {
   return {
     ...original,
     getMobileSupabaseClient: jest.fn(),
+  };
+});
+
+jest.mock('../lib/get-mobile-auth-session-safe', () => {
+  const original = jest.requireActual('../lib/get-mobile-auth-session-safe');
+  return {
+    ...original,
+    getMobileAuthSessionSafe: jest.fn(),
   };
 });
 
@@ -77,6 +90,12 @@ beforeEach(() => {
   jest
     .mocked(getMobileSupabaseClient)
     .mockReturnValue(makeMockClient() as unknown as AbstrackSupabaseClient);
+
+  jest.mocked(getMobileAuthSessionSafe).mockImplementation(async () => {
+    const client = jest.mocked(getMobileSupabaseClient)();
+    const { data, error } = await client.auth.getSession();
+    return { data, error } as MobileAuthGetSessionResult;
+  });
 });
 
 afterEach(() => {
@@ -139,6 +158,24 @@ describe('mobile auth state sync', () => {
       };
     });
     const emitAuth = (event: string, session: Session | null) => {
+      if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+        jest
+          .mocked(getMobileAuthSessionSafe)
+          .mockResolvedValue(
+            (session
+              ? { data: { session }, error: null }
+              : {
+                  data: { session: null },
+                  error: null,
+                }) as MobileAuthGetSessionResult,
+          );
+      }
+      if (event === 'SIGNED_OUT') {
+        jest.mocked(getMobileAuthSessionSafe).mockResolvedValue({
+          data: { session: null },
+          error: null,
+        } as MobileAuthGetSessionResult);
+      }
       for (const cb of callbacks) {
         cb(event, session);
       }

--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -159,16 +159,14 @@ describe('mobile auth state sync', () => {
     });
     const emitAuth = (event: string, session: Session | null) => {
       if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
-        jest
-          .mocked(getMobileAuthSessionSafe)
-          .mockResolvedValue(
-            (session
-              ? { data: { session }, error: null }
-              : {
-                  data: { session: null },
-                  error: null,
-                }) as MobileAuthGetSessionResult,
-          );
+        jest.mocked(getMobileAuthSessionSafe).mockResolvedValue(
+          (session
+            ? { data: { session }, error: null }
+            : {
+                data: { session: null },
+                error: null,
+              }) as MobileAuthGetSessionResult,
+        );
       }
       if (event === 'SIGNED_OUT') {
         jest.mocked(getMobileAuthSessionSafe).mockResolvedValue({

--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -19,6 +19,7 @@ import {
   isHttpsCaretakerJoinWithoutCodeUrl,
 } from '../lib/caretaker-invite-deep-link';
 import {
+  clearMobileVerifiedAuthUserCache,
   getMobileAuthSessionSafe,
   getMobileSupabaseClient,
   isAuthSessionRecoveryFailure,
@@ -509,6 +510,7 @@ function AppBootstrap() {
       data: { subscription },
     } = mobileSupabase.auth.onAuthStateChange((event) => {
       if (event === 'SIGNED_OUT') {
+        clearMobileVerifiedAuthUserCache();
         authSessionReadGenerationRef.current += 1;
         authRouteRef.current = 'Login';
         recoveryFlowActiveRef.current = false;

--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -166,6 +166,11 @@ function AppBootstrap() {
   const resumeRefreshInFlightRef = useRef(false);
   /** Prevents resume handler `setInitializing(false)` from racing cold start `bootstrap` `finally`. */
   const bootstrapCompleteRef = useRef(false);
+  /**
+   * Invalidates in-flight {@link getMobileAuthSessionSafe} completions from `onAuthStateChange`
+   * when a newer auth event (e.g. `SIGNED_OUT`) arrives before the promise resolves.
+   */
+  const authSessionReadGenerationRef = useRef(0);
 
   const stackScreenOptions = useMemo(
     () => ({
@@ -504,6 +509,7 @@ function AppBootstrap() {
       data: { subscription },
     } = mobileSupabase.auth.onAuthStateChange((event) => {
       if (event === 'SIGNED_OUT') {
+        authSessionReadGenerationRef.current += 1;
         authRouteRef.current = 'Login';
         recoveryFlowActiveRef.current = false;
         setAuthRoute('Login');
@@ -514,8 +520,9 @@ function AppBootstrap() {
       }
 
       if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+        const generation = ++authSessionReadGenerationRef.current;
         void getMobileAuthSessionSafe().then(({ data, error }) => {
-          if (!mounted) {
+          if (!mounted || generation !== authSessionReadGenerationRef.current) {
             return;
           }
           if (error) {
@@ -534,6 +541,7 @@ function AppBootstrap() {
 
     return () => {
       mounted = false;
+      authSessionReadGenerationRef.current += 1;
       subscription.unsubscribe();
       urlSubscription?.remove?.();
       appStateSubscription?.remove?.();

--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -527,10 +527,7 @@ function AppBootstrap() {
             }
             return;
           }
-          const nextSession = data.session ?? null;
-          if (nextSession != null) {
-            setSession(nextSession);
-          }
+          setSession(data.session ?? null);
         });
       }
     });

--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -21,6 +21,7 @@ import {
 import {
   getMobileAuthSessionSafe,
   getMobileSupabaseClient,
+  isAuthSessionRecoveryFailure,
 } from '../lib/supabase-wiring';
 import { AppProviders } from './components/AppProviders';
 import { SyncHealthFooter } from './components/SyncHealthFooter';
@@ -513,11 +514,23 @@ function AppBootstrap() {
       }
 
       if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
-        void getMobileAuthSessionSafe().then(({ data }) => {
+        void getMobileAuthSessionSafe().then(({ data, error }) => {
           if (!mounted) {
             return;
           }
-          setSession(data.session ?? null);
+          if (error) {
+            if (!isAuthSessionRecoveryFailure(error)) {
+              console.warn(
+                'Auth state changed but session read failed; keeping in-memory session',
+                error,
+              );
+            }
+            return;
+          }
+          const nextSession = data.session ?? null;
+          if (nextSession != null) {
+            setSession(nextSession);
+          }
         });
       }
     });

--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -501,21 +501,21 @@ function AppBootstrap() {
 
     const {
       data: { subscription },
-    } = mobileSupabase.auth.onAuthStateChange((event, nextSession) => {
+    } = mobileSupabase.auth.onAuthStateChange((event) => {
       if (event === 'SIGNED_OUT') {
         authRouteRef.current = 'Login';
         recoveryFlowActiveRef.current = false;
         setAuthRoute('Login');
         setRecoveryFlowActive(false);
         setRecoveryError(null);
+        setSession(null);
+        return;
       }
 
-      if (
-        event === 'SIGNED_IN' ||
-        event === 'SIGNED_OUT' ||
-        event === 'TOKEN_REFRESHED'
-      ) {
-        setSession(nextSession ?? null);
+      if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
+        void getMobileAuthSessionSafe().then(({ data }) => {
+          setSession(data.session ?? null);
+        });
       }
     });
 

--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -514,6 +514,9 @@ function AppBootstrap() {
 
       if (event === 'SIGNED_IN' || event === 'TOKEN_REFRESHED') {
         void getMobileAuthSessionSafe().then(({ data }) => {
+          if (!mounted) {
+            return;
+          }
           setSession(data.session ?? null);
         });
       }

--- a/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateCreateScreen.tsx
@@ -237,6 +237,8 @@ export function EpisodeTemplateCreateScreen() {
     return () => {
       ac.abort();
     };
+    // listsLoading/listsError: auth-hydration skip only — omit to avoid refetch loops.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- preset fetch keyed on viewer/PHI scope
   }, [
     viewerUserId,
     phiSubjectUserId,

--- a/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeTemplateEditorScreen.tsx
@@ -282,6 +282,8 @@ export function EpisodeTemplateEditorScreen() {
     return () => {
       ac.abort();
     };
+    // status/errorMessage: auth-hydration skip only — omit to avoid refetch loops.
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- template load keyed on viewer/PHI scope
   }, [
     templateId,
     viewerUserId,

--- a/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
+++ b/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
@@ -500,9 +500,7 @@ export function EpisodesManagementPanel({
     setLoadingMoreRecent(true);
     try {
       const client = getMobileSupabaseClient();
-      const {
-        data: { session },
-      } = await getMobileAuthSessionSafe();
+      await getMobileAuthSessionSafe();
       if (stale()) {
         return;
       }

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -417,16 +417,16 @@ export function HomeScreen({
     try {
       const mobileSupabase = getMobileSupabaseClient();
       const {
-        data: { session },
-        error: sessionError,
-      } = await mobileSupabase.auth.getSession();
+        data: { user },
+        error: userError,
+      } = await mobileSupabase.auth.getUser();
 
-      if (sessionError || !session?.user) {
+      if (userError || !user) {
         if (isMountedRef.current) {
           setHealthCheck({
             success: false,
             message: 'Health check failed',
-            error: sessionError?.message ?? 'No authenticated user found',
+            error: userError?.message ?? 'No authenticated user found',
           });
         }
         return;

--- a/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
+++ b/apps/mobile/src/app/screens/StandaloneHealthMarkersScreen.tsx
@@ -118,16 +118,41 @@ export function StandaloneHealthMarkersScreen() {
         }
       }
     })();
-    const { data: sub } = supabase.auth.onAuthStateChange((_event, session) => {
+    const { data: sub } = supabase.auth.onAuthStateChange(() => {
       authSnapshotGenerationRef.current += 1;
       // Invalidate in-flight getMobileAuthSessionSafe completions (see runGeneration above).
       if (cancelled) {
         return;
       }
-      const uid = session?.user?.id ?? null;
-      setAuthUserId(uid);
-      setAuthSessionError(null);
-      setAuthLoading(false);
+      void (async () => {
+        const runGeneration = authSnapshotGenerationRef.current;
+        setAuthLoading(true);
+        try {
+          const { data, error } = await getMobileAuthSessionSafe();
+          if (
+            cancelled ||
+            authSnapshotGenerationRef.current !== runGeneration
+          ) {
+            return;
+          }
+          if (error) {
+            setAuthUserId(null);
+            setAuthSessionError(
+              error.message || 'Unable to read your sign-in session.',
+            );
+            return;
+          }
+          setAuthSessionError(null);
+          setAuthUserId(data.session?.user?.id ?? null);
+        } finally {
+          if (
+            !cancelled &&
+            authSnapshotGenerationRef.current === runGeneration
+          ) {
+            setAuthLoading(false);
+          }
+        }
+      })();
     });
     return () => {
       cancelled = true;

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -74,10 +74,7 @@ import {
   powerSyncReplicaSqliteReady,
   usePowerSyncBridgeState,
 } from '../../lib/powersync/PowerSyncSessionBridge';
-import {
-  getMobileAuthSessionSafe,
-  getMobileSupabaseClient,
-} from '../../lib/supabase-wiring';
+import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { resolveMobilePhiSubjectUserContext } from '../../lib/phi-subject/resolve-mobile-phi-subject-user-context';
 import {
   clearSymptomPromptSession,

--- a/apps/mobile/src/lib/auth/use-mobile-auth-user-id.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-auth-user-id.ts
@@ -107,7 +107,7 @@ export function useMobileAuthUserId(): string | null {
 
     const {
       data: { subscription },
-    } = client.auth.onAuthStateChange((event, session) => {
+    } = client.auth.onAuthStateChange((event, _session) => {
       if (event === 'SIGNED_OUT') {
         const generation = ++refreshGeneration;
         lastKnownUserIdRef.current = null;

--- a/apps/mobile/src/lib/auth/use-mobile-auth-user-id.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-auth-user-id.ts
@@ -114,10 +114,6 @@ export function useMobileAuthUserId(): string | null {
         applyIfCurrent(generation, null);
         return;
       }
-      const primed = session?.user?.id;
-      if (primed != null && primed !== '') {
-        lastKnownUserIdRef.current = primed;
-      }
       refresh();
     });
 

--- a/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
@@ -86,7 +86,10 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
     setPhiSubjectUserId(result.data.phiSubjectUserId);
     setProfileAppRole(result.data.profileAppRole);
     setErrorMessage(null);
-  }, [dbForPhi]);
+    // `authUserId` is not read here; it is listed so sign-in/sign-out/account switches
+    // recreate `runResolve` and re-run the effect below (see module JSDoc).
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- PHI scope must refresh on auth change
+  }, [authUserId, dbForPhi]);
 
   /**
    * Invalidate in-flight resolves only on real unmount. Do not bump `genRef` from other effect

--- a/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
@@ -86,7 +86,7 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
     setPhiSubjectUserId(result.data.phiSubjectUserId);
     setProfileAppRole(result.data.profileAppRole);
     setErrorMessage(null);
-  }, [authUserId, dbForPhi]);
+  }, [dbForPhi]);
 
   /**
    * Invalidate in-flight resolves only on real unmount. Do not bump `genRef` from other effect

--- a/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
@@ -86,9 +86,6 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
     setPhiSubjectUserId(result.data.phiSubjectUserId);
     setProfileAppRole(result.data.profileAppRole);
     setErrorMessage(null);
-    // `authUserId` is not read here; it is listed so sign-in/sign-out/account switches
-    // recreate `runResolve` and re-run the effect below (see module JSDoc).
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- PHI scope must refresh on auth change
   }, [authUserId, dbForPhi]);
 
   /**

--- a/apps/mobile/src/lib/caretaker-invite-complete.ts
+++ b/apps/mobile/src/lib/caretaker-invite-complete.ts
@@ -4,6 +4,7 @@ import {
   isMissingPublishableKeyForCaretakerEdge,
   resolvePatientCaretakerAccessUrl,
 } from './patient-caretaker-edge-api';
+import { getAccessTokenFromSession } from '@abstrack/supabase';
 import { getMobileSupabaseClient } from './supabase-wiring';
 
 /** PostgREST duplicate key — profile row may have been created concurrently. */
@@ -27,18 +28,20 @@ export type CompleteCaretakerInviteResult =
 export async function completeCaretakerInviteAfterAuth(): Promise<CompleteCaretakerInviteResult> {
   const supabase = getMobileSupabaseClient();
   const {
-    data: { session },
-    error: sessErr,
-  } = await supabase.auth.getSession();
+    data: { user },
+    error: userErr,
+  } = await supabase.auth.getUser();
+  const { accessToken, error: tokenErr } =
+    await getAccessTokenFromSession(supabase);
 
-  if (sessErr || !session?.user || !session.access_token?.trim()) {
+  if (userErr || !user || tokenErr || !accessToken) {
     return {
       ok: false,
       message: 'No active session after opening the invite link.',
     };
   }
 
-  const inviteIdRaw = session.user.user_metadata?.abstrack_caretaker_invite_id;
+  const inviteIdRaw = user.user_metadata?.abstrack_caretaker_invite_id;
   const inviteId =
     typeof inviteIdRaw === 'string' && inviteIdRaw.trim().length > 0
       ? inviteIdRaw.trim()
@@ -55,7 +58,7 @@ export async function completeCaretakerInviteAfterAuth(): Promise<CompleteCareta
   const { data: profile, error: readPErr } = await supabase
     .from('profiles')
     .select('app_role')
-    .eq('id', session.user.id)
+    .eq('id', user.id)
     .maybeSingle();
 
   if (readPErr) {
@@ -67,7 +70,7 @@ export async function completeCaretakerInviteAfterAuth(): Promise<CompleteCareta
 
   if (!profile) {
     const { error: insPErr } = await supabase.from('profiles').insert({
-      id: session.user.id,
+      id: user.id,
       app_role: 'caretaker',
     });
     if (insPErr) {
@@ -75,7 +78,7 @@ export async function completeCaretakerInviteAfterAuth(): Promise<CompleteCareta
         const { data: afterRace, error: raceReadErr } = await supabase
           .from('profiles')
           .select('app_role')
-          .eq('id', session.user.id)
+          .eq('id', user.id)
           .maybeSingle();
         if (raceReadErr || !afterRace) {
           return {
@@ -118,7 +121,7 @@ export async function completeCaretakerInviteAfterAuth(): Promise<CompleteCareta
 
   let res: Response;
   try {
-    res = await fetchCaretakerAccessPostJson(session.access_token, {
+    res = await fetchCaretakerAccessPostJson(accessToken, {
       finalizeCaretakerInvite: true,
       inviteId,
     });

--- a/apps/mobile/src/lib/caretaker-invite-complete.ts
+++ b/apps/mobile/src/lib/caretaker-invite-complete.ts
@@ -4,8 +4,12 @@ import {
   isMissingPublishableKeyForCaretakerEdge,
   resolvePatientCaretakerAccessUrl,
 } from './patient-caretaker-edge-api';
-import { getAccessTokenFromSession } from '@abstrack/supabase';
-import { getMobileSupabaseClient } from './supabase-wiring';
+import type { Session } from '@abstrack/supabase';
+import {
+  getMobileAuthSessionSafe,
+  getMobileSupabaseClient,
+  hasUsableSupabaseAccessTokenForNetwork,
+} from './supabase-wiring';
 
 /** PostgREST duplicate key — profile row may have been created concurrently. */
 function isPostgresUniqueViolation(err: { code?: string } | null): boolean {
@@ -27,14 +31,26 @@ export type CompleteCaretakerInviteResult =
  */
 export async function completeCaretakerInviteAfterAuth(): Promise<CompleteCaretakerInviteResult> {
   const supabase = getMobileSupabaseClient();
-  const {
-    data: { user },
-    error: userErr,
-  } = await supabase.auth.getUser();
-  const { accessToken, error: tokenErr } =
-    await getAccessTokenFromSession(supabase);
+  let session: Session | null = null;
+  let sessionError: Error | null = null;
+  try {
+    const result = await getMobileAuthSessionSafe();
+    session = result.data.session;
+    sessionError = result.error;
+  } catch {
+    return {
+      ok: false,
+      message: 'No active session after opening the invite link.',
+    };
+  }
 
-  if (userErr || !user || tokenErr || !accessToken) {
+  const user = session?.user;
+  const accessToken =
+    session != null && hasUsableSupabaseAccessTokenForNetwork(session)
+      ? session.access_token.trim()
+      : null;
+
+  if (sessionError || !user?.id || !accessToken) {
     return {
       ok: false,
       message: 'No active session after opening the invite link.',

--- a/apps/mobile/src/lib/get-mobile-auth-session-safe.spec.ts
+++ b/apps/mobile/src/lib/get-mobile-auth-session-safe.spec.ts
@@ -1,6 +1,7 @@
 import type { AbstrackSupabaseClient, Session } from '@abstrack/supabase';
 
 import {
+  clearMobileVerifiedAuthUserCache,
   getMobileAuthSessionSafe,
   hasUsableSupabaseAccessTokenForNetwork,
   isAuthSessionRecoveryFailure,
@@ -149,12 +150,106 @@ describe('getMobileAuthSessionSafe', () => {
   beforeEach(() => {
     jest.useFakeTimers();
     jest.setSystemTime(nowSec * 1000);
+    clearMobileVerifiedAuthUserCache();
     jest.mocked(getMobileSupabaseClient).mockReset();
     jest.mocked(mobileAuthStorage.getItem).mockReset();
   });
 
   afterEach(() => {
     jest.useRealTimers();
+  });
+
+  it('reuses verified user cache for the same refresh token without a second getUser', async () => {
+    const verifiedUser = { id: 'verified-user', email: 'v@example.com' };
+    const getUser = jest.fn().mockResolvedValue({
+      data: { user: verifiedUser },
+      error: null,
+    });
+    const liveSession = {
+      access_token: jwtWithExp(nowSec + 3600),
+      refresh_token: 'same-refresh',
+      expires_in: 3600,
+      token_type: 'bearer',
+      user: { id: 'stale-from-getSession' },
+    } as Session;
+
+    jest.mocked(getMobileSupabaseClient).mockReturnValue({
+      auth: {
+        storageKey,
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: liveSession },
+          error: null,
+        }),
+        getUser,
+      },
+    } as unknown as AbstrackSupabaseClient);
+
+    const first = await getMobileAuthSessionSafe();
+    const second = await getMobileAuthSessionSafe();
+
+    expect(getUser).toHaveBeenCalledTimes(1);
+    expect(first.data.session?.user).toEqual(verifiedUser);
+    expect(second.data.session?.user).toEqual(verifiedUser);
+    expect(second.data.session?.user?.id).toBe('verified-user');
+  });
+
+  it('skips getUser when verifyUser is false', async () => {
+    const getUser = jest.fn();
+    const liveSession = {
+      access_token: jwtWithExp(nowSec + 3600),
+      refresh_token: 'r1',
+      expires_in: 3600,
+      token_type: 'bearer',
+      user: { id: 'persisted-only' },
+    } as Session;
+
+    jest.mocked(getMobileSupabaseClient).mockReturnValue({
+      auth: {
+        storageKey,
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: liveSession },
+          error: null,
+        }),
+        getUser,
+      },
+    } as unknown as AbstrackSupabaseClient);
+
+    const result = await getMobileAuthSessionSafe({ verifyUser: false });
+
+    expect(getUser).not.toHaveBeenCalled();
+    expect(result.data.session?.user?.id).toBe('persisted-only');
+  });
+
+  it('returns getSession error without calling getUser when getSession reports an error', async () => {
+    const getUser = jest.fn();
+    const sessionError = Object.assign(new Error('refresh failed'), {
+      __isAuthError: true as const,
+    });
+    const staleSession = {
+      access_token: jwtWithExp(nowSec + 3600),
+      refresh_token: 'r',
+      expires_in: 3600,
+      token_type: 'bearer',
+      user: { id: 'stale-user' },
+    } as Session;
+
+    jest.mocked(getMobileSupabaseClient).mockReturnValue({
+      auth: {
+        storageKey,
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: staleSession },
+          error: sessionError,
+        }),
+        getUser,
+      },
+    } as unknown as AbstrackSupabaseClient);
+
+    await expect(getMobileAuthSessionSafe()).resolves.toEqual({
+      data: { session: null },
+      error: sessionError,
+    });
+    expect(getUser).not.toHaveBeenCalled();
+    expect(mobileAuthStorage.getItem).not.toHaveBeenCalled();
   });
 
   it('returns identity session with redacted access_token when persisted JWT exp is already past', async () => {

--- a/apps/mobile/src/lib/get-mobile-auth-session-safe.ts
+++ b/apps/mobile/src/lib/get-mobile-auth-session-safe.ts
@@ -141,10 +141,56 @@ export function persistedSessionIdentityWithRedactedAccessJwt(
  *
  * @returns Same shape as `SupabaseClient.auth.getSession()`.
  */
+async function attachVerifiedUserToSession(
+  client: AbstrackSupabaseClient,
+  session: Session,
+): Promise<Session> {
+  try {
+    const {
+      data: { user },
+      error,
+    } = await client.auth.getUser();
+    if (!error && user) {
+      return { ...session, user };
+    }
+  } catch {
+    // Offline: keep tokens from getSession but avoid reading session.user from that return value.
+  }
+  const storageKey = (client.auth as unknown as { storageKey?: string })
+    .storageKey;
+  if (!storageKey) {
+    return session;
+  }
+  try {
+    const raw = await mobileAuthStorage.getItem(storageKey);
+    if (!raw) {
+      return session;
+    }
+    const persisted = JSON.parse(raw) as Session;
+    if (persisted?.user?.id) {
+      return { ...session, user: persisted.user };
+    }
+  } catch {
+    // Best-effort offline identity only.
+  }
+  return session;
+}
+
 export async function getMobileAuthSessionSafe(): Promise<MobileAuthGetSessionResult> {
   const client = getMobileSupabaseClient();
   try {
-    return await client.auth.getSession();
+    const result = await client.auth.getSession();
+    if (result.data.session) {
+      const session = await attachVerifiedUserToSession(
+        client,
+        result.data.session,
+      );
+      if (result.error) {
+        return { data: { session: null }, error: result.error };
+      }
+      return { data: { session }, error: null };
+    }
+    return result;
   } catch (getSessionError) {
     const storageKey = (client.auth as unknown as { storageKey?: string })
       .storageKey;
@@ -178,14 +224,12 @@ export async function getMobileAuthSessionSafe(): Promise<MobileAuthGetSessionRe
         };
       }
       if (isPersistedSupabaseSessionAccessExpired(session)) {
-        return {
-          data: {
-            session: persistedSessionIdentityWithRedactedAccessJwt(session),
-          },
-          error: null,
-        };
+        const redacted = persistedSessionIdentityWithRedactedAccessJwt(session);
+        const withUser = await attachVerifiedUserToSession(client, redacted);
+        return { data: { session: withUser }, error: null };
       }
-      return { data: { session }, error: null };
+      const withUser = await attachVerifiedUserToSession(client, session);
+      return { data: { session: withUser }, error: null };
     } catch (persistedReadError) {
       return {
         data: { session: null },

--- a/apps/mobile/src/lib/get-mobile-auth-session-safe.ts
+++ b/apps/mobile/src/lib/get-mobile-auth-session-safe.ts
@@ -141,20 +141,47 @@ export function persistedSessionIdentityWithRedactedAccessJwt(
  *
  * @returns Same shape as `SupabaseClient.auth.getSession()`.
  */
-async function attachVerifiedUserToSession(
+export type GetMobileAuthSessionSafeOptions = {
+  /**
+   * When `false`, skips `auth.getUser()` and uses `session.user` from storage only (tokens still
+   * from `getSession()`). Use for callers that only need `access_token` (e.g. PowerSync JWT).
+   * Default `true`.
+   */
+  verifyUser?: boolean;
+};
+
+/** Cache key for {@link verifiedAuthUserCache} (refresh token preferred; rotates on refresh). */
+function sessionUserCacheKey(session: Session): string | null {
+  const refresh = session.refresh_token?.trim();
+  if (refresh && refresh.length > 0) {
+    return `rt:${refresh}`;
+  }
+  const access = session.access_token?.trim();
+  if (access && access.length > 0) {
+    return `at:${access}`;
+  }
+  return null;
+}
+
+let verifiedAuthUserCache: {
+  key: string;
+  user: NonNullable<Session['user']>;
+} | null = null;
+
+/**
+ * Clears the in-memory verified-user cache (e.g. after sign-out). New tokens get a fresh
+ * {@link client.auth.getUser} on the next {@link getMobileAuthSessionSafe} with `verifyUser: true`.
+ */
+export function clearMobileVerifiedAuthUserCache(): void {
+  verifiedAuthUserCache = null;
+}
+
+async function readPersistedUserForSession(
   client: AbstrackSupabaseClient,
   session: Session,
 ): Promise<Session> {
-  try {
-    const {
-      data: { user },
-      error,
-    } = await client.auth.getUser();
-    if (!error && user) {
-      return { ...session, user };
-    }
-  } catch {
-    // Offline: keep tokens from getSession but avoid reading session.user from that return value.
+  if (session.user?.id) {
+    return session;
   }
   const storageKey = (client.auth as unknown as { storageKey?: string })
     .storageKey;
@@ -176,20 +203,67 @@ async function attachVerifiedUserToSession(
   return session;
 }
 
-export async function getMobileAuthSessionSafe(): Promise<MobileAuthGetSessionResult> {
+async function attachVerifiedUserToSession(
+  client: AbstrackSupabaseClient,
+  session: Session,
+  options?: GetMobileAuthSessionSafeOptions,
+): Promise<Session> {
+  if (options?.verifyUser === false) {
+    return readPersistedUserForSession(client, session);
+  }
+
+  const cacheKey = sessionUserCacheKey(session);
+  if (cacheKey && verifiedAuthUserCache?.key === cacheKey) {
+    return { ...session, user: verifiedAuthUserCache.user };
+  }
+
+  try {
+    const {
+      data: { user },
+      error,
+    } = await client.auth.getUser();
+    if (!error && user) {
+      if (cacheKey) {
+        verifiedAuthUserCache = { key: cacheKey, user };
+      }
+      return { ...session, user };
+    }
+  } catch {
+    // Offline: keep tokens from getSession but avoid reading session.user from that return value.
+  }
+
+  const withPersistedUser = await readPersistedUserForSession(client, session);
+  if (cacheKey && withPersistedUser.user?.id) {
+    verifiedAuthUserCache = {
+      key: cacheKey,
+      user: withPersistedUser.user,
+    };
+  }
+  return withPersistedUser;
+}
+
+/**
+ * @param options - Optional flags; see {@link GetMobileAuthSessionSafeOptions}.
+ * @returns Same shape as `SupabaseClient.auth.getSession()`.
+ */
+export async function getMobileAuthSessionSafe(
+  options?: GetMobileAuthSessionSafeOptions,
+): Promise<MobileAuthGetSessionResult> {
   const client = getMobileSupabaseClient();
   try {
     const result = await client.auth.getSession();
+    if (result.error) {
+      return { data: { session: null }, error: result.error };
+    }
     if (result.data.session) {
       const session = await attachVerifiedUserToSession(
         client,
         result.data.session,
+        options,
       );
-      if (result.error) {
-        return { data: { session: null }, error: result.error };
-      }
       return { data: { session }, error: null };
     }
+    clearMobileVerifiedAuthUserCache();
     return result;
   } catch (getSessionError) {
     const storageKey = (client.auth as unknown as { storageKey?: string })
@@ -225,10 +299,18 @@ export async function getMobileAuthSessionSafe(): Promise<MobileAuthGetSessionRe
       }
       if (isPersistedSupabaseSessionAccessExpired(session)) {
         const redacted = persistedSessionIdentityWithRedactedAccessJwt(session);
-        const withUser = await attachVerifiedUserToSession(client, redacted);
+        const withUser = await attachVerifiedUserToSession(
+          client,
+          redacted,
+          options,
+        );
         return { data: { session: withUser }, error: null };
       }
-      const withUser = await attachVerifiedUserToSession(client, session);
+      const withUser = await attachVerifiedUserToSession(
+        client,
+        session,
+        options,
+      );
       return { data: { session: withUser }, error: null };
     } catch (persistedReadError) {
       return {

--- a/apps/mobile/src/lib/powersync/PowerSyncSessionBridge.tsx
+++ b/apps/mobile/src/lib/powersync/PowerSyncSessionBridge.tsx
@@ -300,7 +300,7 @@ export function PowerSyncSessionBridge({
       powerSyncUrl,
       getSession: async () => {
         try {
-          const { data } = await getMobileAuthSessionSafe();
+          const { data } = await getMobileAuthSessionSafe({ verifyUser: false });
           const next = data.session;
           if (!next?.access_token) {
             return null;

--- a/apps/mobile/src/lib/powersync/PowerSyncSessionBridge.tsx
+++ b/apps/mobile/src/lib/powersync/PowerSyncSessionBridge.tsx
@@ -300,7 +300,9 @@ export function PowerSyncSessionBridge({
       powerSyncUrl,
       getSession: async () => {
         try {
-          const { data } = await getMobileAuthSessionSafe({ verifyUser: false });
+          const { data } = await getMobileAuthSessionSafe({
+            verifyUser: false,
+          });
           const next = data.session;
           if (!next?.access_token) {
             return null;

--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -108,6 +108,11 @@ function createLoginSupabaseMock(options?: {
   };
   /** Access token for default `getSession()` results (e.g. JWT with `aal` for post-verify flows). */
   sessionAccessToken?: string;
+  /** Second `getUser()` after trust restore (login now verifies with `getUser`, not `getSession`). */
+  afterTrustRestoreGetUser?: {
+    error?: { message: string } | null;
+    user?: { id: string } | null;
+  };
 }): { client: { auth: Record<string, unknown> }; mfa: MfaMock } {
   const signInError = options?.signInError ?? null;
   const totpList = options?.listFactors?.totp ?? [
@@ -122,7 +127,18 @@ function createLoginSupabaseMock(options?: {
     error: null as Error | null,
     user: { id: USER_ID },
   };
-  const getUser = jest.fn().mockResolvedValue({
+  const getUser = jest.fn().mockResolvedValueOnce({
+    data: { user: getUserResolved.user },
+    error: getUserResolved.error,
+  });
+  if (options?.afterTrustRestoreGetUser !== undefined) {
+    const followUp = options.afterTrustRestoreGetUser;
+    getUser.mockResolvedValueOnce({
+      data: { user: followUp.user ?? null },
+      error: followUp.error ?? null,
+    });
+  }
+  getUser.mockResolvedValue({
     data: { user: getUserResolved.user },
     error: getUserResolved.error,
   });
@@ -167,20 +183,7 @@ function createLoginSupabaseMock(options?: {
     },
     error: mfaSessionOpts?.error ?? null,
   };
-  /** Login calls `getSession` after `tryRestoreTrustedMfaSession` before MFA; keep that success when verify-phase mocks simulate failure. */
-  const postTrustRestoreGetSessionOk = {
-    data: { session: defaultMfaSession },
-    error: null as const,
-  };
-  const verifyPhaseDiffersFromHealthy =
-    mfaSessionOpts != null &&
-    (mfaSessionOpts.error != null || mfaSessionOpts.session === null);
-  const getSession = verifyPhaseDiffersFromHealthy
-    ? jest
-        .fn()
-        .mockResolvedValueOnce(postTrustRestoreGetSessionOk)
-        .mockResolvedValue(verifyPhaseGetSessionResult)
-    : jest.fn().mockResolvedValue(verifyPhaseGetSessionResult);
+  const getSession = jest.fn().mockResolvedValue(verifyPhaseGetSessionResult);
   const signOut = jest.fn().mockResolvedValue({ error: null });
 
   const challenge = jest.fn().mockResolvedValue({
@@ -532,13 +535,13 @@ describe('LoginPage MFA state machine', () => {
     expect(mockPush).not.toHaveBeenCalledWith('/patients');
   });
 
-  it('returns to credentials when getSession fails after trust restore returns false', async () => {
+  it('returns to credentials when getUser fails after trust restore returns false', async () => {
     const { client } = createLoginSupabaseMock({
       assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
-    });
-    (client.auth.getSession as jest.Mock).mockResolvedValueOnce({
-      error: { message: 'storage read failed' },
-      data: { session: null },
+      afterTrustRestoreGetUser: {
+        error: { message: 'storage read failed' },
+        user: null,
+      },
     });
     mockedGetClient.mockReturnValue(client as never);
 
@@ -554,13 +557,10 @@ describe('LoginPage MFA state machine', () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
-  it('returns to credentials when getSession returns no session after trust restore returns false', async () => {
+  it('returns to credentials when getUser returns no user after trust restore returns false', async () => {
     const { client } = createLoginSupabaseMock({
       assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
-    });
-    (client.auth.getSession as jest.Mock).mockResolvedValueOnce({
-      error: null,
-      data: { session: null },
+      afterTrustRestoreGetUser: { error: null, user: null },
     });
     mockedGetClient.mockReturnValue(client as never);
 
@@ -576,18 +576,12 @@ describe('LoginPage MFA state machine', () => {
     expect(mockPush).not.toHaveBeenCalled();
   });
 
-  it('returns to credentials when session user id differs after trust restore returns false', async () => {
+  it('returns to credentials when user id differs after trust restore returns false', async () => {
     const { client } = createLoginSupabaseMock({
       assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
-    });
-    (client.auth.getSession as jest.Mock).mockResolvedValueOnce({
-      error: null,
-      data: {
-        session: {
-          user: { id: '99999999-9999-9999-9999-999999999999' },
-          refresh_token: 'refresh-token',
-          access_token: 'access-token',
-        },
+      afterTrustRestoreGetUser: {
+        error: null,
+        user: { id: '99999999-9999-9999-9999-999999999999' },
       },
     });
     mockedGetClient.mockReturnValue(client as never);

--- a/apps/practitioner/src/app/auth/callback/fragment/page.tsx
+++ b/apps/practitioner/src/app/auth/callback/fragment/page.tsx
@@ -157,10 +157,13 @@ function PractitionerAuthCallbackFragmentContent() {
             'Failed to verify user during auth callback fragment handling',
             err,
           );
-          finishErr(AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE);
-          return;
+        } else {
+          console.error(
+            'Unexpected error during auth callback fragment handling',
+            err,
+          );
         }
-        finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
+        finishErr(AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE);
       }
     };
 

--- a/apps/practitioner/src/app/auth/callback/fragment/page.tsx
+++ b/apps/practitioner/src/app/auth/callback/fragment/page.tsx
@@ -2,6 +2,7 @@
 
 import { Suspense, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
+import { isSupabaseAuthApiError } from '@abstrack/supabase';
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import {
   AUTH_CALLBACK_INVALID_LINK_MESSAGE,
@@ -9,7 +10,6 @@ import {
   getSafePractitionerAuthCallbackRedirectPath,
 } from '@/lib/auth-callback-redirect';
 import {
-  isSupabaseAuthApiError,
   isSupabaseBrowserConfigError,
   parseImplicitHashParams,
 } from '@/lib/auth-callback-fragment-helpers';

--- a/apps/practitioner/src/app/auth/callback/fragment/page.tsx
+++ b/apps/practitioner/src/app/auth/callback/fragment/page.tsx
@@ -83,10 +83,10 @@ function PractitionerAuthCallbackFragmentContent() {
         const supabase = getSupabaseBrowserClient();
 
         const {
-          data: { session: existing },
-        } = await supabase.auth.getSession();
+          data: { user: existingUser },
+        } = await supabase.auth.getUser();
 
-        if (existing?.user) {
+        if (existingUser) {
           finishOk();
           return;
         }
@@ -125,10 +125,10 @@ function PractitionerAuthCallbackFragmentContent() {
         }
 
         const {
-          data: { session: afterDetect },
-        } = await supabase.auth.getSession();
+          data: { user: afterDetectUser },
+        } = await supabase.auth.getUser();
 
-        if (afterDetect?.user) {
+        if (afterDetectUser) {
           finishOk();
           return;
         }

--- a/apps/practitioner/src/app/auth/callback/fragment/page.tsx
+++ b/apps/practitioner/src/app/auth/callback/fragment/page.tsx
@@ -5,9 +5,11 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import {
   AUTH_CALLBACK_INVALID_LINK_MESSAGE,
+  AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
   getSafePractitionerAuthCallbackRedirectPath,
 } from '@/lib/auth-callback-redirect';
 import {
+  isSupabaseAuthApiError,
   isSupabaseBrowserConfigError,
   parseImplicitHashParams,
 } from '@/lib/auth-callback-fragment-helpers';
@@ -84,7 +86,12 @@ function PractitionerAuthCallbackFragmentContent() {
 
         const {
           data: { user: existingUser },
+          error: existingUserError,
         } = await supabase.auth.getUser();
+        if (cancelled) return;
+        if (existingUserError) {
+          throw existingUserError;
+        }
 
         if (existingUser) {
           finishOk();
@@ -126,7 +133,12 @@ function PractitionerAuthCallbackFragmentContent() {
 
         const {
           data: { user: afterDetectUser },
+          error: afterDetectUserError,
         } = await supabase.auth.getUser();
+        if (cancelled) return;
+        if (afterDetectUserError) {
+          throw afterDetectUserError;
+        }
 
         if (afterDetectUser) {
           finishOk();
@@ -140,7 +152,15 @@ function PractitionerAuthCallbackFragmentContent() {
           setSurfaceError(err.message);
           return;
         }
-        setSurfaceError(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
+        if (isSupabaseAuthApiError(err)) {
+          console.error(
+            'Failed to verify user during auth callback fragment handling',
+            err,
+          );
+          finishErr(AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE);
+          return;
+        }
+        finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
       }
     };
 

--- a/apps/practitioner/src/app/auth/callback/fragment/page.tsx
+++ b/apps/practitioner/src/app/auth/callback/fragment/page.tsx
@@ -2,7 +2,10 @@
 
 import { Suspense, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { isSupabaseAuthApiError } from '@abstrack/supabase';
+import {
+  isAuthSessionMissingError,
+  isSupabaseAuthApiError,
+} from '@abstrack/supabase';
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import {
   AUTH_CALLBACK_INVALID_LINK_MESSAGE,
@@ -10,6 +13,7 @@ import {
   getSafePractitionerAuthCallbackRedirectPath,
 } from '@/lib/auth-callback-redirect';
 import {
+  interpretAuthCallbackGetUserProbe,
   isSupabaseBrowserConfigError,
   parseImplicitHashParams,
 } from '@/lib/auth-callback-fragment-helpers';
@@ -28,6 +32,9 @@ function redirectWithError(
  * Completes Supabase **implicit** auth (tokens in `#access_token=…`) after `/auth/callback` is
  * rewritten here from `src/proxy.ts` (Next.js 16 proxy). PKCE (`?code=`) is handled in the parent
  * `route.ts` on the server so session cookies are set without exchanging the code in client JS.
+ *
+ * `AuthSessionMissingError` from `getUser()` means no existing session (signed out), not a
+ * verification failure — the handler continues to `setSession()` from the hash when present.
  *
  * @returns Fragment callback UI (brief loading state).
  */
@@ -89,11 +96,15 @@ function PractitionerAuthCallbackFragmentContent() {
           error: existingUserError,
         } = await supabase.auth.getUser();
         if (cancelled) return;
-        if (existingUserError) {
-          throw existingUserError;
-        }
 
-        if (existingUser) {
+        const existingUserProbe = interpretAuthCallbackGetUserProbe(
+          existingUser,
+          existingUserError,
+        );
+        if (existingUserProbe.status === 'verification_failed') {
+          throw existingUserProbe.error;
+        }
+        if (existingUserProbe.status === 'authenticated') {
           finishOk();
           return;
         }
@@ -117,30 +128,36 @@ function PractitionerAuthCallbackFragmentContent() {
           }
 
           if (access_token && refresh_token) {
-            const { error } = await supabase.auth.setSession({
+            const { error: setSessionError } = await supabase.auth.setSession({
               access_token,
               refresh_token,
             });
             if (cancelled) return;
-            if (error) {
+            if (setSessionError) {
               finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
               return;
             }
+            // Implicit grant succeeded; do not require getUser() immediately after (signed-out
+            // visitors often still report AuthSessionMissingError until the client catches up).
             finishOk();
             return;
           }
         }
 
         const {
-          data: { user: afterDetectUser },
-          error: afterDetectUserError,
+          data: { user: afterHashUser },
+          error: afterHashUserError,
         } = await supabase.auth.getUser();
         if (cancelled) return;
-        if (afterDetectUserError) {
-          throw afterDetectUserError;
-        }
 
-        if (afterDetectUser) {
+        const afterHashProbe = interpretAuthCallbackGetUserProbe(
+          afterHashUser,
+          afterHashUserError,
+        );
+        if (afterHashProbe.status === 'verification_failed') {
+          throw afterHashProbe.error;
+        }
+        if (afterHashProbe.status === 'authenticated') {
           finishOk();
           return;
         }
@@ -148,16 +165,20 @@ function PractitionerAuthCallbackFragmentContent() {
         finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
       } catch (err) {
         if (cancelled) return;
+        if (isAuthSessionMissingError(err)) {
+          finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
+          return;
+        }
         if (isSupabaseBrowserConfigError(err)) {
           setSurfaceError(err.message);
           return;
         }
-        if (isSupabaseAuthApiError(err)) {
+        if (isSupabaseAuthApiError(err) && !isAuthSessionMissingError(err)) {
           console.error(
             'Failed to verify user during auth callback fragment handling',
             err,
           );
-        } else {
+        } else if (!isAuthSessionMissingError(err)) {
           console.error(
             'Unexpected error during auth callback fragment handling',
             err,

--- a/apps/practitioner/src/app/invite/join/page.tsx
+++ b/apps/practitioner/src/app/invite/join/page.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { useEffect, useId, useState } from 'react';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { getAccessTokenFromSession } from '@abstrack/supabase';
 import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import { completePractitionerInviteAfterAuth } from '@/lib/practitioner-invite-complete';
 import { PRACTITIONER_INVITE_SET_PASSWORD_FROM } from '@/lib/practitioner-invite-join';
@@ -37,19 +38,18 @@ export default function PractitionerInviteJoinPage() {
       try {
         const supabase = getSupabaseBrowserClient();
         const {
-          data: { session },
-          error: sessionError,
-        } = await supabase.auth.getSession();
+          data: { user },
+          error: userError,
+        } = await supabase.auth.getUser();
 
-        if (sessionError || !session?.user) {
+        if (userError || !user) {
           if (!cancelled) {
             setState({ kind: 'need_sign_in' });
           }
           return;
         }
 
-        const inviteIdRaw =
-          session.user.user_metadata?.abstrack_practitioner_invite_id;
+        const inviteIdRaw = user.user_metadata?.abstrack_practitioner_invite_id;
         const inviteId =
           typeof inviteIdRaw === 'string' && inviteIdRaw.trim().length > 0
             ? inviteIdRaw.trim()
@@ -59,12 +59,11 @@ export default function PractitionerInviteJoinPage() {
           const { data: profile } = await supabase
             .from('profiles')
             .select('app_role')
-            .eq('id', session.user.id)
+            .eq('id', user.id)
             .maybeSingle();
           if (!cancelled && profile?.app_role === 'practitioner') {
-            const passwordSignInEnabled = practitionerUserHasPasswordSignIn(
-              session.user,
-            );
+            const passwordSignInEnabled =
+              practitionerUserHasPasswordSignIn(user);
             setState({ kind: 'done', passwordSignInEnabled });
             announce(
               passwordSignInEnabled
@@ -78,7 +77,19 @@ export default function PractitionerInviteJoinPage() {
           return;
         }
 
-        const token = session.access_token?.trim() ?? '';
+        const { accessToken, error: tokenError } =
+          await getAccessTokenFromSession(supabase);
+        const token = accessToken ?? '';
+        if (tokenError) {
+          if (!cancelled) {
+            setState({
+              kind: 'error',
+              message:
+                'Unable to verify your session. Open the invite link from your email again.',
+            });
+          }
+          return;
+        }
         if (!token) {
           if (!cancelled) {
             setState({
@@ -117,10 +128,20 @@ export default function PractitionerInviteJoinPage() {
         }
 
         const {
-          data: { session: refreshedSession },
-        } = await supabase.auth.getSession();
+          data: { user: activeUser },
+          error: refreshedUserError,
+        } = await supabase.auth.getUser();
 
-        const activeUser = refreshedSession?.user ?? session.user;
+        if (refreshedUserError || !activeUser) {
+          if (!cancelled) {
+            setState({
+              kind: 'error',
+              message:
+                'Unable to verify your session after completing the invite. Open the invite link again.',
+            });
+          }
+          return;
+        }
 
         const { data: profile, error: profileErr } = await supabase
           .from('profiles')

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -341,9 +341,9 @@ export default function LoginPage() {
         return;
       }
 
-      const afterRestoreSession = await supabase.auth.getSession();
-      if (afterRestoreSession.error) {
-        console.error(afterRestoreSession.error);
+      const afterRestoreUser = await supabase.auth.getUser();
+      if (afterRestoreUser.error) {
+        console.error(afterRestoreUser.error);
         resetToCredentials({
           clearPassword: true,
           message:
@@ -351,7 +351,7 @@ export default function LoginPage() {
         });
         return;
       }
-      if (afterRestoreSession.data.session?.user?.id == null) {
+      if (afterRestoreUser.data.user?.id == null) {
         resetToCredentials({
           clearPassword: true,
           message:
@@ -359,7 +359,7 @@ export default function LoginPage() {
         });
         return;
       }
-      if (afterRestoreSession.data.session.user.id !== user.id) {
+      if (afterRestoreUser.data.user.id !== user.id) {
         try {
           await supabase.auth.signOut();
           clearMfaTrustBundle();

--- a/apps/practitioner/src/app/update-password/page.tsx
+++ b/apps/practitioner/src/app/update-password/page.tsx
@@ -48,10 +48,10 @@ export default function PractitionerUpdatePasswordPage() {
 
       try {
         const {
-          data: { session },
-        } = await supabase.auth.getSession();
+          data: { user },
+        } = await supabase.auth.getUser();
 
-        if (!session && mounted && !errorParam) {
+        if (!user && mounted && !errorParam) {
           setError(
             fromParam === PRACTITIONER_INVITE_SET_PASSWORD_FROM
               ? 'You must be signed in to create a password. Open your invite link again, then return here.'
@@ -115,10 +115,10 @@ export default function PractitionerUpdatePasswordPage() {
 
     try {
       const {
-        data: { session },
-      } = await supabase.auth.getSession();
+        data: { user },
+      } = await supabase.auth.getUser();
 
-      if (!session) {
+      if (!user) {
         setError(
           postInvite
             ? 'Your session expired. Open your invite link again, then return here to create a password.'

--- a/apps/practitioner/src/app/update-password/page.tsx
+++ b/apps/practitioner/src/app/update-password/page.tsx
@@ -4,6 +4,10 @@ import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  AUTH_CALLBACK_INVALID_LINK_MESSAGE,
+  AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
+} from '@/lib/auth-callback-redirect';
 import { PRACTITIONER_INVITE_SET_PASSWORD_FROM } from '@/lib/practitioner-invite-join';
 import { PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY } from '@/lib/practitioner-password-sign-in';
 
@@ -49,22 +53,35 @@ export default function PractitionerUpdatePasswordPage() {
       try {
         const {
           data: { user },
+          error: getUserError,
         } = await supabase.auth.getUser();
 
-        if (!user && mounted && !errorParam) {
+        if (getUserError) {
+          console.error(
+            'Failed to verify user on practitioner update-password page',
+            getUserError,
+          );
+          if (mounted && !errorParam) {
+            setError(
+              fromParam === PRACTITIONER_INVITE_SET_PASSWORD_FROM
+                ? 'Unable to verify your session. Open your invite link again, or reload this page.'
+                : AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
+            );
+          }
+        } else if (!user && mounted && !errorParam) {
           setError(
             fromParam === PRACTITIONER_INVITE_SET_PASSWORD_FROM
               ? 'You must be signed in to create a password. Open your invite link again, then return here.'
-              : 'This sign-in link is invalid or expired. Request a new one.',
+              : AUTH_CALLBACK_INVALID_LINK_MESSAGE,
           );
         }
       } catch (sessionError) {
         console.error(sessionError);
-        if (mounted) {
+        if (mounted && !errorParam) {
           setError(
             fromParam === PRACTITIONER_INVITE_SET_PASSWORD_FROM
               ? 'Unable to verify your session. Open your invite link again, or reload this page.'
-              : 'Unable to validate sign-in link. Request a new one.',
+              : AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
           );
         }
       } finally {
@@ -116,13 +133,27 @@ export default function PractitionerUpdatePasswordPage() {
     try {
       const {
         data: { user },
+        error: getUserError,
       } = await supabase.auth.getUser();
+
+      if (getUserError) {
+        console.error(
+          'Failed to verify user before practitioner password update',
+          getUserError,
+        );
+        setError(
+          postInvite
+            ? 'Unable to verify your session. Open your invite link again, or reload this page.'
+            : AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
+        );
+        return;
+      }
 
       if (!user) {
         setError(
           postInvite
             ? 'Your session expired. Open your invite link again, then return here to create a password.'
-            : 'This sign-in link is invalid or expired. Request a new one.',
+            : AUTH_CALLBACK_INVALID_LINK_MESSAGE,
         );
         return;
       }

--- a/apps/practitioner/src/components/practitioner-sign-out-button.tsx
+++ b/apps/practitioner/src/components/practitioner-sign-out-button.tsx
@@ -54,12 +54,12 @@ export function PractitionerSignOutButton({
     const sync = async () => {
       try {
         const {
-          data: { session },
-        } = await supabase.auth.getSession();
+          data: { user },
+        } = await supabase.auth.getUser();
         if (!mountedRef.current) {
           return;
         }
-        setTrustActive(isPractitionerMfaDeviceTrustActive(session?.user?.id));
+        setTrustActive(isPractitionerMfaDeviceTrustActive(user?.id));
       } catch (syncError) {
         console.error(
           'Practitioner sign-out button: session sync failed',
@@ -76,11 +76,8 @@ export function PractitionerSignOutButton({
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      if (!mountedRef.current) {
-        return;
-      }
-      setTrustActive(isPractitionerMfaDeviceTrustActive(session?.user?.id));
+    } = supabase.auth.onAuthStateChange(() => {
+      void sync();
     });
 
     return () => subscription.unsubscribe();

--- a/apps/practitioner/src/lib/auth-callback-fragment-helpers.spec.ts
+++ b/apps/practitioner/src/lib/auth-callback-fragment-helpers.spec.ts
@@ -1,4 +1,39 @@
-import { parseImplicitHashParams } from './auth-callback-fragment-helpers';
+import {
+  interpretAuthCallbackGetUserProbe,
+  parseImplicitHashParams,
+} from './auth-callback-fragment-helpers';
+
+describe('interpretAuthCallbackGetUserProbe', () => {
+  it('treats AuthSessionMissingError as signed out (invalid link), not verification failed', () => {
+    const err = Object.assign(new Error('Auth session missing!'), {
+      name: 'AuthSessionMissingError',
+    });
+    expect(interpretAuthCallbackGetUserProbe(null, err)).toEqual({
+      status: 'signed_out',
+    });
+  });
+
+  it('treats other getUser errors as verification failed', () => {
+    const err = new Error('network');
+    expect(interpretAuthCallbackGetUserProbe(null, err)).toEqual({
+      status: 'verification_failed',
+      error: err,
+    });
+  });
+
+  it('returns authenticated when user id is present', () => {
+    expect(interpretAuthCallbackGetUserProbe({ id: 'user-1' }, null)).toEqual({
+      status: 'authenticated',
+      userId: 'user-1',
+    });
+  });
+
+  it('returns signed out when user is absent without error', () => {
+    expect(interpretAuthCallbackGetUserProbe(null, null)).toEqual({
+      status: 'signed_out',
+    });
+  });
+});
 
 describe('parseImplicitHashParams', () => {
   it('parses access_token and refresh_token from a typical invite hash', () => {

--- a/apps/practitioner/src/lib/auth-callback-fragment-helpers.spec.ts
+++ b/apps/practitioner/src/lib/auth-callback-fragment-helpers.spec.ts
@@ -1,4 +1,7 @@
-import { parseImplicitHashParams } from './auth-callback-fragment-helpers';
+import {
+  isSupabaseAuthApiError,
+  parseImplicitHashParams,
+} from './auth-callback-fragment-helpers';
 
 describe('parseImplicitHashParams', () => {
   it('parses access_token and refresh_token from a typical invite hash', () => {
@@ -17,5 +20,20 @@ describe('parseImplicitHashParams', () => {
       access_token: 'a',
       refresh_token: 'b',
     });
+  });
+});
+
+describe('isSupabaseAuthApiError', () => {
+  it('returns true for Supabase Auth API errors', () => {
+    expect(
+      isSupabaseAuthApiError({
+        __isAuthError: true,
+        message: 'Network error',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for ordinary errors', () => {
+    expect(isSupabaseAuthApiError(new Error('nope'))).toBe(false);
   });
 });

--- a/apps/practitioner/src/lib/auth-callback-fragment-helpers.spec.ts
+++ b/apps/practitioner/src/lib/auth-callback-fragment-helpers.spec.ts
@@ -1,7 +1,4 @@
-import {
-  isSupabaseAuthApiError,
-  parseImplicitHashParams,
-} from './auth-callback-fragment-helpers';
+import { parseImplicitHashParams } from './auth-callback-fragment-helpers';
 
 describe('parseImplicitHashParams', () => {
   it('parses access_token and refresh_token from a typical invite hash', () => {
@@ -20,20 +17,5 @@ describe('parseImplicitHashParams', () => {
       access_token: 'a',
       refresh_token: 'b',
     });
-  });
-});
-
-describe('isSupabaseAuthApiError', () => {
-  it('returns true for Supabase Auth API errors', () => {
-    expect(
-      isSupabaseAuthApiError({
-        __isAuthError: true,
-        message: 'Network error',
-      }),
-    ).toBe(true);
-  });
-
-  it('returns false for ordinary errors', () => {
-    expect(isSupabaseAuthApiError(new Error('nope'))).toBe(false);
   });
 });

--- a/apps/practitioner/src/lib/auth-callback-fragment-helpers.ts
+++ b/apps/practitioner/src/lib/auth-callback-fragment-helpers.ts
@@ -1,3 +1,38 @@
+import { isAuthSessionMissingError } from '@abstrack/supabase';
+
+/**
+ * Result of interpreting `getUser()` during auth callback fragment handling.
+ */
+export type AuthCallbackGetUserProbe =
+  | { status: 'authenticated'; userId: string }
+  | { status: 'signed_out' }
+  | { status: 'verification_failed'; error: unknown };
+
+/**
+ * Maps `getUser()` to callback flow outcomes. `AuthSessionMissingError` is “signed out”
+ * (invalid link after hash handling), not a fatal verification error.
+ *
+ * @param user - `data.user` from `getUser()`.
+ * @param error - `error` from `getUser()`.
+ * @returns Probe result for the fragment callback handler.
+ */
+export function interpretAuthCallbackGetUserProbe(
+  user: { id?: string | null } | null | undefined,
+  error: unknown,
+): AuthCallbackGetUserProbe {
+  if (error) {
+    if (isAuthSessionMissingError(error)) {
+      return { status: 'signed_out' };
+    }
+    return { status: 'verification_failed', error };
+  }
+  const id = user?.id;
+  if (typeof id === 'string' && id.length > 0) {
+    return { status: 'authenticated', userId: id };
+  }
+  return { status: 'signed_out' };
+}
+
 /**
  * Parses Supabase Auth implicit-flow parameters from the URL hash
  * (`#access_token=…&refresh_token=…`). The fragment is never sent to the server.

--- a/apps/practitioner/src/lib/auth-callback-fragment-helpers.ts
+++ b/apps/practitioner/src/lib/auth-callback-fragment-helpers.ts
@@ -16,6 +16,20 @@ export function parseImplicitHashParams(hash: string): Record<string, string> {
 }
 
 /**
+ * True when `err` is a Supabase Auth API error from `getUser()` / `setSession()` (not a config throw).
+ *
+ * @param err - Value from `catch` or `getUser()` `error`.
+ */
+export function isSupabaseAuthApiError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    '__isAuthError' in err &&
+    (err as { __isAuthError?: boolean }).__isAuthError === true
+  );
+}
+
+/**
  * True when `getSupabaseBrowserClient()` failed because URL / publishable key env is missing or invalid.
  *
  * @param err - Value from `catch`.

--- a/apps/practitioner/src/lib/auth-callback-fragment-helpers.ts
+++ b/apps/practitioner/src/lib/auth-callback-fragment-helpers.ts
@@ -16,20 +16,6 @@ export function parseImplicitHashParams(hash: string): Record<string, string> {
 }
 
 /**
- * True when `err` is a Supabase Auth API error from `getUser()` / `setSession()` (not a config throw).
- *
- * @param err - Value from `catch` or `getUser()` `error`.
- */
-export function isSupabaseAuthApiError(err: unknown): boolean {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    '__isAuthError' in err &&
-    (err as { __isAuthError?: boolean }).__isAuthError === true
-  );
-}
-
-/**
  * True when `getSupabaseBrowserClient()` failed because URL / publishable key env is missing or invalid.
  *
  * @param err - Value from `catch`.

--- a/apps/practitioner/src/lib/auth-callback-redirect.ts
+++ b/apps/practitioner/src/lib/auth-callback-redirect.ts
@@ -9,6 +9,13 @@ export const AUTH_CALLBACK_INVALID_LINK_MESSAGE =
   'This sign-in link is invalid or expired. Request a new one.';
 
 /**
+ * User-facing message when {@link AbstrackSupabaseClient.auth.getUser} fails during callback
+ * handling (distinct from an invalid or expired link).
+ */
+export const AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE =
+  "We couldn't verify your sign-in. Try again in a moment.";
+
+/**
  * Returns a same-origin relative path for post-auth redirect on the practitioner app, or the
  * default when `next` is unsafe.
  *

--- a/apps/practitioner/src/lib/auth-provider.spec.tsx
+++ b/apps/practitioner/src/lib/auth-provider.spec.tsx
@@ -205,4 +205,43 @@ describe('AuthProvider', () => {
     expect(readAuthState().userId).toBeNull();
     expect(syncMfaTrustBundleAfterTokenRefreshMock).not.toHaveBeenCalled();
   });
+
+  it('keeps session when MFA trust sync fails after TOKEN_REFRESHED', async () => {
+    const session = makeSession('practitioner-1');
+
+    getVerifiedAuthSessionMock
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: null,
+      })
+      .mockResolvedValue({
+        data: { user: session.user, session },
+        error: null,
+      });
+
+    syncMfaTrustBundleAfterTokenRefreshMock.mockRejectedValueOnce(
+      new Error('trust bundle storage failed'),
+    );
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    act(() => {
+      authStateChangeHandler?.('TOKEN_REFRESHED');
+    });
+
+    await waitFor(() => {
+      expect(readAuthState().userId).toBe('practitioner-1');
+    });
+
+    expect(signOutMock).not.toHaveBeenCalled();
+    expect(syncMfaTrustBundleAfterTokenRefreshMock).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/practitioner/src/lib/auth-provider.spec.tsx
+++ b/apps/practitioner/src/lib/auth-provider.spec.tsx
@@ -154,6 +154,32 @@ describe('AuthProvider', () => {
     expect(readAuthState().userId).toBeNull();
   });
 
+  it('does not call getVerifiedAuthSession again on SIGNED_OUT', async () => {
+    getVerifiedAuthSessionMock.mockResolvedValue({
+      data: { user: null, session: null },
+      error: null,
+    });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    expect(getVerifiedAuthSessionMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      authStateChangeHandler?.('SIGNED_OUT');
+    });
+
+    expect(getVerifiedAuthSessionMock).toHaveBeenCalledTimes(1);
+    expect(readAuthState().userId).toBeNull();
+  });
+
   it('does not run MFA trust sync when TOKEN_REFRESHED verify is superseded by SIGNED_OUT', async () => {
     type VerifiedResult = Awaited<
       ReturnType<typeof getVerifiedAuthSessionMock>

--- a/apps/practitioner/src/lib/auth-provider.spec.tsx
+++ b/apps/practitioner/src/lib/auth-provider.spec.tsx
@@ -292,6 +292,52 @@ describe('AuthProvider', () => {
     expect(signOutMock).not.toHaveBeenCalled();
   });
 
+  it('clears session when verify returns no session without error', async () => {
+    const session = makeSession('practitioner-1');
+
+    getVerifiedAuthSessionMock
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: session.user, session },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: null,
+      });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    act(() => {
+      authStateChangeHandler?.('SIGNED_IN');
+    });
+
+    await waitFor(() => {
+      expect(readAuthState().userId).toBe('practitioner-1');
+    });
+
+    act(() => {
+      authStateChangeHandler?.('TOKEN_REFRESHED');
+    });
+
+    await waitFor(() => {
+      expect(readAuthState().userId).toBeNull();
+    });
+
+    expect(signOutMock).not.toHaveBeenCalled();
+  });
+
   it('clears session when verify reports a refresh-token failure', async () => {
     const session = makeSession('practitioner-1');
 

--- a/apps/practitioner/src/lib/auth-provider.spec.tsx
+++ b/apps/practitioner/src/lib/auth-provider.spec.tsx
@@ -1,0 +1,208 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import type { Session } from '@abstrack/supabase';
+import { AuthProvider, useAuth } from './auth-provider';
+
+const getVerifiedAuthSessionMock = jest.fn();
+const signOutMock = jest.fn().mockResolvedValue({ error: null });
+const onAuthStateChangeMock = jest.fn();
+const unsubscribeMock = jest.fn();
+const syncMfaTrustBundleAfterTokenRefreshMock = jest
+  .fn()
+  .mockResolvedValue(undefined);
+
+let authStateChangeHandler:
+  | ((
+      event: 'SIGNED_IN' | 'SIGNED_OUT' | 'TOKEN_REFRESHED',
+    ) => void | Promise<void>)
+  | undefined;
+
+function makeSession(userId: string): Session {
+  return {
+    access_token: 'access-token',
+    refresh_token: 'refresh-token',
+    expires_in: 3600,
+    expires_at: Math.floor(Date.now() / 1000) + 3600,
+    token_type: 'bearer',
+    user: {
+      id: userId,
+      aud: 'authenticated',
+      role: 'authenticated',
+      email: `${userId}@example.com`,
+      email_confirmed_at: new Date().toISOString(),
+      phone: '',
+      confirmed_at: new Date().toISOString(),
+      last_sign_in_at: new Date().toISOString(),
+      app_metadata: {},
+      user_metadata: {},
+      identities: [],
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      is_anonymous: false,
+    },
+  } as Session;
+}
+
+jest.mock('@abstrack/supabase', () => {
+  const actual = jest.requireActual('@abstrack/supabase');
+  return {
+    ...actual,
+    getVerifiedAuthSession: (...args: unknown[]) =>
+      getVerifiedAuthSessionMock(...args),
+    fetchProfileByUserId: jest
+      .fn()
+      .mockResolvedValue({ data: { app_role: 'practitioner' }, error: null }),
+  };
+});
+
+jest.mock('@abstrack/supabase/browser', () => ({
+  getSupabaseBrowserClient: jest.fn(() => ({
+    auth: {
+      signOut: (...args: unknown[]) => signOutMock(...args),
+      onAuthStateChange: (handler: typeof authStateChangeHandler) => {
+        authStateChangeHandler = handler;
+        return onAuthStateChangeMock(handler);
+      },
+    },
+  })),
+}));
+
+jest.mock('./practitioner-device-trust', () => ({
+  syncMfaTrustBundleAfterTokenRefresh: (...args: unknown[]) =>
+    syncMfaTrustBundleAfterTokenRefreshMock(...args),
+}));
+
+function AuthProbe() {
+  const { session, loading } = useAuth();
+
+  return (
+    <div data-testid="auth-state">
+      {JSON.stringify({
+        loading,
+        userId: session?.user?.id ?? null,
+      })}
+    </div>
+  );
+}
+
+function readAuthState() {
+  const raw = screen.getByTestId('auth-state').textContent ?? '{}';
+  return JSON.parse(raw) as {
+    loading: boolean;
+    userId: string | null;
+  };
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    authStateChangeHandler = undefined;
+    onAuthStateChangeMock.mockReturnValue({
+      data: { subscription: { unsubscribe: unsubscribeMock } },
+    });
+  });
+
+  it('does not restore session when SIGNED_OUT invalidates an in-flight SIGNED_IN verify', async () => {
+    type VerifiedResult = Awaited<
+      ReturnType<typeof getVerifiedAuthSessionMock>
+    >;
+    let resolveSlow: (value: VerifiedResult) => void;
+    const slowVerify = new Promise<VerifiedResult>((resolve) => {
+      resolveSlow = resolve;
+    });
+
+    getVerifiedAuthSessionMock
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: null,
+      })
+      .mockReturnValueOnce(slowVerify)
+      .mockResolvedValue({
+        data: { user: null, session: null },
+        error: null,
+      });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    act(() => {
+      authStateChangeHandler?.('SIGNED_IN');
+    });
+    act(() => {
+      authStateChangeHandler?.('SIGNED_OUT');
+    });
+
+    expect(readAuthState().userId).toBeNull();
+
+    await act(async () => {
+      resolveSlow({
+        data: {
+          user: makeSession('stale-user').user,
+          session: makeSession('stale-user'),
+        },
+        error: null,
+      });
+      await slowVerify;
+    });
+
+    expect(readAuthState().userId).toBeNull();
+  });
+
+  it('does not run MFA trust sync when TOKEN_REFRESHED verify is superseded by SIGNED_OUT', async () => {
+    type VerifiedResult = Awaited<
+      ReturnType<typeof getVerifiedAuthSessionMock>
+    >;
+    let resolveSlow: (value: VerifiedResult) => void;
+    const slowVerify = new Promise<VerifiedResult>((resolve) => {
+      resolveSlow = resolve;
+    });
+
+    getVerifiedAuthSessionMock
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: null,
+      })
+      .mockReturnValueOnce(slowVerify)
+      .mockResolvedValue({
+        data: { user: null, session: null },
+        error: null,
+      });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    act(() => {
+      authStateChangeHandler?.('TOKEN_REFRESHED');
+    });
+    act(() => {
+      authStateChangeHandler?.('SIGNED_OUT');
+    });
+
+    await act(async () => {
+      resolveSlow({
+        data: {
+          user: makeSession('stale-user').user,
+          session: makeSession('stale-user'),
+        },
+        error: null,
+      });
+      await slowVerify;
+    });
+
+    expect(readAuthState().userId).toBeNull();
+    expect(syncMfaTrustBundleAfterTokenRefreshMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/practitioner/src/lib/auth-provider.spec.tsx
+++ b/apps/practitioner/src/lib/auth-provider.spec.tsx
@@ -271,6 +271,55 @@ describe('AuthProvider', () => {
     expect(syncMfaTrustBundleAfterTokenRefreshMock).toHaveBeenCalledTimes(1);
   });
 
+  it('clears session when verify returns AuthSessionMissingError', async () => {
+    const session = makeSession('practitioner-1');
+    const missingError = Object.assign(new Error('Auth session missing!'), {
+      name: 'AuthSessionMissingError',
+    });
+
+    getVerifiedAuthSessionMock
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: session.user, session },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: missingError,
+      });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    act(() => {
+      authStateChangeHandler?.('SIGNED_IN');
+    });
+
+    await waitFor(() => {
+      expect(readAuthState().userId).toBe('practitioner-1');
+    });
+
+    act(() => {
+      authStateChangeHandler?.('TOKEN_REFRESHED');
+    });
+
+    await waitFor(() => {
+      expect(readAuthState().userId).toBeNull();
+    });
+
+    expect(signOutMock).not.toHaveBeenCalled();
+  });
+
   it('preserves session when verify returns a transient error', async () => {
     const session = makeSession('practitioner-1');
 

--- a/apps/practitioner/src/lib/auth-provider.spec.tsx
+++ b/apps/practitioner/src/lib/auth-provider.spec.tsx
@@ -244,4 +244,100 @@ describe('AuthProvider', () => {
     expect(signOutMock).not.toHaveBeenCalled();
     expect(syncMfaTrustBundleAfterTokenRefreshMock).toHaveBeenCalledTimes(1);
   });
+
+  it('preserves session when verify returns a transient error', async () => {
+    const session = makeSession('practitioner-1');
+
+    getVerifiedAuthSessionMock
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: session.user, session },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: new Error('Failed to fetch'),
+      });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    act(() => {
+      authStateChangeHandler?.('SIGNED_IN');
+    });
+
+    await waitFor(() => {
+      expect(readAuthState().userId).toBe('practitioner-1');
+    });
+
+    act(() => {
+      authStateChangeHandler?.('TOKEN_REFRESHED');
+    });
+
+    await waitFor(() => {
+      expect(getVerifiedAuthSessionMock).toHaveBeenCalledTimes(3);
+    });
+
+    expect(readAuthState().userId).toBe('practitioner-1');
+    expect(signOutMock).not.toHaveBeenCalled();
+  });
+
+  it('clears session when verify reports a refresh-token failure', async () => {
+    const session = makeSession('practitioner-1');
+
+    getVerifiedAuthSessionMock
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: session.user, session },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: {
+          code: 'refresh_token_not_found',
+          message: 'Invalid Refresh Token: Refresh Token Not Found',
+        },
+      });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    act(() => {
+      authStateChangeHandler?.('SIGNED_IN');
+    });
+
+    await waitFor(() => {
+      expect(readAuthState().userId).toBe('practitioner-1');
+    });
+
+    act(() => {
+      authStateChangeHandler?.('TOKEN_REFRESHED');
+    });
+
+    await waitFor(() => {
+      expect(readAuthState().userId).toBeNull();
+    });
+
+    expect(signOutMock).toHaveBeenCalled();
+  });
 });

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -3,6 +3,7 @@
 import {
   fetchProfileByUserId,
   getVerifiedAuthSession,
+  isAuthSessionMissingError,
   parseAbstrackAccessTokenClaims,
   resolvePractitionerAppGate,
   type AbstrackAccessTokenClaims,
@@ -123,7 +124,9 @@ async function loadVerifiedAuthSessionWithTimeout(
     } = raceResult;
 
     if (error) {
-      console.error('Failed to verify practitioner auth session', error);
+      if (!isAuthSessionMissingError(error)) {
+        console.error('Failed to verify practitioner auth session', error);
+      }
       if (isRefreshTokenFailure(error)) {
         await client.auth.signOut();
         return { action: 'clear' };
@@ -138,7 +141,9 @@ async function loadVerifiedAuthSessionWithTimeout(
     // Verified signed out (`getVerifiedAuthSession`: no user / no session, no error).
     return { action: 'clear' };
   } catch (error) {
-    console.error('Failed to verify practitioner auth session', error);
+    if (!isAuthSessionMissingError(error)) {
+      console.error('Failed to verify practitioner auth session', error);
+    }
     if (isRefreshTokenFailure(error)) {
       await client.auth.signOut();
       return { action: 'clear' };

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -185,13 +185,27 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event) => {
       void (async () => {
-        const nextSession = await loadVerifiedAuthSessionWithTimeout(supabase);
-        if (!mounted) {
-          return;
-        }
-        setSession(nextSession);
-        if (event === 'TOKEN_REFRESHED' && nextSession) {
-          await syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
+        try {
+          const nextSession =
+            await loadVerifiedAuthSessionWithTimeout(supabase);
+          if (!mounted) {
+            return;
+          }
+          setSession(nextSession);
+          if (event === 'TOKEN_REFRESHED' && nextSession) {
+            await syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
+          }
+        } catch (error) {
+          console.error(
+            'Failed to handle practitioner auth state change',
+            error,
+          );
+          if (isRefreshTokenFailure(error)) {
+            await supabase.auth.signOut();
+          }
+          if (mounted) {
+            setSession(null);
+          }
         }
       })();
     });

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -251,6 +251,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         if (mounted) {
           setSession(null);
         }
+        return;
       }
       void syncVerifiedSession(event);
     });

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -68,16 +68,22 @@ function isRefreshTokenFailure(error: unknown): boolean {
   return false;
 }
 
+/** Result of {@link loadVerifiedAuthSessionWithTimeout} for in-memory session updates. */
+type VerifiedSessionLoadResult =
+  | { action: 'set'; session: Session }
+  | { action: 'clear' }
+  | { action: 'preserve' };
+
 /**
  * Loads a verified practitioner session with a bounded wait, shared by bootstrap and
  * `onAuthStateChange`. On bootstrap timeout or refresh-token failure, signs out locally.
  *
  * @param client - Browser Supabase client.
- * @returns Verified session to store in context, or `null` when signed out / verification failed.
+ * @returns Whether to set, clear, or preserve the in-memory session (transient verify failures preserve).
  */
 async function loadVerifiedAuthSessionWithTimeout(
   client: AbstrackSupabaseClient,
-): Promise<Session | null> {
+): Promise<VerifiedSessionLoadResult> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   try {
     const timeoutPromise = new Promise<never>((_, reject) => {
@@ -86,10 +92,7 @@ async function loadVerifiedAuthSessionWithTimeout(
       }, SESSION_BOOTSTRAP_TIMEOUT_MS);
     });
 
-    const {
-      data: { session: nextSession },
-      error,
-    } = await Promise.race([
+    const raceResult = await Promise.race([
       getVerifiedAuthSession(client),
       timeoutPromise,
     ]).catch(async (raceError: unknown) => {
@@ -101,26 +104,45 @@ async function loadVerifiedAuthSessionWithTimeout(
           'Auth session bootstrap timed out; clearing local session',
         );
         await client.auth.signOut();
-        return { data: { user: null, session: null }, error: null };
+        return { action: 'clear' as const };
       }
       throw raceError;
     });
+
+    if (
+      typeof raceResult === 'object' &&
+      raceResult !== null &&
+      'action' in raceResult
+    ) {
+      return raceResult;
+    }
+
+    const {
+      data: { session: nextSession },
+      error,
+    } = raceResult;
 
     if (error) {
       console.error('Failed to verify practitioner auth session', error);
       if (isRefreshTokenFailure(error)) {
         await client.auth.signOut();
+        return { action: 'clear' };
       }
-      return null;
+      return { action: 'preserve' };
     }
 
-    return nextSession;
+    if (nextSession) {
+      return { action: 'set', session: nextSession };
+    }
+
+    return { action: 'preserve' };
   } catch (error) {
     console.error('Failed to verify practitioner auth session', error);
     if (isRefreshTokenFailure(error)) {
       await client.auth.signOut();
+      return { action: 'clear' };
     }
-    return null;
+    return { action: 'preserve' };
   } finally {
     if (timeoutId !== undefined) {
       clearTimeout(timeoutId);
@@ -175,28 +197,35 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     ): Promise<void> => {
       const generation = ++verifyGenerationRef.current;
       try {
-        const nextSession = await loadVerifiedAuthSessionWithTimeout(supabase);
+        const loadResult = await loadVerifiedAuthSessionWithTimeout(supabase);
         if (!mounted || generation !== verifyGenerationRef.current) {
           return;
         }
-        setSession(nextSession);
-        if (event === 'TOKEN_REFRESHED' && nextSession) {
-          try {
-            await syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
-          } catch (trustError) {
-            console.error(
-              'Failed to sync MFA trust bundle after token refresh',
-              trustError,
-            );
+        if (loadResult.action === 'set') {
+          setSession(loadResult.session);
+          if (event === 'TOKEN_REFRESHED') {
+            try {
+              await syncMfaTrustBundleAfterTokenRefresh(
+                supabase,
+                loadResult.session,
+              );
+            } catch (trustError) {
+              console.error(
+                'Failed to sync MFA trust bundle after token refresh',
+                trustError,
+              );
+            }
           }
+        } else if (loadResult.action === 'clear') {
+          setSession(null);
         }
       } catch (error) {
         console.error('Failed to handle practitioner auth state change', error);
         if (isRefreshTokenFailure(error)) {
           await supabase.auth.signOut();
-        }
-        if (mounted && generation === verifyGenerationRef.current) {
-          setSession(null);
+          if (mounted && generation === verifyGenerationRef.current) {
+            setSession(null);
+          }
         }
       }
     };

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -124,9 +124,10 @@ async function loadVerifiedAuthSessionWithTimeout(
     } = raceResult;
 
     if (error) {
-      if (!isAuthSessionMissingError(error)) {
-        console.error('Failed to verify practitioner auth session', error);
+      if (isAuthSessionMissingError(error)) {
+        return { action: 'clear' };
       }
+      console.error('Failed to verify practitioner auth session', error);
       if (isRefreshTokenFailure(error)) {
         await client.auth.signOut();
         return { action: 'clear' };
@@ -141,9 +142,10 @@ async function loadVerifiedAuthSessionWithTimeout(
     // Verified signed out (`getVerifiedAuthSession`: no user / no session, no error).
     return { action: 'clear' };
   } catch (error) {
-    if (!isAuthSessionMissingError(error)) {
-      console.error('Failed to verify practitioner auth session', error);
+    if (isAuthSessionMissingError(error)) {
+      return { action: 'clear' };
     }
+    console.error('Failed to verify practitioner auth session', error);
     if (isRefreshTokenFailure(error)) {
       await client.auth.signOut();
       return { action: 'clear' };

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -2,6 +2,7 @@
 
 import {
   fetchProfileByUserId,
+  getVerifiedAuthSession,
   parseAbstrackAccessTokenClaims,
   resolvePractitionerAppGate,
   type AbstrackAccessTokenClaims,
@@ -39,7 +40,7 @@ interface AuthContextType {
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
-/** Avoid infinite loading if `getSession` never settles. */
+/** Avoid infinite loading if auth bootstrap never settles. */
 const SESSION_BOOTSTRAP_TIMEOUT_MS = 8_000;
 
 function isRefreshTokenFailure(error: unknown): boolean {
@@ -100,7 +101,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   useEffect(() => {
     let mounted = true;
 
-    const initializeSession = async () => {
+    const syncVerifiedSession = async () => {
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
       try {
         const timeoutPromise = new Promise<never>((_, reject) => {
@@ -113,7 +114,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           data: { session: nextSession },
           error,
         } = await Promise.race([
-          supabase.auth.getSession(),
+          getVerifiedAuthSession(supabase),
           timeoutPromise,
         ]).catch(async (raceError: unknown) => {
           if (
@@ -124,13 +125,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
               'Auth session bootstrap timed out; clearing local session',
             );
             await supabase.auth.signOut();
-            return { data: { session: null }, error: null };
+            return { data: { user: null, session: null }, error: null };
           }
           throw raceError;
         });
 
         if (error) {
-          console.error('Failed to load practitioner auth session', error);
+          console.error('Failed to verify practitioner auth session', error);
           if (isRefreshTokenFailure(error)) {
             await supabase.auth.signOut();
           }
@@ -144,29 +145,79 @@ export function AuthProvider({ children }: { children: ReactNode }) {
           setSession(nextSession);
         }
       } catch (error) {
-        console.error('Failed to load practitioner auth session', error);
+        console.error('Failed to verify practitioner auth session', error);
         if (isRefreshTokenFailure(error)) {
           await supabase.auth.signOut();
+        }
+        if (mounted) {
+          setSession(null);
         }
       } finally {
         if (timeoutId !== undefined) {
           clearTimeout(timeoutId);
         }
+      }
+    };
+
+    const initializeAuth = async () => {
+      try {
+        await syncVerifiedSession();
+      } finally {
         if (mounted) {
           setAuthLoading(false);
         }
       }
     };
 
-    void initializeSession();
+    void initializeAuth();
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((event, nextSession) => {
-      setSession(nextSession);
-      if (event === 'TOKEN_REFRESHED') {
-        void syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
-      }
+    } = supabase.auth.onAuthStateChange((event) => {
+      void (async () => {
+        let timeoutId: ReturnType<typeof setTimeout> | undefined;
+        try {
+          const timeoutPromise = new Promise<never>((_, reject) => {
+            timeoutId = setTimeout(() => {
+              reject(new Error('session_bootstrap_timeout'));
+            }, SESSION_BOOTSTRAP_TIMEOUT_MS);
+          });
+          const {
+            data: { session: nextSession },
+            error,
+          } = await Promise.race([
+            getVerifiedAuthSession(supabase),
+            timeoutPromise,
+          ]);
+          if (error) {
+            if (isRefreshTokenFailure(error)) {
+              await supabase.auth.signOut();
+            }
+            if (mounted) {
+              setSession(null);
+            }
+            return;
+          }
+          if (mounted) {
+            setSession(nextSession);
+          }
+          if (event === 'TOKEN_REFRESHED' && nextSession) {
+            await syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
+          }
+        } catch (error) {
+          console.error('Failed to verify practitioner auth session', error);
+          if (isRefreshTokenFailure(error)) {
+            await supabase.auth.signOut();
+          }
+          if (mounted) {
+            setSession(null);
+          }
+        } finally {
+          if (timeoutId !== undefined) {
+            clearTimeout(timeoutId);
+          }
+        }
+      })();
     });
 
     return () => {
@@ -218,11 +269,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setProfile(data);
         return;
       }
-      const { data: liveSession } = await supabase.auth.getSession();
+      const { data: liveUserData } = await supabase.auth.getUser();
       const pendingInviteId =
-        typeof liveSession.session?.user?.user_metadata
+        typeof liveUserData.user?.user_metadata
           ?.abstrack_practitioner_invite_id === 'string'
-          ? liveSession.session.user.user_metadata.abstrack_practitioner_invite_id.trim()
+          ? liveUserData.user.user_metadata.abstrack_practitioner_invite_id.trim()
           : '';
       if (pendingInviteId !== '') {
         // Finalize runs on `/invite/join`; keep loading until profile exists.

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -181,9 +181,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         }
         setSession(nextSession);
         if (event === 'TOKEN_REFRESHED' && nextSession) {
-          await syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
-          if (!mounted || generation !== verifyGenerationRef.current) {
-            return;
+          try {
+            await syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
+          } catch (trustError) {
+            console.error(
+              'Failed to sync MFA trust bundle after token refresh',
+              trustError,
+            );
           }
         }
       } catch (error) {

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -135,7 +135,8 @@ async function loadVerifiedAuthSessionWithTimeout(
       return { action: 'set', session: nextSession };
     }
 
-    return { action: 'preserve' };
+    // Verified signed out (`getVerifiedAuthSession`: no user / no session, no error).
+    return { action: 'clear' };
   } catch (error) {
     console.error('Failed to verify practitioner auth session', error);
     if (isRefreshTokenFailure(error)) {

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -259,13 +259,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         setProfile(data);
         return;
       }
-      const { data: liveUserData } = await supabase.auth.getUser();
-      const pendingInviteId =
-        typeof liveUserData.user?.user_metadata
-          ?.abstrack_practitioner_invite_id === 'string'
-          ? liveUserData.user.user_metadata.abstrack_practitioner_invite_id.trim()
-          : '';
-      if (pendingInviteId !== '') {
+      if (pendingInviteMetadataId !== '') {
         // Finalize runs on `/invite/join`; keep loading until profile exists.
         setProfile(undefined);
         return;

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -17,12 +17,18 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
   type ReactNode,
 } from 'react';
 import { syncMfaTrustBundleAfterTokenRefresh } from './practitioner-device-trust';
 
 type ProfileRow = Database['public']['Tables']['profiles']['Row'];
+
+/** Auth listener event type from the shared Supabase client (no direct `supabase-js` import). */
+type AuthStateChangeEvent = Parameters<
+  Parameters<AbstrackSupabaseClient['auth']['onAuthStateChange']>[0]
+>[0];
 
 interface AuthContextType {
   session: Session | null;
@@ -158,14 +164,36 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     Boolean(session?.user) && profile === undefined && profileError === null;
 
   const loading = authLoading || identityLoading;
+  /** Drops stale verify completions after newer auth events or unmount. */
+  const verifyGenerationRef = useRef(0);
 
   useEffect(() => {
     let mounted = true;
 
-    const syncVerifiedSession = async () => {
-      const nextSession = await loadVerifiedAuthSessionWithTimeout(supabase);
-      if (mounted) {
+    const syncVerifiedSession = async (
+      event?: AuthStateChangeEvent,
+    ): Promise<void> => {
+      const generation = ++verifyGenerationRef.current;
+      try {
+        const nextSession = await loadVerifiedAuthSessionWithTimeout(supabase);
+        if (!mounted || generation !== verifyGenerationRef.current) {
+          return;
+        }
         setSession(nextSession);
+        if (event === 'TOKEN_REFRESHED' && nextSession) {
+          await syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
+          if (!mounted || generation !== verifyGenerationRef.current) {
+            return;
+          }
+        }
+      } catch (error) {
+        console.error('Failed to handle practitioner auth state change', error);
+        if (isRefreshTokenFailure(error)) {
+          await supabase.auth.signOut();
+        }
+        if (mounted && generation === verifyGenerationRef.current) {
+          setSession(null);
+        }
       }
     };
 
@@ -184,34 +212,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event) => {
-      void (async () => {
-        try {
-          const nextSession =
-            await loadVerifiedAuthSessionWithTimeout(supabase);
-          if (!mounted) {
-            return;
-          }
-          setSession(nextSession);
-          if (event === 'TOKEN_REFRESHED' && nextSession) {
-            await syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
-          }
-        } catch (error) {
-          console.error(
-            'Failed to handle practitioner auth state change',
-            error,
-          );
-          if (isRefreshTokenFailure(error)) {
-            await supabase.auth.signOut();
-          }
-          if (mounted) {
-            setSession(null);
-          }
+      if (event === 'SIGNED_OUT') {
+        verifyGenerationRef.current += 1;
+        if (mounted) {
+          setSession(null);
         }
-      })();
+      }
+      void syncVerifiedSession(event);
     });
 
     return () => {
       mounted = false;
+      verifyGenerationRef.current += 1;
       subscription.unsubscribe();
     };
   }, [supabase]);

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -6,6 +6,7 @@ import {
   parseAbstrackAccessTokenClaims,
   resolvePractitionerAppGate,
   type AbstrackAccessTokenClaims,
+  type AbstrackSupabaseClient,
   type Database,
   type PractitionerAppGate,
   type Session,
@@ -62,6 +63,66 @@ function isRefreshTokenFailure(error: unknown): boolean {
 }
 
 /**
+ * Loads a verified practitioner session with a bounded wait, shared by bootstrap and
+ * `onAuthStateChange`. On bootstrap timeout or refresh-token failure, signs out locally.
+ *
+ * @param client - Browser Supabase client.
+ * @returns Verified session to store in context, or `null` when signed out / verification failed.
+ */
+async function loadVerifiedAuthSessionWithTimeout(
+  client: AbstrackSupabaseClient,
+): Promise<Session | null> {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  try {
+    const timeoutPromise = new Promise<never>((_, reject) => {
+      timeoutId = setTimeout(() => {
+        reject(new Error('session_bootstrap_timeout'));
+      }, SESSION_BOOTSTRAP_TIMEOUT_MS);
+    });
+
+    const {
+      data: { session: nextSession },
+      error,
+    } = await Promise.race([
+      getVerifiedAuthSession(client),
+      timeoutPromise,
+    ]).catch(async (raceError: unknown) => {
+      if (
+        raceError instanceof Error &&
+        raceError.message === 'session_bootstrap_timeout'
+      ) {
+        console.warn(
+          'Auth session bootstrap timed out; clearing local session',
+        );
+        await client.auth.signOut();
+        return { data: { user: null, session: null }, error: null };
+      }
+      throw raceError;
+    });
+
+    if (error) {
+      console.error('Failed to verify practitioner auth session', error);
+      if (isRefreshTokenFailure(error)) {
+        await client.auth.signOut();
+      }
+      return null;
+    }
+
+    return nextSession;
+  } catch (error) {
+    console.error('Failed to verify practitioner auth session', error);
+    if (isRefreshTokenFailure(error)) {
+      await client.auth.signOut();
+    }
+    return null;
+  } finally {
+    if (timeoutId !== undefined) {
+      clearTimeout(timeoutId);
+    }
+  }
+}
+
+/**
  * Provides practitioner auth session state, `profiles.app_role`, and JWT claim metadata from
  * Supabase browser auth. See `docs/AUTH_CLAIM_CONTRACT.md`.
  *
@@ -102,60 +163,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     let mounted = true;
 
     const syncVerifiedSession = async () => {
-      let timeoutId: ReturnType<typeof setTimeout> | undefined;
-      try {
-        const timeoutPromise = new Promise<never>((_, reject) => {
-          timeoutId = setTimeout(() => {
-            reject(new Error('session_bootstrap_timeout'));
-          }, SESSION_BOOTSTRAP_TIMEOUT_MS);
-        });
-
-        const {
-          data: { session: nextSession },
-          error,
-        } = await Promise.race([
-          getVerifiedAuthSession(supabase),
-          timeoutPromise,
-        ]).catch(async (raceError: unknown) => {
-          if (
-            raceError instanceof Error &&
-            raceError.message === 'session_bootstrap_timeout'
-          ) {
-            console.warn(
-              'Auth session bootstrap timed out; clearing local session',
-            );
-            await supabase.auth.signOut();
-            return { data: { user: null, session: null }, error: null };
-          }
-          throw raceError;
-        });
-
-        if (error) {
-          console.error('Failed to verify practitioner auth session', error);
-          if (isRefreshTokenFailure(error)) {
-            await supabase.auth.signOut();
-          }
-          if (mounted) {
-            setSession(null);
-          }
-          return;
-        }
-
-        if (mounted) {
-          setSession(nextSession);
-        }
-      } catch (error) {
-        console.error('Failed to verify practitioner auth session', error);
-        if (isRefreshTokenFailure(error)) {
-          await supabase.auth.signOut();
-        }
-        if (mounted) {
-          setSession(null);
-        }
-      } finally {
-        if (timeoutId !== undefined) {
-          clearTimeout(timeoutId);
-        }
+      const nextSession = await loadVerifiedAuthSessionWithTimeout(supabase);
+      if (mounted) {
+        setSession(nextSession);
       }
     };
 
@@ -175,47 +185,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event) => {
       void (async () => {
-        let timeoutId: ReturnType<typeof setTimeout> | undefined;
-        try {
-          const timeoutPromise = new Promise<never>((_, reject) => {
-            timeoutId = setTimeout(() => {
-              reject(new Error('session_bootstrap_timeout'));
-            }, SESSION_BOOTSTRAP_TIMEOUT_MS);
-          });
-          const {
-            data: { session: nextSession },
-            error,
-          } = await Promise.race([
-            getVerifiedAuthSession(supabase),
-            timeoutPromise,
-          ]);
-          if (error) {
-            if (isRefreshTokenFailure(error)) {
-              await supabase.auth.signOut();
-            }
-            if (mounted) {
-              setSession(null);
-            }
-            return;
-          }
-          if (mounted) {
-            setSession(nextSession);
-          }
-          if (event === 'TOKEN_REFRESHED' && nextSession) {
-            await syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
-          }
-        } catch (error) {
-          console.error('Failed to verify practitioner auth session', error);
-          if (isRefreshTokenFailure(error)) {
-            await supabase.auth.signOut();
-          }
-          if (mounted) {
-            setSession(null);
-          }
-        } finally {
-          if (timeoutId !== undefined) {
-            clearTimeout(timeoutId);
-          }
+        const nextSession = await loadVerifiedAuthSessionWithTimeout(supabase);
+        if (!mounted) {
+          return;
+        }
+        setSession(nextSession);
+        if (event === 'TOKEN_REFRESHED' && nextSession) {
+          await syncMfaTrustBundleAfterTokenRefresh(supabase, nextSession);
         }
       })();
     });

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -25,18 +25,18 @@ jest.mock('@abstrack/supabase', () => {
           error: userResult.error,
         };
       }
-      const sessionResult = await client.auth.getSession();
-      if (sessionResult.error) {
-        return {
-          data: { user: null, session: null },
-          error: sessionResult.error,
-        };
-      }
       const user = userResult.data.user;
-      const session = sessionResult.data.session;
       if (!user) {
         return { data: { user: null, session: null }, error: null };
       }
+      const sessionResult = await client.auth.getSession();
+      if (sessionResult.error) {
+        return {
+          data: { user, session: null },
+          error: sessionResult.error,
+        };
+      }
+      const session = sessionResult.data.session;
       if (!session) {
         return { data: { user, session: null }, error: null };
       }

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -452,7 +452,42 @@ describe('tryRestoreTrustedMfaSession', () => {
     expect(signOut).not.toHaveBeenCalled();
   });
 
-  it('clears the trust bundle and signs out when initial getSession fails', async () => {
+  it('returns not_restored when initial getUser fails transiently without signing out', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const refreshSession = jest.fn();
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
+    const supabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+          error: new Error('Failed to fetch'),
+        }),
+        refreshSession,
+        setSession: jest.fn(),
+        signOut,
+        getSession: jest.fn(),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn(),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).toBeNull();
+    expect(refreshSession).not.toHaveBeenCalled();
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it('returns not_restored when initial getSession fails transiently without signing out', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
@@ -476,12 +511,12 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     await expect(
       tryRestoreTrustedMfaSession(supabase, userId),
-    ).resolves.toEqual({ status: 'signed_out' });
+    ).resolves.toEqual({ status: 'not_restored' });
     expect(
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).toBeNull();
     expect(setSession).not.toHaveBeenCalled();
-    expect(signOut).toHaveBeenCalled();
+    expect(signOut).not.toHaveBeenCalled();
   });
 
   it('clears the trust bundle and reverts when refreshSession fails', async () => {

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -10,6 +10,44 @@ import {
   tryRestoreTrustedMfaSession,
 } from './practitioner-device-trust';
 
+jest.mock('@abstrack/supabase', () => {
+  const actual =
+    jest.requireActual<typeof import('@abstrack/supabase')>(
+      '@abstrack/supabase',
+    );
+  return {
+    ...actual,
+    getVerifiedAuthSession: jest.fn(async (client: AbstrackSupabaseClient) => {
+      const userResult = await client.auth.getUser();
+      if (userResult.error) {
+        return {
+          data: { user: null, session: null },
+          error: userResult.error,
+        };
+      }
+      const sessionResult = await client.auth.getSession();
+      if (sessionResult.error) {
+        return {
+          data: { user: null, session: null },
+          error: sessionResult.error,
+        };
+      }
+      const user = userResult.data.user;
+      const session = sessionResult.data.session;
+      if (!user) {
+        return { data: { user: null, session: null }, error: null };
+      }
+      if (!session) {
+        return { data: { user, session: null }, error: null };
+      }
+      return {
+        data: { user, session: { ...session, user } },
+        error: null,
+      };
+    }),
+  };
+});
+
 const prevPractitionerDeviceTrustEnv =
   process.env['NEXT_PUBLIC_PRACTITIONER_MFA_DEVICE_TRUST'];
 
@@ -66,6 +104,26 @@ function prePasswordSession(id: string) {
   };
 }
 
+/** Default `auth.getUser` for restore/sign-out tests (pre-check + post-refresh). */
+function mockGetUserForId(userId: string, callCount = 2) {
+  const getUser = jest.fn();
+  for (let i = 0; i < callCount; i++) {
+    getUser.mockResolvedValueOnce({
+      data: { user: { id: userId } },
+      error: null,
+    });
+  }
+  getUser.mockResolvedValue({ data: { user: { id: userId } }, error: null });
+  return getUser;
+}
+
+function mockGetUserOnce(id: string) {
+  return jest.fn().mockResolvedValue({
+    data: { user: { id } },
+    error: null,
+  });
+}
+
 describe('tryRestoreTrustedMfaSession', () => {
   const userId = '00000000-0000-0000-0000-000000000042';
 
@@ -88,6 +146,7 @@ describe('tryRestoreTrustedMfaSession', () => {
     });
     const supabase = {
       auth: {
+        getUser: mockGetUserForId(userId),
         refreshSession,
         setSession: jest.fn().mockResolvedValue({ error: null }),
         signOut: jest.fn(),
@@ -162,6 +221,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const supabase = {
       auth: {
+        getUser: mockGetUserForId(userId),
         refreshSession,
         setSession,
         signOut,
@@ -215,6 +275,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const supabase = {
       auth: {
+        getUser: mockGetUserForId(userId),
         refreshSession,
         setSession,
         signOut,
@@ -261,11 +322,10 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const supabase = {
       auth: {
+        getUser: mockGetUserOnce(otherId),
         setSession,
         signOut,
-        getSession: jest.fn().mockResolvedValue({
-          data: { session: prePasswordSession(otherId) },
-        }),
+        getSession: jest.fn(),
         mfa: {
           getAuthenticatorAssuranceLevel: jest.fn(),
         },
@@ -303,8 +363,20 @@ describe('tryRestoreTrustedMfaSession', () => {
     const setSession = jest.fn().mockResolvedValue({ error: null });
     const signOut = jest.fn().mockResolvedValue({ error: null });
 
+    const getUser = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: { user: { id: userId } },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: { id: otherId } },
+        error: null,
+      });
+
     const supabase = {
       auth: {
+        getUser,
         refreshSession,
         setSession,
         signOut,
@@ -351,6 +423,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const supabase = {
       auth: {
+        getUser: mockGetUserForId(userId),
         refreshSession,
         setSession,
         signOut,
@@ -390,6 +463,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const supabase = {
       auth: {
+        getUser: mockGetUserOnce(userId),
         refreshSession: jest.fn(),
         setSession,
         signOut,
@@ -425,6 +499,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const supabase = {
       auth: {
+        getUser: mockGetUserForId(userId),
         refreshSession,
         setSession,
         signOut,
@@ -475,6 +550,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const supabase = {
       auth: {
+        getUser: mockGetUserForId(userId),
         refreshSession,
         setSession,
         signOut,
@@ -528,6 +604,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const supabase = {
       auth: {
+        getUser: mockGetUserForId(userId),
         refreshSession,
         setSession,
         signOut,
@@ -583,6 +660,7 @@ describe('tryRestoreTrustedMfaSession', () => {
 
     const supabase = {
       auth: {
+        getUser: mockGetUserForId(userId),
         refreshSession,
         setSession,
         signOut,
@@ -773,6 +851,7 @@ describe('practitionerSignOut', () => {
     const signOut = jest.fn().mockResolvedValue({ error: null });
     const supabase = {
       auth: {
+        getUser: mockGetUserOnce(userId),
         getSession: jest.fn().mockResolvedValue({
           data: {
             session: sessionForUser(userId),
@@ -804,6 +883,7 @@ describe('practitionerSignOut', () => {
     const signOut = jest.fn().mockResolvedValue({ error: null });
     const supabase = {
       auth: {
+        getUser: mockGetUserOnce(userId),
         getSession: jest.fn().mockResolvedValue({
           data: { session: sessionForUser(userId) },
         }),
@@ -829,6 +909,9 @@ describe('practitionerSignOut', () => {
     const signOut = jest.fn().mockResolvedValue({ error: null });
     const supabase = {
       auth: {
+        getUser: jest
+          .fn()
+          .mockResolvedValue({ data: { user: null }, error: null }),
         getSession: jest.fn().mockResolvedValue({ data: { session: null } }),
         signOut,
       },
@@ -860,6 +943,7 @@ describe('practitionerSignOut', () => {
     const signOut = jest.fn().mockResolvedValue({ error: null });
     const supabase = {
       auth: {
+        getUser: mockGetUserOnce(userId),
         getSession: jest.fn().mockResolvedValue({
           data: {
             session: sessionForUser(userId),
@@ -898,6 +982,7 @@ describe('practitionerSignOut', () => {
       .mockResolvedValue({ error: { message: 'sign-out failed' } });
     const supabase = {
       auth: {
+        getUser: mockGetUserOnce(userId),
         getSession: jest.fn().mockResolvedValue({
           data: { session: sessionForUser(userId) },
         }),

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -841,6 +841,38 @@ describe('practitionerSignOut', () => {
     localStorage.clear();
   });
 
+  it('soft sign-out when getUser fails but session user id matches trust bundle', async () => {
+    localStorage.setItem(
+      PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const removeItem = jest.fn().mockResolvedValue(undefined);
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+    const supabase = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: null },
+          error: { message: 'Network error', __isAuthError: true },
+        }),
+        getSession: jest.fn().mockResolvedValue({
+          data: { session: sessionForUser(userId) },
+        }),
+        signOut,
+        storage: { removeItem },
+        storageKey: 'sb-test-auth-token',
+      },
+    } as unknown as BrowserClient;
+
+    await practitionerSignOut(supabase);
+
+    expect(
+      localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
+    ).not.toBeNull();
+    expect(signOut).not.toHaveBeenCalled();
+    expect(removeItem).toHaveBeenCalledWith('sb-test-auth-token');
+  });
+
   it('soft sign-out: clears auth storage without POST /logout, keeps MFA bundle', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -841,13 +841,17 @@ describe('practitionerSignOut', () => {
     localStorage.clear();
   });
 
-  it('soft sign-out when getUser fails but session user id matches trust bundle', async () => {
+  it('soft sign-out when getUser fails but persisted auth user id matches trust bundle', async () => {
     localStorage.setItem(
       PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY,
       buildBundleJson(userId, Date.now() + 60_000),
     );
 
     const removeItem = jest.fn().mockResolvedValue(undefined);
+    const getItem = jest
+      .fn()
+      .mockResolvedValue(JSON.stringify(sessionForUser(userId)));
+    const getSession = jest.fn();
     const signOut = jest.fn().mockResolvedValue({ error: null });
     const supabase = {
       auth: {
@@ -855,11 +859,9 @@ describe('practitionerSignOut', () => {
           data: { user: null },
           error: { message: 'Network error', __isAuthError: true },
         }),
-        getSession: jest.fn().mockResolvedValue({
-          data: { session: sessionForUser(userId) },
-        }),
+        getSession,
         signOut,
-        storage: { removeItem },
+        storage: { getItem, removeItem },
         storageKey: 'sb-test-auth-token',
       },
     } as unknown as BrowserClient;
@@ -870,6 +872,8 @@ describe('practitionerSignOut', () => {
       localStorage.getItem(PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY),
     ).not.toBeNull();
     expect(signOut).not.toHaveBeenCalled();
+    expect(getSession).not.toHaveBeenCalled();
+    expect(getItem).toHaveBeenCalledWith('sb-test-auth-token');
     expect(removeItem).toHaveBeenCalledWith('sb-test-auth-token');
   });
 

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -30,6 +30,7 @@
 
 import {
   getVerifiedAuthSession,
+  isAuthSessionMissingError,
   type AbstrackSupabaseClient,
   type Session,
 } from '@abstrack/supabase';
@@ -438,7 +439,7 @@ async function finishFailedBundleRestore(
  *   password session was re-applied). The user typically remains signed in at AAL1; caller should
  *   continue MFA flow.
  * - **`signed_out`**: Auth state was cleared during failure handling (e.g. unsafe mismatch,
- *   `getSession` error before tokens were captured, or reversion to the password session failed).
+ *   missing session on pre-restore probes, or reversion to the password session failed).
  *   Caller must not assume a session.
  */
 export type TryRestoreTrustedMfaSessionResult =
@@ -455,7 +456,7 @@ export type TryRestoreTrustedMfaSessionResult =
  * Restore uses `auth.refreshSession({ refresh_token })` with the stored refresh token, not
  * `setSession({ access_token, refresh_token })` alone (see implementation comment).
  * On failure (revoked or expired tokens, **session user mismatch** after restore, assurance error,
- * **getSession error**, **missing session** after a successful `getSession()` call, or session not at
+ * **missing session** after a successful `getSession()` call, or session not at
  * **aal2**), clears the bundle and restores the pre-restore
  * password session (or signs out) so the client is not left authenticated as the wrong user. If the
  * **initial** `getSession()` user id does not match `userId`, clears the bundle and **signs out**
@@ -485,8 +486,11 @@ export async function tryRestoreTrustedMfaSession(
   const preUserResult = await supabase.auth.getUser();
   if (preUserResult.error) {
     clearMfaTrustBundle();
-    await revertToPreRestoreSession(supabase, null);
-    return { status: 'signed_out' };
+    if (isAuthSessionMissingError(preUserResult.error)) {
+      await supabase.auth.signOut();
+      return { status: 'signed_out' };
+    }
+    return { status: 'not_restored' };
   }
 
   if (preUserResult.data.user?.id !== userId) {
@@ -498,8 +502,11 @@ export async function tryRestoreTrustedMfaSession(
   const preSessionResult = await supabase.auth.getSession();
   if (preSessionResult.error) {
     clearMfaTrustBundle();
-    await revertToPreRestoreSession(supabase, null);
-    return { status: 'signed_out' };
+    if (isAuthSessionMissingError(preSessionResult.error)) {
+      await supabase.auth.signOut();
+      return { status: 'signed_out' };
+    }
+    return { status: 'not_restored' };
   }
 
   const preRestoreSession = preSessionResult.data.session;

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -28,7 +28,11 @@
  * @module practitioner-device-trust
  */
 
-import type { AbstrackSupabaseClient, Session } from '@abstrack/supabase';
+import {
+  getVerifiedAuthSession,
+  type AbstrackSupabaseClient,
+  type Session,
+} from '@abstrack/supabase';
 
 type PractitionerBrowserClient = AbstrackSupabaseClient;
 
@@ -478,6 +482,19 @@ export async function tryRestoreTrustedMfaSession(
     return { status: 'not_restored' };
   }
 
+  const preUserResult = await supabase.auth.getUser();
+  if (preUserResult.error) {
+    clearMfaTrustBundle();
+    await revertToPreRestoreSession(supabase, null);
+    return { status: 'signed_out' };
+  }
+
+  if (preUserResult.data.user?.id !== userId) {
+    clearMfaTrustBundle();
+    await supabase.auth.signOut();
+    return { status: 'signed_out' };
+  }
+
   const preSessionResult = await supabase.auth.getSession();
   if (preSessionResult.error) {
     clearMfaTrustBundle();
@@ -486,8 +503,7 @@ export async function tryRestoreTrustedMfaSession(
   }
 
   const preRestoreSession = preSessionResult.data.session;
-
-  if (preRestoreSession?.user?.id !== userId) {
+  if (!preRestoreSession) {
     clearMfaTrustBundle();
     await supabase.auth.signOut();
     return { status: 'signed_out' };
@@ -519,10 +535,11 @@ export async function tryRestoreTrustedMfaSession(
     return finishFailedBundleRestore(supabase, preSessionTokens);
   }
 
-  const sessionAfterRefresh = refreshData.session;
+  const refreshedUserResult = await supabase.auth.getUser();
   if (
-    sessionAfterRefresh.user?.id == null ||
-    sessionAfterRefresh.user.id !== userId
+    refreshedUserResult.error ||
+    refreshedUserResult.data.user?.id == null ||
+    refreshedUserResult.data.user.id !== userId
   ) {
     return finishFailedBundleRestore(supabase, preSessionTokens);
   }
@@ -535,17 +552,13 @@ export async function tryRestoreTrustedMfaSession(
     return finishFailedBundleRestore(supabase, preSessionTokens);
   }
 
-  const finalSessionResult = await supabase.auth.getSession();
-  if (finalSessionResult.error) {
+  const { data: verified, error: verifiedError } =
+    await getVerifiedAuthSession(supabase);
+  if (verifiedError || verified.session == null) {
     return finishFailedBundleRestore(supabase, preSessionTokens);
   }
 
-  const session = finalSessionResult.data.session;
-  if (session == null) {
-    return finishFailedBundleRestore(supabase, preSessionTokens);
-  }
-
-  saveMfaTrustBundle(session, bundle.trustedUntilMs);
+  saveMfaTrustBundle(verified.session, bundle.trustedUntilMs);
 
   return { status: 'restored' };
 }
@@ -625,13 +638,14 @@ async function clearBrowserSessionWithoutServerLogout(
 export async function practitionerSignOut(
   supabase: PractitionerBrowserClient,
 ): Promise<void> {
-  const { data: sessionData } = await supabase.auth.getSession();
-  const session = sessionData.session;
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   const bundle = readBundle();
   const trustActiveForUser =
-    session &&
+    user &&
     bundle &&
-    bundle.userId === session.user.id &&
+    bundle.userId === user.id &&
     bundle.trustedUntilMs > Date.now();
 
   if (trustActiveForUser) {

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -589,6 +589,40 @@ export function practitionerSignOutEverywhere(): void {
 }
 
 /**
+ * Resolves the current user id for soft vs full sign-out when matching the MFA trust bundle.
+ * Prefers verified {@link AbstrackSupabaseClient.auth.getUser}; on failure, best-effort
+ * `getSession().session.user.id` so offline verification does not force full sign-out and
+ * revoke the refresh token still held in the bundle.
+ *
+ * @param supabase - Browser Supabase client.
+ * @returns User id string, or `null` when none can be resolved.
+ */
+async function resolveUserIdForMfaTrustSignOut(
+  supabase: PractitionerBrowserClient,
+): Promise<string | null> {
+  const { data: userData, error: userError } = await supabase.auth.getUser();
+  if (!userError) {
+    const id = userData.user?.id;
+    return id != null && id !== '' ? id : null;
+  }
+  console.warn(
+    'practitionerSignOut: getUser failed; using session user id for trust-bundle check',
+    userError,
+  );
+  try {
+    const { data: sessionData, error: sessionError } =
+      await supabase.auth.getSession();
+    if (sessionError) {
+      return null;
+    }
+    const id = sessionData.session?.user?.id;
+    return id != null && id !== '' ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Clears the browser auth session **without** calling GoTrue’s `POST /logout` endpoint.
  *
  * **`signOut({ scope: 'local' })` still revokes the current session’s refresh token on the server**
@@ -638,14 +672,12 @@ async function clearBrowserSessionWithoutServerLogout(
 export async function practitionerSignOut(
   supabase: PractitionerBrowserClient,
 ): Promise<void> {
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
+  const userId = await resolveUserIdForMfaTrustSignOut(supabase);
   const bundle = readBundle();
   const trustActiveForUser =
-    user &&
-    bundle &&
-    bundle.userId === user.id &&
+    userId != null &&
+    bundle != null &&
+    bundle.userId === userId &&
     bundle.trustedUntilMs > Date.now();
 
   if (trustActiveForUser) {

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -589,10 +589,42 @@ export function practitionerSignOutEverywhere(): void {
 }
 
 /**
+ * Reads `user.id` from persisted Supabase auth JSON in browser storage without calling
+ * `getSession()` (avoids relying on an unverified `session.user` from the client API).
+ *
+ * @param supabase - Browser Supabase client.
+ * @returns Non-empty user id, or `null` when storage is unavailable or unreadable.
+ */
+async function readUserIdFromPersistedAuthStorage(
+  supabase: PractitionerBrowserClient,
+): Promise<string | null> {
+  const auth = supabase.auth as unknown as {
+    storage?: {
+      getItem: (key: string) => Promise<string | null> | string | null;
+    };
+    storageKey?: string;
+  };
+  const { storage, storageKey } = auth;
+  if (!storage?.getItem || !storageKey) {
+    return null;
+  }
+  try {
+    const raw = await storage.getItem(storageKey);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as { user?: { id?: unknown } };
+    const id = parsed.user?.id;
+    return typeof id === 'string' && id.trim() !== '' ? id.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Resolves the current user id for soft vs full sign-out when matching the MFA trust bundle.
- * Prefers verified {@link AbstrackSupabaseClient.auth.getUser}; on failure, best-effort
- * `getSession().session.user.id` so offline verification does not force full sign-out and
- * revoke the refresh token still held in the bundle.
+ * Prefers verified {@link AbstrackSupabaseClient.auth.getUser}; on failure, reads `user.id`
+ * from persisted auth storage when available, then `getSession()` only if storage is missing.
  *
  * @param supabase - Browser Supabase client.
  * @returns User id string, or `null` when none can be resolved.
@@ -606,9 +638,20 @@ async function resolveUserIdForMfaTrustSignOut(
     return id != null && id !== '' ? id : null;
   }
   console.warn(
-    'practitionerSignOut: getUser failed; using session user id for trust-bundle check',
+    'practitionerSignOut: getUser failed; reading user id from persisted auth storage for trust-bundle check',
     userError,
   );
+  const persistedId = await readUserIdFromPersistedAuthStorage(supabase);
+  if (persistedId != null) {
+    return persistedId;
+  }
+  const auth = supabase.auth as unknown as {
+    storage?: { getItem: (key: string) => unknown };
+    storageKey?: string;
+  };
+  if (auth.storage?.getItem && auth.storageKey) {
+    return null;
+  }
   try {
     const { data: sessionData, error: sessionError } =
       await supabase.auth.getSession();

--- a/apps/web/src/app/(app)/dashboard/page.tsx
+++ b/apps/web/src/app/(app)/dashboard/page.tsx
@@ -1,175 +1,40 @@
-import { redirect } from 'next/navigation';
-import Link from 'next/link';
 import { EpisodeStartHomeCta } from '@/components/episode-flow/EpisodeStartHomeCta';
-import { createServerClient } from '@/lib/supabase/server-client';
-import { healthCheckProfilesLimit1 } from '@abstrack/supabase';
-
-interface HealthCheckResult {
-  success: boolean;
-  message: string;
-  error?: string;
-}
+import { DashboardHomeCtaCard } from '@/components/dashboard/DashboardHomeCtaCard';
+import { DashboardRecentEpisodes } from '@/components/dashboard/DashboardRecentEpisodes';
 
 /**
- * Patient dashboard: dev-only Supabase health check and account summary. Auth and shell come from
- * the parent `(app)` layout.
+ * Patient home dashboard: episode logging, standalone health markers and food diary entry,
+ * and a short preview of recent ended episodes. Auth and shell come from the parent `(app)`
+ * layout.
  *
  * @returns Dashboard content.
  */
-export default async function DashboardPage() {
-  const supabase = await createServerClient();
-  const showHealthCheck = process.env.NODE_ENV !== 'production';
-  const {
-    data: { user },
-    error: getUserError,
-  } = await supabase.auth.getUser();
-  const allowDevAuthErrorDebugView = showHealthCheck && !!getUserError;
-
-  if (getUserError) {
-    console.error(
-      'Failed to fetch authenticated user for dashboard',
-      getUserError,
-    );
-  }
-
-  let healthCheck: HealthCheckResult | null = null;
-
-  if (showHealthCheck && getUserError) {
-    healthCheck = {
-      success: false,
-      message: 'Health check failed during auth user lookup',
-      error: getUserError.message,
-    };
-  }
-
-  if (!user && !allowDevAuthErrorDebugView) {
-    redirect('/login');
-  }
-
-  if (showHealthCheck && user && !healthCheck) {
-    try {
-      const result = await healthCheckProfilesLimit1(supabase);
-
-      if (result.error) {
-        healthCheck = {
-          success: false,
-          message: 'Health check failed',
-          error: result.error.message,
-        };
-      } else {
-        healthCheck = {
-          success: true,
-          message:
-            'Health check passed: authenticated user found and profiles query executed without API error (empty rows may still indicate no profile or restrictive RLS).',
-        };
-      }
-    } catch (err) {
-      healthCheck = {
-        success: false,
-        message: 'Health check error',
-        error: err instanceof Error ? err.message : 'Unknown error',
-      };
-    }
-  }
-
+export default function DashboardPage() {
   return (
     <div className="w-full space-y-8">
       <div>
         <h1 className="text-2xl font-bold tracking-tight text-app-ink">
           Dashboard
         </h1>
-        <p className="mt-1 text-sm text-app-muted">
-          Account overview and development health checks.
-        </p>
       </div>
 
       <EpisodeStartHomeCta />
 
-      <div className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8">
-        {showHealthCheck && healthCheck && (
-          <div
-            className={`mb-6 rounded-lg border p-4 ${
-              healthCheck.success
-                ? 'border-green-200 bg-green-50 dark:border-green-800/60 dark:bg-green-950/35'
-                : 'border-red-200 bg-red-50 dark:border-red-800/60 dark:bg-red-950/35'
-            }`}
-          >
-            <div
-              className={`mb-2 font-semibold ${
-                healthCheck.success
-                  ? 'text-green-800 dark:text-green-200'
-                  : 'text-red-800 dark:text-red-200'
-              }`}
-            >
-              {healthCheck.success
-                ? '✓ Health Check Passed'
-                : '✗ Health Check Failed'}
-            </div>
-            <p
-              className={`text-sm ${
-                healthCheck.success
-                  ? 'text-green-700 dark:text-green-300/95'
-                  : 'text-red-700 dark:text-red-300/95'
-              }`}
-            >
-              {healthCheck.message}
-            </p>
-            {healthCheck.error && (
-              <details className="mt-2 cursor-pointer">
-                <summary className="text-xs font-medium underline">
-                  Error Details
-                </summary>
-                <pre className="mt-2 overflow-auto rounded border border-app-border bg-app-bg p-2 text-xs text-app-ink">
-                  {healthCheck.error}
-                </pre>
-              </details>
-            )}
-          </div>
-        )}
+      <DashboardHomeCtaCard
+        heading="Health markers"
+        description="Log vitals and wellness markers outside an episode using your health marker presets."
+        href="/health-markers/new"
+        ctaLabel="Log health markers"
+      />
 
-        <div className="space-y-4">
-          <div>
-            <p className="text-sm text-app-muted">Health markers</p>
-            <Link
-              href="/health-markers/new"
-              className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-app-border bg-app-surface px-3 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-            >
-              Log health markers
-            </Link>
-          </div>
-          <div>
-            <p className="text-sm text-app-muted">Food diary</p>
-            <Link
-              href="/food-diary/new"
-              className="inline-flex min-h-[44px] items-center justify-center rounded-lg border border-app-border bg-app-surface px-3 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-surface/80 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-            >
-              Add a food diary entry
-            </Link>
-          </div>
-          {user ? (
-            <>
-              <div>
-                <p className="text-sm text-app-muted">Email</p>
-                <p className="font-medium text-app-ink">{user.email}</p>
-              </div>
+      <DashboardHomeCtaCard
+        heading="Food diary"
+        description="Record meals and notes on their own, or link entries when you log during an episode."
+        href="/food-diary/new"
+        ctaLabel="Add a food diary entry"
+      />
 
-              <div>
-                <p className="text-sm text-app-muted">User ID</p>
-                <p className="break-all font-mono text-sm text-app-ink">
-                  {user.id}
-                </p>
-              </div>
-            </>
-          ) : (
-            <div>
-              <p className="text-sm text-app-muted">Authentication Status</p>
-              <p className="font-medium text-red-700 dark:text-red-300">
-                No authenticated user available (development debug view)
-              </p>
-            </div>
-          )}
-        </div>
-      </div>
+      <DashboardRecentEpisodes />
     </div>
   );
 }

--- a/apps/web/src/app/(public)/caretaker/join/page.tsx
+++ b/apps/web/src/app/(public)/caretaker/join/page.tsx
@@ -43,19 +43,18 @@ export default function CaretakerJoinPage() {
       try {
         const supabase = createBrowserClient();
         const {
-          data: { session },
-          error: sessionError,
-        } = await supabase.auth.getSession();
+          data: { user },
+          error: userError,
+        } = await supabase.auth.getUser();
 
-        if (sessionError || !session?.user) {
+        if (userError || !user) {
           if (!cancelled) {
             setState({ kind: 'need_sign_in' });
           }
           return;
         }
 
-        const inviteIdRaw =
-          session.user.user_metadata?.abstrack_caretaker_invite_id;
+        const inviteIdRaw = user.user_metadata?.abstrack_caretaker_invite_id;
         const inviteId =
           typeof inviteIdRaw === 'string' && inviteIdRaw.trim().length > 0
             ? inviteIdRaw.trim()
@@ -71,7 +70,7 @@ export default function CaretakerJoinPage() {
         const { data: profile, error: profileReadErr } = await supabase
           .from('profiles')
           .select('app_role')
-          .eq('id', session.user.id)
+          .eq('id', user.id)
           .maybeSingle();
 
         if (profileReadErr) {
@@ -86,7 +85,7 @@ export default function CaretakerJoinPage() {
 
         if (!profile) {
           const { error: insErr } = await supabase.from('profiles').insert({
-            id: session.user.id,
+            id: user.id,
             app_role: 'caretaker',
           });
           if (insErr) {
@@ -94,7 +93,7 @@ export default function CaretakerJoinPage() {
               const { data: afterRace, error: raceReadErr } = await supabase
                 .from('profiles')
                 .select('app_role')
-                .eq('id', session.user.id)
+                .eq('id', user.id)
                 .maybeSingle();
               if (raceReadErr || !afterRace) {
                 if (!cancelled) {

--- a/apps/web/src/app/(public)/update-password/page.tsx
+++ b/apps/web/src/app/(public)/update-password/page.tsx
@@ -51,10 +51,10 @@ export default function UpdatePasswordPage() {
 
       try {
         const {
-          data: { session },
-        } = await supabase.auth.getSession();
+          data: { user },
+        } = await supabase.auth.getUser();
 
-        if (!session && mounted && !errorParam) {
+        if (!user && mounted && !errorParam) {
           setError(
             fromParam === CARETAKER_INVITE_SET_PASSWORD_FROM
               ? 'You must be signed in to create a password. Open your invite link again, then return here.'
@@ -118,10 +118,10 @@ export default function UpdatePasswordPage() {
 
     try {
       const {
-        data: { session },
-      } = await supabase.auth.getSession();
+        data: { user },
+      } = await supabase.auth.getUser();
 
-      if (!session) {
+      if (!user) {
         setError(
           postInviteCaretaker
             ? 'Your session expired. Open your invite link again, then return here to create a password.'

--- a/apps/web/src/app/(public)/update-password/page.tsx
+++ b/apps/web/src/app/(public)/update-password/page.tsx
@@ -5,6 +5,10 @@ import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { CARETAKER_INVITE_SET_PASSWORD_FROM } from '@/lib/auth/caretaker-invite-password';
 import { PUBLIC_PAGE_CENTER_CLASS } from '@/components/app-shell/public-page-layout-classes';
+import {
+  AUTH_CALLBACK_INVALID_LINK_MESSAGE,
+  AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
+} from '@/lib/auth/auth-callback-redirect';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { updateUserPassword } from '@abstrack/supabase';
 
@@ -52,22 +56,35 @@ export default function UpdatePasswordPage() {
       try {
         const {
           data: { user },
+          error: getUserError,
         } = await supabase.auth.getUser();
 
-        if (!user && mounted && !errorParam) {
+        if (getUserError) {
+          console.error(
+            'Failed to verify user on update-password page',
+            getUserError,
+          );
+          if (mounted && !errorParam) {
+            setError(
+              fromParam === CARETAKER_INVITE_SET_PASSWORD_FROM
+                ? 'Unable to verify your session. Open your invite link again, or reload this page.'
+                : AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
+            );
+          }
+        } else if (!user && mounted && !errorParam) {
           setError(
             fromParam === CARETAKER_INVITE_SET_PASSWORD_FROM
               ? 'You must be signed in to create a password. Open your invite link again, then return here.'
-              : 'This sign-in link is invalid or expired. Request a new one.',
+              : AUTH_CALLBACK_INVALID_LINK_MESSAGE,
           );
         }
       } catch (sessionError) {
         console.error(sessionError);
-        if (mounted) {
+        if (mounted && !errorParam) {
           setError(
             fromParam === CARETAKER_INVITE_SET_PASSWORD_FROM
               ? 'Unable to verify your session. Open your invite link again, or reload this page.'
-              : 'Unable to validate sign-in link. Request a new one.',
+              : AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
           );
         }
       } finally {
@@ -119,13 +136,27 @@ export default function UpdatePasswordPage() {
     try {
       const {
         data: { user },
+        error: getUserError,
       } = await supabase.auth.getUser();
+
+      if (getUserError) {
+        console.error(
+          'Failed to verify user before password update',
+          getUserError,
+        );
+        setError(
+          postInviteCaretaker
+            ? 'Unable to verify your session. Open your invite link again, or reload this page.'
+            : AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
+        );
+        return;
+      }
 
       if (!user) {
         setError(
           postInviteCaretaker
             ? 'Your session expired. Open your invite link again, then return here to create a password.'
-            : 'This sign-in link is invalid or expired. Request a new one.',
+            : AUTH_CALLBACK_INVALID_LINK_MESSAGE,
         );
         return;
       }

--- a/apps/web/src/app/auth/callback/fragment/page.tsx
+++ b/apps/web/src/app/auth/callback/fragment/page.tsx
@@ -79,10 +79,10 @@ function AuthCallbackFragmentContent() {
         const supabase = createBrowserClient();
 
         const {
-          data: { session: existing },
-        } = await supabase.auth.getSession();
+          data: { user: existingUser },
+        } = await supabase.auth.getUser();
 
-        if (existing?.user) {
+        if (existingUser) {
           finishOk();
           return;
         }
@@ -121,10 +121,10 @@ function AuthCallbackFragmentContent() {
         }
 
         const {
-          data: { session: afterDetect },
-        } = await supabase.auth.getSession();
+          data: { user: afterDetectUser },
+        } = await supabase.auth.getUser();
 
-        if (afterDetect?.user) {
+        if (afterDetectUser) {
           finishOk();
           return;
         }

--- a/apps/web/src/app/auth/callback/fragment/page.tsx
+++ b/apps/web/src/app/auth/callback/fragment/page.tsx
@@ -153,10 +153,13 @@ function AuthCallbackFragmentContent() {
             'Failed to verify user during auth callback fragment handling',
             err,
           );
-          finishErr(AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE);
-          return;
+        } else {
+          console.error(
+            'Unexpected error during auth callback fragment handling',
+            err,
+          );
         }
-        finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
+        finishErr(AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE);
       }
     };
 

--- a/apps/web/src/app/auth/callback/fragment/page.tsx
+++ b/apps/web/src/app/auth/callback/fragment/page.tsx
@@ -7,7 +7,10 @@ import {
   AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
   getSafeAuthCallbackRedirectPath,
 } from '@/lib/auth/auth-callback-redirect';
-import { isSupabaseAuthApiError } from '@abstrack/supabase';
+import {
+  isAuthSessionMissingError,
+  isSupabaseAuthApiError,
+} from '@abstrack/supabase';
 import {
   isSupabaseBrowserConfigError,
   parseImplicitHashParams,
@@ -85,7 +88,10 @@ function AuthCallbackFragmentContent() {
           error: existingUserError,
         } = await supabase.auth.getUser();
         if (cancelled) return;
-        if (existingUserError) {
+        if (
+          existingUserError &&
+          !isAuthSessionMissingError(existingUserError)
+        ) {
           throw existingUserError;
         }
 
@@ -113,16 +119,33 @@ function AuthCallbackFragmentContent() {
           }
 
           if (access_token && refresh_token) {
-            const { error } = await supabase.auth.setSession({
+            const { error: setSessionError } = await supabase.auth.setSession({
               access_token,
               refresh_token,
             });
             if (cancelled) return;
-            if (error) {
+            if (setSessionError) {
               finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
               return;
             }
-            finishOk();
+
+            const {
+              data: { user: userAfterSetSession },
+              error: userAfterSetSessionError,
+            } = await supabase.auth.getUser();
+            if (cancelled) return;
+            if (userAfterSetSessionError) {
+              if (isAuthSessionMissingError(userAfterSetSessionError)) {
+                finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
+                return;
+              }
+              throw userAfterSetSessionError;
+            }
+            if (userAfterSetSession) {
+              finishOk();
+              return;
+            }
+            finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
             return;
           }
         }
@@ -133,6 +156,10 @@ function AuthCallbackFragmentContent() {
         } = await supabase.auth.getUser();
         if (cancelled) return;
         if (afterDetectUserError) {
+          if (isAuthSessionMissingError(afterDetectUserError)) {
+            finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
+            return;
+          }
           throw afterDetectUserError;
         }
 
@@ -144,16 +171,20 @@ function AuthCallbackFragmentContent() {
         finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
       } catch (err) {
         if (cancelled) return;
+        if (isAuthSessionMissingError(err)) {
+          finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
+          return;
+        }
         if (isSupabaseBrowserConfigError(err)) {
           setSurfaceError(err.message);
           return;
         }
-        if (isSupabaseAuthApiError(err)) {
+        if (isSupabaseAuthApiError(err) && !isAuthSessionMissingError(err)) {
           console.error(
             'Failed to verify user during auth callback fragment handling',
             err,
           );
-        } else {
+        } else if (!isAuthSessionMissingError(err)) {
           console.error(
             'Unexpected error during auth callback fragment handling',
             err,

--- a/apps/web/src/app/auth/callback/fragment/page.tsx
+++ b/apps/web/src/app/auth/callback/fragment/page.tsx
@@ -7,8 +7,8 @@ import {
   AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
   getSafeAuthCallbackRedirectPath,
 } from '@/lib/auth/auth-callback-redirect';
+import { isSupabaseAuthApiError } from '@abstrack/supabase';
 import {
-  isSupabaseAuthApiError,
   isSupabaseBrowserConfigError,
   parseImplicitHashParams,
 } from '@/lib/auth/auth-callback-fragment-helpers';

--- a/apps/web/src/app/auth/callback/fragment/page.tsx
+++ b/apps/web/src/app/auth/callback/fragment/page.tsx
@@ -4,9 +4,11 @@ import { Suspense, useEffect, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import {
   AUTH_CALLBACK_INVALID_LINK_MESSAGE,
+  AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
   getSafeAuthCallbackRedirectPath,
 } from '@/lib/auth/auth-callback-redirect';
 import {
+  isSupabaseAuthApiError,
   isSupabaseBrowserConfigError,
   parseImplicitHashParams,
 } from '@/lib/auth/auth-callback-fragment-helpers';
@@ -80,7 +82,12 @@ function AuthCallbackFragmentContent() {
 
         const {
           data: { user: existingUser },
+          error: existingUserError,
         } = await supabase.auth.getUser();
+        if (cancelled) return;
+        if (existingUserError) {
+          throw existingUserError;
+        }
 
         if (existingUser) {
           finishOk();
@@ -122,7 +129,12 @@ function AuthCallbackFragmentContent() {
 
         const {
           data: { user: afterDetectUser },
+          error: afterDetectUserError,
         } = await supabase.auth.getUser();
+        if (cancelled) return;
+        if (afterDetectUserError) {
+          throw afterDetectUserError;
+        }
 
         if (afterDetectUser) {
           finishOk();
@@ -136,7 +148,15 @@ function AuthCallbackFragmentContent() {
           setSurfaceError(err.message);
           return;
         }
-        setSurfaceError(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
+        if (isSupabaseAuthApiError(err)) {
+          console.error(
+            'Failed to verify user during auth callback fragment handling',
+            err,
+          );
+          finishErr(AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE);
+          return;
+        }
+        finishErr(AUTH_CALLBACK_INVALID_LINK_MESSAGE);
       }
     };
 

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -8,7 +8,7 @@ import { WebAppShell } from '../components/app-shell/WebAppShell';
 import { WebPublicTopNav } from '../components/app-shell/WebPublicTopNav';
 import { LiveAnnouncerRoot } from '../components/a11y/LiveAnnouncerRoot';
 import { AuthProvider } from '../lib/auth-provider';
-import { mapSupabaseSessionToAuthContext } from '../lib/auth-provider-session';
+import { mapSupabaseUserToAuthContext } from '../lib/auth-provider-session';
 import { createServerClient } from '../lib/supabase/server-client';
 
 const fontSans = Plus_Jakarta_Sans({
@@ -29,9 +29,9 @@ export default async function RootLayout({
 }) {
   const supabase = await createServerClient();
   const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const initialSession = mapSupabaseSessionToAuthContext(session);
+    data: { user },
+  } = await supabase.auth.getUser();
+  const initialSession = mapSupabaseUserToAuthContext(user);
 
   return (
     <html lang="en" className={fontSans.variable} suppressHydrationWarning>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { THEME_INIT_SCRIPT } from '../lib/theme-init-script';
 import { WebAppShell } from '../components/app-shell/WebAppShell';
 import { WebPublicTopNav } from '../components/app-shell/WebPublicTopNav';
 import { LiveAnnouncerRoot } from '../components/a11y/LiveAnnouncerRoot';
+import { isAuthSessionMissingError } from '@abstrack/supabase';
 import { AuthProvider } from '../lib/auth-provider';
 import { mapSupabaseUserToAuthContext } from '../lib/auth-provider-session';
 import { createServerClient } from '../lib/supabase/server-client';
@@ -33,16 +34,17 @@ export default async function RootLayout({
     error: getUserError,
   } = await supabase.auth.getUser();
 
-  if (getUserError) {
+  if (getUserError && !isAuthSessionMissingError(getUserError)) {
     console.error(
       'Failed to verify user for root layout; deferring session to client',
       getUserError,
     );
   }
 
-  const initialSession = getUserError
-    ? undefined
-    : mapSupabaseUserToAuthContext(user);
+  const initialSession =
+    getUserError && !isAuthSessionMissingError(getUserError)
+      ? undefined
+      : mapSupabaseUserToAuthContext(user);
 
   return (
     <html lang="en" className={fontSans.variable} suppressHydrationWarning>

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -30,8 +30,19 @@ export default async function RootLayout({
   const supabase = await createServerClient();
   const {
     data: { user },
+    error: getUserError,
   } = await supabase.auth.getUser();
-  const initialSession = mapSupabaseUserToAuthContext(user);
+
+  if (getUserError) {
+    console.error(
+      'Failed to verify user for root layout; deferring session to client',
+      getUserError,
+    );
+  }
+
+  const initialSession = getUserError
+    ? undefined
+    : mapSupabaseUserToAuthContext(user);
 
   return (
     <html lang="en" className={fontSans.variable} suppressHydrationWarning>

--- a/apps/web/src/components/dashboard/DashboardHomeCtaCard.tsx
+++ b/apps/web/src/components/dashboard/DashboardHomeCtaCard.tsx
@@ -1,0 +1,59 @@
+import Link from 'next/link';
+
+export type DashboardHomeCtaCardProps = {
+  /** Visible section heading (also used for `aria-labelledby`). */
+  heading: string;
+  /** Short explanatory copy under the heading. */
+  description: string;
+  /** Primary action destination. */
+  href: string;
+  /** Primary link label. */
+  ctaLabel: string;
+  /** Extra classes on the outer section (spacing, etc.). */
+  className?: string;
+};
+
+const cardShellClass =
+  'rounded-2xl border border-app-border/90 bg-app-surface p-5 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-6';
+
+const primaryLinkClass =
+  'inline-flex min-h-[56px] w-full items-center justify-center rounded-xl bg-app-primary-solid px-5 py-4 text-center text-base font-semibold leading-snug text-app-on-primary-solid shadow-md outline-none ring-2 ring-transparent transition hover:opacity-95 focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg';
+
+/**
+ * Neutral-themed home dashboard card for logging flows (health markers, food diary, etc.).
+ * Episode logging uses {@link EpisodeStartHomeCta} with distinct urgent styling.
+ *
+ * @param props - Card copy and CTA target.
+ * @returns Section with heading, description, and primary link.
+ */
+export function DashboardHomeCtaCard({
+  heading,
+  description,
+  href,
+  ctaLabel,
+  className = '',
+}: DashboardHomeCtaCardProps) {
+  const headingId = `dashboard-cta-${heading.replace(/\s+/g, '-').toLowerCase()}-heading`;
+
+  return (
+    <section
+      className={`${cardShellClass} ${className}`.trim()}
+      aria-labelledby={headingId}
+    >
+      <h2
+        id={headingId}
+        className="text-lg font-semibold tracking-tight text-app-ink"
+      >
+        {heading}
+      </h2>
+      <p className="mt-1.5 text-sm leading-relaxed text-app-muted">
+        {description}
+      </p>
+      <div className="mt-5">
+        <Link href={href} className={primaryLinkClass}>
+          {ctaLabel}
+        </Link>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/components/dashboard/DashboardHomeCtaCard.tsx
+++ b/apps/web/src/components/dashboard/DashboardHomeCtaCard.tsx
@@ -1,7 +1,8 @@
 import Link from 'next/link';
+import { useId } from 'react';
 
 export type DashboardHomeCtaCardProps = {
-  /** Visible section heading (also used for `aria-labelledby`). */
+  /** Visible section heading. */
   heading: string;
   /** Short explanatory copy under the heading. */
   description: string;
@@ -33,7 +34,8 @@ export function DashboardHomeCtaCard({
   ctaLabel,
   className = '',
 }: DashboardHomeCtaCardProps) {
-  const headingId = `dashboard-cta-${heading.replace(/\s+/g, '-').toLowerCase()}-heading`;
+  const instanceId = useId();
+  const headingId = `dashboard-cta-heading-${instanceId}`;
 
   return (
     <section

--- a/apps/web/src/components/dashboard/DashboardHomeCtaCard.tsx
+++ b/apps/web/src/components/dashboard/DashboardHomeCtaCard.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import Link from 'next/link';
 import { useId } from 'react';
 

--- a/apps/web/src/components/dashboard/DashboardRecentEpisodes.tsx
+++ b/apps/web/src/components/dashboard/DashboardRecentEpisodes.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useEffect, useId, useState } from 'react';
+import Link from 'next/link';
+import { listCompletedEpisodesForUser } from '@abstrack/supabase';
+import { formatEpisodeDurationSimple, type EpisodeRow } from '@abstrack/types';
+import { EpisodeLocaleInstant } from '@/components/episodes/EpisodeLocaleInstant';
+import { formatEpisodeTypeSummary } from '@/lib/episodes/format-episode-meta';
+import { useWebPhiSubjectUserContext } from '@/lib/patient/use-web-phi-subject-user-context';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+
+/** Number of ended episodes shown on the home dashboard. */
+const DASHBOARD_RECENT_EPISODES_LIMIT = 3;
+
+const cardShellClass =
+  'rounded-2xl border border-app-border/90 bg-app-surface p-5 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-6';
+
+export type DashboardRecentEpisodesProps = {
+  /** Extra classes on the outer section. */
+  className?: string;
+};
+
+/**
+ * Home dashboard preview of the patient's most recently ended episodes.
+ *
+ * @param props - Optional layout classes.
+ * @returns Card with a short list and link to full episode history.
+ */
+export function DashboardRecentEpisodes({
+  className = '',
+}: DashboardRecentEpisodesProps) {
+  const instanceId = useId();
+  const headingId = `dashboard-recent-episodes-heading${instanceId}`;
+
+  const {
+    phiSubjectUserId,
+    loading: phiLoading,
+    errorMessage: phiError,
+  } = useWebPhiSubjectUserContext();
+
+  const [episodes, setEpisodes] = useState<EpisodeRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (phiLoading) {
+      return;
+    }
+    if (phiError) {
+      setEpisodes([]);
+      setError(phiError);
+      setLoading(false);
+      return;
+    }
+    if (!phiSubjectUserId) {
+      setEpisodes([]);
+      setError(null);
+      setLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    const run = async (): Promise<void> => {
+      try {
+        const supabase = createBrowserClient();
+        const result = await listCompletedEpisodesForUser(
+          supabase,
+          phiSubjectUserId,
+          { limit: DASHBOARD_RECENT_EPISODES_LIMIT, offset: 0 },
+        );
+        if (cancelled) {
+          return;
+        }
+        if (!result.ok) {
+          setEpisodes([]);
+          setError(result.error.message);
+          return;
+        }
+        setEpisodes(result.data);
+        setError(null);
+      } catch {
+        if (!cancelled) {
+          setEpisodes([]);
+          setError('Unable to load recent episodes.');
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [phiError, phiLoading, phiSubjectUserId]);
+
+  return (
+    <section
+      className={`${cardShellClass} ${className}`.trim()}
+      aria-labelledby={headingId}
+    >
+      <h2
+        id={headingId}
+        className="text-lg font-semibold tracking-tight text-app-ink"
+      >
+        Recent episodes
+      </h2>
+      <p className="mt-1.5 text-sm leading-relaxed text-app-muted">
+        Your latest ended episodes. Open Manage for the full history, filters,
+        and delete actions.
+      </p>
+
+      {loading ? (
+        <p className="mt-4 text-sm text-app-muted" aria-busy="true">
+          Loading recent episodes…
+        </p>
+      ) : null}
+
+      {!loading && error ? (
+        <p className="mt-4 text-sm text-red-700 dark:text-red-300" role="alert">
+          {error}
+        </p>
+      ) : null}
+
+      {!loading && !error && episodes.length === 0 ? (
+        <p className="mt-4 rounded-xl border border-dashed border-app-border/90 bg-app-bg/40 p-4 text-sm text-app-muted">
+          No ended episodes yet.{' '}
+          <Link
+            href="/episode/start"
+            className="font-semibold text-app-primary underline underline-offset-2"
+          >
+            Start an episode
+          </Link>{' '}
+          when you are ready to log symptoms.
+        </p>
+      ) : null}
+
+      {!loading && !error && episodes.length > 0 ? (
+        <>
+          <ul className="mt-4 space-y-3" role="list">
+            {episodes.map((ep) => (
+              <li key={ep.id}>
+                <div className="rounded-xl border border-app-border/90 bg-app-bg/40 p-4 ring-1 ring-[color:var(--app-ring-slate)] dark:bg-app-surface-dark/40">
+                  <p className="text-base font-semibold text-app-ink">
+                    {formatEpisodeTypeSummary(ep)}
+                  </p>
+                  <dl className="mt-2 space-y-1 text-sm text-app-muted">
+                    <div className="flex flex-wrap gap-x-2">
+                      <dt className="font-medium text-app-ink/80">Ended</dt>
+                      <dd>
+                        {ep.ended_at ? (
+                          <EpisodeLocaleInstant iso={ep.ended_at} />
+                        ) : (
+                          '—'
+                        )}
+                      </dd>
+                    </div>
+                    <div className="flex flex-wrap gap-x-2">
+                      <dt className="font-medium text-app-ink/80">Duration</dt>
+                      <dd>
+                        {formatEpisodeDurationSimple(
+                          ep.started_at,
+                          ep.ended_at,
+                        ) ?? '—'}
+                      </dd>
+                    </div>
+                  </dl>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <Link
+            href="/manage?segment=episodes"
+            className="mt-4 inline-flex min-h-[44px] items-center justify-center rounded-full border border-app-border bg-app-surface px-5 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:border-app-border-dark dark:bg-app-surface-dark"
+          >
+            View all episodes
+          </Link>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/src/components/dashboard/DashboardRecentEpisodes.tsx
+++ b/apps/web/src/components/dashboard/DashboardRecentEpisodes.tsx
@@ -44,6 +44,9 @@ export function DashboardRecentEpisodes({
 
   useEffect(() => {
     if (phiLoading) {
+      setEpisodes([]);
+      setError(null);
+      setLoading(true);
       return;
     }
     if (phiError) {
@@ -100,6 +103,8 @@ export function DashboardRecentEpisodes({
     };
   }, [phiError, phiLoading, phiSubjectUserId]);
 
+  const episodesLoading = phiLoading || loading;
+
   return (
     <section
       className={`${cardShellClass} ${className}`.trim()}
@@ -116,19 +121,19 @@ export function DashboardRecentEpisodes({
         and delete actions.
       </p>
 
-      {loading ? (
+      {episodesLoading ? (
         <p className="mt-4 text-sm text-app-muted" aria-busy="true">
           Loading recent episodes…
         </p>
       ) : null}
 
-      {!loading && error ? (
+      {!episodesLoading && error ? (
         <p className="mt-4 text-sm text-red-700 dark:text-red-300" role="alert">
           {error}
         </p>
       ) : null}
 
-      {!loading && !error && episodes.length === 0 ? (
+      {!episodesLoading && !error && episodes.length === 0 ? (
         <p className="mt-4 rounded-xl border border-dashed border-app-border/90 bg-app-bg/40 p-4 text-sm text-app-muted">
           No ended episodes yet.{' '}
           <Link
@@ -141,7 +146,7 @@ export function DashboardRecentEpisodes({
         </p>
       ) : null}
 
-      {!loading && !error && episodes.length > 0 ? (
+      {!episodesLoading && !error && episodes.length > 0 ? (
         <>
           <ul className="mt-4 space-y-3" role="list">
             {episodes.map((ep) => (

--- a/apps/web/src/lib/auth-provider-session.spec.ts
+++ b/apps/web/src/lib/auth-provider-session.spec.ts
@@ -1,25 +1,23 @@
-import { mapSupabaseSessionToAuthContext } from './auth-provider-session';
+import { mapSupabaseUserToAuthContext } from './auth-provider-session';
 
-describe('mapSupabaseSessionToAuthContext', () => {
-  it('returns null when session or user id is missing', () => {
-    expect(mapSupabaseSessionToAuthContext(null)).toBeNull();
+describe('mapSupabaseUserToAuthContext', () => {
+  it('returns null when user or user id is missing', () => {
+    expect(mapSupabaseUserToAuthContext(null)).toBeNull();
+    expect(mapSupabaseUserToAuthContext(undefined)).toBeNull();
     expect(
-      mapSupabaseSessionToAuthContext({
-        user: { id: '', email: 'a@b.com' },
-      }),
+      mapSupabaseUserToAuthContext({ id: '', email: 'a@b.com' }),
     ).toBeNull();
   });
 
   it('maps user id and normalizes null email to undefined', () => {
-    expect(
-      mapSupabaseSessionToAuthContext({
-        user: { id: 'user-1', email: null },
-      }),
-    ).toEqual({ user: { id: 'user-1' } });
+    expect(mapSupabaseUserToAuthContext({ id: 'user-1', email: null })).toEqual(
+      { user: { id: 'user-1' } },
+    );
 
     expect(
-      mapSupabaseSessionToAuthContext({
-        user: { id: 'user-2', email: 'user@example.com' },
+      mapSupabaseUserToAuthContext({
+        id: 'user-2',
+        email: 'user@example.com',
       }),
     ).toEqual({ user: { id: 'user-2', email: 'user@example.com' } });
   });

--- a/apps/web/src/lib/auth-provider-session.ts
+++ b/apps/web/src/lib/auth-provider-session.ts
@@ -4,21 +4,22 @@ export type AuthProviderSession = {
 } | null;
 
 /**
- * Maps a Supabase session from the server client to {@link AuthProviderSession}.
+ * Maps a verified Supabase user from {@link AbstrackSupabaseClient.auth.getUser} to
+ * {@link AuthProviderSession}.
  *
- * @param session - Result of `supabase.auth.getSession()` on the server.
+ * @param user - Authenticated user from `getUser()`, or `null` when signed out.
  * @returns Context session or `null` when signed out.
  */
-export function mapSupabaseSessionToAuthContext(
-  session: { user: { id: string; email?: string | null } } | null,
+export function mapSupabaseUserToAuthContext(
+  user: { id: string; email?: string | null } | null | undefined,
 ): AuthProviderSession {
-  if (!session?.user?.id) {
+  if (!user?.id) {
     return null;
   }
   return {
     user: {
-      id: session.user.id,
-      email: session.user.email ?? undefined,
+      id: user.id,
+      email: user.email ?? undefined,
     },
   };
 }

--- a/apps/web/src/lib/auth-provider.spec.tsx
+++ b/apps/web/src/lib/auth-provider.spec.tsx
@@ -1,4 +1,5 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
+import { isAuthSessionMissingError } from '@abstrack/supabase';
 import { AuthProvider, useAuth } from './auth-provider';
 
 const getUserMock = jest.fn();
@@ -260,6 +261,38 @@ describe('AuthProvider', () => {
 
     expect(getUserMock).toHaveBeenCalledTimes(1);
     expect(readAuthState().userId).toBeNull();
+  });
+
+  it('clears initialSession when getUser returns AuthSessionMissingError', async () => {
+    const missingError = Object.assign(new Error('Auth session missing!'), {
+      name: 'AuthSessionMissingError',
+      __isAuthError: true as const,
+    });
+    expect(isAuthSessionMissingError(missingError)).toBe(true);
+
+    getUserMock.mockResolvedValue({
+      data: { user: null },
+      error: missingError,
+    });
+
+    render(
+      <AuthProvider
+        initialSession={{ user: { id: 'user-1', email: 'user@example.com' } }}
+      >
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().userId).toBeNull();
+    });
+
+    expect(readAuthState()).toEqual({
+      loading: false,
+      userId: null,
+      email: null,
+    });
+    expect(signOutMock).not.toHaveBeenCalled();
   });
 
   it('clears invalid refresh tokens via signOut and still finishes loading', async () => {

--- a/apps/web/src/lib/auth-provider.spec.tsx
+++ b/apps/web/src/lib/auth-provider.spec.tsx
@@ -239,6 +239,29 @@ describe('AuthProvider', () => {
     expect(readAuthState().userId).toBeNull();
   });
 
+  it('does not call getUser again on SIGNED_OUT', async () => {
+    getUserMock.mockResolvedValue({ data: { user: null }, error: null });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    expect(getUserMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      authStateChangeHandler?.('SIGNED_OUT');
+    });
+
+    expect(getUserMock).toHaveBeenCalledTimes(1);
+    expect(readAuthState().userId).toBeNull();
+  });
+
   it('clears invalid refresh tokens via signOut and still finishes loading', async () => {
     getUserMock.mockResolvedValue({
       data: { user: null },

--- a/apps/web/src/lib/auth-provider.spec.tsx
+++ b/apps/web/src/lib/auth-provider.spec.tsx
@@ -1,22 +1,19 @@
 import { act, render, screen, waitFor } from '@testing-library/react';
 import { AuthProvider, useAuth } from './auth-provider';
 
-const getSessionMock = jest.fn();
+const getUserMock = jest.fn();
 const signOutMock = jest.fn().mockResolvedValue({ error: null });
 const onAuthStateChangeMock = jest.fn();
 const unsubscribeMock = jest.fn();
 
 let authStateChangeHandler:
-  | ((
-      event: 'SIGNED_IN' | 'SIGNED_OUT' | 'TOKEN_REFRESHED',
-      session: { user: { id: string; email?: string } } | null,
-    ) => void)
+  | ((event: 'SIGNED_IN' | 'SIGNED_OUT' | 'TOKEN_REFRESHED') => void)
   | undefined;
 
 jest.mock('./supabase/browser-client', () => ({
   createBrowserClient: () => ({
     auth: {
-      getSession: (...args: unknown[]) => getSessionMock(...args),
+      getUser: (...args: unknown[]) => getUserMock(...args),
       signOut: (...args: unknown[]) => signOutMock(...args),
       onAuthStateChange: (handler: typeof authStateChangeHandler) => {
         authStateChangeHandler = handler;
@@ -74,8 +71,8 @@ describe('AuthProvider', () => {
     });
   });
 
-  it('transitions loading from true to false after initial session bootstrap', async () => {
-    getSessionMock.mockResolvedValue({ data: { session: null } });
+  it('transitions loading from true to false after initial user bootstrap', async () => {
+    getUserMock.mockResolvedValue({ data: { user: null } });
 
     render(
       <AuthProvider>
@@ -97,12 +94,18 @@ describe('AuthProvider', () => {
       });
     });
 
-    expect(getSessionMock).toHaveBeenCalledTimes(1);
+    expect(getUserMock).toHaveBeenCalledTimes(1);
     expect(onAuthStateChangeMock).toHaveBeenCalledTimes(1);
   });
 
   it('updates context session when auth state change events fire', async () => {
-    getSessionMock.mockResolvedValue({ data: { session: null } });
+    getUserMock
+      .mockResolvedValueOnce({ data: { user: null } })
+      .mockResolvedValueOnce({
+        data: {
+          user: { id: 'user-123', email: 'patient@example.com' },
+        },
+      });
 
     render(
       <AuthProvider>
@@ -114,12 +117,8 @@ describe('AuthProvider', () => {
       expect(readAuthState().loading).toBe(false);
     });
 
-    const nextSession = {
-      user: { id: 'user-123', email: 'patient@example.com' },
-    };
-
     act(() => {
-      authStateChangeHandler?.('SIGNED_IN', nextSession);
+      authStateChangeHandler?.('SIGNED_IN');
     });
 
     await waitFor(() => {
@@ -129,10 +128,12 @@ describe('AuthProvider', () => {
         email: 'patient@example.com',
       });
     });
+
+    expect(getUserMock).toHaveBeenCalledTimes(2);
   });
 
   it('unsubscribes from auth events on unmount', () => {
-    getSessionMock.mockResolvedValue({ data: { session: null } });
+    getUserMock.mockResolvedValue({ data: { user: null } });
 
     const { unmount } = render(
       <AuthProvider>
@@ -146,8 +147,8 @@ describe('AuthProvider', () => {
   });
 
   it('clears invalid refresh tokens via signOut and still finishes loading', async () => {
-    getSessionMock.mockResolvedValue({
-      data: { session: null },
+    getUserMock.mockResolvedValue({
+      data: { user: null },
       error: {
         code: 'refresh_token_not_found',
         message: 'Invalid Refresh Token: Refresh Token Not Found',

--- a/apps/web/src/lib/auth-provider.spec.tsx
+++ b/apps/web/src/lib/auth-provider.spec.tsx
@@ -195,6 +195,50 @@ describe('AuthProvider', () => {
     expect(signOutMock).not.toHaveBeenCalled();
   });
 
+  it('does not restore session when SIGNED_OUT invalidates an in-flight SIGNED_IN verify', async () => {
+    type GetUserResult = Awaited<ReturnType<typeof getUserMock>>;
+    let resolveSlow: (value: GetUserResult) => void;
+    const slowGetUser = new Promise<GetUserResult>((resolve) => {
+      resolveSlow = resolve;
+    });
+
+    getUserMock
+      .mockResolvedValueOnce({ data: { user: null }, error: null })
+      .mockReturnValueOnce(slowGetUser)
+      .mockResolvedValue({ data: { user: null }, error: null });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    act(() => {
+      authStateChangeHandler?.('SIGNED_IN');
+    });
+    act(() => {
+      authStateChangeHandler?.('SIGNED_OUT');
+    });
+
+    expect(readAuthState().userId).toBeNull();
+
+    await act(async () => {
+      resolveSlow({
+        data: {
+          user: { id: 'stale-user', email: 'stale@example.com' },
+        },
+        error: null,
+      });
+      await slowGetUser;
+    });
+
+    expect(readAuthState().userId).toBeNull();
+  });
+
   it('clears invalid refresh tokens via signOut and still finishes loading', async () => {
     getUserMock.mockResolvedValue({
       data: { user: null },

--- a/apps/web/src/lib/auth-provider.spec.tsx
+++ b/apps/web/src/lib/auth-provider.spec.tsx
@@ -146,6 +146,55 @@ describe('AuthProvider', () => {
     expect(unsubscribeMock).toHaveBeenCalledTimes(1);
   });
 
+  it('preserves initialSession when getUser returns a transient error', async () => {
+    getUserMock.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'Failed to fetch' },
+    });
+
+    render(
+      <AuthProvider
+        initialSession={{ user: { id: 'user-1', email: 'user@example.com' } }}
+      >
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(getUserMock).toHaveBeenCalled();
+    });
+
+    expect(readAuthState()).toEqual({
+      loading: false,
+      userId: 'user-1',
+      email: 'user@example.com',
+    });
+    expect(signOutMock).not.toHaveBeenCalled();
+  });
+
+  it('preserves initialSession when getUser throws a transient error', async () => {
+    getUserMock.mockRejectedValue(new TypeError('Failed to fetch'));
+
+    render(
+      <AuthProvider
+        initialSession={{ user: { id: 'user-1', email: 'user@example.com' } }}
+      >
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(getUserMock).toHaveBeenCalled();
+    });
+
+    expect(readAuthState()).toEqual({
+      loading: false,
+      userId: 'user-1',
+      email: 'user@example.com',
+    });
+    expect(signOutMock).not.toHaveBeenCalled();
+  });
+
   it('clears invalid refresh tokens via signOut and still finishes loading', async () => {
     getUserMock.mockResolvedValue({
       data: { user: null },

--- a/apps/web/src/lib/auth-provider.tsx
+++ b/apps/web/src/lib/auth-provider.tsx
@@ -97,9 +97,13 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
         } = result;
 
         if (error) {
-          if (!isAuthSessionMissingError(error)) {
-            console.error('Failed to verify authenticated user', error);
+          if (isAuthSessionMissingError(error)) {
+            if (mounted && generation === verifyGenerationRef.current) {
+              setSession(null);
+            }
+            return;
           }
+          console.error('Failed to verify authenticated user', error);
           if (isRefreshTokenFailure(error)) {
             await supabase.auth.signOut();
             if (mounted && generation === verifyGenerationRef.current) {
@@ -113,9 +117,13 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
           setSession(mapSupabaseUserToAuthContext(user));
         }
       } catch (error) {
-        if (!isAuthSessionMissingError(error)) {
-          console.error('Failed to verify authenticated user', error);
+        if (isAuthSessionMissingError(error)) {
+          if (mounted && generation === verifyGenerationRef.current) {
+            setSession(null);
+          }
+          return;
         }
+        console.error('Failed to verify authenticated user', error);
         if (isRefreshTokenFailure(error)) {
           await supabase.auth.signOut();
           if (mounted && generation === verifyGenerationRef.current) {

--- a/apps/web/src/lib/auth-provider.tsx
+++ b/apps/web/src/lib/auth-provider.tsx
@@ -3,7 +3,7 @@
 import { createContext, useContext, useEffect, useState } from 'react';
 import {
   type AuthProviderSession,
-  mapSupabaseSessionToAuthContext,
+  mapSupabaseUserToAuthContext,
 } from './auth-provider-session';
 import { createBrowserClient } from './supabase/browser-client';
 
@@ -19,14 +19,14 @@ export type AuthProviderProps = {
   /**
    * Server-hydrated session from the root layout. When provided (including `null`),
    * `loading` starts `false` so authenticated private routes can render app chrome on
-   * first paint without waiting for client `getSession`.
+   * first paint without waiting for client `getUser`.
    */
   initialSession?: AuthProviderSession | null;
 };
 
 const AuthContext = createContext<AuthContextType | null>(null);
 
-/** Avoid infinite loading if `getSession` never settles (e.g. bad refresh cookie edge cases). */
+/** Avoid infinite loading if `getUser` never settles (e.g. bad refresh cookie edge cases). */
 const SESSION_BOOTSTRAP_TIMEOUT_MS = 8_000;
 
 function isRefreshTokenFailure(error: unknown): boolean {
@@ -58,8 +58,7 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
     let mounted = true;
     const supabase = createBrowserClient();
 
-    // Get initial session and always clear loading, even on failure.
-    const initializeSession = async () => {
+    const syncVerifiedUser = async (): Promise<void> => {
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
       try {
         const timeoutPromise = new Promise<never>((_, reject) => {
@@ -69,27 +68,26 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
         });
 
         const {
-          data: { session: nextSession },
+          data: { user },
           error,
-        } = await Promise.race([
-          supabase.auth.getSession(),
-          timeoutPromise,
-        ]).catch(async (raceError: unknown) => {
-          if (
-            raceError instanceof Error &&
-            raceError.message === 'session_bootstrap_timeout'
-          ) {
-            console.warn(
-              'Auth session bootstrap timed out; clearing local session',
-            );
-            await supabase.auth.signOut();
-            return { data: { session: null }, error: null };
-          }
-          throw raceError;
-        });
+        } = await Promise.race([supabase.auth.getUser(), timeoutPromise]).catch(
+          async (raceError: unknown) => {
+            if (
+              raceError instanceof Error &&
+              raceError.message === 'session_bootstrap_timeout'
+            ) {
+              console.warn(
+                'Auth user bootstrap timed out; clearing local session',
+              );
+              await supabase.auth.signOut();
+              return { data: { user: null }, error: null };
+            }
+            throw raceError;
+          },
+        );
 
         if (error) {
-          console.error('Failed to load auth session', error);
+          console.error('Failed to verify authenticated user', error);
           if (isRefreshTokenFailure(error)) {
             await supabase.auth.signOut();
           }
@@ -100,30 +98,39 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
         }
 
         if (mounted) {
-          setSession(mapSupabaseSessionToAuthContext(nextSession));
+          setSession(mapSupabaseUserToAuthContext(user));
         }
       } catch (error) {
-        console.error('Failed to load auth session', error);
+        console.error('Failed to verify authenticated user', error);
         if (isRefreshTokenFailure(error)) {
           await supabase.auth.signOut();
+        }
+        if (mounted) {
+          setSession(null);
         }
       } finally {
         if (timeoutId !== undefined) {
           clearTimeout(timeoutId);
         }
+      }
+    };
+
+    const initializeAuth = async () => {
+      try {
+        await syncVerifiedUser();
+      } finally {
         if (mounted) {
           setLoading(false);
         }
       }
     };
 
-    void initializeSession();
+    void initializeAuth();
 
-    // Listen for auth state changes
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((_event, session) => {
-      setSession(mapSupabaseSessionToAuthContext(session));
+    } = supabase.auth.onAuthStateChange(() => {
+      void syncVerifiedUser();
     });
 
     return () => {

--- a/apps/web/src/lib/auth-provider.tsx
+++ b/apps/web/src/lib/auth-provider.tsx
@@ -144,6 +144,7 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
         if (mounted) {
           setSession(null);
         }
+        return;
       }
       void syncVerifiedUser();
     });

--- a/apps/web/src/lib/auth-provider.tsx
+++ b/apps/web/src/lib/auth-provider.tsx
@@ -67,32 +67,38 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
           }, SESSION_BOOTSTRAP_TIMEOUT_MS);
         });
 
+        const result = await Promise.race([
+          supabase.auth.getUser(),
+          timeoutPromise,
+        ]).catch(async (raceError: unknown) => {
+          if (
+            raceError instanceof Error &&
+            raceError.message === 'session_bootstrap_timeout'
+          ) {
+            console.warn(
+              'Auth user bootstrap timed out; keeping in-memory session',
+            );
+            return null;
+          }
+          throw raceError;
+        });
+
+        if (result === null) {
+          return;
+        }
+
         const {
           data: { user },
           error,
-        } = await Promise.race([supabase.auth.getUser(), timeoutPromise]).catch(
-          async (raceError: unknown) => {
-            if (
-              raceError instanceof Error &&
-              raceError.message === 'session_bootstrap_timeout'
-            ) {
-              console.warn(
-                'Auth user bootstrap timed out; clearing local session',
-              );
-              await supabase.auth.signOut();
-              return { data: { user: null }, error: null };
-            }
-            throw raceError;
-          },
-        );
+        } = result;
 
         if (error) {
           console.error('Failed to verify authenticated user', error);
           if (isRefreshTokenFailure(error)) {
             await supabase.auth.signOut();
-          }
-          if (mounted) {
-            setSession(null);
+            if (mounted) {
+              setSession(null);
+            }
           }
           return;
         }
@@ -104,9 +110,9 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
         console.error('Failed to verify authenticated user', error);
         if (isRefreshTokenFailure(error)) {
           await supabase.auth.signOut();
-        }
-        if (mounted) {
-          setSession(null);
+          if (mounted) {
+            setSession(null);
+          }
         }
       } finally {
         if (timeoutId !== undefined) {

--- a/apps/web/src/lib/auth-provider.tsx
+++ b/apps/web/src/lib/auth-provider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useContext, useEffect, useState } from 'react';
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import {
   type AuthProviderSession,
   mapSupabaseUserToAuthContext,
@@ -53,12 +53,15 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
     hasInitialSession ? initialSession : null,
   );
   const [loading, setLoading] = useState(!hasInitialSession);
+  /** Drops stale verify completions after newer auth events or unmount. */
+  const verifyGenerationRef = useRef(0);
 
   useEffect(() => {
     let mounted = true;
     const supabase = createBrowserClient();
 
     const syncVerifiedUser = async (): Promise<void> => {
+      const generation = ++verifyGenerationRef.current;
       let timeoutId: ReturnType<typeof setTimeout> | undefined;
       try {
         const timeoutPromise = new Promise<never>((_, reject) => {
@@ -96,21 +99,21 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
           console.error('Failed to verify authenticated user', error);
           if (isRefreshTokenFailure(error)) {
             await supabase.auth.signOut();
-            if (mounted) {
+            if (mounted && generation === verifyGenerationRef.current) {
               setSession(null);
             }
           }
           return;
         }
 
-        if (mounted) {
+        if (mounted && generation === verifyGenerationRef.current) {
           setSession(mapSupabaseUserToAuthContext(user));
         }
       } catch (error) {
         console.error('Failed to verify authenticated user', error);
         if (isRefreshTokenFailure(error)) {
           await supabase.auth.signOut();
-          if (mounted) {
+          if (mounted && generation === verifyGenerationRef.current) {
             setSession(null);
           }
         }
@@ -135,12 +138,19 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange(() => {
+    } = supabase.auth.onAuthStateChange((event) => {
+      if (event === 'SIGNED_OUT') {
+        verifyGenerationRef.current += 1;
+        if (mounted) {
+          setSession(null);
+        }
+      }
       void syncVerifiedUser();
     });
 
     return () => {
       mounted = false;
+      verifyGenerationRef.current += 1;
       subscription.unsubscribe();
     };
   }, []);

--- a/apps/web/src/lib/auth-provider.tsx
+++ b/apps/web/src/lib/auth-provider.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { isAuthSessionMissingError } from '@abstrack/supabase';
 import { createContext, useContext, useEffect, useRef, useState } from 'react';
 import {
   type AuthProviderSession,
@@ -96,7 +97,9 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
         } = result;
 
         if (error) {
-          console.error('Failed to verify authenticated user', error);
+          if (!isAuthSessionMissingError(error)) {
+            console.error('Failed to verify authenticated user', error);
+          }
           if (isRefreshTokenFailure(error)) {
             await supabase.auth.signOut();
             if (mounted && generation === verifyGenerationRef.current) {
@@ -110,7 +113,9 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
           setSession(mapSupabaseUserToAuthContext(user));
         }
       } catch (error) {
-        console.error('Failed to verify authenticated user', error);
+        if (!isAuthSessionMissingError(error)) {
+          console.error('Failed to verify authenticated user', error);
+        }
         if (isRefreshTokenFailure(error)) {
           await supabase.auth.signOut();
           if (mounted && generation === verifyGenerationRef.current) {

--- a/apps/web/src/lib/auth/auth-callback-fragment-helpers.spec.ts
+++ b/apps/web/src/lib/auth/auth-callback-fragment-helpers.spec.ts
@@ -1,4 +1,7 @@
-import { parseImplicitHashParams } from './auth-callback-fragment-helpers';
+import {
+  isSupabaseAuthApiError,
+  parseImplicitHashParams,
+} from './auth-callback-fragment-helpers';
 
 describe('parseImplicitHashParams', () => {
   it('parses access_token and refresh_token from a Supabase-style hash', () => {
@@ -10,5 +13,20 @@ describe('parseImplicitHashParams', () => {
       expires_in: '3600',
       token_type: 'bearer',
     });
+  });
+});
+
+describe('isSupabaseAuthApiError', () => {
+  it('returns true for Supabase Auth API errors', () => {
+    expect(
+      isSupabaseAuthApiError({
+        __isAuthError: true,
+        message: 'Network error',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for ordinary errors', () => {
+    expect(isSupabaseAuthApiError(new Error('nope'))).toBe(false);
   });
 });

--- a/apps/web/src/lib/auth/auth-callback-fragment-helpers.spec.ts
+++ b/apps/web/src/lib/auth/auth-callback-fragment-helpers.spec.ts
@@ -1,7 +1,4 @@
-import {
-  isSupabaseAuthApiError,
-  parseImplicitHashParams,
-} from './auth-callback-fragment-helpers';
+import { parseImplicitHashParams } from './auth-callback-fragment-helpers';
 
 describe('parseImplicitHashParams', () => {
   it('parses access_token and refresh_token from a Supabase-style hash', () => {
@@ -13,20 +10,5 @@ describe('parseImplicitHashParams', () => {
       expires_in: '3600',
       token_type: 'bearer',
     });
-  });
-});
-
-describe('isSupabaseAuthApiError', () => {
-  it('returns true for Supabase Auth API errors', () => {
-    expect(
-      isSupabaseAuthApiError({
-        __isAuthError: true,
-        message: 'Network error',
-      }),
-    ).toBe(true);
-  });
-
-  it('returns false for ordinary errors', () => {
-    expect(isSupabaseAuthApiError(new Error('nope'))).toBe(false);
   });
 });

--- a/apps/web/src/lib/auth/auth-callback-fragment-helpers.ts
+++ b/apps/web/src/lib/auth/auth-callback-fragment-helpers.ts
@@ -16,20 +16,6 @@ export function parseImplicitHashParams(hash: string): Record<string, string> {
 }
 
 /**
- * True when `err` is a Supabase Auth API error from `getUser()` / `setSession()` (not a config throw).
- *
- * @param err - Value from `catch` or `getUser()` `error`.
- */
-export function isSupabaseAuthApiError(err: unknown): boolean {
-  return (
-    typeof err === 'object' &&
-    err !== null &&
-    '__isAuthError' in err &&
-    (err as { __isAuthError?: boolean }).__isAuthError === true
-  );
-}
-
-/**
  * True when `createBrowserClient()` failed because URL / publishable key env is missing or invalid
  * (throws from `apps/web` Supabase env helpers or `@abstrack/supabase` publishable key guards).
  *

--- a/apps/web/src/lib/auth/auth-callback-fragment-helpers.ts
+++ b/apps/web/src/lib/auth/auth-callback-fragment-helpers.ts
@@ -16,6 +16,20 @@ export function parseImplicitHashParams(hash: string): Record<string, string> {
 }
 
 /**
+ * True when `err` is a Supabase Auth API error from `getUser()` / `setSession()` (not a config throw).
+ *
+ * @param err - Value from `catch` or `getUser()` `error`.
+ */
+export function isSupabaseAuthApiError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    '__isAuthError' in err &&
+    (err as { __isAuthError?: boolean }).__isAuthError === true
+  );
+}
+
+/**
  * True when `createBrowserClient()` failed because URL / publishable key env is missing or invalid
  * (throws from `apps/web` Supabase env helpers or `@abstrack/supabase` publishable key guards).
  *

--- a/apps/web/src/lib/auth/auth-callback-redirect.spec.ts
+++ b/apps/web/src/lib/auth/auth-callback-redirect.spec.ts
@@ -1,5 +1,6 @@
 import {
   AUTH_CALLBACK_INVALID_LINK_MESSAGE,
+  AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
   getSafeAuthCallbackRedirectPath,
 } from './auth-callback-redirect';
 
@@ -24,5 +25,13 @@ describe('getSafeAuthCallbackRedirectPath', () => {
 describe('AUTH_CALLBACK_INVALID_LINK_MESSAGE', () => {
   it('is a non-empty user-facing string', () => {
     expect(AUTH_CALLBACK_INVALID_LINK_MESSAGE.length).toBeGreaterThan(10);
+  });
+});
+
+describe('AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE', () => {
+  it('is a non-empty user-facing string', () => {
+    expect(AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE.length).toBeGreaterThan(
+      10,
+    );
   });
 });

--- a/apps/web/src/lib/auth/auth-callback-redirect.ts
+++ b/apps/web/src/lib/auth/auth-callback-redirect.ts
@@ -7,6 +7,13 @@ export const AUTH_CALLBACK_INVALID_LINK_MESSAGE =
   'This sign-in link is invalid or expired. Request a new one.';
 
 /**
+ * User-facing message when {@link AbstrackSupabaseClient.auth.getUser} fails during callback
+ * handling (distinct from an invalid or expired link).
+ */
+export const AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE =
+  "We couldn't verify your sign-in. Try again in a moment.";
+
+/**
  * Returns a same-origin relative path for post-auth redirect, or the default when `next` is unsafe.
  *
  * @param nextParam - Optional `next` query value from `/auth/callback`.

--- a/apps/web/src/lib/patient/caretaker-edge-client.ts
+++ b/apps/web/src/lib/patient/caretaker-edge-client.ts
@@ -1,6 +1,10 @@
 'use client';
 
-import { getSupabasePublishableKey, getSupabaseUrl } from '@abstrack/supabase';
+import {
+  getAccessTokenFromSession,
+  getSupabasePublishableKey,
+  getSupabaseUrl,
+} from '@abstrack/supabase';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 
 /**
@@ -89,14 +93,11 @@ export function caretakerEdgeClientPreflightErrorMessage(
 
 async function requireAccessToken(): Promise<string> {
   const supabase = createBrowserClient();
-  const {
-    data: { session },
-    error,
-  } = await supabase.auth.getSession();
-  if (error || !session?.access_token?.trim()) {
+  const { accessToken, error } = await getAccessTokenFromSession(supabase);
+  if (error || !accessToken) {
     throw new Error(PATIENT_CARETAKER_ACCESS_ERROR_MISSING_TOKEN);
   }
-  return session.access_token;
+  return accessToken;
 }
 
 /**

--- a/apps/web/src/lib/patient/practitioner-edge-client.ts
+++ b/apps/web/src/lib/patient/practitioner-edge-client.ts
@@ -1,6 +1,10 @@
 'use client';
 
-import { getSupabasePublishableKey, getSupabaseUrl } from '@abstrack/supabase';
+import {
+  getAccessTokenFromSession,
+  getSupabasePublishableKey,
+  getSupabaseUrl,
+} from '@abstrack/supabase';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 
 /**
@@ -76,14 +80,11 @@ export function practitionerEdgeClientPreflightErrorMessage(
 
 async function requireAccessToken(): Promise<string> {
   const supabase = createBrowserClient();
-  const {
-    data: { session },
-    error,
-  } = await supabase.auth.getSession();
-  if (error || !session?.access_token?.trim()) {
+  const { accessToken, error } = await getAccessTokenFromSession(supabase);
+  if (error || !accessToken) {
     throw new Error(PATIENT_PRACTITIONER_ACCESS_ERROR_MISSING_TOKEN);
   }
-  return session.access_token;
+  return accessToken;
 }
 
 async function invokeWithPractitionerClientEnvGuards<T>(

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -23,6 +23,7 @@ export {
   getAuthUser,
   getSession,
   getVerifiedAuthSession,
+  isSupabaseAuthApiError,
   resetPasswordForEmail,
   signInWithEmailPassword,
   signOut,

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -19,8 +19,10 @@ export {
   type NativeClientOptions,
 } from './lib/native-client.js';
 export {
+  getAccessTokenFromSession,
   getAuthUser,
   getSession,
+  getVerifiedAuthSession,
   resetPasswordForEmail,
   signInWithEmailPassword,
   signOut,

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -23,6 +23,7 @@ export {
   getAuthUser,
   getSession,
   getVerifiedAuthSession,
+  isAuthSessionMissingError,
   isSupabaseAuthApiError,
   resetPasswordForEmail,
   signInWithEmailPassword,

--- a/packages/supabase/src/lib/auth-errors.spec.ts
+++ b/packages/supabase/src/lib/auth-errors.spec.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { isSupabaseAuthApiError } from './auth.js';
+
+describe('isSupabaseAuthApiError', () => {
+  it('returns true for Supabase Auth API errors', () => {
+    expect(
+      isSupabaseAuthApiError({
+        __isAuthError: true,
+        message: 'Network error',
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false for ordinary errors', () => {
+    expect(isSupabaseAuthApiError(new Error('nope'))).toBe(false);
+  });
+});

--- a/packages/supabase/src/lib/auth-errors.spec.ts
+++ b/packages/supabase/src/lib/auth-errors.spec.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isSupabaseAuthApiError } from './auth.js';
+import { isAuthSessionMissingError, isSupabaseAuthApiError } from './auth.js';
 
 describe('isSupabaseAuthApiError', () => {
   it('returns true for Supabase Auth API errors', () => {
@@ -13,5 +13,26 @@ describe('isSupabaseAuthApiError', () => {
 
   it('returns false for ordinary errors', () => {
     expect(isSupabaseAuthApiError(new Error('nope'))).toBe(false);
+  });
+});
+
+describe('isAuthSessionMissingError', () => {
+  it('returns true for AuthSessionMissingError', () => {
+    expect(
+      isAuthSessionMissingError(
+        Object.assign(new Error('Auth session missing!'), {
+          name: 'AuthSessionMissingError',
+        }),
+      ),
+    ).toBe(true);
+  });
+
+  it('returns false for other auth errors', () => {
+    expect(
+      isAuthSessionMissingError({
+        __isAuthError: true,
+        message: 'Invalid JWT',
+      }),
+    ).toBe(false);
   });
 });

--- a/packages/supabase/src/lib/auth-session.spec.ts
+++ b/packages/supabase/src/lib/auth-session.spec.ts
@@ -120,7 +120,28 @@ describe('getAccessTokenFromSession', () => {
 });
 
 describe('getVerifiedAuthSession', () => {
-  it('returns null user and session when getUser fails', async () => {
+  it('returns signed out when getUser reports AuthSessionMissingError', async () => {
+    const missingError = Object.assign(new Error('Auth session missing!'), {
+      name: 'AuthSessionMissingError',
+    });
+    const client = createAuthMockClient({
+      getUser: async () => ({
+        data: { user: null },
+        error: missingError,
+      }),
+      getSession: async () => {
+        throw new Error('getSession should not run');
+      },
+    });
+
+    expect(await getVerifiedAuthSession(client)).toEqual({
+      data: { user: null, session: null },
+      error: null,
+    });
+    expect(client.auth.getSession).not.toHaveBeenCalled();
+  });
+
+  it('returns null user and session when getUser fails with a real error', async () => {
     const userError = new Error('getUser failed');
     const client = createAuthMockClient({
       getUser: async () => ({
@@ -157,6 +178,27 @@ describe('getVerifiedAuthSession', () => {
       error: null,
     });
     expect(client.auth.getSession).not.toHaveBeenCalled();
+  });
+
+  it('returns signed out when getSession reports AuthSessionMissingError', async () => {
+    const missingError = Object.assign(new Error('Auth session missing!'), {
+      name: 'AuthSessionMissingError',
+    });
+    const client = createAuthMockClient({
+      getUser: async () => ({
+        data: { user: verifiedUser },
+        error: null,
+      }),
+      getSession: async () => ({
+        data: { session: null },
+        error: missingError,
+      }),
+    });
+
+    expect(await getVerifiedAuthSession(client)).toEqual({
+      data: { user: null, session: null },
+      error: null,
+    });
   });
 
   it('keeps the verified user when getSession fails', async () => {

--- a/packages/supabase/src/lib/auth-session.spec.ts
+++ b/packages/supabase/src/lib/auth-session.spec.ts
@@ -1,0 +1,223 @@
+import type { Session, User } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+import { getAccessTokenFromSession, getVerifiedAuthSession } from './auth.js';
+
+const verifiedUser = {
+  id: 'user-verified',
+  email: 'verified@example.com',
+} as User;
+
+function makePersistedSession(overrides?: Partial<Session>): Session {
+  return {
+    access_token: 'persisted-access',
+    refresh_token: 'persisted-refresh',
+    expires_in: 3600,
+    expires_at: 1_700_000_000,
+    token_type: 'bearer',
+    user: {
+      id: 'stale-session-user',
+      aud: 'authenticated',
+      role: 'authenticated',
+      email: 'stale@example.com',
+      email_confirmed_at: null,
+      phone: '',
+      confirmed_at: null,
+      last_sign_in_at: null,
+      app_metadata: {},
+      user_metadata: {},
+      identities: [],
+      created_at: '',
+      updated_at: '',
+      is_anonymous: false,
+    },
+    ...overrides,
+  } as Session;
+}
+
+function createAuthMockClient(handlers: {
+  getUser?: () => Promise<{
+    data: { user: User | null };
+    error: Error | null;
+  }>;
+  getSession?: () => Promise<{
+    data: { session: Session | null };
+    error: Error | null;
+  }>;
+}): AbstrackSupabaseClient {
+  return {
+    auth: {
+      getUser: vi.fn(handlers.getUser),
+      getSession: vi.fn(handlers.getSession),
+    },
+  } as unknown as AbstrackSupabaseClient;
+}
+
+describe('getAccessTokenFromSession', () => {
+  it('returns a trimmed access token when the persisted session has one', async () => {
+    const client = createAuthMockClient({
+      getSession: async () => ({
+        data: {
+          session: makePersistedSession({
+            access_token: '  trimmed-token  ',
+          }),
+        },
+        error: null,
+      }),
+    });
+
+    const result = await getAccessTokenFromSession(client);
+
+    expect(result).toEqual({
+      accessToken: 'trimmed-token',
+      error: null,
+    });
+    expect(client.auth.getSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null when the access token is missing or whitespace-only', async () => {
+    const client = createAuthMockClient({
+      getSession: async () => ({
+        data: { session: makePersistedSession({ access_token: '   ' }) },
+        error: null,
+      }),
+    });
+
+    expect(await getAccessTokenFromSession(client)).toEqual({
+      accessToken: null,
+      error: null,
+    });
+  });
+
+  it('returns null when there is no persisted session', async () => {
+    const client = createAuthMockClient({
+      getSession: async () => ({
+        data: { session: null },
+        error: null,
+      }),
+    });
+
+    expect(await getAccessTokenFromSession(client)).toEqual({
+      accessToken: null,
+      error: null,
+    });
+  });
+
+  it('returns the getSession error without reading session.user', async () => {
+    const sessionError = new Error('session read failed');
+    const client = createAuthMockClient({
+      getSession: async () => ({
+        data: { session: null },
+        error: sessionError,
+      }),
+    });
+
+    expect(await getAccessTokenFromSession(client)).toEqual({
+      accessToken: null,
+      error: sessionError,
+    });
+  });
+});
+
+describe('getVerifiedAuthSession', () => {
+  it('returns null user and session when getUser fails', async () => {
+    const userError = new Error('getUser failed');
+    const client = createAuthMockClient({
+      getUser: async () => ({
+        data: { user: null },
+        error: userError,
+      }),
+      getSession: async () => {
+        throw new Error('getSession should not run');
+      },
+    });
+
+    const result = await getVerifiedAuthSession(client);
+
+    expect(result).toEqual({
+      data: { user: null, session: null },
+      error: userError,
+    });
+    expect(client.auth.getSession).not.toHaveBeenCalled();
+  });
+
+  it('returns signed out when getUser succeeds with no user', async () => {
+    const client = createAuthMockClient({
+      getUser: async () => ({
+        data: { user: null },
+        error: null,
+      }),
+      getSession: async () => {
+        throw new Error('getSession should not run');
+      },
+    });
+
+    expect(await getVerifiedAuthSession(client)).toEqual({
+      data: { user: null, session: null },
+      error: null,
+    });
+    expect(client.auth.getSession).not.toHaveBeenCalled();
+  });
+
+  it('keeps the verified user when getSession fails', async () => {
+    const sessionError = new Error('getSession failed');
+    const client = createAuthMockClient({
+      getUser: async () => ({
+        data: { user: verifiedUser },
+        error: null,
+      }),
+      getSession: async () => ({
+        data: { session: null },
+        error: sessionError,
+      }),
+    });
+
+    expect(await getVerifiedAuthSession(client)).toEqual({
+      data: { user: verifiedUser, session: null },
+      error: sessionError,
+    });
+  });
+
+  it('returns verified user with null session when persisted session is missing', async () => {
+    const client = createAuthMockClient({
+      getUser: async () => ({
+        data: { user: verifiedUser },
+        error: null,
+      }),
+      getSession: async () => ({
+        data: { session: null },
+        error: null,
+      }),
+    });
+
+    expect(await getVerifiedAuthSession(client)).toEqual({
+      data: { user: verifiedUser, session: null },
+      error: null,
+    });
+  });
+
+  it('merges the verified user onto the persisted session', async () => {
+    const persisted = makePersistedSession();
+    const client = createAuthMockClient({
+      getUser: async () => ({
+        data: { user: verifiedUser },
+        error: null,
+      }),
+      getSession: async () => ({
+        data: { session: persisted },
+        error: null,
+      }),
+    });
+
+    const result = await getVerifiedAuthSession(client);
+
+    expect(result.error).toBeNull();
+    expect(result.data.user).toEqual(verifiedUser);
+    expect(result.data.session).toEqual({
+      ...persisted,
+      user: verifiedUser,
+    });
+    expect(result.data.session?.user.id).toBe('user-verified');
+    expect(result.data.session?.access_token).toBe('persisted-access');
+  });
+});

--- a/packages/supabase/src/lib/auth.ts
+++ b/packages/supabase/src/lib/auth.ts
@@ -79,6 +79,21 @@ export async function getAuthUser(client: AbstrackSupabaseClient) {
 }
 
 /**
+ * True when `err` is a Supabase Auth API error from `getUser()` / `setSession()` (not a config throw).
+ *
+ * @param err - Value from `catch` or auth method `error`.
+ * @returns Whether `err` is tagged as a Supabase Auth API error (`__isAuthError`).
+ */
+export function isSupabaseAuthApiError(err: unknown): boolean {
+  return (
+    typeof err === 'object' &&
+    err !== null &&
+    '__isAuthError' in err &&
+    (err as { __isAuthError?: boolean }).__isAuthError === true
+  );
+}
+
+/**
  * Returns a trimmed access token from {@link getSession} without using `session.user`
  * for identity (avoids Supabase insecure-user warnings).
  *

--- a/packages/supabase/src/lib/auth.ts
+++ b/packages/supabase/src/lib/auth.ts
@@ -114,7 +114,7 @@ export async function getVerifiedAuthSession(
   data: { user: User | null; session: Session | null };
   error: Error | null;
 }> {
-  const { data: userData, error: userError } = await client.auth.getUser();
+  const { data: userData, error: userError } = await getAuthUser(client);
   if (userError) {
     return { data: { user: null, session: null }, error: userError };
   }
@@ -123,8 +123,7 @@ export async function getVerifiedAuthSession(
     return { data: { user: null, session: null }, error: null };
   }
 
-  const { data: sessionData, error: sessionError } =
-    await client.auth.getSession();
+  const { data: sessionData, error: sessionError } = await getSession(client);
   if (sessionError) {
     return { data: { user, session: null }, error: sessionError };
   }

--- a/packages/supabase/src/lib/auth.ts
+++ b/packages/supabase/src/lib/auth.ts
@@ -104,7 +104,9 @@ export async function getAccessTokenFromSession(
  * Use instead of trusting `getSession().data.session.user` alone.
  *
  * @param client - Supabase client.
- * @returns Verified user, session (with verified user), and any error.
+ * @returns Verified user, session (with verified user), and any error. When `getUser()`
+ * succeeds but `getSession()` fails, returns the verified `user` with `session: null` and the
+ * session error (does not discard the verified user).
  */
 export async function getVerifiedAuthSession(
   client: AbstrackSupabaseClient,
@@ -124,7 +126,7 @@ export async function getVerifiedAuthSession(
   const { data: sessionData, error: sessionError } =
     await client.auth.getSession();
   if (sessionError) {
-    return { data: { user: null, session: null }, error: sessionError };
+    return { data: { user, session: null }, error: sessionError };
   }
 
   const persisted = sessionData.session;

--- a/packages/supabase/src/lib/auth.ts
+++ b/packages/supabase/src/lib/auth.ts
@@ -141,7 +141,8 @@ export async function getAccessTokenFromSession(
  * @param client - Supabase client.
  * @returns Verified user, session (with verified user), and any error. When `getUser()`
  * succeeds but `getSession()` fails, returns the verified `user` with `session: null` and the
- * session error (does not discard the verified user).
+ * session error (does not discard the verified user). {@link AuthSessionMissingError} from
+ * `getUser()` is treated as signed out (`error: null`), not a verification failure.
  */
 export async function getVerifiedAuthSession(
   client: AbstrackSupabaseClient,
@@ -151,6 +152,9 @@ export async function getVerifiedAuthSession(
 }> {
   const { data: userData, error: userError } = await getAuthUser(client);
   if (userError) {
+    if (isAuthSessionMissingError(userError)) {
+      return { data: { user: null, session: null }, error: null };
+    }
     return { data: { user: null, session: null }, error: userError };
   }
   const user = userData.user;
@@ -160,6 +164,9 @@ export async function getVerifiedAuthSession(
 
   const { data: sessionData, error: sessionError } = await getSession(client);
   if (sessionError) {
+    if (isAuthSessionMissingError(sessionError)) {
+      return { data: { user: null, session: null }, error: null };
+    }
     return { data: { user, session: null }, error: sessionError };
   }
 

--- a/packages/supabase/src/lib/auth.ts
+++ b/packages/supabase/src/lib/auth.ts
@@ -79,8 +79,11 @@ export async function getAuthUser(client: AbstrackSupabaseClient) {
 }
 
 /**
- * Returns a trimmed access token from persisted session storage only.
- * Does not read `session.user` (avoids Supabase insecure-user warnings).
+ * Returns a trimmed access token from {@link getSession} without using `session.user`
+ * for identity (avoids Supabase insecure-user warnings).
+ *
+ * `getSession()` may refresh expired tokens over the network; this is not a guaranteed
+ * local-only storage read.
  *
  * @param client - Supabase client.
  * @returns Access token or `null` when missing or on error.

--- a/packages/supabase/src/lib/auth.ts
+++ b/packages/supabase/src/lib/auth.ts
@@ -94,6 +94,23 @@ export function isSupabaseAuthApiError(err: unknown): boolean {
 }
 
 /**
+ * True when `getUser()` failed because there is no session (e.g. after logout or before sign-in).
+ * Expected on public routes — not a verification failure.
+ *
+ * @param err - Value from `getUser()` `error`.
+ */
+export function isAuthSessionMissingError(err: unknown): boolean {
+  if (!err || typeof err !== 'object') {
+    return false;
+  }
+  const e = err as { name?: string; message?: string };
+  return (
+    e.name === 'AuthSessionMissingError' ||
+    (typeof e.message === 'string' && /auth session missing/i.test(e.message))
+  );
+}
+
+/**
  * Returns a trimmed access token from {@link getSession} without using `session.user`
  * for identity (avoids Supabase insecure-user warnings).
  *

--- a/packages/supabase/src/lib/auth.ts
+++ b/packages/supabase/src/lib/auth.ts
@@ -1,3 +1,4 @@
+import type { Session, User } from '@supabase/supabase-js';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 
 export type { AbstrackSupabaseClient };
@@ -72,7 +73,67 @@ export async function getSession(client: AbstrackSupabaseClient) {
   return client.auth.getSession();
 }
 
-/** Prefer on the server when verifying identity (validates with Auth server). */
+/** Prefer when verifying identity (validates with the Auth server). */
 export async function getAuthUser(client: AbstrackSupabaseClient) {
   return client.auth.getUser();
+}
+
+/**
+ * Returns a trimmed access token from persisted session storage only.
+ * Does not read `session.user` (avoids Supabase insecure-user warnings).
+ *
+ * @param client - Supabase client.
+ * @returns Access token or `null` when missing or on error.
+ */
+export async function getAccessTokenFromSession(
+  client: AbstrackSupabaseClient,
+): Promise<{ accessToken: string | null; error: Error | null }> {
+  const { data, error } = await client.auth.getSession();
+  if (error) {
+    return { accessToken: null, error };
+  }
+  const token = data.session?.access_token?.trim();
+  return {
+    accessToken: token && token.length > 0 ? token : null,
+    error: null,
+  };
+}
+
+/**
+ * Loads persisted session tokens and attaches a **verified** `user` from {@link getAuthUser}.
+ * Use instead of trusting `getSession().data.session.user` alone.
+ *
+ * @param client - Supabase client.
+ * @returns Verified user, session (with verified user), and any error.
+ */
+export async function getVerifiedAuthSession(
+  client: AbstrackSupabaseClient,
+): Promise<{
+  data: { user: User | null; session: Session | null };
+  error: Error | null;
+}> {
+  const { data: userData, error: userError } = await client.auth.getUser();
+  if (userError) {
+    return { data: { user: null, session: null }, error: userError };
+  }
+  const user = userData.user;
+  if (!user) {
+    return { data: { user: null, session: null }, error: null };
+  }
+
+  const { data: sessionData, error: sessionError } =
+    await client.auth.getSession();
+  if (sessionError) {
+    return { data: { user: null, session: null }, error: sessionError };
+  }
+
+  const persisted = sessionData.session;
+  if (!persisted) {
+    return { data: { user, session: null }, error: null };
+  }
+
+  return {
+    data: { user, session: { ...persisted, user } },
+    error: null,
+  };
 }


### PR DESCRIPTION
Closes #202

## Summary

### Dashboard (patient web)

- Redesigns the patient web **Dashboard** around logging actions instead of dev/account metadata.
- Removes the subtitle, dev-only Supabase health check, email, and User ID display.
- Adds neutral-themed **Health markers** and **Food diary** CTA cards (`DashboardHomeCtaCard`) using app tokens for light/dark mode; episode logging keeps the existing urgent red `EpisodeStartHomeCta`.
- Adds a **Recent episodes** preview (`DashboardRecentEpisodes`) showing the three most recently ended episodes, with a link to full history on Manage.

### Auth (web, practitioner, mobile, `@abstrack/supabase`)

- Addresses the Supabase console warning that `session.user` from `getSession()` / `onAuthStateChange` may be insecure; identity now comes from verified **`getUser()`** (or merged verified user on session) instead of trusting callback/session user objects.
- Adds shared helpers in `@abstrack/supabase`: **`getVerifiedAuthSession()`** (verify user, then attach to session) and **`getAccessTokenFromSession()`** (tokens only, no `session.user`) for Edge Function clients.
- **Web:** `AuthProvider` bootstrap and `onAuthStateChange` use `getUser()`; root layout initial session; auth callback, caretaker join, update-password, and edge clients updated.
- **Practitioner:** `AuthProvider`, device-trust restore/sign-out, login post–trust-restore, invite join, update-password, auth callback, and sign-out button updated; tests adjusted for `getUser` / `getVerifiedAuthSession`.
- **Mobile:** `getMobileAuthSessionSafe()` merges verified user from `getUser()` (offline fallback: persisted storage user); `App` auth listener and screens/hooks that read user id use the safe session path.

## Test plan

### Dashboard

- [ ] Sign in and open `/dashboard` — confirm episode CTA (start or resume), health markers card, food diary card, and recent episodes section render.
- [ ] Verify health markers and food diary CTAs navigate to `/health-markers/new` and `/food-diary/new`.
- [ ] With ended episodes in history, confirm up to three appear with type, end time, and duration; **View all episodes** opens `/manage?segment=episodes`.
- [ ] With no ended episodes, confirm empty state and link to start an episode.
- [ ] Toggle light/dark theme — cards and primary buttons use semantic tokens (no hard-coded red on health/food cards).
- [ ] As a caretaker with a linked patient, confirm recent episodes reflect the patient scope (not the caretaker account).
- [ ] Confirm dev health check, email, and User ID are no longer shown on the dashboard.

### Auth

- [ ] **Web:** Sign in, refresh, sign out — session/bootstrap still works; no Supabase “insecure getSession user” warning in console for normal flows.
- [ ] **Web:** Caretaker join, password update, and auth callback (fragment) still complete with correct user context.
- [ ] **Web:** Edge-backed flows (caretaker/practitioner patient actions) still send a valid access token.
- [ ] **Practitioner:** Login with device trust / MFA paths; trust restore and sign-out; invite join and update-password.
- [ ] **Mobile:** Cold start and resume while signed in; sign-in/sign-out; `onAuthStateChange` updates UI with correct user; offline/persisted session still shows expected identity where applicable.
- [ ] **Mobile:** Caretaker invite complete and PHI-scoped screens (home, manage, health markers) still resolve the correct subject user.