### PR TITLE
feat(web): add consolidated settings page with account, security, and invites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Sarah alone decides when schema hits cloud, when history is rewritten, and when 
 
 Details: **[docs/SUPABASE_CLOUD_DEVELOPER.md](docs/SUPABASE_CLOUD_DEVELOPER.md)**.
 
-- **`supabase db reset`** is **local Docker only** (or CI-only), not cloud.
+- **`supabase db reset`** (no flags) is **local Docker only** (`supabase start`). **`supabase db reset --linked`** resets the **linked cloud** project per [Supabase CLI](https://supabase.com/docs/reference/cli/supabase-db-reset).
 - **`database.types.ts` is not auto-committed** by any bot.
 
 ### Correct flow for migrations and database.types.ts (agents: follow this)

--- a/apps/mobile/src/app/screens/SignupScreen.tsx
+++ b/apps/mobile/src/app/screens/SignupScreen.tsx
@@ -1,5 +1,8 @@
 import React, { useState } from 'react';
-import { signUpWithEmailPassword } from '@abstrack/supabase';
+import {
+  signUpWithEmailPassword,
+  ensurePatientProfileRow,
+} from '@abstrack/supabase';
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { AuthForm } from '../components/AuthForm';
 import {
@@ -39,6 +42,16 @@ export function SignupScreen({ onGoToLogin }: { onGoToLogin: () => void }) {
 
       if (authError) {
         setErrorMessage(mapAuthError(authError.message));
+      } else if (data.session && data.user?.id) {
+        const ensured = await ensurePatientProfileRow(
+          mobileSupabase,
+          data.user.id,
+        );
+        if (!ensured.ok) {
+          setErrorMessage(
+            'Account created, but we could not finish setting up your profile. Try signing in again.',
+          );
+        }
       } else if (!data.session) {
         setStatusMessage(
           'Account created. Check your email to confirm your account.',

--- a/apps/web/csp-config.js
+++ b/apps/web/csp-config.js
@@ -1,0 +1,126 @@
+/**
+ * Builds a single-line Content-Security-Policy value for the user web Next.js app.
+ * Used from `next.config.js` (Node at build time). See `docs/SECURITY_BASELINE.md`.
+ */
+
+/**
+ * Normalizes a CSP header string for a single-line HTTP header value.
+ *
+ * @param {string} raw - Multi-line or padded policy text.
+ * @returns {string} Header-safe single-line value.
+ */
+function normalizeCspHeaderValue(raw) {
+  return raw
+    .replace(/\r\n|\r|\n/g, ' ')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+/**
+ * @param {Set<string>} connectParts - Mutable set of `connect-src` tokens.
+ * @param {boolean} isDev - Whether `NODE_ENV === 'development'`.
+ */
+function addDevLocalConnectSources(connectParts, isDev) {
+  if (!isDev) {
+    return;
+  }
+  const devPorts = ['3000', '3001', '4200'];
+  const hosts = ['localhost', '127.0.0.1'];
+  for (const host of hosts) {
+    connectParts.add(`http://${host}:54321`);
+    connectParts.add(`ws://${host}:54321`);
+    for (const port of devPorts) {
+      connectParts.add(`http://${host}:${port}`);
+      connectParts.add(`ws://${host}:${port}`);
+    }
+  }
+}
+
+/**
+ * @param {string | undefined} supabaseUrl - `NEXT_PUBLIC_SUPABASE_URL`.
+ * @returns {{ httpOrigin: string, wsOrigin: string } | null}
+ */
+function supabaseHttpAndWsOrigins(supabaseUrl) {
+  if (!supabaseUrl) {
+    return null;
+  }
+  try {
+    const u = new URL(supabaseUrl);
+    const httpOrigin = u.origin;
+    const wsProtocol = u.protocol === 'https:' ? 'wss:' : 'ws:';
+    const wsOrigin = `${wsProtocol}//${u.host}`;
+    return { httpOrigin, wsOrigin };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Builds the user web CSP directive string (before newline normalization).
+ *
+ * @param {object} opts - Options.
+ * @param {string | undefined} opts.supabaseUrl - Supabase project URL from the build environment.
+ * @param {boolean} opts.isDev - True when `NODE_ENV === 'development'`.
+ * @param {boolean} opts.isProduction - True when `NODE_ENV === 'production'`.
+ * @returns {string} Semicolon-separated CSP directives.
+ */
+function buildUserWebCspDirectives(opts) {
+  const { supabaseUrl, isDev, isProduction } = opts;
+
+  const connectParts = new Set(["'self'"]);
+  const origins = supabaseHttpAndWsOrigins(supabaseUrl);
+  if (origins) {
+    connectParts.add(origins.httpOrigin);
+    connectParts.add(origins.wsOrigin);
+  }
+  addDevLocalConnectSources(connectParts, isDev);
+
+  const connectSrc = Array.from(connectParts).join(' ');
+
+  const imgParts = new Set(["'self'", 'blob:', 'data:']);
+  const mediaParts = new Set(["'self'", 'blob:']);
+  if (origins) {
+    imgParts.add(origins.httpOrigin);
+    mediaParts.add(origins.httpOrigin);
+  }
+  const imgSrc = Array.from(imgParts).join(' ');
+  const mediaSrc = Array.from(mediaParts).join(' ');
+
+  const scriptParts = ["'self'", "'unsafe-inline'"];
+  if (isDev) {
+    scriptParts.push("'unsafe-eval'");
+  }
+
+  /** @type {string[]} */
+  const directives = [
+    "default-src 'self'",
+    `script-src ${scriptParts.join(' ')}`,
+    "style-src 'self' 'unsafe-inline'",
+    `img-src ${imgSrc}`,
+    `media-src ${mediaSrc}`,
+    "font-src 'self'",
+    `connect-src ${connectSrc}`,
+    "worker-src 'self' blob:",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "form-action 'self'",
+    "frame-ancestors 'none'",
+    "frame-src 'none'",
+  ];
+
+  if (
+    isProduction &&
+    supabaseUrl &&
+    supabaseUrl.trim().toLowerCase().startsWith('https://')
+  ) {
+    directives.push('upgrade-insecure-requests');
+  }
+
+  return directives.join('; ');
+}
+
+module.exports = {
+  buildUserWebCspDirectives,
+  normalizeCspHeaderValue,
+  supabaseHttpAndWsOrigins,
+};

--- a/apps/web/jest-setup.ts
+++ b/apps/web/jest-setup.ts
@@ -1,7 +1,16 @@
+import { TextDecoder, TextEncoder } from 'node:util';
+
 /**
  * Shared Jest setup for `apps/web` (jsdom). `window.matchMedia` is used by theme code and
  * the landing header but is not always provided by the test environment.
  */
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
+}
+if (typeof globalThis.TextDecoder === 'undefined') {
+  globalThis.TextDecoder = TextDecoder as typeof globalThis.TextDecoder;
+}
+
 Object.defineProperty(window, 'matchMedia', {
   writable: true,
   configurable: true,

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -11,6 +11,47 @@ const isProduction = process.env.NODE_ENV === 'production';
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
 const cspEnforce = process.env.USER_WEB_CSP_ENFORCE === 'true';
 
+/**
+ * @param {string | undefined} raw
+ * @returns {boolean}
+ */
+function isExplicitTruthyEnvValue(raw) {
+  if (raw == null || String(raw).trim() === '') {
+    return false;
+  }
+  const flag = String(raw).trim().toLowerCase();
+  return flag === 'true' || flag === '1';
+}
+
+/**
+ * Fail closed when a production build would enable MFA device trust in the client bundle
+ * (`NEXT_PUBLIC_*` flags) but ship Report-Only CSP headers (`USER_WEB_CSP_ENFORCE` unset).
+ */
+function assertProductionMfaDeviceTrustRequiresEnforcedCsp() {
+  if (!isProduction) {
+    return;
+  }
+
+  const clientTrustWouldEnable =
+    isExplicitTruthyEnvValue(process.env.NEXT_PUBLIC_USER_MFA_DEVICE_TRUST) &&
+    isExplicitTruthyEnvValue(process.env.NEXT_PUBLIC_USER_WEB_CSP_ENFORCE);
+
+  if (!clientTrustWouldEnable) {
+    return;
+  }
+
+  if (process.env.USER_WEB_CSP_ENFORCE !== 'true') {
+    throw new Error(
+      'Production build misconfiguration: MFA device trust is enabled in the client bundle ' +
+        '(NEXT_PUBLIC_USER_MFA_DEVICE_TRUST and NEXT_PUBLIC_USER_WEB_CSP_ENFORCE) but USER_WEB_CSP_ENFORCE is not "true". ' +
+        'Device trust stores session tokens in localStorage and requires enforced Content-Security-Policy headers. ' +
+        'Set USER_WEB_CSP_ENFORCE=true at build/deploy time, or unset NEXT_PUBLIC_USER_WEB_CSP_ENFORCE until Phase B CSP.',
+    );
+  }
+}
+
+assertProductionMfaDeviceTrustRequiresEnforcedCsp();
+
 const userWebCspHeaderValue = normalizeCspHeaderValue(
   buildUserWebCspDirectives({
     supabaseUrl,

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -1,6 +1,32 @@
 //@ts-check
 const path = require('path');
 const { composePlugins, withNx } = require('@nx/next');
+const {
+  buildUserWebCspDirectives,
+  normalizeCspHeaderValue,
+} = require('./csp-config.js');
+
+const isDev = process.env.NODE_ENV === 'development';
+const isProduction = process.env.NODE_ENV === 'production';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const cspEnforce = process.env.USER_WEB_CSP_ENFORCE === 'true';
+
+const userWebCspHeaderValue = normalizeCspHeaderValue(
+  buildUserWebCspDirectives({
+    supabaseUrl,
+    isDev,
+    isProduction,
+  }),
+);
+
+const userWebCspHeaders = cspEnforce
+  ? [{ key: 'Content-Security-Policy', value: userWebCspHeaderValue }]
+  : [
+      {
+        key: 'Content-Security-Policy-Report-Only',
+        value: userWebCspHeaderValue,
+      },
+    ];
 
 /**
  * @type {import('@nx/next/plugins/with-nx').WithNxOptions}
@@ -42,6 +68,14 @@ const nextConfig = {
       '@abstrack/ui-web/sidebar': path.join(uiWebSrc, 'components/sidebar.tsx'),
     };
     return config;
+  },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: userWebCspHeaders,
+      },
+    ];
   },
 };
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "@supabase/ssr": "^0.6.1",
     "chart.js": "^4.5.1",
     "next": "~16.0.1",
+    "qrcode": "^1.5.4",
     "react": "19.1.0",
     "react-day-picker": "^10.0.1",
     "react-dom": "19.1.0",
@@ -18,6 +19,7 @@
     "recharts": "^3.8.1"
   },
   "devDependencies": {
+    "@types/qrcode": "^1.5.6",
     "tailwindcss-animate": "^1.0.7"
   }
 }

--- a/apps/web/src/app/(app)/settings/caretaker/page.tsx
+++ b/apps/web/src/app/(app)/settings/caretaker/page.tsx
@@ -1,8 +1,0 @@
-import { redirect } from 'next/navigation';
-
-/**
- * Legacy caretaker settings URL; redirects to Settings → Invites.
- */
-export default function CaretakerSettingsRedirectPage() {
-  redirect('/settings?tab=invites');
-}

--- a/apps/web/src/app/(app)/settings/caretaker/page.tsx
+++ b/apps/web/src/app/(app)/settings/caretaker/page.tsx
@@ -1,24 +1,8 @@
-import type { Metadata } from 'next';
-import { CaretakerAccessPage } from '@/components/settings/CaretakerAccessPage';
-
-export const metadata: Metadata = {
-  title: 'Caretaker access | ABStrack',
-  description:
-    'Link or revoke a caretaker who can log episodes on your behalf using their own account.',
-};
+import { redirect } from 'next/navigation';
 
 /**
- * Patient settings surface for a single active caretaker grant (PRD §7).
- *
- * @returns Caretaker settings page.
+ * Legacy caretaker settings URL; redirects to Settings → Invites.
  */
-export default function CaretakerSettingsPage() {
-  return (
-    <main
-      id="main-content"
-      className="mx-auto w-full max-w-2xl flex-1 px-4 py-8 sm:px-6 lg:px-8"
-    >
-      <CaretakerAccessPage />
-    </main>
-  );
+export default function CaretakerSettingsRedirectPage() {
+  redirect('/settings?tab=invites');
 }

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -1,0 +1,33 @@
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+import { SettingsPage } from '@/components/settings/SettingsPage';
+
+export const metadata: Metadata = {
+  title: 'Settings | ABStrack',
+  description:
+    'Account, security, and invite settings for your ABStrack patient account.',
+};
+
+/**
+ * Settings hub: account profile, security, and patient invite management.
+ *
+ * @returns Settings page wrapped in Suspense for search-param tabs.
+ */
+export default function SettingsRoutePage() {
+  return (
+    <main
+      id="main-content"
+      className="mx-auto w-full max-w-2xl flex-1 px-4 py-8 sm:px-6 lg:px-8"
+    >
+      <Suspense
+        fallback={
+          <p className="text-sm text-app-muted" role="status">
+            Loading settings…
+          </p>
+        }
+      >
+        <SettingsPage />
+      </Suspense>
+    </main>
+  );
+}

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -5,11 +5,12 @@ import { SettingsPage } from '@/components/settings/SettingsPage';
 export const metadata: Metadata = {
   title: 'Settings | ABStrack',
   description:
-    'Account, security, and invite settings for your ABStrack patient account.',
+    'Account and security settings for patients and caretakers on ABStrack user web. Patients can manage caretaker and practitioner invites.',
 };
 
 /**
- * Settings hub: account profile, security, and patient invite management.
+ * Settings hub for user web: account and security for patients and caretakers;
+ * invite management for patients only (not the practitioner app).
  *
  * @returns Settings page wrapped in Suspense for search-param tabs.
  */

--- a/apps/web/src/app/(app)/settings/practitioner/page.tsx
+++ b/apps/web/src/app/(app)/settings/practitioner/page.tsx
@@ -1,24 +1,8 @@
-import type { Metadata } from 'next';
-import { PractitionerAccessPage } from '@/components/settings/PractitionerAccessPage';
-
-export const metadata: Metadata = {
-  title: 'Practitioner access | ABStrack',
-  description:
-    'Invite or revoke a healthcare practitioner who can read your ABStrack data from the practitioner web app; two-factor is required only if they use password sign-in.',
-};
+import { redirect } from 'next/navigation';
 
 /**
- * Patient settings for practitioner sharing (PRD §8).
- *
- * @returns Practitioner settings page.
+ * Legacy practitioner settings URL; redirects to Settings → Invites.
  */
-export default function PractitionerSettingsPage() {
-  return (
-    <main
-      id="main-content"
-      className="mx-auto w-full max-w-2xl flex-1 px-4 py-8 sm:px-6 lg:px-8"
-    >
-      <PractitionerAccessPage />
-    </main>
-  );
+export default function PractitionerSettingsRedirectPage() {
+  redirect('/settings?tab=invites');
 }

--- a/apps/web/src/app/(app)/settings/practitioner/page.tsx
+++ b/apps/web/src/app/(app)/settings/practitioner/page.tsx
@@ -1,8 +1,0 @@
-import { redirect } from 'next/navigation';
-
-/**
- * Legacy practitioner settings URL; redirects to Settings → Invites.
- */
-export default function PractitionerSettingsRedirectPage() {
-  redirect('/settings?tab=invites');
-}

--- a/apps/web/src/app/(public)/caretaker/join/page.tsx
+++ b/apps/web/src/app/(public)/caretaker/join/page.tsx
@@ -9,6 +9,7 @@ import {
   fetchPatientCaretakerAccessFinalize,
 } from '@/lib/patient/caretaker-edge-client';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { ensureProfileRow } from '@abstrack/supabase';
 
 type JoinState =
   | { kind: 'loading' }
@@ -17,11 +18,6 @@ type JoinState =
   | { kind: 'wrong_role'; message: string }
   | { kind: 'error'; message: string }
   | { kind: 'done' };
-
-/** True when PostgREST reports a duplicate key (concurrent profile insert). */
-function isPostgresUniqueViolation(err: { code?: string } | null): boolean {
-  return err?.code === '23505';
-}
 
 /**
  * Post-invite landing: after the caretaker accepts the Supabase email link, the session may need a
@@ -83,51 +79,43 @@ export default function CaretakerJoinPage() {
           return;
         }
 
+        let appRole = profile?.app_role;
         if (!profile) {
-          const { error: insErr } = await supabase.from('profiles').insert({
-            id: user.id,
-            app_role: 'caretaker',
-          });
-          if (insErr) {
-            if (isPostgresUniqueViolation(insErr)) {
-              const { data: afterRace, error: raceReadErr } = await supabase
-                .from('profiles')
-                .select('app_role')
-                .eq('id', user.id)
-                .maybeSingle();
-              if (raceReadErr || !afterRace) {
-                if (!cancelled) {
-                  setState({
-                    kind: 'error',
-                    message:
-                      'Unable to verify your profile after sign-up. Try again in a moment.',
-                  });
-                }
-                return;
-              }
-              if (afterRace.app_role !== 'caretaker') {
-                if (!cancelled) {
-                  setState({
-                    kind: 'wrong_role',
-                    message:
-                      'This invite is for a caretaker account, but your profile is not set to caretaker. Use the account your patient invited, or contact support.',
-                  });
-                }
-                return;
-              }
-            } else {
-              if (!cancelled) {
-                setState({
-                  kind: 'error',
-                  message:
-                    insErr.message ||
-                    'Unable to create your caretaker profile. Try again or contact support.',
-                });
-              }
-              return;
+          const ensured = await ensureProfileRow(
+            supabase,
+            user.id,
+            'caretaker',
+          );
+          if (!ensured.ok) {
+            if (!cancelled) {
+              setState({
+                kind: 'error',
+                message:
+                  ensured.message ||
+                  'Unable to create your caretaker profile. Try again or contact support.',
+              });
             }
+            return;
           }
-        } else if (profile.app_role !== 'caretaker') {
+          const { data: afterEnsure, error: afterEnsureErr } = await supabase
+            .from('profiles')
+            .select('app_role')
+            .eq('id', user.id)
+            .maybeSingle();
+          if (afterEnsureErr || !afterEnsure) {
+            if (!cancelled) {
+              setState({
+                kind: 'error',
+                message:
+                  'Unable to verify your profile after sign-up. Try again in a moment.',
+              });
+            }
+            return;
+          }
+          appRole = afterEnsure.app_role;
+        }
+
+        if (appRole !== 'caretaker') {
           if (!cancelled) {
             setState({
               kind: 'wrong_role',

--- a/apps/web/src/app/(public)/caretaker/join/page.tsx
+++ b/apps/web/src/app/(public)/caretaker/join/page.tsx
@@ -220,7 +220,7 @@ export default function CaretakerJoinPage() {
             href={`/update-password?from=${CARETAKER_INVITE_SET_PASSWORD_FROM}`}
             className="min-h-[44px] rounded-full bg-app-primary-solid px-5 py-3 text-center text-sm font-semibold text-app-on-primary-solid focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring"
           >
-            Create password (recommended)
+            Create password
           </Link>
           <Link
             href="/"

--- a/apps/web/src/app/(public)/caretaker/join/page.tsx
+++ b/apps/web/src/app/(public)/caretaker/join/page.tsx
@@ -88,11 +88,12 @@ export default function CaretakerJoinPage() {
           );
           if (!ensured.ok) {
             if (!cancelled) {
+              if (ensured.cause) {
+                console.error('ensureProfileRow failed', ensured.cause);
+              }
               setState({
                 kind: 'error',
-                message:
-                  ensured.message ||
-                  'Unable to create your caretaker profile. Try again or contact support.',
+                message: ensured.message,
               });
             }
             return;

--- a/apps/web/src/app/(public)/login/page.tsx
+++ b/apps/web/src/app/(public)/login/page.tsx
@@ -1,46 +1,10 @@
 'use client';
 
-import { useState } from 'react';
-import { useRouter } from 'next/navigation';
 import Link from 'next/link';
-import { createBrowserClient } from '@/lib/supabase/browser-client';
-import { signInWithEmailPassword } from '@abstrack/supabase';
+import { UserLoginForm } from '@/components/auth/UserLoginForm';
 import { PUBLIC_PAGE_CENTER_CLASS } from '@/components/app-shell/public-page-layout-classes';
 
 export default function LoginPage() {
-  const [email, setEmail] = useState('');
-  const [password, setPassword] = useState('');
-  const [error, setError] = useState<string | null>(null);
-  const [loading, setLoading] = useState(false);
-  const router = useRouter();
-
-  const handleLogin = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setError(null);
-    setLoading(true);
-
-    try {
-      const supabase = createBrowserClient();
-      const { error: authError } = await signInWithEmailPassword(
-        supabase,
-        email,
-        password,
-      );
-
-      if (authError) {
-        setError(authError.message);
-      } else {
-        // Redirect to dashboard on successful login
-        router.push('/dashboard');
-      }
-    } catch (err) {
-      setError('An unexpected error occurred');
-      console.error(err);
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
     <div className={PUBLIC_PAGE_CENTER_CLASS}>
       <div className="w-full max-w-md rounded-2xl border border-app-border/90 bg-app-surface p-8 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
@@ -48,71 +12,13 @@ export default function LoginPage() {
           Login
         </h1>
 
-        {error && (
-          <div className="mb-4 rounded border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800/60 dark:bg-red-950/35 dark:text-red-200">
-            {error}
-          </div>
-        )}
-
-        <form onSubmit={handleLogin} className="space-y-4">
-          <div>
-            <label
-              htmlFor="email"
-              className="block text-sm font-medium text-app-muted"
-            >
-              Email
-            </label>
-            <input
-              id="email"
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              required
-              className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
-              placeholder="you@example.com"
-            />
-          </div>
-
-          <div>
-            <label
-              htmlFor="password"
-              className="block text-sm font-medium text-app-muted"
-            >
-              Password
-            </label>
-            <input
-              id="password"
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              required
-              className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
-              placeholder="••••••••"
-            />
-            <div className="mt-2 text-right">
-              <Link
-                href="/forgot-password"
-                className="text-sm text-app-primary hover:underline"
-              >
-                Forgot password?
-              </Link>
-            </div>
-          </div>
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full rounded-md bg-app-primary-solid px-4 py-2 text-app-on-primary-solid transition hover:brightness-105 disabled:opacity-50"
-          >
-            {loading ? 'Logging in...' : 'Login'}
-          </button>
-        </form>
+        <UserLoginForm />
 
         <p className="mt-4 text-center text-sm text-app-muted">
           Don&apos;t have an account?{' '}
-          <a href="/signup" className="text-app-primary hover:underline">
+          <Link href="/signup" className="text-app-primary hover:underline">
             Sign up
-          </a>
+          </Link>
         </p>
       </div>
     </div>

--- a/apps/web/src/app/(public)/signup/page.tsx
+++ b/apps/web/src/app/(public)/signup/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { signUpWithEmailPassword } from '@abstrack/supabase';
+import { USER_PASSWORD_SET_USER_METADATA_KEY } from '@/lib/user-password-sign-in';
 import { PUBLIC_PAGE_CENTER_CLASS } from '@/components/app-shell/public-page-layout-classes';
 
 export default function SignupPage() {
@@ -31,6 +32,9 @@ export default function SignupPage() {
         supabase,
         email,
         password,
+        {
+          data: { [USER_PASSWORD_SET_USER_METADATA_KEY]: true },
+        },
       );
 
       if (authError) {

--- a/apps/web/src/app/(public)/signup/page.tsx
+++ b/apps/web/src/app/(public)/signup/page.tsx
@@ -11,6 +11,7 @@ import {
   AUTH_PASSWORD_MAX_LENGTH,
   AUTH_PASSWORD_MIN_LENGTH,
   USER_PASSWORD_SET_USER_METADATA_KEY,
+  clampAuthPasswordInput,
   getAuthPasswordValidationError,
 } from '@/lib/user-password-sign-in';
 import { PUBLIC_PAGE_CENTER_CLASS } from '@/components/app-shell/public-page-layout-classes';
@@ -122,8 +123,9 @@ export default function SignupPage() {
               id="password"
               type="password"
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              maxLength={AUTH_PASSWORD_MAX_LENGTH}
+              onChange={(e) =>
+                setPassword(clampAuthPasswordInput(e.target.value))
+              }
               required
               className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
               placeholder="••••••••"
@@ -141,8 +143,9 @@ export default function SignupPage() {
               id="confirmPassword"
               type="password"
               value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
-              maxLength={AUTH_PASSWORD_MAX_LENGTH}
+              onChange={(e) =>
+                setConfirmPassword(clampAuthPasswordInput(e.target.value))
+              }
               required
               className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
               placeholder="••••••••"

--- a/apps/web/src/app/(public)/signup/page.tsx
+++ b/apps/web/src/app/(public)/signup/page.tsx
@@ -7,7 +7,12 @@ import {
   signUpWithEmailPassword,
   ensurePatientProfileRow,
 } from '@abstrack/supabase';
-import { USER_PASSWORD_SET_USER_METADATA_KEY } from '@/lib/user-password-sign-in';
+import {
+  AUTH_PASSWORD_MAX_LENGTH,
+  AUTH_PASSWORD_MIN_LENGTH,
+  USER_PASSWORD_SET_USER_METADATA_KEY,
+  getAuthPasswordValidationError,
+} from '@/lib/user-password-sign-in';
 import { PUBLIC_PAGE_CENTER_CLASS } from '@/components/app-shell/public-page-layout-classes';
 
 export default function SignupPage() {
@@ -22,6 +27,13 @@ export default function SignupPage() {
     e.preventDefault();
     setError(null);
     setLoading(true);
+
+    const passwordValidationError = getAuthPasswordValidationError(password);
+    if (passwordValidationError) {
+      setError(passwordValidationError);
+      setLoading(false);
+      return;
+    }
 
     if (password !== confirmPassword) {
       setError('Passwords do not match');
@@ -75,6 +87,11 @@ export default function SignupPage() {
           </div>
         )}
 
+        <p className="mb-4 text-center text-sm text-app-muted">
+          Passwords must be at least {AUTH_PASSWORD_MIN_LENGTH} characters and
+          no more than {AUTH_PASSWORD_MAX_LENGTH} bytes.
+        </p>
+
         <form onSubmit={handleSignup} className="space-y-4">
           <div>
             <label
@@ -106,6 +123,7 @@ export default function SignupPage() {
               type="password"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
+              maxLength={AUTH_PASSWORD_MAX_LENGTH}
               required
               className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
               placeholder="••••••••"
@@ -124,6 +142,7 @@ export default function SignupPage() {
               type="password"
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
+              maxLength={AUTH_PASSWORD_MAX_LENGTH}
               required
               className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
               placeholder="••••••••"

--- a/apps/web/src/app/(public)/signup/page.tsx
+++ b/apps/web/src/app/(public)/signup/page.tsx
@@ -8,8 +8,6 @@ import {
   ensurePatientProfileRow,
 } from '@abstrack/supabase';
 import {
-  AUTH_PASSWORD_MAX_LENGTH,
-  AUTH_PASSWORD_MIN_LENGTH,
   USER_PASSWORD_SET_USER_METADATA_KEY,
   clampAuthPasswordInput,
   getAuthPasswordValidationError,
@@ -87,11 +85,6 @@ export default function SignupPage() {
             {error}
           </div>
         )}
-
-        <p className="mb-4 text-center text-sm text-app-muted">
-          Passwords must be at least {AUTH_PASSWORD_MIN_LENGTH} characters and
-          no more than {AUTH_PASSWORD_MAX_LENGTH} bytes.
-        </p>
 
         <form onSubmit={handleSignup} className="space-y-4">
           <div>

--- a/apps/web/src/app/(public)/signup/page.tsx
+++ b/apps/web/src/app/(public)/signup/page.tsx
@@ -3,7 +3,10 @@
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
-import { signUpWithEmailPassword } from '@abstrack/supabase';
+import {
+  signUpWithEmailPassword,
+  ensurePatientProfileRow,
+} from '@abstrack/supabase';
 import { USER_PASSWORD_SET_USER_METADATA_KEY } from '@/lib/user-password-sign-in';
 import { PUBLIC_PAGE_CENTER_CLASS } from '@/components/app-shell/public-page-layout-classes';
 
@@ -28,7 +31,7 @@ export default function SignupPage() {
 
     try {
       const supabase = createBrowserClient();
-      const { error: authError } = await signUpWithEmailPassword(
+      const { data, error: authError } = await signUpWithEmailPassword(
         supabase,
         email,
         password,
@@ -39,8 +42,16 @@ export default function SignupPage() {
 
       if (authError) {
         setError(authError.message);
+      } else if (data.session && data.user?.id) {
+        const ensured = await ensurePatientProfileRow(supabase, data.user.id);
+        if (!ensured.ok) {
+          setError(
+            'Account created, but we could not finish setting up your profile. Try signing in, or contact support.',
+          );
+          return;
+        }
+        router.push('/dashboard');
       } else {
-        // Redirect to dashboard on successful signup
         router.push('/dashboard');
       }
     } catch (err) {

--- a/apps/web/src/app/(public)/update-password/page.tsx
+++ b/apps/web/src/app/(public)/update-password/page.tsx
@@ -10,7 +10,7 @@ import {
   AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
 } from '@/lib/auth/auth-callback-redirect';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
-import { updateUserPassword } from '@abstrack/supabase';
+import { USER_PASSWORD_SET_USER_METADATA_KEY } from '@/lib/user-password-sign-in';
 
 const MIN_PASSWORD_LENGTH = 8;
 
@@ -161,7 +161,10 @@ export default function UpdatePasswordPage() {
         return;
       }
 
-      const { error: authError } = await updateUserPassword(supabase, password);
+      const { error: authError } = await supabase.auth.updateUser({
+        password,
+        data: { [USER_PASSWORD_SET_USER_METADATA_KEY]: true },
+      });
       if (authError) {
         setError(authError.message);
         return;

--- a/apps/web/src/app/(public)/update-password/page.tsx
+++ b/apps/web/src/app/(public)/update-password/page.tsx
@@ -14,6 +14,7 @@ import {
   AUTH_PASSWORD_MAX_LENGTH,
   AUTH_PASSWORD_MIN_LENGTH,
   USER_PASSWORD_SET_USER_METADATA_KEY,
+  clampAuthPasswordInput,
   getAuthPasswordValidationError,
 } from '@/lib/user-password-sign-in';
 
@@ -248,8 +249,9 @@ export default function UpdatePasswordPage() {
               id="password"
               type="password"
               value={password}
-              onChange={(event) => setPassword(event.target.value)}
-              maxLength={AUTH_PASSWORD_MAX_LENGTH}
+              onChange={(event) =>
+                setPassword(clampAuthPasswordInput(event.target.value))
+              }
               required
               className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
               placeholder="••••••••"
@@ -269,8 +271,9 @@ export default function UpdatePasswordPage() {
               id="confirmPassword"
               type="password"
               value={confirmPassword}
-              onChange={(event) => setConfirmPassword(event.target.value)}
-              maxLength={AUTH_PASSWORD_MAX_LENGTH}
+              onChange={(event) =>
+                setConfirmPassword(clampAuthPasswordInput(event.target.value))
+              }
               required
               className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
               placeholder="••••••••"

--- a/apps/web/src/app/(public)/update-password/page.tsx
+++ b/apps/web/src/app/(public)/update-password/page.tsx
@@ -10,9 +10,12 @@ import {
   AUTH_CALLBACK_VERIFICATION_FAILED_MESSAGE,
 } from '@/lib/auth/auth-callback-redirect';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
-import { USER_PASSWORD_SET_USER_METADATA_KEY } from '@/lib/user-password-sign-in';
-
-const MIN_PASSWORD_LENGTH = 8;
+import {
+  AUTH_PASSWORD_MAX_LENGTH,
+  AUTH_PASSWORD_MIN_LENGTH,
+  USER_PASSWORD_SET_USER_METADATA_KEY,
+  getAuthPasswordValidationError,
+} from '@/lib/user-password-sign-in';
 
 /**
  * Lets a signed-in user set or change their password (`updateUser`). Supports the post–caretaker-invite
@@ -112,8 +115,9 @@ export default function UpdatePasswordPage() {
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
 
-    if (password.length < MIN_PASSWORD_LENGTH) {
-      setError(`Password must be at least ${MIN_PASSWORD_LENGTH} characters.`);
+    const passwordValidationError = getAuthPasswordValidationError(password);
+    if (passwordValidationError) {
+      setError(passwordValidationError);
       setStatus(null);
       return;
     }
@@ -227,6 +231,11 @@ export default function UpdatePasswordPage() {
           </div>
         ) : null}
 
+        <p className="mb-4 text-center text-sm text-app-muted">
+          Passwords must be at least {AUTH_PASSWORD_MIN_LENGTH} characters and
+          no more than {AUTH_PASSWORD_MAX_LENGTH} bytes.
+        </p>
+
         <form onSubmit={handleSubmit} className="space-y-4">
           <div>
             <label
@@ -240,6 +249,7 @@ export default function UpdatePasswordPage() {
               type="password"
               value={password}
               onChange={(event) => setPassword(event.target.value)}
+              maxLength={AUTH_PASSWORD_MAX_LENGTH}
               required
               className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
               placeholder="••••••••"
@@ -260,6 +270,7 @@ export default function UpdatePasswordPage() {
               type="password"
               value={confirmPassword}
               onChange={(event) => setConfirmPassword(event.target.value)}
+              maxLength={AUTH_PASSWORD_MAX_LENGTH}
               required
               className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
               placeholder="••••••••"

--- a/apps/web/src/app/api/auth/logout/route.spec.ts
+++ b/apps/web/src/app/api/auth/logout/route.spec.ts
@@ -60,6 +60,7 @@ describe('logout route', () => {
 
     const request = {
       url: 'https://example.com/api/auth/logout',
+      nextUrl: new URL('https://example.com/api/auth/logout'),
       cookies: {
         getAll: jest.fn(() => [{ name: 'sb-access-token', value: 'token' }]),
       },
@@ -74,6 +75,7 @@ describe('logout route', () => {
       }),
     );
     expect(signOut).toHaveBeenCalledTimes(1);
+    expect(signOut).toHaveBeenCalledWith(undefined);
     expect(response).toEqual(
       expect.objectContaining({
         type: 'redirect',
@@ -86,5 +88,27 @@ describe('logout route', () => {
       '',
       expect.objectContaining({ maxAge: 0, path: '/' }),
     );
+  });
+
+  it('passes global scope to signOut when scope=global is in the query string', async () => {
+    const signOut = jest.fn(async () => undefined);
+
+    createServerClientMock.mockImplementation(() =>
+      Promise.resolve({
+        auth: { signOut },
+      } as unknown as ServerClient),
+    );
+
+    const request = {
+      url: 'https://example.com/api/auth/logout?scope=global',
+      nextUrl: new URL('https://example.com/api/auth/logout?scope=global'),
+      cookies: {
+        getAll: jest.fn(() => []),
+      },
+    } as unknown as Parameters<typeof POST>[0];
+
+    await POST(request);
+
+    expect(signOut).toHaveBeenCalledWith({ scope: 'global' });
   });
 });

--- a/apps/web/src/app/api/auth/logout/route.spec.ts
+++ b/apps/web/src/app/api/auth/logout/route.spec.ts
@@ -7,6 +7,11 @@ jest.mock('../../../../lib/supabase/server-client', () => ({
 
 jest.mock('next/server', () => ({
   NextResponse: {
+    json: jest.fn((body: unknown, init?: { status?: number }) => ({
+      type: 'json',
+      body,
+      status: init?.status ?? 200,
+    })),
     redirect: jest.fn((url: URL, status?: number) => ({
       type: 'redirect',
       location: url.toString(),
@@ -18,6 +23,20 @@ jest.mock('next/server', () => ({
   },
 }));
 
+function logoutRequest(
+  url: string,
+  headers: Record<string, string> = { Origin: 'https://example.com' },
+) {
+  return {
+    url,
+    headers: new Headers(headers),
+    nextUrl: new URL(url),
+    cookies: {
+      getAll: jest.fn(() => [{ name: 'sb-access-token', value: 'token' }]),
+    },
+  } as unknown as Parameters<typeof POST>[0];
+}
+
 describe('logout route', () => {
   const createServerClientMock = jest.mocked(createServerClient);
   type CookieMethodsArg = Parameters<typeof createServerClient>[0];
@@ -25,6 +44,19 @@ describe('logout route', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  it('returns 403 and does not sign out when Origin is wrong', async () => {
+    const response = await POST(
+      logoutRequest('https://example.com/api/auth/logout', {
+        Origin: 'https://evil.example',
+      }),
+    );
+
+    expect(response).toEqual(
+      expect.objectContaining({ type: 'json', status: 403 }),
+    );
+    expect(createServerClientMock).not.toHaveBeenCalled();
   });
 
   it('redirects to login and applies auth cookie updates to the response', async () => {
@@ -58,15 +90,9 @@ describe('logout route', () => {
       } as unknown as ServerClient);
     });
 
-    const request = {
-      url: 'https://example.com/api/auth/logout',
-      nextUrl: new URL('https://example.com/api/auth/logout'),
-      cookies: {
-        getAll: jest.fn(() => [{ name: 'sb-access-token', value: 'token' }]),
-      },
-    } as unknown as Parameters<typeof POST>[0];
-
-    const response = await POST(request);
+    const response = await POST(
+      logoutRequest('https://example.com/api/auth/logout'),
+    );
 
     expect(createServerClientMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -99,15 +125,9 @@ describe('logout route', () => {
       } as unknown as ServerClient),
     );
 
-    const request = {
-      url: 'https://example.com/api/auth/logout?scope=global',
-      nextUrl: new URL('https://example.com/api/auth/logout?scope=global'),
-      cookies: {
-        getAll: jest.fn(() => []),
-      },
-    } as unknown as Parameters<typeof POST>[0];
-
-    await POST(request);
+    await POST(
+      logoutRequest('https://example.com/api/auth/logout?scope=global'),
+    );
 
     expect(signOut).toHaveBeenCalledWith({ scope: 'global' });
   });

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -15,7 +15,10 @@ export async function POST(request: NextRequest) {
     },
   });
 
-  await supabase.auth.signOut();
+  const scopeParam = request.nextUrl.searchParams.get('scope');
+  const scope = scopeParam === 'global' ? 'global' : undefined;
+
+  await supabase.auth.signOut(scope ? { scope } : undefined);
 
   // Redirect to login page after logout
   return response;

--- a/apps/web/src/app/api/auth/logout/route.ts
+++ b/apps/web/src/app/api/auth/logout/route.ts
@@ -1,7 +1,26 @@
+import { getSameOriginLogoutPostFailure } from '@/lib/same-origin-logout-post';
 import { createServerClient } from '../../../../lib/supabase/server-client';
 import { NextRequest, NextResponse } from 'next/server';
 
+/**
+ * Signs out the current user-web session and clears auth cookies. Supports optional
+ * `?scope=global` to revoke refresh tokens on all devices.
+ *
+ * Rejects cross-site `POST` requests (same-origin / `Sec-Fetch-Site` / `Referer` checks) before
+ * mutating session state, to mitigate CSRF-driven logouts.
+ *
+ * @param request - Incoming request with current cookies.
+ * @returns Redirect to login, or **400** / **403** when same-origin validation fails.
+ */
 export async function POST(request: NextRequest) {
+  const csrfFailure = getSameOriginLogoutPostFailure(request);
+  if (csrfFailure) {
+    return NextResponse.json(
+      { error: csrfFailure.error },
+      { status: csrfFailure.status },
+    );
+  }
+
   const response = NextResponse.redirect(new URL('/login', request.url), 303);
 
   const supabase = await createServerClient({
@@ -20,6 +39,5 @@ export async function POST(request: NextRequest) {
 
   await supabase.auth.signOut(scope ? { scope } : undefined);
 
-  // Redirect to login page after logout
   return response;
 }

--- a/apps/web/src/app/auth/callback/route.spec.ts
+++ b/apps/web/src/app/auth/callback/route.spec.ts
@@ -80,11 +80,46 @@ describe('auth callback route', () => {
     );
   });
 
+  it('redirects successfully when code exchange fails but an existing session is valid', async () => {
+    const refreshSession = jest.fn(async () => ({
+      data: { session: {} },
+      error: null,
+    }));
+    createServerClientMock.mockResolvedValue({
+      auth: {
+        exchangeCodeForSession: jest.fn(async () => ({
+          error: { message: 'invalid grant' },
+        })),
+        getUser: jest.fn(async () => ({
+          data: { user: { id: 'user-1' } },
+          error: null,
+        })),
+        refreshSession,
+      },
+    } as unknown as ServerClient);
+
+    const response = await GET(
+      makeRequest(
+        'https://example.com/auth/callback?code=abc&next=/settings?tab=account',
+      ),
+    );
+    const redirectUrl = new URL(response.location);
+
+    expect(refreshSession).toHaveBeenCalled();
+    expect(redirectUrl.pathname).toBe('/settings');
+    expect(redirectUrl.searchParams.get('tab')).toBe('account');
+    expect(redirectUrl.searchParams.get('error')).toBeNull();
+  });
+
   it('redirects with an error when session exchange fails', async () => {
     createServerClientMock.mockResolvedValue({
       auth: {
         exchangeCodeForSession: jest.fn(async () => ({
           error: { message: 'invalid grant' },
+        })),
+        getUser: jest.fn(async () => ({
+          data: { user: null },
+          error: null,
         })),
       },
     } as unknown as ServerClient);

--- a/apps/web/src/app/auth/callback/route.ts
+++ b/apps/web/src/app/auth/callback/route.ts
@@ -20,6 +20,10 @@ function redirectWithError(
  * cookies. Implicit auth (`#access_token=…` only) is rewritten to `/auth/callback/fragment` in
  * `src/proxy.ts` (middleware); this handler returns **400** if it receives a request
  * without `code` (e.g. direct hits without middleware).
+ *
+ * When {@link AbstrackSupabaseClient.auth.exchangeCodeForSession} fails but the request already
+ * has a valid session (common after email-change verification), redirects to `next` without an
+ * `error` query param and refreshes the session so JWT claims match the updated user.
  */
 export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get('code');
@@ -58,8 +62,19 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    const { error } = await supabase.auth.exchangeCodeForSession(code);
-    if (error) {
+    const { error: exchangeError } =
+      await supabase.auth.exchangeCodeForSession(code);
+    if (exchangeError) {
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
+      if (user && !userError) {
+        // Email change and similar flows can verify server-side while the PKCE code is
+        // already consumed or unnecessary when the browser still holds a valid session.
+        await supabase.auth.refreshSession();
+        return response;
+      }
       return redirectWithError(
         request,
         redirectPath,

--- a/apps/web/src/app/global.css
+++ b/apps/web/src/app/global.css
@@ -20,6 +20,10 @@
     --app-primary-on-solid: 255 255 255;
     --app-primary-soft: 219 234 254;
     --app-ring: 37 99 235;
+    /* Segmented tab lists (Settings, Manage): active pill bg + label must meet contrast in both themes. */
+    --app-tab-active-bg: 219 234 254;
+    --app-tab-active-text: 29 78 216;
+    --app-tab-active-ring: 29 78 216;
     --app-header-bg: rgba(255, 255, 255, 0.92);
     --app-sidebar-bg: rgba(255, 255, 255, 0.94);
     --app-header-border: rgba(226, 232, 240, 0.95);
@@ -45,11 +49,13 @@
     --app-muted: 148 163 184;
     --app-ink: 241 245 249;
     --app-primary: 96 165 250;
-    /* Opaque fill uses `dark:bg-app-primary-soft/28` where applied. */
     --app-primary-solid: 29 78 216;
     --app-primary-on-solid: 255 255 255;
     --app-primary-soft: 37 99 235;
     --app-ring: 147 197 253;
+    --app-tab-active-bg: 30 58 138;
+    --app-tab-active-text: 219 234 254;
+    --app-tab-active-ring: 147 197 253;
     --app-header-bg: rgba(15, 23, 42, 0.92);
     --app-sidebar-bg: rgba(15, 23, 42, 0.94);
     --app-header-border: rgba(51, 65, 85, 0.95);
@@ -81,6 +87,9 @@
       --app-primary-on-solid: 255 255 255;
       --app-primary-soft: 219 234 254;
       --app-ring: 30 64 175;
+      --app-tab-active-bg: 219 234 254;
+      --app-tab-active-text: 30 64 175;
+      --app-tab-active-ring: 30 64 175;
       --app-header-bg: rgba(255, 255, 255, 1);
       --app-sidebar-bg: rgba(255, 255, 255, 1);
       --app-header-border: rgba(15, 23, 42, 0.85);
@@ -103,6 +112,9 @@
       --app-primary-on-solid: 255 255 255;
       --app-primary-soft: 30 64 175;
       --app-ring: 250 204 21;
+      --app-tab-active-bg: 255 255 255;
+      --app-tab-active-text: 0 0 0;
+      --app-tab-active-ring: 250 204 21;
       --app-header-bg: rgba(0, 0, 0, 1);
       --app-sidebar-bg: rgba(0, 0, 0, 1);
       --app-header-border: rgba(255, 255, 255, 0.9);

--- a/apps/web/src/components/app-shell/AuthenticatedShell.spec.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.spec.tsx
@@ -38,6 +38,14 @@ jest.mock('../../lib/patient/use-web-phi-subject-user-context', () => ({
   useWebPhiSubjectUserContext: () => phiContext,
 }));
 
+jest.mock('../../lib/auth-provider', () => ({
+  useAuth: () => ({
+    session: { user: { id: 'user-1', email: 'test@example.com' } },
+    loading: false,
+    supabase: { auth: { signOut: jest.fn() } },
+  }),
+}));
+
 jest.mock('../theme/ThemeMenu', () => ({
   ThemeMenu: () => <button type="button">Theme</button>,
 }));

--- a/apps/web/src/components/app-shell/AuthenticatedShell.spec.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.spec.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
-import { render, screen } from '@testing-library/react';
+import { render, screen, within } from '@testing-library/react';
+import { WEB_APP_NAV_ITEMS } from '@/lib/app-nav-items';
 import type { ReactNode } from 'react';
 
 const usePathnameMock = jest.fn(() => '/dashboard');
@@ -141,8 +142,18 @@ describe('AuthenticatedShell', () => {
       </AuthenticatedShell>,
     );
 
-    const settings = screen.getByRole('link', { name: 'Settings' });
-    expect(settings).toHaveAttribute('href', '/settings');
+    const nav = screen.getByRole('navigation', {
+      name: 'ABStrack application',
+    });
+    const navLinkLabels = within(nav)
+      .getAllByRole('link')
+      .map((link) => link.textContent?.trim());
+    expect(navLinkLabels).toEqual(WEB_APP_NAV_ITEMS.map((item) => item.label));
+    expect(navLinkLabels.at(-1)).toBe('Settings');
+    expect(screen.getByRole('link', { name: 'Settings' })).toHaveAttribute(
+      'href',
+      '/settings',
+    );
     expect(
       screen.queryByRole('link', { name: 'Caretaker' }),
     ).not.toBeInTheDocument();

--- a/apps/web/src/components/app-shell/AuthenticatedShell.spec.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.spec.tsx
@@ -132,7 +132,7 @@ describe('AuthenticatedShell', () => {
     ).toBeInTheDocument();
   });
 
-  it('hides patient-only settings links when the viewer is not a patient', () => {
+  it('shows Settings as the last nav item for all signed-in roles', () => {
     phiContext.profileAppRole = 'caretaker';
 
     render(
@@ -141,12 +141,13 @@ describe('AuthenticatedShell', () => {
       </AuthenticatedShell>,
     );
 
+    const settings = screen.getByRole('link', { name: 'Settings' });
+    expect(settings).toHaveAttribute('href', '/settings');
     expect(
       screen.queryByRole('link', { name: 'Caretaker' }),
     ).not.toBeInTheDocument();
     expect(
       screen.queryByRole('link', { name: 'Practitioner' }),
     ).not.toBeInTheDocument();
-    expect(screen.getByRole('link', { name: 'Insights' })).toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import {
-  ACCOUNT_ACTIONS_SURFACE_CLASS,
   AppShellWithSideNav,
   AppSideNav,
   AppTopNav,
@@ -13,6 +12,7 @@ import { usePathname } from 'next/navigation';
 import { forwardRef, type ReactNode } from 'react';
 
 import { ThemeMenu } from '@/components/theme/ThemeMenu';
+import { WebSignOutButton } from '@/components/auth/WebSignOutButton';
 import { WEB_APP_NAV_ITEMS } from '@/lib/app-nav-items';
 
 const WebNavLink = forwardRef<HTMLAnchorElement, AppSideNavLinkProps>(
@@ -65,13 +65,7 @@ export function AuthenticatedShell({
           email={email}
           themeMenu={<ThemeMenu />}
           showSidebarTrigger
-          actions={
-            <form action="/api/auth/logout" method="POST">
-              <button type="submit" className={ACCOUNT_ACTIONS_SURFACE_CLASS}>
-                Log out
-              </button>
-            </form>
-          }
+          actions={<WebSignOutButton />}
           mobileSheetTitle="Account"
           mobileSheetDescription="Signed-in account, sign out, and appearance settings."
           mobileMenuTriggerAriaLabel="Open account menu"

--- a/apps/web/src/components/app-shell/AuthenticatedShell.tsx
+++ b/apps/web/src/components/app-shell/AuthenticatedShell.tsx
@@ -10,11 +10,10 @@ import {
 } from '@abstrack/ui-web';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import { forwardRef, useMemo, type ReactNode } from 'react';
+import { forwardRef, type ReactNode } from 'react';
 
 import { ThemeMenu } from '@/components/theme/ThemeMenu';
 import { WEB_APP_NAV_ITEMS } from '@/lib/app-nav-items';
-import { useWebPhiSubjectUserContext } from '@/lib/patient/use-web-phi-subject-user-context';
 
 const WebNavLink = forwardRef<HTMLAnchorElement, AppSideNavLinkProps>(
   ({ href, children, ...rest }, ref) => (
@@ -34,8 +33,8 @@ export type AuthenticatedShellProps = {
 /**
  * Authenticated app chrome: skip link, full-width top bar, side navigation (shadcn/ui sidebar),
  * and a centered main column. Surfaces use CSS variables so light/dark tracks the theme toggle.
- * Patient-only Caretaker and Practitioner settings links follow
- * {@link useWebPhiSubjectUserContext} (`profileAppRole === 'patient'`).
+ * Caretaker and practitioner invite management lives under Settings → Invites
+ * (patient accounts only).
  *
  * @param props - Props.
  * @returns Shell layout wrapping page content.
@@ -45,17 +44,6 @@ export function AuthenticatedShell({
   email,
 }: AuthenticatedShellProps) {
   const pathname = usePathname() ?? '/';
-  const { profileAppRole } = useWebPhiSubjectUserContext();
-  const navItems = useMemo(() => {
-    if (profileAppRole !== 'patient') {
-      return WEB_APP_NAV_ITEMS.filter(
-        (item) =>
-          item.href !== '/settings/caretaker' &&
-          item.href !== '/settings/practitioner',
-      );
-    }
-    return WEB_APP_NAV_ITEMS;
-  }, [profileAppRole]);
 
   return (
     <AppShellWithSideNav
@@ -92,7 +80,7 @@ export function AuthenticatedShell({
       sideNav={
         <AppSideNav
           pathname={pathname}
-          items={navItems}
+          items={WEB_APP_NAV_ITEMS}
           LinkComponent={WebNavLink}
           accessibilityLabel="ABStrack application"
         />

--- a/apps/web/src/components/auth/UserLoginForm.spec.tsx
+++ b/apps/web/src/components/auth/UserLoginForm.spec.tsx
@@ -19,17 +19,21 @@ const verifyMock = jest.fn();
 const getUserMock = jest.fn();
 const signOutMock = jest.fn();
 
-jest.mock('../../lib/supabase/browser-client', () => ({
-  createBrowserClient: () => ({
-    auth: {
-      getUser: (...args: unknown[]) => getUserMock(...args),
-      signOut: (...args: unknown[]) => signOutMock(...args),
-      mfa: {
-        listFactors: (...args: unknown[]) => listFactorsMock(...args),
-        getAuthenticatorAssuranceLevel: (...args: unknown[]) =>
-          getAuthenticatorAssuranceLevelMock(...args),
-        challenge: (...args: unknown[]) => challengeMock(...args),
-        verify: (...args: unknown[]) => verifyMock(...args),
+jest.mock('../../lib/auth-provider', () => ({
+  useAuth: () => ({
+    session: null,
+    loading: false,
+    supabase: {
+      auth: {
+        getUser: (...args: unknown[]) => getUserMock(...args),
+        signOut: (...args: unknown[]) => signOutMock(...args),
+        mfa: {
+          listFactors: (...args: unknown[]) => listFactorsMock(...args),
+          getAuthenticatorAssuranceLevel: (...args: unknown[]) =>
+            getAuthenticatorAssuranceLevelMock(...args),
+          challenge: (...args: unknown[]) => challengeMock(...args),
+          verify: (...args: unknown[]) => verifyMock(...args),
+        },
       },
     },
   }),

--- a/apps/web/src/components/auth/UserLoginForm.spec.tsx
+++ b/apps/web/src/components/auth/UserLoginForm.spec.tsx
@@ -1,0 +1,97 @@
+import '@testing-library/jest-dom';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+
+const pushMock = jest.fn();
+const refreshMock = jest.fn();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock, refresh: refreshMock }),
+}));
+
+jest.mock('@abstrack/ui/a11y-web', () => ({
+  useAnnounce: () => ({ announce: jest.fn() }),
+}));
+
+const listFactorsMock = jest.fn();
+const getAuthenticatorAssuranceLevelMock = jest.fn();
+const challengeMock = jest.fn();
+const verifyMock = jest.fn();
+const getUserMock = jest.fn();
+const signOutMock = jest.fn();
+
+jest.mock('../../lib/supabase/browser-client', () => ({
+  createBrowserClient: () => ({
+    auth: {
+      getUser: (...args: unknown[]) => getUserMock(...args),
+      signOut: (...args: unknown[]) => signOutMock(...args),
+      mfa: {
+        listFactors: (...args: unknown[]) => listFactorsMock(...args),
+        getAuthenticatorAssuranceLevel: (...args: unknown[]) =>
+          getAuthenticatorAssuranceLevelMock(...args),
+        challenge: (...args: unknown[]) => challengeMock(...args),
+        verify: (...args: unknown[]) => verifyMock(...args),
+      },
+    },
+  }),
+}));
+
+jest.mock('@abstrack/supabase', () => ({
+  signInWithEmailPassword: jest.fn(async () => ({ error: null })),
+}));
+
+jest.mock('../../lib/user-mfa-device-trust', () => ({
+  isUserMfaDeviceTrustEnabled: () => true,
+  tryRestoreTrustedMfaSession: jest.fn(async () => ({
+    status: 'not_restored',
+  })),
+  clearMfaTrustBundle: jest.fn(),
+  saveMfaTrustBundle: jest.fn(),
+  getTrustedUntilMsForDuration: (duration: string) =>
+    Date.now() + (duration === '1_year' ? 365 : 30) * 24 * 60 * 60 * 1000,
+}));
+
+import { signInWithEmailPassword } from '@abstrack/supabase';
+import { UserLoginForm } from './UserLoginForm';
+
+describe('UserLoginForm', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getUserMock.mockResolvedValue({
+      data: { user: { id: 'user-1', email: 'a@example.com' } },
+      error: null,
+    });
+    listFactorsMock.mockResolvedValue({
+      data: {
+        totp: [{ id: 'factor-1', status: 'verified', friendly_name: 'Phone' }],
+      },
+      error: null,
+    });
+    getAuthenticatorAssuranceLevelMock.mockResolvedValue({
+      data: { currentLevel: 'aal1', nextLevel: 'aal2' },
+      error: null,
+    });
+  });
+
+  it('shows MFA step after password sign-in when a verified TOTP factor exists', async () => {
+    render(<UserLoginForm />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'a@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText(/password/i), {
+      target: { value: 'password123' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /login/i }));
+
+    await waitFor(() => {
+      expect(signInWithEmailPassword).toHaveBeenCalled();
+      expect(screen.getByLabelText(/authenticator code/i)).toBeInTheDocument();
+    });
+    expect(
+      screen.getByLabelText(/do not ask again for 30 days/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByLabelText(/do not ask again for 1 year/i),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/auth/UserLoginForm.tsx
+++ b/apps/web/src/components/auth/UserLoginForm.tsx
@@ -1,0 +1,632 @@
+'use client';
+
+import { signInWithEmailPassword } from '@abstrack/supabase';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type FormEvent,
+} from 'react';
+import {
+  looksLikeTotpSetupPayload,
+  mapMfaVerifyErrorToUserMessage,
+  normalizeTotpCode,
+} from '@/lib/mfa-user-messages';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import {
+  clearMfaTrustBundle,
+  getTrustedUntilMsForDuration,
+  isUserMfaDeviceTrustEnabled,
+  saveMfaTrustBundle,
+  tryRestoreTrustedMfaSession,
+  type UserMfaDeviceTrustDuration,
+} from '@/lib/user-mfa-device-trust';
+
+/** Whether to skip TOTP on later sign-ins from this browser, and for how long. */
+type DeviceTrustChoice = 'none' | UserMfaDeviceTrustDuration;
+
+type LoginStep = 'credentials' | 'mfa_verify';
+
+type ListedTotpFactor = {
+  id: string;
+  friendly_name?: string | null;
+};
+
+function buildMfaFactorChoices(factors: ListedTotpFactor[]): Array<{
+  id: string;
+  label: string;
+}> {
+  return factors.map((f, index) => ({
+    id: f.id,
+    label:
+      typeof f.friendly_name === 'string' && f.friendly_name.trim() !== ''
+        ? f.friendly_name.trim()
+        : `Authenticator ${index + 1}`,
+  }));
+}
+
+/**
+ * Patient/caretaker email/password login with optional TOTP step-up and device trust (30 days or 1 year).
+ *
+ * @returns Login form (credentials and MFA verify steps).
+ */
+export function UserLoginForm() {
+  const formId = useId();
+  const router = useRouter();
+  const { announce } = useAnnounce();
+  const supabase = useMemo(() => createBrowserClient(), []);
+  const deviceTrustFeatureEnabled = useMemo(
+    () => isUserMfaDeviceTrustEnabled(),
+    [],
+  );
+
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [verifyCode, setVerifyCode] = useState('');
+  const [deviceTrustChoice, setDeviceTrustChoice] =
+    useState<DeviceTrustChoice>('none');
+  const [mfaFactorId, setMfaFactorId] = useState<string | null>(null);
+  const [mfaFactorChoices, setMfaFactorChoices] = useState<
+    Array<{ id: string; label: string }>
+  >([]);
+  const [step, setStep] = useState<LoginStep>('credentials');
+  const [loading, setLoading] = useState(false);
+  const [verifyLoading, setVerifyLoading] = useState(false);
+  const [backToSignInLoading, setBackToSignInLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+
+  const credentialLoginInFlightRef = useRef(false);
+  const verifyMfaInFlightRef = useRef(false);
+  const emailInputRef = useRef<HTMLInputElement>(null);
+  const mfaFactorSelectRef = useRef<HTMLSelectElement>(null);
+  const mfaCodeInputRef = useRef<HTMLInputElement>(null);
+  const prevStepRef = useRef<LoginStep>(step);
+
+  useEffect(() => {
+    if (!deviceTrustFeatureEnabled) {
+      setDeviceTrustChoice('none');
+    }
+  }, [deviceTrustFeatureEnabled]);
+
+  useEffect(() => {
+    const previousStep = prevStepRef.current;
+    prevStepRef.current = step;
+
+    if (step === 'mfa_verify' && previousStep !== 'mfa_verify') {
+      const frameId = requestAnimationFrame(() => {
+        if (mfaFactorChoices.length > 1) {
+          mfaFactorSelectRef.current?.focus();
+        } else {
+          mfaCodeInputRef.current?.focus();
+        }
+      });
+      return () => cancelAnimationFrame(frameId);
+    }
+
+    if (step === 'credentials' && previousStep === 'mfa_verify') {
+      const frameId = requestAnimationFrame(() => {
+        emailInputRef.current?.focus();
+      });
+      return () => cancelAnimationFrame(frameId);
+    }
+
+    return undefined;
+  }, [step, mfaFactorChoices.length]);
+
+  const resetToCredentials = useCallback(
+    (options?: { clearPassword?: boolean; message?: string }) => {
+      setStep('credentials');
+      setVerifyCode('');
+      setDeviceTrustChoice('none');
+      setMfaFactorId(null);
+      setMfaFactorChoices([]);
+      setStatus(null);
+      if (options?.clearPassword) {
+        setPassword('');
+      }
+      if (options?.message != null) {
+        setError(options.message);
+        announce(options.message, { politeness: 'assertive' });
+      }
+    },
+    [announce],
+  );
+
+  const finishLogin = useCallback(() => {
+    router.push('/dashboard');
+    router.refresh();
+  }, [router]);
+
+  const handleLogin = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (
+      step !== 'credentials' ||
+      loading ||
+      credentialLoginInFlightRef.current
+    ) {
+      return;
+    }
+    credentialLoginInFlightRef.current = true;
+    setError(null);
+    setStatus(null);
+    setLoading(true);
+
+    let sessionEstablishedAfterPassword = false;
+
+    try {
+      const { error: authError } = await signInWithEmailPassword(
+        supabase,
+        email,
+        password,
+      );
+
+      if (authError) {
+        resetToCredentials({ message: authError.message });
+        return;
+      }
+
+      setPassword('');
+
+      const userResult = await supabase.auth.getUser();
+      const user = userResult.data.user;
+      if (userResult.error || user?.id == null || user.id === '') {
+        try {
+          await supabase.auth.signOut();
+          clearMfaTrustBundle();
+        } catch (cleanupError) {
+          console.error(cleanupError);
+        }
+        router.refresh();
+        resetToCredentials({
+          message: 'Could not resolve your account after sign-in.',
+        });
+        return;
+      }
+
+      sessionEstablishedAfterPassword = true;
+
+      const factorsResult = await supabase.auth.mfa.listFactors();
+      if (factorsResult.error) {
+        throw factorsResult.error;
+      }
+
+      const verifiedTotpFactors = factorsResult.data.totp.filter(
+        (factor) => factor.status === 'verified',
+      );
+
+      if (verifiedTotpFactors.length < 1) {
+        clearMfaTrustBundle();
+        finishLogin();
+        return;
+      }
+
+      const restoreOutcome = await tryRestoreTrustedMfaSession(
+        supabase,
+        user.id,
+      );
+      if (restoreOutcome.status === 'restored') {
+        finishLogin();
+        return;
+      }
+      if (restoreOutcome.status === 'signed_out') {
+        router.refresh();
+        resetToCredentials({
+          clearPassword: true,
+          message:
+            'Your sign-in session ended during the saved device check. Enter your email and password again.',
+        });
+        return;
+      }
+
+      const afterRestoreUser = await supabase.auth.getUser();
+      if (afterRestoreUser.error) {
+        console.error(afterRestoreUser.error);
+        resetToCredentials({
+          clearPassword: true,
+          message:
+            'Could not confirm your session after the saved device check. Enter your email and password again.',
+        });
+        return;
+      }
+      if (afterRestoreUser.data.user?.id == null) {
+        resetToCredentials({
+          clearPassword: true,
+          message:
+            'Your sign-in session ended during the saved device check. Enter your email and password again.',
+        });
+        return;
+      }
+      if (afterRestoreUser.data.user.id !== user.id) {
+        try {
+          await supabase.auth.signOut();
+          clearMfaTrustBundle();
+        } catch (cleanupError) {
+          console.error(cleanupError);
+        }
+        router.refresh();
+        resetToCredentials({
+          clearPassword: true,
+          message:
+            'Your session no longer matches this sign-in. You have been signed out for safety. Enter your email and password again.',
+        });
+        return;
+      }
+
+      const assurance =
+        await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+      if (assurance.error) {
+        throw assurance.error;
+      }
+
+      if (assurance.data.currentLevel === 'aal2') {
+        finishLogin();
+        return;
+      }
+
+      setMfaFactorChoices(buildMfaFactorChoices(verifiedTotpFactors));
+      setMfaFactorId(verifiedTotpFactors[0]?.id ?? null);
+      setStep('mfa_verify');
+      const message =
+        verifiedTotpFactors.length > 1
+          ? 'Choose which authenticator to use, then enter the six-digit code.'
+          : 'Enter the six-digit code from your authenticator app to continue.';
+      setStatus(message);
+      announce(message, { politeness: 'assertive' });
+    } catch (nextError) {
+      console.error(nextError);
+      if (sessionEstablishedAfterPassword) {
+        try {
+          await supabase.auth.signOut();
+          clearMfaTrustBundle();
+        } catch (cleanupError) {
+          console.error(cleanupError);
+        }
+        router.refresh();
+        resetToCredentials({
+          clearPassword: true,
+          message:
+            'Your password was accepted, but we could not finish verifying two-factor sign-in. You have been signed out for safety. Please try again.',
+        });
+      } else {
+        resetToCredentials({
+          message: 'Unable to complete sign-in right now. Please try again.',
+        });
+      }
+    } finally {
+      credentialLoginInFlightRef.current = false;
+      setLoading(false);
+    }
+  };
+
+  const handleVerifyMfa = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (
+      step !== 'mfa_verify' ||
+      verifyLoading ||
+      verifyMfaInFlightRef.current
+    ) {
+      return;
+    }
+    verifyMfaInFlightRef.current = true;
+    try {
+      setError(null);
+      setStatus(null);
+
+      if (mfaFactorId == null) {
+        const message =
+          'Could not determine which authenticator to verify. Please sign in again.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+        return;
+      }
+
+      if (!/^\d{6}$/.test(verifyCode)) {
+        const message =
+          'Enter the current six-digit code from your authenticator app.';
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+        return;
+      }
+
+      setVerifyLoading(true);
+      try {
+        const challenge = await supabase.auth.mfa.challenge({
+          factorId: mfaFactorId,
+        });
+        if (challenge.error) {
+          throw challenge.error;
+        }
+
+        const verify = await supabase.auth.mfa.verify({
+          factorId: mfaFactorId,
+          challengeId: challenge.data.id,
+          code: verifyCode,
+        });
+        if (verify.error) {
+          throw verify.error;
+        }
+
+        const assuranceAfterVerify =
+          await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+        if (assuranceAfterVerify.error) {
+          throw assuranceAfterVerify.error;
+        }
+        if (assuranceAfterVerify.data.currentLevel !== 'aal2') {
+          const message =
+            'Two-factor sign-in did not finish updating your session. Try another code, or use Back to sign in to start over.';
+          setError(message);
+          announce(message, { politeness: 'assertive' });
+          return;
+        }
+
+        const { data: sessionAfterVerify, error: sessionAfterVerifyError } =
+          await supabase.auth.getSession();
+        if (sessionAfterVerifyError || sessionAfterVerify.session == null) {
+          const message =
+            'Your session could not be confirmed after verification. Try a new code from your authenticator app, or use Back to sign in to start over.';
+          setError(message);
+          announce(message, { politeness: 'assertive' });
+          return;
+        }
+
+        if (deviceTrustFeatureEnabled && deviceTrustChoice !== 'none') {
+          saveMfaTrustBundle(
+            sessionAfterVerify.session,
+            getTrustedUntilMsForDuration(deviceTrustChoice),
+          );
+        } else {
+          clearMfaTrustBundle();
+        }
+
+        finishLogin();
+      } catch (verifyError) {
+        const message = mapMfaVerifyErrorToUserMessage(verifyError);
+        setError(message);
+        announce(message, { politeness: 'assertive' });
+      } finally {
+        setVerifyLoading(false);
+      }
+    } finally {
+      verifyMfaInFlightRef.current = false;
+    }
+  };
+
+  const handleBackToSignIn = async () => {
+    if (verifyLoading || backToSignInLoading) {
+      return;
+    }
+    setError(null);
+    setBackToSignInLoading(true);
+    try {
+      const { error: signOutError } = await supabase.auth.signOut();
+      if (signOutError) {
+        throw signOutError;
+      }
+      clearMfaTrustBundle();
+      resetToCredentials({ clearPassword: true });
+      router.refresh();
+      announce(
+        'Signed out. You can enter your email and password to sign in again.',
+        { politeness: 'polite' },
+      );
+    } catch (backError) {
+      console.error(backError);
+      const message =
+        'Could not sign out. Try again, or refresh the page before using a different account.';
+      setError(message);
+      announce(message, { politeness: 'assertive' });
+    } finally {
+      setBackToSignInLoading(false);
+    }
+  };
+
+  const showCredentialsStep = step === 'credentials';
+
+  return (
+    <>
+      {status ? (
+        <p
+          role="status"
+          className="mb-4 rounded border border-app-border bg-app-bg p-3 text-sm text-app-muted"
+        >
+          {status}
+        </p>
+      ) : null}
+
+      {error ? (
+        <div className="mb-4 rounded border border-red-200 bg-red-50 p-4 text-red-700 dark:border-red-800/60 dark:bg-red-950/35 dark:text-red-200">
+          {error}
+        </div>
+      ) : null}
+
+      {showCredentialsStep ? (
+        <form onSubmit={handleLogin} className="space-y-4">
+          <div>
+            <label
+              htmlFor={`${formId}-email`}
+              className="block text-sm font-medium text-app-muted"
+            >
+              Email
+            </label>
+            <input
+              ref={emailInputRef}
+              id={`${formId}-email`}
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              required
+              autoComplete="email"
+              className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+              placeholder="you@example.com"
+            />
+          </div>
+
+          <div>
+            <label
+              htmlFor={`${formId}-password`}
+              className="block text-sm font-medium text-app-muted"
+            >
+              Password
+            </label>
+            <input
+              id={`${formId}-password`}
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              required
+              autoComplete="current-password"
+              className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+              placeholder="••••••••"
+            />
+            <div className="mt-2 text-right">
+              <Link
+                href="/forgot-password"
+                className="text-sm text-app-primary hover:underline"
+              >
+                Forgot password?
+              </Link>
+            </div>
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-md bg-app-primary-solid px-4 py-2 text-app-on-primary-solid transition hover:brightness-105 disabled:opacity-50"
+          >
+            {loading ? 'Logging in...' : 'Login'}
+          </button>
+        </form>
+      ) : (
+        <form onSubmit={handleVerifyMfa} className="space-y-4">
+          {mfaFactorChoices.length > 1 ? (
+            <div>
+              <label
+                htmlFor={`${formId}-mfa-factor`}
+                className="block text-sm font-medium text-app-muted"
+              >
+                Authenticator
+              </label>
+              <select
+                ref={mfaFactorSelectRef}
+                id={`${formId}-mfa-factor`}
+                value={mfaFactorId ?? ''}
+                onChange={(event) => {
+                  setMfaFactorId(event.target.value || null);
+                  setError(null);
+                }}
+                className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+              >
+                {mfaFactorChoices.map((choice) => (
+                  <option key={choice.id} value={choice.id}>
+                    {choice.label}
+                  </option>
+                ))}
+              </select>
+            </div>
+          ) : null}
+          <div>
+            <label
+              htmlFor={`${formId}-mfa-code`}
+              className="block text-sm font-medium text-app-muted"
+            >
+              Authenticator code
+            </label>
+            <input
+              ref={mfaCodeInputRef}
+              id={`${formId}-mfa-code`}
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              maxLength={6}
+              value={verifyCode}
+              onChange={(event) => {
+                const raw = event.target.value;
+                if (looksLikeTotpSetupPayload(raw)) {
+                  const message =
+                    'Enter only the six-digit code from your authenticator app.';
+                  setVerifyCode('');
+                  setError(message);
+                  announce(message, { politeness: 'assertive' });
+                  return;
+                }
+                setError(null);
+                setVerifyCode(normalizeTotpCode(raw));
+              }}
+              className="mt-1 block w-full rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+              placeholder="123456"
+            />
+          </div>
+
+          {deviceTrustFeatureEnabled ? (
+            <fieldset className="space-y-2 rounded-md border border-app-border/80 p-3">
+              <legend className="px-1 text-sm font-medium text-app-ink">
+                Remember this device
+              </legend>
+              <p className="text-xs text-app-muted">
+                Skip the authenticator code on later sign-ins from this browser.
+                Sign out everywhere in Settings to require a code again sooner.
+              </p>
+              <div className="space-y-2 text-sm text-app-muted">
+                <label className="flex items-start gap-2">
+                  <input
+                    type="radio"
+                    name={`${formId}-device-trust`}
+                    className="mt-1 h-4 w-4 border-app-border"
+                    checked={deviceTrustChoice === 'none'}
+                    onChange={() => setDeviceTrustChoice('none')}
+                  />
+                  <span>Ask every time I sign in on this device</span>
+                </label>
+                <label className="flex items-start gap-2">
+                  <input
+                    type="radio"
+                    name={`${formId}-device-trust`}
+                    className="mt-1 h-4 w-4 border-app-border"
+                    checked={deviceTrustChoice === '30_days'}
+                    onChange={() => setDeviceTrustChoice('30_days')}
+                  />
+                  <span>Do not ask again for 30 days</span>
+                </label>
+                <label className="flex items-start gap-2">
+                  <input
+                    type="radio"
+                    name={`${formId}-device-trust`}
+                    className="mt-1 h-4 w-4 border-app-border"
+                    checked={deviceTrustChoice === '1_year'}
+                    onChange={() => setDeviceTrustChoice('1_year')}
+                  />
+                  <span>Do not ask again for 1 year</span>
+                </label>
+              </div>
+            </fieldset>
+          ) : null}
+
+          <button
+            type="submit"
+            disabled={verifyLoading}
+            className="w-full rounded-md bg-app-primary-solid px-4 py-2 text-app-on-primary-solid transition hover:brightness-105 disabled:opacity-50"
+          >
+            {verifyLoading ? 'Verifying code...' : 'Verify and continue'}
+          </button>
+
+          <button
+            type="button"
+            disabled={verifyLoading || backToSignInLoading}
+            onClick={() => {
+              void handleBackToSignIn();
+            }}
+            className="w-full rounded-md border border-app-border bg-app-surface px-4 py-2 text-app-ink transition hover:bg-app-bg disabled:opacity-50"
+          >
+            {backToSignInLoading ? 'Signing out…' : 'Back to sign in'}
+          </button>
+        </form>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/components/auth/UserLoginForm.tsx
+++ b/apps/web/src/components/auth/UserLoginForm.tsx
@@ -18,7 +18,7 @@ import {
   mapMfaVerifyErrorToUserMessage,
   normalizeTotpCode,
 } from '@/lib/mfa-user-messages';
-import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { useAuth } from '@/lib/auth-provider';
 import {
   clearMfaTrustBundle,
   getTrustedUntilMsForDuration,
@@ -60,7 +60,7 @@ export function UserLoginForm() {
   const formId = useId();
   const router = useRouter();
   const { announce } = useAnnounce();
-  const supabase = useMemo(() => createBrowserClient(), []);
+  const { supabase } = useAuth();
   const deviceTrustFeatureEnabled = useMemo(
     () => isUserMfaDeviceTrustEnabled(),
     [],

--- a/apps/web/src/components/auth/WebSignOutButton.tsx
+++ b/apps/web/src/components/auth/WebSignOutButton.tsx
@@ -1,0 +1,33 @@
+'use client';
+
+import { ACCOUNT_ACTIONS_SURFACE_CLASS } from '@abstrack/ui-web';
+import { useMemo, useState } from 'react';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { userSignOut } from '@/lib/user-mfa-device-trust';
+
+/**
+ * Sign-out control that preserves MFA device trust when the user opted in for 30 days
+ * (soft sign-out clears browser session only; full logout revokes server tokens).
+ *
+ * @returns Log out button for the authenticated shell.
+ */
+export function WebSignOutButton() {
+  const supabase = useMemo(() => createBrowserClient(), []);
+  const [loading, setLoading] = useState(false);
+
+  return (
+    <button
+      type="button"
+      disabled={loading}
+      className={ACCOUNT_ACTIONS_SURFACE_CLASS}
+      onClick={() => {
+        setLoading(true);
+        void userSignOut(supabase).finally(() => {
+          setLoading(false);
+        });
+      }}
+    >
+      {loading ? 'Signing out…' : 'Log out'}
+    </button>
+  );
+}

--- a/apps/web/src/components/auth/WebSignOutButton.tsx
+++ b/apps/web/src/components/auth/WebSignOutButton.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { ACCOUNT_ACTIONS_SURFACE_CLASS } from '@abstrack/ui-web';
-import { useMemo, useState } from 'react';
-import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { useState } from 'react';
+import { useAuth } from '@/lib/auth-provider';
 import { userSignOut } from '@/lib/user-mfa-device-trust';
 
 /**
@@ -12,7 +12,7 @@ import { userSignOut } from '@/lib/user-mfa-device-trust';
  * @returns Log out button for the authenticated shell.
  */
 export function WebSignOutButton() {
-  const supabase = useMemo(() => createBrowserClient(), []);
+  const { supabase } = useAuth();
   const [loading, setLoading] = useState(false);
 
   return (

--- a/apps/web/src/components/manage/ManageRecordsPage.tsx
+++ b/apps/web/src/components/manage/ManageRecordsPage.tsx
@@ -629,7 +629,7 @@ export function ManageRecordsPage() {
 
   const tabClass = (s: ManageSegment) =>
     segment === s
-      ? 'inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full bg-app-primary-soft px-4 py-2 text-sm font-semibold text-app-primary shadow-sm ring-1 ring-app-primary/25 dark:bg-app-primary-soft/28'
+      ? 'inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full bg-app-tab-active-bg px-4 py-2 text-sm font-semibold text-app-tab-active-text shadow-sm ring-1 ring-app-tab-active-ring/25'
       : 'inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full px-4 py-2 text-sm font-medium text-app-muted transition hover:bg-[var(--app-nav-hover-bg)] hover:text-app-ink';
   const tabButtonRefs = useRef<
     Partial<Record<ManageSegment, HTMLButtonElement>>

--- a/apps/web/src/components/settings/CaretakerAccessPage.tsx
+++ b/apps/web/src/components/settings/CaretakerAccessPage.tsx
@@ -34,9 +34,15 @@ function formatInviteExpiry(iso: string): string {
  * reflects PRD §7 (caretaker ≈ patient capabilities for impaired-use scenarios; distinct from
  * practitioner).
  *
+ * @param props - Optional layout variant for the consolidated settings page.
  * @returns Settings page content.
  */
-export function CaretakerAccessPage() {
+export function CaretakerAccessPage({
+  embedded = false,
+}: {
+  /** When true, omits standalone page chrome (back link and top-level heading). */
+  embedded?: boolean;
+}) {
   const { announce } = useAnnounce();
   const { session, loading: authLoading } = useAuth();
   const formId = useId();
@@ -266,27 +272,40 @@ export function CaretakerAccessPage() {
   }
 
   return (
-    <div className="w-full space-y-8">
-      <div>
-        <Link
-          href="/dashboard"
-          className="text-sm font-medium text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-        >
-          ← Back to dashboard
-        </Link>
-        <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
-          Caretaker access
-        </h1>
-        <p className="mt-2 text-sm text-app-muted">
-          A caretaker signs in with his or her own ABStrack account and uses the
-          same logging flows as you, with matching data access, once the invite
-          completes. Invite links open the ABStrack mobile app when tapped on a
-          phone (mobile-first), and the same link completes caretaker sign-up on
-          user web when opened in a browser. This is separate from a healthcare
-          practitioner: the practitioner web app is read-only and does not
-          replace you in patient flows.
-        </p>
-      </div>
+    <div className={embedded ? 'w-full space-y-6' : 'w-full space-y-8'}>
+      {embedded ? (
+        <div>
+          <h2 className="text-lg font-semibold text-app-ink">
+            Caretaker access
+          </h2>
+          <p className="mt-2 text-sm text-app-muted">
+            A caretaker signs in with his or her own ABStrack account and uses
+            the same logging flows as you once the invite completes. Invite
+            links open the mobile app on a phone, or user web in a browser.
+          </p>
+        </div>
+      ) : (
+        <div>
+          <Link
+            href="/dashboard"
+            className="text-sm font-medium text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            ← Back to dashboard
+          </Link>
+          <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
+            Caretaker access
+          </h1>
+          <p className="mt-2 text-sm text-app-muted">
+            A caretaker signs in with his or her own ABStrack account and uses
+            the same logging flows as you, with matching data access, once the
+            invite completes. Invite links open the ABStrack mobile app when
+            tapped on a phone (mobile-first), and the same link completes
+            caretaker sign-up on user web when opened in a browser. This is
+            separate from a healthcare practitioner: the practitioner web app is
+            read-only and does not replace you in patient flows.
+          </p>
+        </div>
+      )}
 
       {loadError ? (
         <p className="text-sm text-red-700 dark:text-red-300" role="alert">

--- a/apps/web/src/components/settings/PractitionerAccessPage.tsx
+++ b/apps/web/src/components/settings/PractitionerAccessPage.tsx
@@ -34,9 +34,15 @@ function formatInviteExpiry(iso: string): string {
  * (read-only access after invite acceptance; TOTP required only when they enable password sign-in;
  * PRD §8). Grants and revokes go through the `patient-practitioner-access` Edge Function.
  *
+ * @param props - Optional layout variant for the consolidated settings page.
  * @returns Settings page content.
  */
-export function PractitionerAccessPage() {
+export function PractitionerAccessPage({
+  embedded = false,
+}: {
+  /** When true, omits standalone page chrome (back link and top-level heading). */
+  embedded?: boolean;
+}) {
   const { announce } = useAnnounce();
   const { session, loading: authLoading } = useAuth();
   const formId = useId();
@@ -338,27 +344,40 @@ export function PractitionerAccessPage() {
     'Practitioner account';
 
   return (
-    <div className="w-full space-y-8">
-      <div>
-        <Link
-          href="/dashboard"
-          className="text-sm font-medium text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-        >
-          ← Back to dashboard
-        </Link>
-        <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
-          Practitioner access
-        </h1>
-        <p className="mt-2 text-sm text-app-muted">
-          Enter your clinician&apos;s email to send an invitation. They accept
-          it on the separate ABStrack practitioner web app (not this patient
-          app), usually via the email link. They can read your shared health
-          data while access stays active. Two-factor authentication is required
-          only if they set a password for email sign-in; magic-link sign-in
-          alone does not require it. Revoking stops future reads; it does not
-          erase data they may already have viewed (PRD §8).
-        </p>
-      </div>
+    <div className={embedded ? 'w-full space-y-6' : 'w-full space-y-8'}>
+      {embedded ? (
+        <div>
+          <h2 className="text-lg font-semibold text-app-ink">
+            Practitioner access
+          </h2>
+          <p className="mt-2 text-sm text-app-muted">
+            Invite clinicians who use the separate practitioner web app. They
+            accept the email link there. Two-factor authentication is required
+            only if they set a password for email sign-in.
+          </p>
+        </div>
+      ) : (
+        <div>
+          <Link
+            href="/dashboard"
+            className="text-sm font-medium text-app-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+          >
+            ← Back to dashboard
+          </Link>
+          <h1 className="mt-4 text-2xl font-bold tracking-tight text-app-ink">
+            Practitioner access
+          </h1>
+          <p className="mt-2 text-sm text-app-muted">
+            Enter your clinician&apos;s email to send an invitation. They accept
+            it on the separate ABStrack practitioner web app (not this patient
+            app), usually via the email link. They can read your shared health
+            data while access stays active. Two-factor authentication is
+            required only if they set a password for email sign-in; magic-link
+            sign-in alone does not require it. Revoking stops future reads; it
+            does not erase data they may already have viewed (PRD §8).
+          </p>
+        </div>
+      )}
 
       {loadError ? (
         <p className="text-sm text-red-700 dark:text-red-300" role="alert">

--- a/apps/web/src/components/settings/SettingsPage.tsx
+++ b/apps/web/src/components/settings/SettingsPage.tsx
@@ -27,6 +27,7 @@ import {
   parseSettingsTabId,
 } from '@/lib/settings-tabs';
 import { readPendingEmailChange } from '@/lib/pending-email-change';
+import { ensurePatientProfileRow } from '@abstrack/supabase';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { webSignOutEverywhere } from '@/lib/web-sign-out-everywhere';
 
@@ -142,6 +143,12 @@ export function SettingsPage() {
     nameFormDirtyRef.current = false;
     setProfileLoading(true);
     setNameError(null);
+    const ensured = await ensurePatientProfileRow(supabase, userId);
+    if (!ensured.ok) {
+      setNameError('Unable to load your profile. Try again in a moment.');
+      setProfileLoading(false);
+      return;
+    }
     const { data, error } = await supabase
       .from('profiles')
       .select('display_name')

--- a/apps/web/src/components/settings/SettingsPage.tsx
+++ b/apps/web/src/components/settings/SettingsPage.tsx
@@ -101,6 +101,12 @@ export function SettingsPage() {
     );
   }, [profileAppRole]);
 
+  const activeTabNotVisible = !visibleTabs.includes(activeTab);
+  const displayTab = activeTabNotVisible
+    ? (visibleTabs[0] ?? 'account')
+    : activeTab;
+  const showTabResolutionLoading = phiContextLoading && activeTabNotVisible;
+
   useEffect(() => {
     if (phiContextLoading) {
       return;
@@ -376,9 +382,9 @@ export function SettingsPage() {
             role="tab"
             id={tabId(tab)}
             aria-controls={panelId(tab)}
-            aria-selected={activeTab === tab ? 'true' : 'false'}
-            tabIndex={activeTab === tab ? 0 : -1}
-            className={tabClass(activeTab === tab)}
+            aria-selected={displayTab === tab ? 'true' : 'false'}
+            tabIndex={displayTab === tab ? 0 : -1}
+            className={tabClass(displayTab === tab)}
             ref={(node) => {
               tabButtonRefs.current[tab] = node ?? undefined;
             }}
@@ -390,289 +396,299 @@ export function SettingsPage() {
         ))}
       </div>
 
-      <div
-        role="tabpanel"
-        id={panelId('account')}
-        aria-labelledby={tabId('account')}
-        hidden={activeTab !== 'account'}
-        tabIndex={0}
-        className="space-y-8 outline-none"
-      >
-        {activeTab === 'account' ? (
-          <>
-            <section
-              aria-labelledby={`${formId}-name-heading`}
-              className={SETTINGS_SURFACE_CLASS}
-            >
-              <h2
-                id={`${formId}-name-heading`}
-                className="text-lg font-semibold text-app-ink"
-              >
-                Name
-              </h2>
-              <p className="mt-2 text-sm text-app-muted">
-                Your name may appear when you share access with a caretaker or
-                practitioner.
-              </p>
-              {profileLoading ? (
-                <p className="mt-4 text-sm text-app-muted" role="status">
-                  Loading profile…
-                </p>
-              ) : (
-                <form
-                  className="mt-6 grid gap-4 sm:grid-cols-2"
-                  onSubmit={(e) => {
-                    void onNameSubmit(e);
-                  }}
-                  noValidate
+      {showTabResolutionLoading ? (
+        <p className="text-sm text-app-muted" role="status">
+          Loading settings…
+        </p>
+      ) : (
+        <>
+          <div
+            role="tabpanel"
+            id={panelId('account')}
+            aria-labelledby={tabId('account')}
+            hidden={displayTab !== 'account'}
+            tabIndex={0}
+            className="space-y-8 outline-none"
+          >
+            {displayTab === 'account' ? (
+              <>
+                <section
+                  aria-labelledby={`${formId}-name-heading`}
+                  className={SETTINGS_SURFACE_CLASS}
                 >
-                  <div className="space-y-2">
-                    <label
-                      htmlFor={`${formId}-first-name`}
-                      className="text-sm font-medium text-app-ink"
-                    >
-                      First name
-                    </label>
-                    <input
-                      id={`${formId}-first-name`}
-                      type="text"
-                      autoComplete="given-name"
-                      value={firstName}
-                      onChange={(e) => {
-                        nameFormDirtyRef.current = true;
-                        clearNameSaveFeedback();
-                        setFirstName(e.target.value);
-                      }}
-                      className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
-                    />
-                  </div>
-                  <div className="space-y-2">
-                    <label
-                      htmlFor={`${formId}-last-name`}
-                      className="text-sm font-medium text-app-ink"
-                    >
-                      Last name
-                    </label>
-                    <input
-                      id={`${formId}-last-name`}
-                      type="text"
-                      autoComplete="family-name"
-                      value={lastName}
-                      onChange={(e) => {
-                        nameFormDirtyRef.current = true;
-                        clearNameSaveFeedback();
-                        setLastName(e.target.value);
-                      }}
-                      className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
-                    />
-                  </div>
-                  {nameError ? (
-                    <p
-                      role="alert"
-                      className="sm:col-span-2 text-sm text-red-700 dark:text-red-300"
-                    >
-                      {nameError}
-                    </p>
-                  ) : null}
-                  <div className="sm:col-span-2">
-                    <button
-                      type="submit"
-                      disabled={nameSubmitting}
-                      aria-live="polite"
-                      className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
-                    >
-                      {nameSubmitting
-                        ? 'Saving…'
-                        : nameSavedVisible
-                          ? 'Saved'
-                          : 'Save name'}
-                    </button>
-                  </div>
-                </form>
-              )}
-            </section>
-
-            <section
-              aria-labelledby={`${formId}-email-heading`}
-              className={SETTINGS_SURFACE_CLASS}
-            >
-              <h2
-                id={`${formId}-email-heading`}
-                className="text-lg font-semibold text-app-ink"
-              >
-                Email
-              </h2>
-              <p className="mt-2 text-sm text-app-muted">
-                {pendingEmailChange ? (
-                  <>
-                    Your sign-in email is still{' '}
-                    <span className="font-medium text-app-ink">
-                      {currentEmail || 'Not set'}
-                    </span>
-                    . Finish confirming{' '}
-                    <span className="font-medium text-app-ink">
-                      {pendingEmailChange}
-                    </span>{' '}
-                    using the link we emailed to that address.
-                  </>
-                ) : (
-                  <>
-                    Current address:{' '}
-                    <span className="font-medium text-app-ink">
-                      {currentEmail || 'Not set'}
-                    </span>
-                    . We will send a confirmation link to your new address
-                    before the change takes effect.
-                  </>
-                )}
-              </p>
-              {pendingEmailChange ? (
-                <div
-                  className="mt-6 space-y-4"
-                  role="status"
-                  aria-labelledby={`${formId}-email-pending-heading`}
-                >
-                  <div className="rounded-xl border border-app-border/80 bg-app-bg p-4">
-                    <h3
-                      id={`${formId}-email-pending-heading`}
-                      className="text-sm font-semibold text-app-ink"
-                    >
-                      Email change pending
-                    </h3>
-                    <dl className="mt-3 space-y-2 text-sm">
-                      <div>
-                        <dt className="text-app-muted">Current address</dt>
-                        <dd className="font-medium text-app-ink">
-                          {currentEmail || 'Not set'}
-                        </dd>
-                      </div>
-                      <div>
-                        <dt className="text-app-muted">Changing to</dt>
-                        <dd className="font-medium text-app-ink">
-                          {pendingEmailChange}
-                        </dd>
-                      </div>
-                    </dl>
-                    <p className="mt-3 text-sm text-app-muted">
-                      We sent a confirmation link to{' '}
-                      <span className="font-medium text-app-ink">
-                        {pendingEmailChange}
-                      </span>
-                      . Open that message to finish the change.
-                    </p>
-                  </div>
-                  {!showEmailChangeForm ? (
-                    <button
-                      type="button"
-                      className="min-h-[44px] rounded-full border border-app-border px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
-                      onClick={() => {
-                        setShowEmailChangeForm(true);
-                        setEmailError(null);
-                      }}
-                    >
-                      Use a different address
-                    </button>
-                  ) : null}
-                </div>
-              ) : null}
-              {!pendingEmailChange || showEmailChangeForm ? (
-                <form
-                  className="mt-6 space-y-4"
-                  onSubmit={(e) => {
-                    void onEmailSubmit(e);
-                  }}
-                  noValidate
-                >
-                  <div className="space-y-2">
-                    <label
-                      htmlFor={`${formId}-new-email`}
-                      className="text-sm font-medium text-app-ink"
-                    >
-                      New email
-                    </label>
-                    <input
-                      id={`${formId}-new-email`}
-                      type="email"
-                      autoComplete="email"
-                      value={newEmail}
-                      onChange={(e) => setNewEmail(e.target.value)}
-                      className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
-                    />
-                  </div>
-                  {emailError ? (
-                    <p
-                      role="alert"
-                      className="text-sm text-red-700 dark:text-red-300"
-                    >
-                      {emailError}
-                    </p>
-                  ) : null}
-                  <button
-                    type="submit"
-                    disabled={emailSubmitting}
-                    className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                  <h2
+                    id={`${formId}-name-heading`}
+                    className="text-lg font-semibold text-app-ink"
                   >
-                    {emailSubmitting ? 'Sending…' : 'Send confirmation email'}
+                    Name
+                  </h2>
+                  <p className="mt-2 text-sm text-app-muted">
+                    Your name may appear when you share access with a caretaker
+                    or practitioner.
+                  </p>
+                  {profileLoading ? (
+                    <p className="mt-4 text-sm text-app-muted" role="status">
+                      Loading profile…
+                    </p>
+                  ) : (
+                    <form
+                      className="mt-6 grid gap-4 sm:grid-cols-2"
+                      onSubmit={(e) => {
+                        void onNameSubmit(e);
+                      }}
+                      noValidate
+                    >
+                      <div className="space-y-2">
+                        <label
+                          htmlFor={`${formId}-first-name`}
+                          className="text-sm font-medium text-app-ink"
+                        >
+                          First name
+                        </label>
+                        <input
+                          id={`${formId}-first-name`}
+                          type="text"
+                          autoComplete="given-name"
+                          value={firstName}
+                          onChange={(e) => {
+                            nameFormDirtyRef.current = true;
+                            clearNameSaveFeedback();
+                            setFirstName(e.target.value);
+                          }}
+                          className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                        />
+                      </div>
+                      <div className="space-y-2">
+                        <label
+                          htmlFor={`${formId}-last-name`}
+                          className="text-sm font-medium text-app-ink"
+                        >
+                          Last name
+                        </label>
+                        <input
+                          id={`${formId}-last-name`}
+                          type="text"
+                          autoComplete="family-name"
+                          value={lastName}
+                          onChange={(e) => {
+                            nameFormDirtyRef.current = true;
+                            clearNameSaveFeedback();
+                            setLastName(e.target.value);
+                          }}
+                          className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                        />
+                      </div>
+                      {nameError ? (
+                        <p
+                          role="alert"
+                          className="sm:col-span-2 text-sm text-red-700 dark:text-red-300"
+                        >
+                          {nameError}
+                        </p>
+                      ) : null}
+                      <div className="sm:col-span-2">
+                        <button
+                          type="submit"
+                          disabled={nameSubmitting}
+                          aria-live="polite"
+                          className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                        >
+                          {nameSubmitting
+                            ? 'Saving…'
+                            : nameSavedVisible
+                              ? 'Saved'
+                              : 'Save name'}
+                        </button>
+                      </div>
+                    </form>
+                  )}
+                </section>
+
+                <section
+                  aria-labelledby={`${formId}-email-heading`}
+                  className={SETTINGS_SURFACE_CLASS}
+                >
+                  <h2
+                    id={`${formId}-email-heading`}
+                    className="text-lg font-semibold text-app-ink"
+                  >
+                    Email
+                  </h2>
+                  <p className="mt-2 text-sm text-app-muted">
+                    {pendingEmailChange ? (
+                      <>
+                        Your sign-in email is still{' '}
+                        <span className="font-medium text-app-ink">
+                          {currentEmail || 'Not set'}
+                        </span>
+                        . Finish confirming{' '}
+                        <span className="font-medium text-app-ink">
+                          {pendingEmailChange}
+                        </span>{' '}
+                        using the link we emailed to that address.
+                      </>
+                    ) : (
+                      <>
+                        Current address:{' '}
+                        <span className="font-medium text-app-ink">
+                          {currentEmail || 'Not set'}
+                        </span>
+                        . We will send a confirmation link to your new address
+                        before the change takes effect.
+                      </>
+                    )}
+                  </p>
+                  {pendingEmailChange ? (
+                    <div
+                      className="mt-6 space-y-4"
+                      role="status"
+                      aria-labelledby={`${formId}-email-pending-heading`}
+                    >
+                      <div className="rounded-xl border border-app-border/80 bg-app-bg p-4">
+                        <h3
+                          id={`${formId}-email-pending-heading`}
+                          className="text-sm font-semibold text-app-ink"
+                        >
+                          Email change pending
+                        </h3>
+                        <dl className="mt-3 space-y-2 text-sm">
+                          <div>
+                            <dt className="text-app-muted">Current address</dt>
+                            <dd className="font-medium text-app-ink">
+                              {currentEmail || 'Not set'}
+                            </dd>
+                          </div>
+                          <div>
+                            <dt className="text-app-muted">Changing to</dt>
+                            <dd className="font-medium text-app-ink">
+                              {pendingEmailChange}
+                            </dd>
+                          </div>
+                        </dl>
+                        <p className="mt-3 text-sm text-app-muted">
+                          We sent a confirmation link to{' '}
+                          <span className="font-medium text-app-ink">
+                            {pendingEmailChange}
+                          </span>
+                          . Open that message to finish the change.
+                        </p>
+                      </div>
+                      {!showEmailChangeForm ? (
+                        <button
+                          type="button"
+                          className="min-h-[44px] rounded-full border border-app-border px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                          onClick={() => {
+                            setShowEmailChangeForm(true);
+                            setEmailError(null);
+                          }}
+                        >
+                          Use a different address
+                        </button>
+                      ) : null}
+                    </div>
+                  ) : null}
+                  {!pendingEmailChange || showEmailChangeForm ? (
+                    <form
+                      className="mt-6 space-y-4"
+                      onSubmit={(e) => {
+                        void onEmailSubmit(e);
+                      }}
+                      noValidate
+                    >
+                      <div className="space-y-2">
+                        <label
+                          htmlFor={`${formId}-new-email`}
+                          className="text-sm font-medium text-app-ink"
+                        >
+                          New email
+                        </label>
+                        <input
+                          id={`${formId}-new-email`}
+                          type="email"
+                          autoComplete="email"
+                          value={newEmail}
+                          onChange={(e) => setNewEmail(e.target.value)}
+                          className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                        />
+                      </div>
+                      {emailError ? (
+                        <p
+                          role="alert"
+                          className="text-sm text-red-700 dark:text-red-300"
+                        >
+                          {emailError}
+                        </p>
+                      ) : null}
+                      <button
+                        type="submit"
+                        disabled={emailSubmitting}
+                        className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                      >
+                        {emailSubmitting
+                          ? 'Sending…'
+                          : 'Send confirmation email'}
+                      </button>
+                    </form>
+                  ) : null}
+                </section>
+
+                <section
+                  aria-labelledby={`${formId}-sessions-heading`}
+                  className={SETTINGS_SURFACE_CLASS}
+                >
+                  <h2
+                    id={`${formId}-sessions-heading`}
+                    className="text-lg font-semibold text-app-ink"
+                  >
+                    Sessions
+                  </h2>
+                  <p className="mt-2 text-sm text-app-muted">
+                    Sign out on every device where you are signed in to
+                    ABStrack. Use this on a shared computer or if you think
+                    someone else may have access to your account.
+                  </p>
+                  <button
+                    type="button"
+                    className="mt-4 min-h-[44px] rounded-full bg-red-600 px-5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-700 dark:hover:bg-red-600"
+                    onClick={() => setSignOutEverywhereOpen(true)}
+                  >
+                    Sign out everywhere
                   </button>
-                </form>
-              ) : null}
-            </section>
+                </section>
+              </>
+            ) : null}
+          </div>
 
-            <section
-              aria-labelledby={`${formId}-sessions-heading`}
-              className={SETTINGS_SURFACE_CLASS}
+          <div
+            role="tabpanel"
+            id={panelId('security')}
+            aria-labelledby={tabId('security')}
+            hidden={displayTab !== 'security'}
+            tabIndex={0}
+            className="outline-none"
+          >
+            {displayTab === 'security' ? <SettingsSecuritySection /> : null}
+          </div>
+
+          {profileAppRole === 'patient' ? (
+            <div
+              role="tabpanel"
+              id={panelId('invites')}
+              aria-labelledby={tabId('invites')}
+              hidden={displayTab !== 'invites'}
+              tabIndex={0}
+              className="space-y-12 outline-none"
             >
-              <h2
-                id={`${formId}-sessions-heading`}
-                className="text-lg font-semibold text-app-ink"
-              >
-                Sessions
-              </h2>
-              <p className="mt-2 text-sm text-app-muted">
-                Sign out on every device where you are signed in to ABStrack.
-                Use this on a shared computer or if you think someone else may
-                have access to your account.
-              </p>
-              <button
-                type="button"
-                className="mt-4 min-h-[44px] rounded-full bg-red-600 px-5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-700 dark:hover:bg-red-600"
-                onClick={() => setSignOutEverywhereOpen(true)}
-              >
-                Sign out everywhere
-              </button>
-            </section>
-          </>
-        ) : null}
-      </div>
-
-      <div
-        role="tabpanel"
-        id={panelId('security')}
-        aria-labelledby={tabId('security')}
-        hidden={activeTab !== 'security'}
-        tabIndex={0}
-        className="outline-none"
-      >
-        {activeTab === 'security' ? <SettingsSecuritySection /> : null}
-      </div>
-
-      {profileAppRole === 'patient' ? (
-        <div
-          role="tabpanel"
-          id={panelId('invites')}
-          aria-labelledby={tabId('invites')}
-          hidden={activeTab !== 'invites'}
-          tabIndex={0}
-          className="space-y-12 outline-none"
-        >
-          {activeTab === 'invites' ? (
-            <>
-              <CaretakerAccessPage embedded />
-              <PractitionerAccessPage embedded />
-            </>
+              {displayTab === 'invites' ? (
+                <>
+                  <CaretakerAccessPage embedded />
+                  <PractitionerAccessPage embedded />
+                </>
+              ) : null}
+            </div>
           ) : null}
-        </div>
-      ) : null}
+        </>
+      )}
 
       <ConfirmDialog
         open={signOutEverywhereOpen}

--- a/apps/web/src/components/settings/SettingsPage.tsx
+++ b/apps/web/src/components/settings/SettingsPage.tsx
@@ -26,6 +26,7 @@ import {
   type SettingsTabId,
   parseSettingsTabId,
 } from '@/lib/settings-tabs';
+import { readPendingEmailChange } from '@/lib/pending-email-change';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { webSignOutEverywhere } from '@/lib/web-sign-out-everywhere';
 
@@ -34,9 +35,12 @@ const SETTINGS_SURFACE_CLASS =
 
 const TAB_ORDER = SETTINGS_TAB_IDS;
 
+/** How long the name-save confirmation stays visible before reverting. */
+const NAME_SAVE_FEEDBACK_MS = 3_000;
+
 function tabClass(active: boolean): string {
   return active
-    ? 'inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full bg-app-primary-soft px-4 py-2 text-sm font-semibold text-app-primary shadow-sm ring-1 ring-app-primary/25 dark:bg-app-primary-soft/28'
+    ? 'inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full bg-app-tab-active-bg px-4 py-2 text-sm font-semibold text-app-tab-active-text shadow-sm ring-1 ring-app-tab-active-ring/25'
     : 'inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full px-4 py-2 text-sm font-medium text-app-muted transition hover:bg-[var(--app-nav-hover-bg)] hover:text-app-ink';
 }
 
@@ -62,17 +66,28 @@ export function SettingsPage() {
   const [firstName, setFirstName] = useState('');
   const [lastName, setLastName] = useState('');
   const [nameSubmitting, setNameSubmitting] = useState(false);
+  const [nameSavedVisible, setNameSavedVisible] = useState(false);
   const [nameError, setNameError] = useState<string | null>(null);
+  const nameSavedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   const [currentEmail, setCurrentEmail] = useState('');
   const [newEmail, setNewEmail] = useState('');
   const [emailSubmitting, setEmailSubmitting] = useState(false);
   const [emailError, setEmailError] = useState<string | null>(null);
-  const [emailStatus, setEmailStatus] = useState<string | null>(null);
+  const [pendingEmailChange, setPendingEmailChange] = useState<string | null>(
+    null,
+  );
+  const [showEmailChangeForm, setShowEmailChangeForm] = useState(true);
 
   const tabButtonRefs = useRef<
     Partial<Record<SettingsTabId, HTMLButtonElement>>
   >({});
+  /** Profile row already applied for this auth user (avoids reload on token refresh). */
+  const loadedProfileUserIdRef = useRef<string | null>(null);
+  /** True after the user edits name fields before save. */
+  const nameFormDirtyRef = useRef(false);
   const tabId = (tab: SettingsTabId) => `${formId}-settings-tab-${tab}`;
   const panelId = (tab: SettingsTabId) => `${formId}-settings-panel-${tab}`;
 
@@ -111,35 +126,107 @@ export function SettingsPage() {
   );
 
   const loadProfile = useCallback(async () => {
-    if (!session?.user?.id) {
+    const userId = session?.user?.id;
+    if (!userId) {
       setProfileLoading(false);
+      loadedProfileUserIdRef.current = null;
+      nameFormDirtyRef.current = false;
       return;
     }
+
+    const isInitialLoadForUser = loadedProfileUserIdRef.current !== userId;
+    if (!isInitialLoadForUser) {
+      return;
+    }
+
+    nameFormDirtyRef.current = false;
     setProfileLoading(true);
     setNameError(null);
     const { data, error } = await supabase
       .from('profiles')
       .select('display_name')
-      .eq('id', session.user.id)
+      .eq('id', userId)
       .maybeSingle();
     if (error) {
       setNameError('Unable to load your profile. Try again in a moment.');
       setProfileLoading(false);
       return;
     }
-    const names = splitDisplayNameIntoNameFields(data?.display_name);
-    setFirstName(names.firstName);
-    setLastName(names.lastName);
+    if (!nameFormDirtyRef.current) {
+      const names = splitDisplayNameIntoNameFields(data?.display_name);
+      setFirstName(names.firstName);
+      setLastName(names.lastName);
+    }
     setCurrentEmail(session.user.email ?? '');
+    loadedProfileUserIdRef.current = userId;
     setProfileLoading(false);
-  }, [session?.user?.id, session?.user?.email, supabase]);
+  }, [session?.user?.email, session?.user?.id, supabase]);
 
   useEffect(() => {
-    if (authLoading || !session) {
+    if (authLoading) {
       return;
     }
     void loadProfile();
-  }, [authLoading, session, loadProfile]);
+  }, [authLoading, loadProfile, session?.user?.id]);
+
+  useEffect(() => {
+    if (authLoading || !session?.user?.id) {
+      return;
+    }
+    setCurrentEmail(session.user.email ?? '');
+  }, [authLoading, session?.user?.email, session?.user?.id]);
+
+  useEffect(() => {
+    if (authLoading || !session?.user?.id) {
+      return;
+    }
+    void supabase.auth.getUser().then(({ data: { user } }) => {
+      const pending = readPendingEmailChange(user);
+      if (pending) {
+        setPendingEmailChange(pending);
+        setShowEmailChangeForm(false);
+      }
+    });
+  }, [authLoading, session?.user?.id, supabase]);
+
+  useEffect(() => {
+    if (!pendingEmailChange) {
+      return;
+    }
+    const normalizedCurrent = currentEmail.trim().toLowerCase();
+    if (
+      normalizedCurrent !== '' &&
+      normalizedCurrent === pendingEmailChange.trim().toLowerCase()
+    ) {
+      setPendingEmailChange(null);
+      setShowEmailChangeForm(true);
+    }
+  }, [currentEmail, pendingEmailChange]);
+
+  useEffect(() => {
+    return () => {
+      if (nameSavedTimeoutRef.current) {
+        clearTimeout(nameSavedTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const clearNameSaveFeedback = useCallback(() => {
+    if (nameSavedTimeoutRef.current) {
+      clearTimeout(nameSavedTimeoutRef.current);
+      nameSavedTimeoutRef.current = null;
+    }
+    setNameSavedVisible(false);
+  }, []);
+
+  const showNameSaveFeedback = useCallback(() => {
+    clearNameSaveFeedback();
+    setNameSavedVisible(true);
+    nameSavedTimeoutRef.current = setTimeout(() => {
+      setNameSavedVisible(false);
+      nameSavedTimeoutRef.current = null;
+    }, NAME_SAVE_FEEDBACK_MS);
+  }, [clearNameSaveFeedback]);
 
   const onNameSubmit = async (event: React.FormEvent) => {
     event.preventDefault();
@@ -148,6 +235,7 @@ export function SettingsPage() {
     }
     setNameSubmitting(true);
     setNameError(null);
+    clearNameSaveFeedback();
     const displayName = combineNameFieldsIntoDisplayName({
       firstName,
       lastName,
@@ -162,6 +250,8 @@ export function SettingsPage() {
       announce('Unable to save your name.', { politeness: 'assertive' });
       return;
     }
+    nameFormDirtyRef.current = false;
+    showNameSaveFeedback();
     announce('Name saved.', { politeness: 'polite' });
   };
 
@@ -181,7 +271,6 @@ export function SettingsPage() {
     }
     setEmailSubmitting(true);
     setEmailError(null);
-    setEmailStatus(null);
     const nextPath = '/settings?tab=account';
     const emailRedirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(nextPath)}`;
     const { error } = await supabase.auth.updateUser(
@@ -194,10 +283,10 @@ export function SettingsPage() {
       announce(error.message, { politeness: 'assertive' });
       return;
     }
-    const msg =
-      'Confirmation email sent. Open the link in that message to finish changing your email.';
-    setEmailStatus(msg);
+    setPendingEmailChange(trimmed);
+    setShowEmailChangeForm(false);
     setNewEmail('');
+    const msg = `Confirmation email sent to ${trimmed}. Open the link in that message to finish changing your email.`;
     announce(msg, { politeness: 'polite' });
   };
 
@@ -338,7 +427,11 @@ export function SettingsPage() {
                       type="text"
                       autoComplete="given-name"
                       value={firstName}
-                      onChange={(e) => setFirstName(e.target.value)}
+                      onChange={(e) => {
+                        nameFormDirtyRef.current = true;
+                        clearNameSaveFeedback();
+                        setFirstName(e.target.value);
+                      }}
                       className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
                     />
                   </div>
@@ -354,7 +447,11 @@ export function SettingsPage() {
                       type="text"
                       autoComplete="family-name"
                       value={lastName}
-                      onChange={(e) => setLastName(e.target.value)}
+                      onChange={(e) => {
+                        nameFormDirtyRef.current = true;
+                        clearNameSaveFeedback();
+                        setLastName(e.target.value);
+                      }}
                       className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
                     />
                   </div>
@@ -370,9 +467,14 @@ export function SettingsPage() {
                     <button
                       type="submit"
                       disabled={nameSubmitting}
+                      aria-live="polite"
                       className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
                     >
-                      {nameSubmitting ? 'Saving…' : 'Save name'}
+                      {nameSubmitting
+                        ? 'Saving…'
+                        : nameSavedVisible
+                          ? 'Saved'
+                          : 'Save name'}
                     </button>
                   </div>
                 </form>
@@ -390,57 +492,119 @@ export function SettingsPage() {
                 Email
               </h2>
               <p className="mt-2 text-sm text-app-muted">
-                Current address:{' '}
-                <span className="font-medium text-app-ink">
-                  {currentEmail || 'Not set'}
-                </span>
-                . We will send a confirmation link to your new address before
-                the change takes effect.
+                {pendingEmailChange ? (
+                  <>
+                    Your sign-in email is still{' '}
+                    <span className="font-medium text-app-ink">
+                      {currentEmail || 'Not set'}
+                    </span>
+                    . Finish confirming{' '}
+                    <span className="font-medium text-app-ink">
+                      {pendingEmailChange}
+                    </span>{' '}
+                    using the link we emailed to that address.
+                  </>
+                ) : (
+                  <>
+                    Current address:{' '}
+                    <span className="font-medium text-app-ink">
+                      {currentEmail || 'Not set'}
+                    </span>
+                    . We will send a confirmation link to your new address
+                    before the change takes effect.
+                  </>
+                )}
               </p>
-              <form
-                className="mt-6 space-y-4"
-                onSubmit={(e) => {
-                  void onEmailSubmit(e);
-                }}
-                noValidate
-              >
-                <div className="space-y-2">
-                  <label
-                    htmlFor={`${formId}-new-email`}
-                    className="text-sm font-medium text-app-ink"
-                  >
-                    New email
-                  </label>
-                  <input
-                    id={`${formId}-new-email`}
-                    type="email"
-                    autoComplete="email"
-                    value={newEmail}
-                    onChange={(e) => setNewEmail(e.target.value)}
-                    className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
-                  />
-                </div>
-                {emailError ? (
-                  <p
-                    role="alert"
-                    className="text-sm text-red-700 dark:text-red-300"
-                  >
-                    {emailError}
-                  </p>
-                ) : null}
-                {emailStatus ? (
-                  <p className="text-sm text-app-muted" role="status">
-                    {emailStatus}
-                  </p>
-                ) : null}
-                <button
-                  type="submit"
-                  disabled={emailSubmitting}
-                  className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+              {pendingEmailChange ? (
+                <div
+                  className="mt-6 space-y-4"
+                  role="status"
+                  aria-labelledby={`${formId}-email-pending-heading`}
                 >
-                  {emailSubmitting ? 'Sending…' : 'Send confirmation email'}
-                </button>
-              </form>
+                  <div className="rounded-xl border border-app-border/80 bg-app-bg p-4">
+                    <h3
+                      id={`${formId}-email-pending-heading`}
+                      className="text-sm font-semibold text-app-ink"
+                    >
+                      Email change pending
+                    </h3>
+                    <dl className="mt-3 space-y-2 text-sm">
+                      <div>
+                        <dt className="text-app-muted">Current address</dt>
+                        <dd className="font-medium text-app-ink">
+                          {currentEmail || 'Not set'}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-app-muted">Changing to</dt>
+                        <dd className="font-medium text-app-ink">
+                          {pendingEmailChange}
+                        </dd>
+                      </div>
+                    </dl>
+                    <p className="mt-3 text-sm text-app-muted">
+                      We sent a confirmation link to{' '}
+                      <span className="font-medium text-app-ink">
+                        {pendingEmailChange}
+                      </span>
+                      . Open that message to finish the change.
+                    </p>
+                  </div>
+                  {!showEmailChangeForm ? (
+                    <button
+                      type="button"
+                      className="min-h-[44px] rounded-full border border-app-border px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                      onClick={() => {
+                        setShowEmailChangeForm(true);
+                        setEmailError(null);
+                      }}
+                    >
+                      Use a different address
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+              {!pendingEmailChange || showEmailChangeForm ? (
+                <form
+                  className="mt-6 space-y-4"
+                  onSubmit={(e) => {
+                    void onEmailSubmit(e);
+                  }}
+                  noValidate
+                >
+                  <div className="space-y-2">
+                    <label
+                      htmlFor={`${formId}-new-email`}
+                      className="text-sm font-medium text-app-ink"
+                    >
+                      New email
+                    </label>
+                    <input
+                      id={`${formId}-new-email`}
+                      type="email"
+                      autoComplete="email"
+                      value={newEmail}
+                      onChange={(e) => setNewEmail(e.target.value)}
+                      className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                    />
+                  </div>
+                  {emailError ? (
+                    <p
+                      role="alert"
+                      className="text-sm text-red-700 dark:text-red-300"
+                    >
+                      {emailError}
+                    </p>
+                  ) : null}
+                  <button
+                    type="submit"
+                    disabled={emailSubmitting}
+                    className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {emailSubmitting ? 'Sending…' : 'Send confirmation email'}
+                  </button>
+                </form>
+              ) : null}
             </section>
 
             <section

--- a/apps/web/src/components/settings/SettingsPage.tsx
+++ b/apps/web/src/components/settings/SettingsPage.tsx
@@ -55,7 +55,8 @@ export function SettingsPage() {
   const formId = useId();
   const { announce } = useAnnounce();
   const { session, loading: authLoading } = useAuth();
-  const { profileAppRole } = useWebPhiSubjectUserContext();
+  const { profileAppRole, loading: phiContextLoading } =
+    useWebPhiSubjectUserContext();
   const supabase = useMemo(() => createBrowserClient(), []);
 
   const tabFromUrl = parseSettingsTabId(searchParams.get('tab'));
@@ -101,14 +102,17 @@ export function SettingsPage() {
   }, [profileAppRole]);
 
   useEffect(() => {
-    setActiveTab(tabFromUrl);
-  }, [tabFromUrl]);
-
-  useEffect(() => {
-    if (activeTab === 'invites' && profileAppRole !== 'patient') {
-      setActiveTab('account');
+    if (phiContextLoading) {
+      return;
     }
-  }, [activeTab, profileAppRole]);
+    const invitesVisible = profileAppRole === 'patient';
+    if (tabFromUrl === 'invites' && !invitesVisible) {
+      router.replace('/settings', { scroll: false });
+      setActiveTab('account');
+      return;
+    }
+    setActiveTab(tabFromUrl);
+  }, [tabFromUrl, profileAppRole, phiContextLoading, router]);
 
   const setTab = useCallback(
     (tab: SettingsTabId) => {

--- a/apps/web/src/components/settings/SettingsPage.tsx
+++ b/apps/web/src/components/settings/SettingsPage.tsx
@@ -1,0 +1,518 @@
+'use client';
+
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react';
+import { ConfirmDialog } from '@/components/symptom-presets/ConfirmDialog';
+import { CaretakerAccessPage } from '@/components/settings/CaretakerAccessPage';
+import { PractitionerAccessPage } from '@/components/settings/PractitionerAccessPage';
+import { SettingsSecuritySection } from '@/components/settings/SettingsSecuritySection';
+import { useAuth } from '@/lib/auth-provider';
+import {
+  combineNameFieldsIntoDisplayName,
+  splitDisplayNameIntoNameFields,
+} from '@/lib/profile-display-name';
+import { useWebPhiSubjectUserContext } from '@/lib/patient/use-web-phi-subject-user-context';
+import {
+  SETTINGS_TAB_IDS,
+  type SettingsTabId,
+  parseSettingsTabId,
+} from '@/lib/settings-tabs';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { webSignOutEverywhere } from '@/lib/web-sign-out-everywhere';
+
+const SETTINGS_SURFACE_CLASS =
+  'rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8';
+
+const TAB_ORDER = SETTINGS_TAB_IDS;
+
+function tabClass(active: boolean): string {
+  return active
+    ? 'inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full bg-app-primary-soft px-4 py-2 text-sm font-semibold text-app-primary shadow-sm ring-1 ring-app-primary/25 dark:bg-app-primary-soft/28'
+    : 'inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full px-4 py-2 text-sm font-medium text-app-muted transition hover:bg-[var(--app-nav-hover-bg)] hover:text-app-ink';
+}
+
+/**
+ * Account, security, and invite settings for the user web app.
+ *
+ * @returns Settings hub with tabbed sections.
+ */
+export function SettingsPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const formId = useId();
+  const { announce } = useAnnounce();
+  const { session, loading: authLoading } = useAuth();
+  const { profileAppRole } = useWebPhiSubjectUserContext();
+  const supabase = useMemo(() => createBrowserClient(), []);
+
+  const tabFromUrl = parseSettingsTabId(searchParams.get('tab'));
+  const [activeTab, setActiveTab] = useState<SettingsTabId>(tabFromUrl);
+  const [signOutEverywhereOpen, setSignOutEverywhereOpen] = useState(false);
+
+  const [profileLoading, setProfileLoading] = useState(true);
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [nameSubmitting, setNameSubmitting] = useState(false);
+  const [nameError, setNameError] = useState<string | null>(null);
+
+  const [currentEmail, setCurrentEmail] = useState('');
+  const [newEmail, setNewEmail] = useState('');
+  const [emailSubmitting, setEmailSubmitting] = useState(false);
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [emailStatus, setEmailStatus] = useState<string | null>(null);
+
+  const tabButtonRefs = useRef<
+    Partial<Record<SettingsTabId, HTMLButtonElement>>
+  >({});
+  const tabId = (tab: SettingsTabId) => `${formId}-settings-tab-${tab}`;
+  const panelId = (tab: SettingsTabId) => `${formId}-settings-panel-${tab}`;
+
+  const visibleTabs = useMemo((): SettingsTabId[] => {
+    if (profileAppRole === 'patient') {
+      return [...TAB_ORDER];
+    }
+    return TAB_ORDER.filter(
+      (t): t is Exclude<SettingsTabId, 'invites'> => t !== 'invites',
+    );
+  }, [profileAppRole]);
+
+  useEffect(() => {
+    setActiveTab(tabFromUrl);
+  }, [tabFromUrl]);
+
+  useEffect(() => {
+    if (activeTab === 'invites' && profileAppRole !== 'patient') {
+      setActiveTab('account');
+    }
+  }, [activeTab, profileAppRole]);
+
+  const setTab = useCallback(
+    (tab: SettingsTabId) => {
+      setActiveTab(tab);
+      const params = new URLSearchParams(searchParams.toString());
+      if (tab === 'account') {
+        params.delete('tab');
+      } else {
+        params.set('tab', tab);
+      }
+      const qs = params.toString();
+      router.replace(qs ? `/settings?${qs}` : '/settings', { scroll: false });
+    },
+    [router, searchParams],
+  );
+
+  const loadProfile = useCallback(async () => {
+    if (!session?.user?.id) {
+      setProfileLoading(false);
+      return;
+    }
+    setProfileLoading(true);
+    setNameError(null);
+    const { data, error } = await supabase
+      .from('profiles')
+      .select('display_name')
+      .eq('id', session.user.id)
+      .maybeSingle();
+    if (error) {
+      setNameError('Unable to load your profile. Try again in a moment.');
+      setProfileLoading(false);
+      return;
+    }
+    const names = splitDisplayNameIntoNameFields(data?.display_name);
+    setFirstName(names.firstName);
+    setLastName(names.lastName);
+    setCurrentEmail(session.user.email ?? '');
+    setProfileLoading(false);
+  }, [session?.user?.id, session?.user?.email, supabase]);
+
+  useEffect(() => {
+    if (authLoading || !session) {
+      return;
+    }
+    void loadProfile();
+  }, [authLoading, session, loadProfile]);
+
+  const onNameSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!session?.user?.id) {
+      return;
+    }
+    setNameSubmitting(true);
+    setNameError(null);
+    const displayName = combineNameFieldsIntoDisplayName({
+      firstName,
+      lastName,
+    });
+    const { error } = await supabase
+      .from('profiles')
+      .update({ display_name: displayName })
+      .eq('id', session.user.id);
+    setNameSubmitting(false);
+    if (error) {
+      setNameError('Unable to save your name. Try again.');
+      announce('Unable to save your name.', { politeness: 'assertive' });
+      return;
+    }
+    announce('Name saved.', { politeness: 'polite' });
+  };
+
+  const onEmailSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!session) {
+      return;
+    }
+    const trimmed = newEmail.trim().toLowerCase();
+    if (!trimmed) {
+      setEmailError('Enter a new email address.');
+      return;
+    }
+    if (trimmed === (session.user.email ?? '').trim().toLowerCase()) {
+      setEmailError('That is already your email address.');
+      return;
+    }
+    setEmailSubmitting(true);
+    setEmailError(null);
+    setEmailStatus(null);
+    const nextPath = '/settings?tab=account';
+    const emailRedirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(nextPath)}`;
+    const { error } = await supabase.auth.updateUser(
+      { email: trimmed },
+      { emailRedirectTo },
+    );
+    setEmailSubmitting(false);
+    if (error) {
+      setEmailError(error.message);
+      announce(error.message, { politeness: 'assertive' });
+      return;
+    }
+    const msg =
+      'Confirmation email sent. Open the link in that message to finish changing your email.';
+    setEmailStatus(msg);
+    setNewEmail('');
+    announce(msg, { politeness: 'polite' });
+  };
+
+  const onTabKeyDown = useCallback(
+    (event: KeyboardEvent<HTMLButtonElement>, current: SettingsTabId) => {
+      const currentIndex = visibleTabs.indexOf(current);
+      if (currentIndex < 0) {
+        return;
+      }
+      let nextIndex = currentIndex;
+      if (event.key === 'ArrowRight') {
+        nextIndex = (currentIndex + 1) % visibleTabs.length;
+      } else if (event.key === 'ArrowLeft') {
+        nextIndex =
+          (currentIndex - 1 + visibleTabs.length) % visibleTabs.length;
+      } else if (event.key === 'Home') {
+        nextIndex = 0;
+      } else if (event.key === 'End') {
+        nextIndex = visibleTabs.length - 1;
+      } else {
+        return;
+      }
+      event.preventDefault();
+      const target = visibleTabs[nextIndex];
+      if (!target) {
+        return;
+      }
+      setTab(target);
+      tabButtonRefs.current[target]?.focus();
+    },
+    [setTab, visibleTabs],
+  );
+
+  if (authLoading) {
+    return (
+      <p className="text-sm text-app-muted" role="status">
+        Loading settings…
+      </p>
+    );
+  }
+
+  if (!session) {
+    return (
+      <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+        You must be signed in to open settings.
+      </p>
+    );
+  }
+
+  const tabLabels: Record<SettingsTabId, string> = {
+    account: 'Account',
+    security: 'Security',
+    invites: 'Invites',
+  };
+
+  return (
+    <div className="w-full space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Settings
+        </h1>
+        <p className="mt-2 text-sm text-app-muted">
+          Manage your account, security, and who can access your health data.
+        </p>
+      </div>
+
+      <div
+        role="tablist"
+        aria-label="Settings sections"
+        className="flex flex-wrap gap-2 rounded-2xl border border-app-border/90 bg-app-surface/80 p-2 shadow-sm dark:border-app-border-dark/90 dark:bg-app-surface-dark/60"
+      >
+        {visibleTabs.map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            id={tabId(tab)}
+            aria-controls={panelId(tab)}
+            aria-selected={activeTab === tab ? 'true' : 'false'}
+            tabIndex={activeTab === tab ? 0 : -1}
+            className={tabClass(activeTab === tab)}
+            ref={(node) => {
+              tabButtonRefs.current[tab] = node ?? undefined;
+            }}
+            onKeyDown={(event) => onTabKeyDown(event, tab)}
+            onClick={() => setTab(tab)}
+          >
+            {tabLabels[tab]}
+          </button>
+        ))}
+      </div>
+
+      <div
+        role="tabpanel"
+        id={panelId('account')}
+        aria-labelledby={tabId('account')}
+        hidden={activeTab !== 'account'}
+        tabIndex={0}
+        className="space-y-8 outline-none"
+      >
+        {activeTab === 'account' ? (
+          <>
+            <section
+              aria-labelledby={`${formId}-name-heading`}
+              className={SETTINGS_SURFACE_CLASS}
+            >
+              <h2
+                id={`${formId}-name-heading`}
+                className="text-lg font-semibold text-app-ink"
+              >
+                Name
+              </h2>
+              <p className="mt-2 text-sm text-app-muted">
+                Your name may appear when you share access with a caretaker or
+                practitioner.
+              </p>
+              {profileLoading ? (
+                <p className="mt-4 text-sm text-app-muted" role="status">
+                  Loading profile…
+                </p>
+              ) : (
+                <form
+                  className="mt-6 grid gap-4 sm:grid-cols-2"
+                  onSubmit={(e) => {
+                    void onNameSubmit(e);
+                  }}
+                  noValidate
+                >
+                  <div className="space-y-2">
+                    <label
+                      htmlFor={`${formId}-first-name`}
+                      className="text-sm font-medium text-app-ink"
+                    >
+                      First name
+                    </label>
+                    <input
+                      id={`${formId}-first-name`}
+                      type="text"
+                      autoComplete="given-name"
+                      value={firstName}
+                      onChange={(e) => setFirstName(e.target.value)}
+                      className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label
+                      htmlFor={`${formId}-last-name`}
+                      className="text-sm font-medium text-app-ink"
+                    >
+                      Last name
+                    </label>
+                    <input
+                      id={`${formId}-last-name`}
+                      type="text"
+                      autoComplete="family-name"
+                      value={lastName}
+                      onChange={(e) => setLastName(e.target.value)}
+                      className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                    />
+                  </div>
+                  {nameError ? (
+                    <p
+                      role="alert"
+                      className="sm:col-span-2 text-sm text-red-700 dark:text-red-300"
+                    >
+                      {nameError}
+                    </p>
+                  ) : null}
+                  <div className="sm:col-span-2">
+                    <button
+                      type="submit"
+                      disabled={nameSubmitting}
+                      className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {nameSubmitting ? 'Saving…' : 'Save name'}
+                    </button>
+                  </div>
+                </form>
+              )}
+            </section>
+
+            <section
+              aria-labelledby={`${formId}-email-heading`}
+              className={SETTINGS_SURFACE_CLASS}
+            >
+              <h2
+                id={`${formId}-email-heading`}
+                className="text-lg font-semibold text-app-ink"
+              >
+                Email
+              </h2>
+              <p className="mt-2 text-sm text-app-muted">
+                Current address:{' '}
+                <span className="font-medium text-app-ink">
+                  {currentEmail || 'Not set'}
+                </span>
+                . We will send a confirmation link to your new address before
+                the change takes effect.
+              </p>
+              <form
+                className="mt-6 space-y-4"
+                onSubmit={(e) => {
+                  void onEmailSubmit(e);
+                }}
+                noValidate
+              >
+                <div className="space-y-2">
+                  <label
+                    htmlFor={`${formId}-new-email`}
+                    className="text-sm font-medium text-app-ink"
+                  >
+                    New email
+                  </label>
+                  <input
+                    id={`${formId}-new-email`}
+                    type="email"
+                    autoComplete="email"
+                    value={newEmail}
+                    onChange={(e) => setNewEmail(e.target.value)}
+                    className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                  />
+                </div>
+                {emailError ? (
+                  <p
+                    role="alert"
+                    className="text-sm text-red-700 dark:text-red-300"
+                  >
+                    {emailError}
+                  </p>
+                ) : null}
+                {emailStatus ? (
+                  <p className="text-sm text-app-muted" role="status">
+                    {emailStatus}
+                  </p>
+                ) : null}
+                <button
+                  type="submit"
+                  disabled={emailSubmitting}
+                  className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {emailSubmitting ? 'Sending…' : 'Send confirmation email'}
+                </button>
+              </form>
+            </section>
+
+            <section
+              aria-labelledby={`${formId}-sessions-heading`}
+              className={SETTINGS_SURFACE_CLASS}
+            >
+              <h2
+                id={`${formId}-sessions-heading`}
+                className="text-lg font-semibold text-app-ink"
+              >
+                Sessions
+              </h2>
+              <p className="mt-2 text-sm text-app-muted">
+                Sign out on every device where you are signed in to ABStrack.
+                Use this on a shared computer or if you think someone else may
+                have access to your account.
+              </p>
+              <button
+                type="button"
+                className="mt-4 min-h-[44px] rounded-full bg-red-600 px-5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-700 dark:hover:bg-red-600"
+                onClick={() => setSignOutEverywhereOpen(true)}
+              >
+                Sign out everywhere
+              </button>
+            </section>
+          </>
+        ) : null}
+      </div>
+
+      <div
+        role="tabpanel"
+        id={panelId('security')}
+        aria-labelledby={tabId('security')}
+        hidden={activeTab !== 'security'}
+        tabIndex={0}
+        className="outline-none"
+      >
+        {activeTab === 'security' ? <SettingsSecuritySection /> : null}
+      </div>
+
+      {profileAppRole === 'patient' ? (
+        <div
+          role="tabpanel"
+          id={panelId('invites')}
+          aria-labelledby={tabId('invites')}
+          hidden={activeTab !== 'invites'}
+          tabIndex={0}
+          className="space-y-12 outline-none"
+        >
+          {activeTab === 'invites' ? (
+            <>
+              <CaretakerAccessPage embedded />
+              <PractitionerAccessPage embedded />
+            </>
+          ) : null}
+        </div>
+      ) : null}
+
+      <ConfirmDialog
+        open={signOutEverywhereOpen}
+        title="Sign out everywhere?"
+        description="This ends your ABStrack session on this browser and signs you out on all other devices. You will need to sign in again everywhere."
+        confirmLabel="Sign out everywhere"
+        cancelLabel="Cancel"
+        confirmBusyLabel="Signing out…"
+        onConfirm={() => {
+          announce('Signing out from all sessions.', { politeness: 'polite' });
+          webSignOutEverywhere();
+          return undefined;
+        }}
+        onClose={() => setSignOutEverywhereOpen(false)}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/SettingsPage.tsx
+++ b/apps/web/src/components/settings/SettingsPage.tsx
@@ -27,7 +27,6 @@ import {
   parseSettingsTabId,
 } from '@/lib/settings-tabs';
 import { readPendingEmailChange } from '@/lib/pending-email-change';
-import { ensurePatientProfileRow } from '@abstrack/supabase';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { webSignOutEverywhere } from '@/lib/web-sign-out-everywhere';
 
@@ -143,12 +142,6 @@ export function SettingsPage() {
     nameFormDirtyRef.current = false;
     setProfileLoading(true);
     setNameError(null);
-    const ensured = await ensurePatientProfileRow(supabase, userId);
-    if (!ensured.ok) {
-      setNameError('Unable to load your profile. Try again in a moment.');
-      setProfileLoading(false);
-      return;
-    }
     const { data, error } = await supabase
       .from('profiles')
       .select('display_name')
@@ -156,6 +149,13 @@ export function SettingsPage() {
       .maybeSingle();
     if (error) {
       setNameError('Unable to load your profile. Try again in a moment.');
+      setProfileLoading(false);
+      return;
+    }
+    if (data == null) {
+      setNameError(
+        'Your account is missing a profile record. Sign out and complete sign-up or your invite link again, or contact support.',
+      );
       setProfileLoading(false);
       return;
     }

--- a/apps/web/src/components/settings/SettingsPage.tsx
+++ b/apps/web/src/components/settings/SettingsPage.tsx
@@ -27,7 +27,6 @@ import {
   parseSettingsTabId,
 } from '@/lib/settings-tabs';
 import { readPendingEmailChange } from '@/lib/pending-email-change';
-import { createBrowserClient } from '@/lib/supabase/browser-client';
 import { webSignOutEverywhere } from '@/lib/web-sign-out-everywhere';
 
 const SETTINGS_SURFACE_CLASS =
@@ -54,10 +53,9 @@ export function SettingsPage() {
   const searchParams = useSearchParams();
   const formId = useId();
   const { announce } = useAnnounce();
-  const { session, loading: authLoading } = useAuth();
+  const { session, loading: authLoading, supabase } = useAuth();
   const { profileAppRole, loading: phiContextLoading } =
     useWebPhiSubjectUserContext();
-  const supabase = useMemo(() => createBrowserClient(), []);
 
   const tabFromUrl = parseSettingsTabId(searchParams.get('tab'));
   const [activeTab, setActiveTab] = useState<SettingsTabId>(tabFromUrl);

--- a/apps/web/src/components/settings/SettingsSecuritySection.tsx
+++ b/apps/web/src/components/settings/SettingsSecuritySection.tsx
@@ -14,12 +14,12 @@ import {
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import {
   AUTH_PASSWORD_MAX_LENGTH,
+  AUTH_PASSWORD_MIN_LENGTH,
   USER_PASSWORD_SET_USER_METADATA_KEY,
   buildRevokedPasswordPlaceholder,
+  getAuthPasswordValidationError,
   userHasPasswordSignIn,
 } from '@/lib/user-password-sign-in';
-
-const MIN_PASSWORD_LENGTH = 8;
 
 type TotpEnrollment = {
   id: string;
@@ -141,16 +141,9 @@ export function SettingsSecuritySection() {
     if (!session) {
       return;
     }
-    if (password.length < MIN_PASSWORD_LENGTH) {
-      setPasswordError(
-        `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
-      );
-      return;
-    }
-    if (password.length > AUTH_PASSWORD_MAX_LENGTH) {
-      setPasswordError(
-        `Password must be no more than ${AUTH_PASSWORD_MAX_LENGTH} characters.`,
-      );
+    const passwordValidationError = getAuthPasswordValidationError(password);
+    if (passwordValidationError) {
+      setPasswordError(passwordValidationError);
       return;
     }
     if (password !== confirmPassword) {
@@ -384,8 +377,8 @@ export function SettingsSecuritySection() {
           {hasPassword
             ? 'Update the password you use for email sign-in on web or mobile.'
             : 'You currently sign in with magic links from email. Add a password if you want email and password sign-in too.'}{' '}
-          Passwords must be {MIN_PASSWORD_LENGTH}–{AUTH_PASSWORD_MAX_LENGTH}{' '}
-          characters.
+          Passwords must be at least {AUTH_PASSWORD_MIN_LENGTH} characters and
+          no more than {AUTH_PASSWORD_MAX_LENGTH} bytes.
         </p>
         <form
           className="mt-6 space-y-4"

--- a/apps/web/src/components/settings/SettingsSecuritySection.tsx
+++ b/apps/web/src/components/settings/SettingsSecuritySection.tsx
@@ -13,6 +13,7 @@ import {
 } from '@/lib/mfa-user-messages';
 import { createBrowserClient } from '@/lib/supabase/browser-client';
 import {
+  AUTH_PASSWORD_MAX_LENGTH,
   USER_PASSWORD_SET_USER_METADATA_KEY,
   buildRevokedPasswordPlaceholder,
   userHasPasswordSignIn,
@@ -143,6 +144,12 @@ export function SettingsSecuritySection() {
     if (password.length < MIN_PASSWORD_LENGTH) {
       setPasswordError(
         `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
+      );
+      return;
+    }
+    if (password.length > AUTH_PASSWORD_MAX_LENGTH) {
+      setPasswordError(
+        `Password must be no more than ${AUTH_PASSWORD_MAX_LENGTH} characters.`,
       );
       return;
     }
@@ -376,7 +383,9 @@ export function SettingsSecuritySection() {
         <p className="mt-2 text-sm text-app-muted">
           {hasPassword
             ? 'Update the password you use for email sign-in on web or mobile.'
-            : 'You currently sign in with magic links from email. Add a password if you want email and password sign-in too.'}
+            : 'You currently sign in with magic links from email. Add a password if you want email and password sign-in too.'}{' '}
+          Passwords must be {MIN_PASSWORD_LENGTH}–{AUTH_PASSWORD_MAX_LENGTH}{' '}
+          characters.
         </p>
         <form
           className="mt-6 space-y-4"
@@ -396,6 +405,7 @@ export function SettingsSecuritySection() {
               id={`${formId}-new-password`}
               type="password"
               autoComplete="new-password"
+              maxLength={AUTH_PASSWORD_MAX_LENGTH}
               value={password}
               onChange={(e) => setPassword(e.target.value)}
               className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
@@ -412,6 +422,7 @@ export function SettingsSecuritySection() {
               id={`${formId}-confirm-password`}
               type="password"
               autoComplete="new-password"
+              maxLength={AUTH_PASSWORD_MAX_LENGTH}
               value={confirmPassword}
               onChange={(e) => setConfirmPassword(e.target.value)}
               className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"

--- a/apps/web/src/components/settings/SettingsSecuritySection.tsx
+++ b/apps/web/src/components/settings/SettingsSecuritySection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useAnnounce } from '@abstrack/ui/a11y-web';
-import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { useCallback, useEffect, useId, useState } from 'react';
 import { ConfirmDialog } from '@/components/symptom-presets/ConfirmDialog';
 import { useAuth } from '@/lib/auth-provider';
 import {
@@ -11,7 +11,7 @@ import {
   mapMfaVerifyErrorToUserMessage,
   normalizeTotpCode,
 } from '@/lib/mfa-user-messages';
-import { createBrowserClient } from '@/lib/supabase/browser-client';
+import { refreshBrowserSessionAndSyncMfaTrustBundle } from '@/lib/user-mfa-device-trust';
 import {
   AUTH_PASSWORD_MAX_LENGTH,
   AUTH_PASSWORD_MIN_LENGTH,
@@ -72,8 +72,7 @@ const SETTINGS_SURFACE_CLASS =
 export function SettingsSecuritySection() {
   const formId = useId();
   const { announce } = useAnnounce();
-  const { session, loading: authLoading } = useAuth();
-  const supabase = useMemo(() => createBrowserClient(), []);
+  const { session, loading: authLoading, supabase } = useAuth();
 
   const [password, setPassword] = useState('');
   const [confirmPassword, setConfirmPassword] = useState('');
@@ -165,7 +164,11 @@ export function SettingsSecuritySection() {
       }
       setPassword('');
       setConfirmPassword('');
-      await supabase.auth.refreshSession();
+      const { error: refreshError } =
+        await refreshBrowserSessionAndSyncMfaTrustBundle(supabase);
+      if (refreshError) {
+        console.error('refreshSession after password update', refreshError);
+      }
       const msg = hasPassword
         ? 'Password updated.'
         : 'Password added. You can sign in with your email and password on web or mobile.';
@@ -197,7 +200,11 @@ export function SettingsSecuritySection() {
       }
       setPassword('');
       setConfirmPassword('');
-      await supabase.auth.refreshSession();
+      const { error: refreshError } =
+        await refreshBrowserSessionAndSyncMfaTrustBundle(supabase);
+      if (refreshError) {
+        console.error('refreshSession after password revoke', refreshError);
+      }
       announce(
         'Password sign-in disabled. Use magic links from email to sign in on supported apps.',
         { politeness: 'polite' },

--- a/apps/web/src/components/settings/SettingsSecuritySection.tsx
+++ b/apps/web/src/components/settings/SettingsSecuritySection.tsx
@@ -1,0 +1,644 @@
+'use client';
+
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { useCallback, useEffect, useId, useMemo, useState } from 'react';
+import { ConfirmDialog } from '@/components/symptom-presets/ConfirmDialog';
+import { useAuth } from '@/lib/auth-provider';
+import {
+  isUnenrollAlreadyGoneError,
+  looksLikeTotpSetupPayload,
+  mapMfaUnenrollErrorToUserMessage,
+  mapMfaVerifyErrorToUserMessage,
+  normalizeTotpCode,
+} from '@/lib/mfa-user-messages';
+import { createBrowserClient } from '@/lib/supabase/browser-client';
+import {
+  USER_PASSWORD_SET_USER_METADATA_KEY,
+  buildRevokedPasswordPlaceholder,
+  userHasPasswordSignIn,
+} from '@/lib/user-password-sign-in';
+
+const MIN_PASSWORD_LENGTH = 8;
+
+type TotpEnrollment = {
+  id: string;
+  qrCodeImageSrc: string;
+  secret: string;
+  friendlyName: string;
+};
+
+type VerifiedTotpFactor = {
+  id: string;
+  friendlyName: string;
+};
+
+function getTotpIssuer(): string {
+  return process.env.NEXT_PUBLIC_APP_NAME?.trim() || 'ABStrack';
+}
+
+function buildOtpauthUriFromSecret(secret: string, account: string): string {
+  const issuer = getTotpIssuer();
+  const labelAccount = account.trim() || 'account';
+  const pathLabel = `${encodeURIComponent(issuer)}:${encodeURIComponent(labelAccount)}`;
+  const url = new URL(`otpauth://totp/${pathLabel}`);
+  url.searchParams.set('secret', secret);
+  url.searchParams.set('issuer', issuer);
+  url.searchParams.set('algorithm', 'SHA1');
+  url.searchParams.set('digits', '6');
+  url.searchParams.set('period', '30');
+  return url.toString();
+}
+
+async function otpauthUriToQrPngDataUrl(otpauthUri: string): Promise<string> {
+  const { toDataURL } = await import('qrcode');
+  return toDataURL(otpauthUri, {
+    errorCorrectionLevel: 'H',
+    margin: 4,
+    width: 320,
+    color: { dark: '#000000', light: '#ffffff' },
+  });
+}
+
+const SETTINGS_SURFACE_CLASS =
+  'rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8';
+
+/**
+ * Security settings: password add/change/revoke and optional TOTP enrollment.
+ *
+ * @returns Security section for the settings page.
+ */
+export function SettingsSecuritySection() {
+  const formId = useId();
+  const { announce } = useAnnounce();
+  const { session, loading: authLoading } = useAuth();
+  const supabase = useMemo(() => createBrowserClient(), []);
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordSubmitting, setPasswordSubmitting] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [revokeOpen, setRevokeOpen] = useState(false);
+  const [revokeError, setRevokeError] = useState<string | null>(null);
+
+  const [mfaLoading, setMfaLoading] = useState(true);
+  const [verifiedFactors, setVerifiedFactors] = useState<VerifiedTotpFactor[]>(
+    [],
+  );
+  const [enrollment, setEnrollment] = useState<TotpEnrollment | null>(null);
+  const [isEnrolling, setIsEnrolling] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isCanceling, setIsCanceling] = useState(false);
+  const [verifyCode, setVerifyCode] = useState('');
+  const [verifyFailureMessage, setVerifyFailureMessage] = useState<
+    string | null
+  >(null);
+  const [mfaStatusMessage, setMfaStatusMessage] = useState<string | null>(null);
+  const [unenrollFactorId, setUnenrollFactorId] = useState<string | null>(null);
+  const [unenrollError, setUnenrollError] = useState<string | null>(null);
+
+  const hasPassword = userHasPasswordSignIn(session?.user);
+
+  const refreshMfaState = useCallback(async () => {
+    const factorsResult = await supabase.auth.mfa.listFactors();
+    if (factorsResult.error) {
+      throw factorsResult.error;
+    }
+    setVerifiedFactors(
+      factorsResult.data.totp
+        .filter((f) => f.status === 'verified')
+        .map((f) => ({
+          id: f.id,
+          friendlyName: f.friendly_name ?? 'Authenticator',
+        })),
+    );
+  }, [supabase]);
+
+  useEffect(() => {
+    if (authLoading || !session) {
+      return;
+    }
+    const load = async () => {
+      setMfaLoading(true);
+      try {
+        await refreshMfaState();
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Unable to load two-factor status.';
+        setMfaStatusMessage(message);
+        announce(message, { politeness: 'assertive' });
+      } finally {
+        setMfaLoading(false);
+      }
+    };
+    void load();
+  }, [authLoading, session, refreshMfaState, announce]);
+
+  const onPasswordSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!session) {
+      return;
+    }
+    if (password.length < MIN_PASSWORD_LENGTH) {
+      setPasswordError(
+        `Password must be at least ${MIN_PASSWORD_LENGTH} characters.`,
+      );
+      return;
+    }
+    if (password !== confirmPassword) {
+      setPasswordError('Passwords do not match.');
+      return;
+    }
+    setPasswordSubmitting(true);
+    setPasswordError(null);
+    try {
+      const { error } = await supabase.auth.updateUser({
+        password,
+        data: { [USER_PASSWORD_SET_USER_METADATA_KEY]: true },
+      });
+      if (error) {
+        setPasswordError(error.message);
+        announce(error.message, { politeness: 'assertive' });
+        return;
+      }
+      setPassword('');
+      setConfirmPassword('');
+      await supabase.auth.refreshSession();
+      const msg = hasPassword
+        ? 'Password updated.'
+        : 'Password added. You can sign in with your email and password on web or mobile.';
+      announce(msg, { politeness: 'polite' });
+    } catch {
+      const msg = 'Unable to update password. Try again.';
+      setPasswordError(msg);
+      announce(msg, { politeness: 'assertive' });
+    } finally {
+      setPasswordSubmitting(false);
+    }
+  };
+
+  const onRevokePassword = async () => {
+    if (!session) {
+      return false;
+    }
+    setRevokeError(null);
+    try {
+      const { error } = await supabase.auth.updateUser({
+        password: buildRevokedPasswordPlaceholder(),
+        data: { [USER_PASSWORD_SET_USER_METADATA_KEY]: false },
+      });
+      if (error) {
+        const msg = error.message;
+        setRevokeError(msg);
+        announce(msg, { politeness: 'assertive' });
+        return false;
+      }
+      setPassword('');
+      setConfirmPassword('');
+      await supabase.auth.refreshSession();
+      announce(
+        'Password sign-in disabled. Use magic links from email to sign in on supported apps.',
+        { politeness: 'polite' },
+      );
+      return undefined;
+    } catch {
+      const msg = 'Unable to revoke password. Try again.';
+      setRevokeError(msg);
+      announce(msg, { politeness: 'assertive' });
+      return false;
+    }
+  };
+
+  const startEnrollment = async () => {
+    if (!session) {
+      return;
+    }
+    setIsEnrolling(true);
+    setMfaStatusMessage(null);
+    setVerifyFailureMessage(null);
+    try {
+      const { data, error } = await supabase.auth.mfa.enroll({
+        factorType: 'totp',
+        friendlyName: `ABStrack device ${new Date().toISOString()}`,
+      });
+      if (error) {
+        throw error;
+      }
+      const account = session.user.email ?? 'account';
+      const otpauthUri = buildOtpauthUriFromSecret(data.totp.secret, account);
+      const qrCodeImageSrc = await otpauthUriToQrPngDataUrl(otpauthUri);
+      setEnrollment({
+        id: data.id,
+        qrCodeImageSrc,
+        secret: data.totp.secret,
+        friendlyName: data.friendly_name ?? 'Authenticator',
+      });
+      const msg =
+        'Scan the QR code with your authenticator app, then enter the six-digit code.';
+      setMfaStatusMessage(msg);
+      announce(msg, { politeness: 'polite' });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Unable to start two-factor enrollment.';
+      setMfaStatusMessage(message);
+      announce(message, { politeness: 'assertive' });
+    } finally {
+      setIsEnrolling(false);
+    }
+  };
+
+  const verifyEnrollment = async () => {
+    if (!enrollment || !session) {
+      return;
+    }
+    setIsVerifying(true);
+    setVerifyFailureMessage(null);
+    if (!/^\d{6}$/.test(verifyCode)) {
+      const msg =
+        'Enter exactly six digits from your authenticator, not a setup link.';
+      setVerifyFailureMessage(msg);
+      announce(msg, { politeness: 'assertive' });
+      setIsVerifying(false);
+      return;
+    }
+    try {
+      const challenge = await supabase.auth.mfa.challenge({
+        factorId: enrollment.id,
+      });
+      if (challenge.error) {
+        throw challenge.error;
+      }
+      const verify = await supabase.auth.mfa.verify({
+        factorId: enrollment.id,
+        challengeId: challenge.data.id,
+        code: verifyCode,
+      });
+      if (verify.error) {
+        throw verify.error;
+      }
+      setVerifyCode('');
+      setEnrollment(null);
+      await refreshMfaState();
+      const msg = 'Two-factor authentication is enabled.';
+      setMfaStatusMessage(msg);
+      announce(msg, { politeness: 'polite' });
+    } catch (error) {
+      const message = mapMfaVerifyErrorToUserMessage(error);
+      setVerifyFailureMessage(message);
+      announce(message, { politeness: 'assertive' });
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const cancelEnrollment = async () => {
+    if (!enrollment) {
+      return;
+    }
+    setIsCanceling(true);
+    try {
+      const { error } = await supabase.auth.mfa.unenroll({
+        factorId: enrollment.id,
+      });
+      if (error && !isUnenrollAlreadyGoneError(error)) {
+        announce(mapMfaUnenrollErrorToUserMessage(error), {
+          politeness: 'assertive',
+        });
+        return;
+      }
+      setEnrollment(null);
+      setVerifyCode('');
+      setVerifyFailureMessage(null);
+      await refreshMfaState();
+      announce('Two-factor setup canceled.', { politeness: 'polite' });
+    } finally {
+      setIsCanceling(false);
+    }
+  };
+
+  const onUnenrollFactor = async () => {
+    if (!unenrollFactorId) {
+      return false;
+    }
+    setUnenrollError(null);
+    try {
+      const { error } = await supabase.auth.mfa.unenroll({
+        factorId: unenrollFactorId,
+      });
+      if (error && !isUnenrollAlreadyGoneError(error)) {
+        const msg = mapMfaUnenrollErrorToUserMessage(error);
+        setUnenrollError(msg);
+        announce(msg, { politeness: 'assertive' });
+        return false;
+      }
+      await refreshMfaState();
+      announce('Authenticator removed.', { politeness: 'polite' });
+      return undefined;
+    } catch {
+      const msg = 'Unable to remove authenticator. Try again.';
+      setUnenrollError(msg);
+      announce(msg, { politeness: 'assertive' });
+      return false;
+    }
+  };
+
+  if (authLoading) {
+    return (
+      <p className="text-sm text-app-muted" role="status">
+        Loading security settings…
+      </p>
+    );
+  }
+
+  if (!session) {
+    return (
+      <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+        You must be signed in to manage security settings.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <section
+        aria-labelledby={`${formId}-password-heading`}
+        className={SETTINGS_SURFACE_CLASS}
+      >
+        <h2
+          id={`${formId}-password-heading`}
+          className="text-lg font-semibold text-app-ink"
+        >
+          {hasPassword ? 'Change password' : 'Add a password'}
+        </h2>
+        <p className="mt-2 text-sm text-app-muted">
+          {hasPassword
+            ? 'Update the password you use for email sign-in on web or mobile.'
+            : 'You currently sign in with magic links from email. Add a password if you want email and password sign-in too.'}
+        </p>
+        <form
+          className="mt-6 space-y-4"
+          onSubmit={(e) => {
+            void onPasswordSubmit(e);
+          }}
+          noValidate
+        >
+          <div className="space-y-2">
+            <label
+              htmlFor={`${formId}-new-password`}
+              className="text-sm font-medium text-app-ink"
+            >
+              {hasPassword ? 'New password' : 'Password'}
+            </label>
+            <input
+              id={`${formId}-new-password`}
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+              className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+            />
+          </div>
+          <div className="space-y-2">
+            <label
+              htmlFor={`${formId}-confirm-password`}
+              className="text-sm font-medium text-app-ink"
+            >
+              Confirm password
+            </label>
+            <input
+              id={`${formId}-confirm-password`}
+              type="password"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(e) => setConfirmPassword(e.target.value)}
+              className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+            />
+          </div>
+          {passwordError ? (
+            <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+              {passwordError}
+            </p>
+          ) : null}
+          <button
+            type="submit"
+            disabled={passwordSubmitting}
+            className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {passwordSubmitting
+              ? 'Saving…'
+              : hasPassword
+                ? 'Update password'
+                : 'Add password'}
+          </button>
+        </form>
+        {hasPassword ? (
+          <div className="mt-6 border-t border-app-border/80 pt-6">
+            <h3 className="text-sm font-semibold text-app-ink">
+              Use magic links only
+            </h3>
+            <p className="mt-2 text-sm text-app-muted">
+              Remove password sign-in and rely on magic links from email on
+              supported apps. You will need a new invite or magic link to sign
+              in after revoking.
+            </p>
+            <button
+              type="button"
+              className="mt-4 min-h-[44px] rounded-full border border-app-border px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-bg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+              onClick={() => {
+                setRevokeError(null);
+                setRevokeOpen(true);
+              }}
+            >
+              Revoke password sign-in
+            </button>
+          </div>
+        ) : null}
+      </section>
+
+      <section
+        aria-labelledby={`${formId}-totp-heading`}
+        className={SETTINGS_SURFACE_CLASS}
+      >
+        <h2
+          id={`${formId}-totp-heading`}
+          className="text-lg font-semibold text-app-ink"
+        >
+          Two-factor authentication (TOTP)
+        </h2>
+        <p className="mt-2 text-sm text-app-muted">
+          Optional for patients and caretakers. Add an authenticator app for an
+          extra sign-in step. You can enroll multiple factors as a backup.
+        </p>
+        {mfaStatusMessage ? (
+          <p className="mt-3 text-sm text-app-muted" role="status">
+            {mfaStatusMessage}
+          </p>
+        ) : null}
+        {mfaLoading ? (
+          <p className="mt-4 text-sm text-app-muted" role="status">
+            Loading two-factor status…
+          </p>
+        ) : (
+          <>
+            <p className="mt-4 text-sm text-app-ink">
+              {verifiedFactors.length > 0
+                ? `${verifiedFactors.length} verified authenticator${verifiedFactors.length === 1 ? '' : 's'} enrolled.`
+                : 'No authenticator enrolled yet.'}
+            </p>
+            {verifiedFactors.length > 0 ? (
+              <ul className="mt-4 space-y-2">
+                {verifiedFactors.map((factor) => (
+                  <li
+                    key={factor.id}
+                    className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-app-border/80 bg-app-bg px-4 py-3"
+                  >
+                    <span className="text-sm text-app-ink">
+                      {factor.friendlyName}
+                    </span>
+                    <button
+                      type="button"
+                      className="min-h-[44px] rounded-full border border-app-border px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                      onClick={() => {
+                        setUnenrollError(null);
+                        setUnenrollFactorId(factor.id);
+                      }}
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {!enrollment ? (
+              <button
+                type="button"
+                disabled={isEnrolling}
+                className="mt-4 min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                onClick={() => void startEnrollment()}
+              >
+                {isEnrolling ? 'Starting…' : 'Set up authenticator'}
+              </button>
+            ) : null}
+          </>
+        )}
+        {enrollment ? (
+          <div className="mt-6 space-y-4 border-t border-app-border/80 pt-6">
+            <div className="inline-block rounded-lg border border-app-border bg-white p-4">
+              <img
+                src={enrollment.qrCodeImageSrc}
+                alt="TOTP enrollment QR code"
+                width={320}
+                height={320}
+                className="block h-auto max-h-[min(80vw,20rem)] w-auto max-w-full"
+              />
+            </div>
+            <p className="text-sm text-app-muted">
+              Setup key:{' '}
+              <code className="rounded bg-app-bg px-1 py-0.5 text-app-ink">
+                {enrollment.secret}
+              </code>
+            </p>
+            <label
+              htmlFor={`${formId}-totp-code`}
+              className="block text-sm font-medium text-app-ink"
+            >
+              Six-digit code
+            </label>
+            <input
+              id={`${formId}-totp-code`}
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              maxLength={6}
+              value={verifyCode}
+              onChange={(event) => {
+                const raw = event.target.value;
+                if (looksLikeTotpSetupPayload(raw)) {
+                  setVerifyCode('');
+                  const msg =
+                    'Enter only the six-digit code from your authenticator.';
+                  setVerifyFailureMessage(msg);
+                  announce(msg, { politeness: 'assertive' });
+                  return;
+                }
+                setVerifyFailureMessage(null);
+                setVerifyCode(normalizeTotpCode(raw));
+              }}
+              className="block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+            />
+            {verifyFailureMessage ? (
+              <p
+                role="alert"
+                className="text-sm text-red-700 dark:text-red-300"
+              >
+                {verifyFailureMessage}
+              </p>
+            ) : null}
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                disabled={
+                  isVerifying || isCanceling || !/^\d{6}$/.test(verifyCode)
+                }
+                className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+                onClick={() => void verifyEnrollment()}
+              >
+                {isVerifying ? 'Verifying…' : 'Verify and enable'}
+              </button>
+              <button
+                type="button"
+                disabled={isVerifying || isCanceling}
+                className="min-h-[44px] rounded-full border border-app-border px-4 text-sm font-semibold text-app-ink shadow-sm"
+                onClick={() => void cancelEnrollment()}
+              >
+                {isCanceling ? 'Canceling…' : 'Cancel setup'}
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </section>
+
+      <ConfirmDialog
+        open={revokeOpen}
+        title="Revoke password sign-in?"
+        description="You will no longer be able to sign in with your email and password. Use magic links from email on supported apps instead. This does not sign you out of your current session."
+        confirmLabel="Revoke password"
+        cancelLabel="Keep password"
+        confirmBusyLabel="Revoking…"
+        onConfirm={() => onRevokePassword()}
+        onClose={() => {
+          setRevokeOpen(false);
+          setRevokeError(null);
+        }}
+      >
+        {revokeError ? (
+          <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+            {revokeError}
+          </p>
+        ) : null}
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        open={unenrollFactorId != null}
+        title="Remove authenticator?"
+        description="You will need this device or another enrolled authenticator to complete two-factor sign-in if it is required for your account."
+        confirmLabel="Remove"
+        cancelLabel="Keep"
+        confirmBusyLabel="Removing…"
+        onConfirm={() => onUnenrollFactor()}
+        onClose={() => {
+          setUnenrollFactorId(null);
+          setUnenrollError(null);
+        }}
+      >
+        {unenrollError ? (
+          <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+            {unenrollError}
+          </p>
+        ) : null}
+      </ConfirmDialog>
+    </div>
+  );
+}

--- a/apps/web/src/components/settings/SettingsSecuritySection.tsx
+++ b/apps/web/src/components/settings/SettingsSecuritySection.tsx
@@ -17,6 +17,7 @@ import {
   AUTH_PASSWORD_MIN_LENGTH,
   USER_PASSWORD_SET_USER_METADATA_KEY,
   buildRevokedPasswordPlaceholder,
+  clampAuthPasswordInput,
   getAuthPasswordValidationError,
   userHasPasswordSignIn,
 } from '@/lib/user-password-sign-in';
@@ -405,9 +406,10 @@ export function SettingsSecuritySection() {
               id={`${formId}-new-password`}
               type="password"
               autoComplete="new-password"
-              maxLength={AUTH_PASSWORD_MAX_LENGTH}
               value={password}
-              onChange={(e) => setPassword(e.target.value)}
+              onChange={(e) =>
+                setPassword(clampAuthPasswordInput(e.target.value))
+              }
               className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
             />
           </div>
@@ -422,9 +424,10 @@ export function SettingsSecuritySection() {
               id={`${formId}-confirm-password`}
               type="password"
               autoComplete="new-password"
-              maxLength={AUTH_PASSWORD_MAX_LENGTH}
               value={confirmPassword}
-              onChange={(e) => setConfirmPassword(e.target.value)}
+              onChange={(e) =>
+                setConfirmPassword(clampAuthPasswordInput(e.target.value))
+              }
               className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
             />
           </div>

--- a/apps/web/src/components/settings/SettingsSecuritySection.tsx
+++ b/apps/web/src/components/settings/SettingsSecuritySection.tsx
@@ -304,7 +304,9 @@ export function SettingsSecuritySection() {
         factorId: enrollment.id,
       });
       if (error && !isUnenrollAlreadyGoneError(error)) {
-        announce(mapMfaUnenrollErrorToUserMessage(error), {
+        const message = mapMfaUnenrollErrorToUserMessage(error);
+        setMfaStatusMessage(message);
+        announce(message, {
           politeness: 'assertive',
         });
         return;
@@ -314,6 +316,11 @@ export function SettingsSecuritySection() {
       setVerifyFailureMessage(null);
       await refreshMfaState();
       announce('Two-factor setup canceled.', { politeness: 'polite' });
+    } catch {
+      const message =
+        'Unable to cancel two-factor setup. Check your connection and try again.';
+      setMfaStatusMessage(message);
+      announce(message, { politeness: 'assertive' });
     } finally {
       setIsCanceling(false);
     }

--- a/apps/web/src/csp-config.spec.ts
+++ b/apps/web/src/csp-config.spec.ts
@@ -1,0 +1,121 @@
+import {
+  buildUserWebCspDirectives,
+  normalizeCspHeaderValue,
+  supabaseHttpAndWsOrigins,
+} from '../csp-config.js';
+
+describe('csp-config', () => {
+  it('maps Supabase URL to HTTP and WebSocket origins', () => {
+    expect(supabaseHttpAndWsOrigins('https://abc.supabase.co')).toEqual({
+      httpOrigin: 'https://abc.supabase.co',
+      wsOrigin: 'wss://abc.supabase.co',
+    });
+    expect(supabaseHttpAndWsOrigins('http://127.0.0.1:54321')).toEqual({
+      httpOrigin: 'http://127.0.0.1:54321',
+      wsOrigin: 'ws://127.0.0.1:54321',
+    });
+    expect(supabaseHttpAndWsOrigins(undefined)).toBeNull();
+    expect(supabaseHttpAndWsOrigins('not-a-url')).toBeNull();
+  });
+
+  describe('normalizeCspHeaderValue', () => {
+    /**
+     * Guards the contract when policy text is built with a multi-line template literal
+     * (one directive per line); the HTTP header value must still be a single line.
+     */
+    it('strips actual newlines and CRLF from raw policy text while preserving token spacing', () => {
+      const rawMultilineTemplate = `default-src 'self';
+script-src 'self' 'unsafe-inline';
+connect-src 'self' https://abc.supabase.co wss://abc.supabase.co`;
+
+      const fromLf = normalizeCspHeaderValue(rawMultilineTemplate);
+
+      expect(fromLf).not.toMatch(/[\r\n]/);
+      expect(fromLf).toBe(
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' https://abc.supabase.co wss://abc.supabase.co",
+      );
+
+      const rawCrLf = [
+        "default-src 'self';",
+        "script-src 'self' 'unsafe-inline';",
+        "connect-src 'self' https://abc.supabase.co",
+      ].join('\r\n');
+
+      const fromCrLf = normalizeCspHeaderValue(rawCrLf);
+
+      expect(fromCrLf).not.toMatch(/[\r\n]/);
+      expect(fromCrLf).toBe(
+        "default-src 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self' https://abc.supabase.co",
+      );
+    });
+
+    it('normalizes inline escape sequences and mixed padding', () => {
+      expect(
+        normalizeCspHeaderValue("default-src 'self';\nscript-src 'self'"),
+      ).toBe("default-src 'self'; script-src 'self'");
+      expect(normalizeCspHeaderValue('a\r\nb\rc')).toBe('a b c');
+      expect(normalizeCspHeaderValue('x  \n  y')).toBe('x y');
+    });
+  });
+
+  it('emits a single-line policy without accidental newlines', () => {
+    const raw = buildUserWebCspDirectives({
+      supabaseUrl: 'https://abc.supabase.co',
+      isDev: false,
+      isProduction: true,
+    });
+    const value = normalizeCspHeaderValue(raw);
+    expect(value).not.toMatch(/\n/);
+    expect(value).toContain('connect-src');
+    expect(value).toContain('https://abc.supabase.co');
+    expect(value).toContain('wss://abc.supabase.co');
+    expect(value).toContain('img-src');
+    expect(value).toContain('media-src');
+    expect(value).toMatch(/img-src[^;]*https:\/\/abc\.supabase\.co/);
+    expect(value).toMatch(/media-src[^;]*https:\/\/abc\.supabase\.co/);
+    expect(value).toContain('upgrade-insecure-requests');
+  });
+
+  it("adds 'unsafe-eval' only in development", () => {
+    const prod = normalizeCspHeaderValue(
+      buildUserWebCspDirectives({
+        supabaseUrl: 'https://abc.supabase.co',
+        isDev: false,
+        isProduction: true,
+      }),
+    );
+    expect(prod).not.toContain("'unsafe-eval'");
+
+    const dev = normalizeCspHeaderValue(
+      buildUserWebCspDirectives({
+        supabaseUrl: 'https://abc.supabase.co',
+        isDev: true,
+        isProduction: false,
+      }),
+    );
+    expect(dev).toContain("'unsafe-eval'");
+  });
+
+  it('includes local dev connect-src origins only in development', () => {
+    const prod = normalizeCspHeaderValue(
+      buildUserWebCspDirectives({
+        supabaseUrl: 'https://abc.supabase.co',
+        isDev: false,
+        isProduction: true,
+      }),
+    );
+    expect(prod).not.toContain('http://localhost:3000');
+    expect(prod).not.toContain('ws://localhost:54321');
+
+    const dev = normalizeCspHeaderValue(
+      buildUserWebCspDirectives({
+        supabaseUrl: 'https://abc.supabase.co',
+        isDev: true,
+        isProduction: false,
+      }),
+    );
+    expect(dev).toContain('http://localhost:3000');
+    expect(dev).toContain('ws://localhost:54321');
+    expect(dev).toContain('http://127.0.0.1:54321');
+  });
+});

--- a/apps/web/src/lib/app-nav-items.ts
+++ b/apps/web/src/lib/app-nav-items.ts
@@ -40,16 +40,8 @@ export const WEB_APP_NAV_ITEMS: AppSideNavItem[] = [
       path.startsWith('/presets/episode-templates/'),
   },
   {
-    href: '/settings/caretaker',
-    label: 'Caretaker',
-    match: (path) =>
-      path === '/settings/caretaker' || path.startsWith('/settings/caretaker/'),
-  },
-  {
-    href: '/settings/practitioner',
-    label: 'Practitioner',
-    match: (path) =>
-      path === '/settings/practitioner' ||
-      path.startsWith('/settings/practitioner/'),
+    href: '/settings',
+    label: 'Settings',
+    match: (path) => path === '/settings' || path.startsWith('/settings/'),
   },
 ];

--- a/apps/web/src/lib/auth-provider-session.spec.ts
+++ b/apps/web/src/lib/auth-provider-session.spec.ts
@@ -11,7 +11,7 @@ describe('mapSupabaseUserToAuthContext', () => {
 
   it('maps user id and normalizes null email to undefined', () => {
     expect(mapSupabaseUserToAuthContext({ id: 'user-1', email: null })).toEqual(
-      { user: { id: 'user-1' } },
+      { user: { id: 'user-1', email: undefined, user_metadata: null } },
     );
 
     expect(
@@ -19,6 +19,12 @@ describe('mapSupabaseUserToAuthContext', () => {
         id: 'user-2',
         email: 'user@example.com',
       }),
-    ).toEqual({ user: { id: 'user-2', email: 'user@example.com' } });
+    ).toEqual({
+      user: {
+        id: 'user-2',
+        email: 'user@example.com',
+        user_metadata: null,
+      },
+    });
   });
 });

--- a/apps/web/src/lib/auth-provider-session.ts
+++ b/apps/web/src/lib/auth-provider-session.ts
@@ -1,6 +1,10 @@
 /** Session shape exposed to client components via {@link useAuth}. */
 export type AuthProviderSession = {
-  user: { id: string; email?: string };
+  user: {
+    id: string;
+    email?: string;
+    user_metadata?: Record<string, unknown> | null;
+  };
 } | null;
 
 /**
@@ -11,7 +15,14 @@ export type AuthProviderSession = {
  * @returns Context session or `null` when signed out.
  */
 export function mapSupabaseUserToAuthContext(
-  user: { id: string; email?: string | null } | null | undefined,
+  user:
+    | {
+        id: string;
+        email?: string | null;
+        user_metadata?: Record<string, unknown> | null;
+      }
+    | null
+    | undefined,
 ): AuthProviderSession {
   if (!user?.id) {
     return null;
@@ -20,6 +31,7 @@ export function mapSupabaseUserToAuthContext(
     user: {
       id: user.id,
       email: user.email ?? undefined,
+      user_metadata: user.user_metadata ?? null,
     },
   };
 }

--- a/apps/web/src/lib/auth-provider.tsx
+++ b/apps/web/src/lib/auth-provider.tsx
@@ -9,6 +9,7 @@ import {
   useRef,
   useState,
 } from 'react';
+import type { AbstrackSupabaseClient } from '@abstrack/supabase';
 import {
   type AuthProviderSession,
   mapSupabaseUserToAuthContext,
@@ -21,6 +22,8 @@ export type { AuthProviderSession } from './auth-provider-session';
 interface AuthContextType {
   session: AuthProviderSession;
   loading: boolean;
+  /** Shared browser Supabase client (single `onAuthStateChange` / MFA trust-bundle sync). */
+  supabase: AbstrackSupabaseClient;
 }
 
 export type AuthProviderProps = {
@@ -181,7 +184,7 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
   }, [supabase]);
 
   return (
-    <AuthContext.Provider value={{ session, loading }}>
+    <AuthContext.Provider value={{ session, loading, supabase }}>
       {children}
     </AuthContext.Provider>
   );

--- a/apps/web/src/lib/auth-provider.tsx
+++ b/apps/web/src/lib/auth-provider.tsx
@@ -1,11 +1,19 @@
 'use client';
 
 import { isAuthSessionMissingError } from '@abstrack/supabase';
-import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import {
+  createContext,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import {
   type AuthProviderSession,
   mapSupabaseUserToAuthContext,
 } from './auth-provider-session';
+import { syncMfaTrustBundleAfterTokenRefresh } from './user-mfa-device-trust';
 import { createBrowserClient } from './supabase/browser-client';
 
 export type { AuthProviderSession } from './auth-provider-session';
@@ -50,6 +58,7 @@ function isRefreshTokenFailure(error: unknown): boolean {
 
 export function AuthProvider({ children, initialSession }: AuthProviderProps) {
   const hasInitialSession = initialSession !== undefined;
+  const supabase = useMemo(() => createBrowserClient(), []);
   const [session, setSession] = useState<AuthProviderSession>(
     hasInitialSession ? initialSession : null,
   );
@@ -59,7 +68,6 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
 
   useEffect(() => {
     let mounted = true;
-    const supabase = createBrowserClient();
 
     const syncVerifiedUser = async (): Promise<void> => {
       const generation = ++verifyGenerationRef.current;
@@ -151,13 +159,16 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
 
     const {
       data: { subscription },
-    } = supabase.auth.onAuthStateChange((event) => {
+    } = supabase.auth.onAuthStateChange((event, authSession) => {
       if (event === 'SIGNED_OUT') {
         verifyGenerationRef.current += 1;
         if (mounted) {
           setSession(null);
         }
         return;
+      }
+      if (event === 'TOKEN_REFRESHED' && authSession != null) {
+        void syncMfaTrustBundleAfterTokenRefresh(supabase, authSession);
       }
       void syncVerifiedUser();
     });
@@ -167,7 +178,7 @@ export function AuthProvider({ children, initialSession }: AuthProviderProps) {
       verifyGenerationRef.current += 1;
       subscription.unsubscribe();
     };
-  }, []);
+  }, [supabase]);
 
   return (
     <AuthContext.Provider value={{ session, loading }}>

--- a/apps/web/src/lib/mfa-user-messages.spec.ts
+++ b/apps/web/src/lib/mfa-user-messages.spec.ts
@@ -1,0 +1,156 @@
+import {
+  isUnenrollAlreadyGoneError,
+  looksLikeTotpSetupPayload,
+  mapMfaUnenrollErrorToUserMessage,
+  mapMfaVerifyErrorToUserMessage,
+  normalizeTotpCode,
+} from './mfa-user-messages';
+
+describe('normalizeTotpCode', () => {
+  it('strips non-digits and caps at six characters', () => {
+    expect(normalizeTotpCode('12 34 56')).toBe('123456');
+    expect(normalizeTotpCode('abc123456789')).toBe('123456');
+  });
+
+  it('returns empty when no digits are present', () => {
+    expect(normalizeTotpCode('abc')).toBe('');
+    expect(normalizeTotpCode('')).toBe('');
+  });
+});
+
+describe('looksLikeTotpSetupPayload', () => {
+  it('detects otpauth URI', () => {
+    expect(
+      looksLikeTotpSetupPayload(
+        'otpauth://totp/Issuer:u@e?secret=XXX&issuer=Y',
+      ),
+    ).toBe(true);
+  });
+
+  it('detects secret= and issuer= fragments', () => {
+    expect(looksLikeTotpSetupPayload('secret=JBSWY3DPEHPK3PXP')).toBe(true);
+    expect(looksLikeTotpSetupPayload('issuer=ABStrack')).toBe(true);
+  });
+
+  it('detects ://…totp path', () => {
+    expect(looksLikeTotpSetupPayload('foo://x/totp/y')).toBe(true);
+  });
+
+  it('allows plain six-digit codes', () => {
+    expect(looksLikeTotpSetupPayload('123456')).toBe(false);
+    expect(looksLikeTotpSetupPayload('12 34 56')).toBe(false);
+  });
+});
+
+describe('mapMfaVerifyErrorToUserMessage', () => {
+  const wrongCode =
+    'That code did not match. Enter the current six-digit code from your authenticator.';
+  const sessionExpired =
+    'Your session may have expired. Sign in again, then retry verification.';
+
+  it('maps 422 with empty message to wrong-code copy', () => {
+    expect(mapMfaVerifyErrorToUserMessage({ message: '', status: 422 })).toBe(
+      wrongCode,
+    );
+  });
+
+  it('maps 400 with empty message to wrong-code copy', () => {
+    expect(mapMfaVerifyErrorToUserMessage({ status: 400, message: '' })).toBe(
+      wrongCode,
+    );
+  });
+
+  it('maps 401 to session copy', () => {
+    expect(mapMfaVerifyErrorToUserMessage({ status: 401, message: 'x' })).toBe(
+      sessionExpired,
+    );
+  });
+
+  it('maps invalid token text to not-valid copy', () => {
+    expect(
+      mapMfaVerifyErrorToUserMessage({
+        message: 'invalid TOTP',
+        status: 500,
+      }),
+    ).toContain('not valid');
+  });
+
+  it('maps expired challenge text', () => {
+    expect(
+      mapMfaVerifyErrorToUserMessage({
+        message: 'Challenge expired',
+        status: 500,
+      }),
+    ).toContain('expired');
+  });
+
+  it('maps mfa_verification_failed code when message is empty', () => {
+    expect(
+      mapMfaVerifyErrorToUserMessage({
+        message: '',
+        code: 'mfa_verification_failed',
+      }),
+    ).toBe(
+      'We could not verify that code yet. Please try again with a fresh code.',
+    );
+  });
+
+  it('maps unknown non-empty message through verbatim when no keyword match', () => {
+    expect(
+      mapMfaVerifyErrorToUserMessage({ message: 'Custom server text' }),
+    ).toBe('Custom server text');
+  });
+
+  it('reads msg when message is absent', () => {
+    expect(
+      mapMfaVerifyErrorToUserMessage({ msg: 'invalid code', status: 500 }),
+    ).toContain('not valid');
+  });
+
+  it('falls back to Error.message when object message is missing', () => {
+    const err = new Error('invalid TOTP');
+    expect(mapMfaVerifyErrorToUserMessage(err)).toContain('not valid');
+  });
+
+  it('maps totally empty error to wrong-code fallback', () => {
+    expect(mapMfaVerifyErrorToUserMessage({})).toBe(wrongCode);
+    expect(mapMfaVerifyErrorToUserMessage(null)).toBe(wrongCode);
+  });
+});
+
+describe('isUnenrollAlreadyGoneError', () => {
+  it('treats 404 and 410 as gone', () => {
+    expect(isUnenrollAlreadyGoneError({ status: 404, message: 'nope' })).toBe(
+      true,
+    );
+    expect(isUnenrollAlreadyGoneError({ status: 410, message: 'gone' })).toBe(
+      true,
+    );
+  });
+
+  it('detects not found in message', () => {
+    expect(isUnenrollAlreadyGoneError({ message: 'Factor not found' })).toBe(
+      true,
+    );
+  });
+
+  it('returns false for other server errors', () => {
+    expect(
+      isUnenrollAlreadyGoneError({ status: 500, message: 'db down' }),
+    ).toBe(false);
+  });
+});
+
+describe('mapMfaUnenrollErrorToUserMessage', () => {
+  it('maps 401 to session copy', () => {
+    expect(mapMfaUnenrollErrorToUserMessage({ status: 401 })).toContain(
+      'session',
+    );
+  });
+
+  it('maps other errors to generic copy', () => {
+    expect(mapMfaUnenrollErrorToUserMessage({ status: 503 })).toContain(
+      'Could not cancel',
+    );
+  });
+});

--- a/apps/web/src/lib/mfa-user-messages.ts
+++ b/apps/web/src/lib/mfa-user-messages.ts
@@ -1,0 +1,143 @@
+/**
+ * Pure helpers for TOTP/MFA verification UX — extracted for unit testing (Supabase error shapes vary).
+ */
+
+export function normalizeTotpCode(raw: string): string {
+  return raw.replace(/\D/g, '').slice(0, 6);
+}
+
+/**
+ * Detects pasted Key URIs or setup blobs — not a six-digit OTP. We refuse these so
+ * {@link normalizeTotpCode} cannot pull arbitrary digits out of an `otpauth://` string.
+ *
+ * @param raw - Field value (may include a full paste).
+ * @returns Whether this looks like a setup payload rather than digits-only entry.
+ */
+export function looksLikeTotpSetupPayload(raw: string): boolean {
+  return (
+    /otpauth/i.test(raw) ||
+    /:\/\/[^\s]*totp/i.test(raw) ||
+    /\bsecret=/i.test(raw) ||
+    /\bissuer=/i.test(raw)
+  );
+}
+
+function getVerificationMessage(message?: string): string {
+  const lower = message?.toLowerCase() ?? '';
+  if (lower.includes('expired')) {
+    return 'That code expired. Enter the latest code from your authenticator app and try again.';
+  }
+  if (lower.includes('invalid')) {
+    return 'That code was not valid. Check the six-digit code and your device time, then try again.';
+  }
+  const trimmed = message?.trim();
+  if (trimmed) {
+    return trimmed;
+  }
+  return 'We could not verify that code yet. Please try again with a fresh code.';
+}
+
+type AuthLikeErrorFields = {
+  message: string;
+  status?: number;
+  code?: string;
+};
+
+function readAuthLikeError(error: unknown): AuthLikeErrorFields {
+  if (typeof error === 'string') {
+    return { message: error };
+  }
+  if (typeof error !== 'object' || error === null) {
+    return { message: '' };
+  }
+  const o = error as Record<string, unknown>;
+  const message =
+    typeof o.message === 'string'
+      ? o.message
+      : typeof o.msg === 'string'
+        ? o.msg
+        : '';
+  const status = typeof o.status === 'number' ? o.status : undefined;
+  const code = typeof o.code === 'string' ? o.code : undefined;
+  if (!message && error instanceof Error) {
+    return { message: error.message, status, code };
+  }
+  return { message, status, code };
+}
+
+/**
+ * Maps MFA verify (and related) failures to accessible copy.
+ *
+ * @param error - Caught error from `mfa.challenge` / `mfa.verify`.
+ * @returns User-visible message.
+ */
+export function mapMfaVerifyErrorToUserMessage(error: unknown): string {
+  const { message: raw, status, code } = readAuthLikeError(error);
+  const lower = raw.toLowerCase();
+
+  if (status === 401) {
+    return 'Your session may have expired. Sign in again, then retry verification.';
+  }
+
+  if (status === 422 || status === 400) {
+    return 'That code did not match. Enter the current six-digit code from your authenticator.';
+  }
+
+  if (
+    lower.includes('invalid') ||
+    lower.includes('incorrect') ||
+    lower.includes('mismatch') ||
+    lower.includes('wrong') ||
+    lower.includes('verification failed')
+  ) {
+    return getVerificationMessage(raw);
+  }
+
+  if (lower.includes('expired') || lower.includes('challenge')) {
+    return getVerificationMessage(raw);
+  }
+
+  if (code === 'mfa_verification_failed' || code === 'mfa_challenge_expired') {
+    return getVerificationMessage(raw);
+  }
+
+  if (raw.trim()) {
+    return getVerificationMessage(raw);
+  }
+
+  return 'That code did not match. Enter the current six-digit code from your authenticator.';
+}
+
+/**
+ * DELETE `/factors/:id` may 404 if the factor was already removed — treat as success so Cancel
+ * stays idempotent.
+ *
+ * @param error - Result from `mfa.unenroll` or thrown value.
+ * @returns Whether local enrollment UI can be cleared without surfacing an error.
+ */
+export function isUnenrollAlreadyGoneError(error: unknown): boolean {
+  const { message, status } = readAuthLikeError(error);
+  if (status === 404 || status === 410) {
+    return true;
+  }
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('not found') ||
+    lower.includes('no rows') ||
+    lower.includes('already been deleted')
+  );
+}
+
+/**
+ * User-visible copy when `mfa.unenroll` fails for reasons other than an already-removed factor.
+ *
+ * @param error - Error from `mfa.unenroll`.
+ * @returns Message for announcements.
+ */
+export function mapMfaUnenrollErrorToUserMessage(error: unknown): string {
+  const { status } = readAuthLikeError(error);
+  if (status === 401) {
+    return 'Your session may have expired. Sign in again, then try canceling enrollment.';
+  }
+  return 'Could not cancel enrollment on the server. Check your connection and try again.';
+}

--- a/apps/web/src/lib/pending-email-change.spec.ts
+++ b/apps/web/src/lib/pending-email-change.spec.ts
@@ -1,0 +1,16 @@
+import { readPendingEmailChange } from './pending-email-change';
+
+describe('readPendingEmailChange', () => {
+  it('returns null for missing or empty new_email', () => {
+    expect(readPendingEmailChange(null)).toBeNull();
+    expect(readPendingEmailChange({})).toBeNull();
+    expect(readPendingEmailChange({ new_email: '' })).toBeNull();
+    expect(readPendingEmailChange({ new_email: '   ' })).toBeNull();
+  });
+
+  it('returns normalized pending address from GoTrue user', () => {
+    expect(readPendingEmailChange({ new_email: '  New@Example.com  ' })).toBe(
+      'new@example.com',
+    );
+  });
+});

--- a/apps/web/src/lib/pending-email-change.ts
+++ b/apps/web/src/lib/pending-email-change.ts
@@ -1,0 +1,18 @@
+/**
+ * Reads GoTrue `new_email` when an address change awaits confirmation via
+ * {@link AbstrackSupabaseClient.auth.updateUser} (Supabase `email_change` template).
+ *
+ * @param user - Auth user from `getUser()` / session.
+ * @returns Normalized pending address, or `null` when none is set.
+ */
+export function readPendingEmailChange(user: unknown): string | null {
+  if (!user || typeof user !== 'object') {
+    return null;
+  }
+  const raw = (user as { new_email?: unknown }).new_email;
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const trimmed = raw.trim().toLowerCase();
+  return trimmed === '' ? null : trimmed;
+}

--- a/apps/web/src/lib/profile-display-name.spec.ts
+++ b/apps/web/src/lib/profile-display-name.spec.ts
@@ -1,0 +1,35 @@
+import {
+  combineNameFieldsIntoDisplayName,
+  splitDisplayNameIntoNameFields,
+} from './profile-display-name';
+
+describe('profile-display-name', () => {
+  it('splits display name into first and last', () => {
+    expect(splitDisplayNameIntoNameFields('Jordan Lee')).toEqual({
+      firstName: 'Jordan',
+      lastName: 'Lee',
+    });
+  });
+
+  it('returns empty fields for null display name', () => {
+    expect(splitDisplayNameIntoNameFields(null)).toEqual({
+      firstName: '',
+      lastName: '',
+    });
+  });
+
+  it('combines trimmed name fields into display name', () => {
+    expect(
+      combineNameFieldsIntoDisplayName({
+        firstName: '  Sam  ',
+        lastName: ' Taylor ',
+      }),
+    ).toBe('Sam Taylor');
+  });
+
+  it('returns null when both name fields are empty', () => {
+    expect(
+      combineNameFieldsIntoDisplayName({ firstName: ' ', lastName: '' }),
+    ).toBeNull();
+  });
+});

--- a/apps/web/src/lib/profile-display-name.ts
+++ b/apps/web/src/lib/profile-display-name.ts
@@ -1,0 +1,39 @@
+export type ProfileNameFields = {
+  firstName: string;
+  lastName: string;
+};
+
+/**
+ * Splits `profiles.display_name` into first and last name fields for settings forms.
+ * Uses the first whitespace-delimited token as the first name and the remainder as last name.
+ *
+ * @param displayName - Stored profile display name.
+ * @returns Editable first/last name fields.
+ */
+export function splitDisplayNameIntoNameFields(
+  displayName: string | null | undefined,
+): ProfileNameFields {
+  const trimmed = displayName?.trim() ?? '';
+  if (trimmed === '') {
+    return { firstName: '', lastName: '' };
+  }
+  const parts = trimmed.split(/\s+/);
+  const firstName = parts[0] ?? '';
+  const lastName = parts.slice(1).join(' ');
+  return { firstName, lastName };
+}
+
+/**
+ * Combines first and last name fields into the single `profiles.display_name` value.
+ *
+ * @param fields - Form first/last name values.
+ * @returns Trimmed display name, or `null` when both fields are empty.
+ */
+export function combineNameFieldsIntoDisplayName(
+  fields: ProfileNameFields,
+): string | null {
+  const firstName = fields.firstName.trim();
+  const lastName = fields.lastName.trim();
+  const combined = [firstName, lastName].filter(Boolean).join(' ');
+  return combined === '' ? null : combined;
+}

--- a/apps/web/src/lib/same-origin-logout-post.spec.ts
+++ b/apps/web/src/lib/same-origin-logout-post.spec.ts
@@ -1,0 +1,76 @@
+import { getSameOriginLogoutPostFailure } from './same-origin-logout-post';
+
+const BASE = 'https://example.com/api/auth/logout';
+
+function req(headers: Record<string, string>) {
+  return {
+    url: BASE,
+    headers: new Headers(headers),
+  };
+}
+
+describe('getSameOriginLogoutPostFailure', () => {
+  it('returns null when Origin matches the request URL origin', () => {
+    expect(
+      getSameOriginLogoutPostFailure(req({ Origin: 'https://example.com' })),
+    ).toBeNull();
+  });
+
+  it('returns 403 when Origin is a different host', () => {
+    expect(
+      getSameOriginLogoutPostFailure(req({ Origin: 'https://evil.example' })),
+    ).toEqual({ status: 403, error: 'Invalid Origin' });
+  });
+
+  it('returns 403 when Sec-Fetch-Site is cross-site', () => {
+    expect(
+      getSameOriginLogoutPostFailure(req({ 'Sec-Fetch-Site': 'cross-site' })),
+    ).toEqual({ status: 403, error: 'Cross-site request rejected' });
+  });
+
+  it('returns null when Referer matches origin and Origin is absent', () => {
+    expect(
+      getSameOriginLogoutPostFailure(
+        req({
+          Referer: 'https://example.com/settings',
+          'Sec-Fetch-Site': 'same-origin',
+        }),
+      ),
+    ).toBeNull();
+  });
+
+  it('returns 403 when Referer origin does not match', () => {
+    expect(
+      getSameOriginLogoutPostFailure(
+        req({
+          Referer: 'https://evil.example/',
+          'Sec-Fetch-Site': 'same-origin',
+        }),
+      ),
+    ).toEqual({ status: 403, error: 'Invalid Referer' });
+  });
+
+  it('returns null when Origin is absent but Sec-Fetch-Site is same-origin', () => {
+    expect(
+      getSameOriginLogoutPostFailure(req({ 'Sec-Fetch-Site': 'same-origin' })),
+    ).toBeNull();
+  });
+
+  it('returns 403 when Origin and Referer are absent and Sec-Fetch-Site is none', () => {
+    expect(
+      getSameOriginLogoutPostFailure(req({ 'Sec-Fetch-Site': 'none' })),
+    ).toEqual({
+      status: 403,
+      error: 'Could not validate request origin',
+    });
+  });
+
+  it('returns 403 when Origin and Referer are absent and Sec-Fetch-Site is same-site (strict same-origin)', () => {
+    expect(
+      getSameOriginLogoutPostFailure(req({ 'Sec-Fetch-Site': 'same-site' })),
+    ).toEqual({
+      status: 403,
+      error: 'Could not validate request origin',
+    });
+  });
+});

--- a/apps/web/src/lib/same-origin-logout-post.ts
+++ b/apps/web/src/lib/same-origin-logout-post.ts
@@ -1,0 +1,57 @@
+/**
+ * Failure payload when a logout `POST` fails same-origin / anti-CSRF checks.
+ */
+export type SameOriginLogoutPostFailure = {
+  status: 400 | 403;
+  error: string;
+};
+
+/**
+ * Blocks cross-site `POST` requests to the user-web logout endpoint so a malicious page cannot
+ * forge a form that signs users out (CSRF). Checks enforce **same-origin** (exact URL origin), not
+ * schemeful same-site: prefer a non-empty matching `Origin`, else a matching `Referer` origin; if both
+ * are absent, only `Sec-Fetch-Site: same-origin` is accepted (`same-site` is rejected so the guard
+ * matches its name and stays predictable when browsers omit `Origin` on some `POST`s).
+ *
+ * This is not a substitute for CSRF tokens when you must support trusted cross-origin clients;
+ * user-web logout is intended to be same-origin only.
+ *
+ * @param request - Minimal request shape (`url` + `headers`), e.g. Next.js `NextRequest`.
+ * @returns `null` if the request may proceed, or a failure object the route should turn into a 4xx response.
+ */
+export function getSameOriginLogoutPostFailure(
+  request: Pick<Request, 'url' | 'headers'>,
+): SameOriginLogoutPostFailure | null {
+  const expectedOrigin = new URL(request.url).origin;
+
+  const origin = request.headers.get('Origin');
+  if (origin !== null && origin !== '') {
+    if (origin !== expectedOrigin) {
+      return { status: 403, error: 'Invalid Origin' };
+    }
+    return null;
+  }
+
+  if (request.headers.get('Sec-Fetch-Site') === 'cross-site') {
+    return { status: 403, error: 'Cross-site request rejected' };
+  }
+
+  const referer = request.headers.get('Referer');
+  if (referer) {
+    try {
+      if (new URL(referer).origin !== expectedOrigin) {
+        return { status: 403, error: 'Invalid Referer' };
+      }
+      return null;
+    } catch {
+      return { status: 400, error: 'Invalid Referer' };
+    }
+  }
+
+  const secFetchSite = request.headers.get('Sec-Fetch-Site');
+  if (secFetchSite === 'same-origin') {
+    return null;
+  }
+
+  return { status: 403, error: 'Could not validate request origin' };
+}

--- a/apps/web/src/lib/settings-tabs.spec.ts
+++ b/apps/web/src/lib/settings-tabs.spec.ts
@@ -1,0 +1,13 @@
+import { parseSettingsTabId } from './settings-tabs';
+
+describe('parseSettingsTabId', () => {
+  it('defaults to account', () => {
+    expect(parseSettingsTabId(null)).toBe('account');
+    expect(parseSettingsTabId('invalid')).toBe('account');
+  });
+
+  it('parses security and invites', () => {
+    expect(parseSettingsTabId('security')).toBe('security');
+    expect(parseSettingsTabId('invites')).toBe('invites');
+  });
+});

--- a/apps/web/src/lib/settings-tabs.ts
+++ b/apps/web/src/lib/settings-tabs.ts
@@ -1,0 +1,16 @@
+export const SETTINGS_TAB_IDS = ['account', 'security', 'invites'] as const;
+
+export type SettingsTabId = (typeof SETTINGS_TAB_IDS)[number];
+
+/**
+ * Parses a settings tab id from a query string value.
+ *
+ * @param raw - Raw `tab` search param.
+ * @returns A valid tab id, or `account` when missing/invalid.
+ */
+export function parseSettingsTabId(raw: string | null): SettingsTabId {
+  if (raw === 'security' || raw === 'invites') {
+    return raw;
+  }
+  return 'account';
+}

--- a/apps/web/src/lib/user-mfa-device-trust-duration.spec.ts
+++ b/apps/web/src/lib/user-mfa-device-trust-duration.spec.ts
@@ -1,0 +1,28 @@
+import {
+  getTrustedUntilMsForDuration,
+  getTrustedUntilMsAfterVerification,
+} from './user-mfa-device-trust';
+
+describe('getTrustedUntilMsForDuration', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('adds 30 days for 30_days', () => {
+    const expected =
+      Date.parse('2026-05-22T12:00:00.000Z') + 30 * 24 * 60 * 60 * 1000;
+    expect(getTrustedUntilMsForDuration('30_days')).toBe(expected);
+    expect(getTrustedUntilMsAfterVerification()).toBe(expected);
+  });
+
+  it('adds 365 days for 1_year', () => {
+    const expected =
+      Date.parse('2026-05-22T12:00:00.000Z') + 365 * 24 * 60 * 60 * 1000;
+    expect(getTrustedUntilMsForDuration('1_year')).toBe(expected);
+  });
+});

--- a/apps/web/src/lib/user-mfa-device-trust-gate.spec.ts
+++ b/apps/web/src/lib/user-mfa-device-trust-gate.spec.ts
@@ -1,0 +1,68 @@
+const prevTrustEnv = process.env['NEXT_PUBLIC_USER_MFA_DEVICE_TRUST'];
+const prevCspEnv = process.env['NEXT_PUBLIC_USER_WEB_CSP_ENFORCE'];
+const prevNodeEnv = process.env['NODE_ENV'];
+
+afterEach(() => {
+  if (prevTrustEnv === undefined) {
+    delete process.env['NEXT_PUBLIC_USER_MFA_DEVICE_TRUST'];
+  } else {
+    process.env['NEXT_PUBLIC_USER_MFA_DEVICE_TRUST'] = prevTrustEnv;
+  }
+  if (prevCspEnv === undefined) {
+    delete process.env['NEXT_PUBLIC_USER_WEB_CSP_ENFORCE'];
+  } else {
+    process.env['NEXT_PUBLIC_USER_WEB_CSP_ENFORCE'] = prevCspEnv;
+  }
+  if (prevNodeEnv === undefined) {
+    delete process.env['NODE_ENV'];
+  } else {
+    process.env['NODE_ENV'] = prevNodeEnv;
+  }
+});
+
+describe('isUserMfaDeviceTrustEnabled', () => {
+  it('is disabled when the trust env var is unset', async () => {
+    delete process.env['NEXT_PUBLIC_USER_MFA_DEVICE_TRUST'];
+    delete process.env['NEXT_PUBLIC_USER_WEB_CSP_ENFORCE'];
+    const { isUserMfaDeviceTrustEnabled } = await import(
+      './user-mfa-device-trust'
+    );
+    expect(isUserMfaDeviceTrustEnabled()).toBe(false);
+  });
+
+  it('is disabled when trust is explicitly false', async () => {
+    process.env['NEXT_PUBLIC_USER_MFA_DEVICE_TRUST'] = 'false';
+    const { isUserMfaDeviceTrustEnabled } = await import(
+      './user-mfa-device-trust'
+    );
+    expect(isUserMfaDeviceTrustEnabled()).toBe(false);
+  });
+
+  it('is enabled in development when trust is explicitly true', async () => {
+    process.env['NODE_ENV'] = 'development';
+    process.env['NEXT_PUBLIC_USER_MFA_DEVICE_TRUST'] = 'true';
+    delete process.env['NEXT_PUBLIC_USER_WEB_CSP_ENFORCE'];
+    const { isUserMfaDeviceTrustEnabled } = await import(
+      './user-mfa-device-trust'
+    );
+    expect(isUserMfaDeviceTrustEnabled()).toBe(true);
+  });
+
+  it('requires enforced CSP in production builds', async () => {
+    process.env['NODE_ENV'] = 'production';
+    process.env['NEXT_PUBLIC_USER_MFA_DEVICE_TRUST'] = 'true';
+    delete process.env['NEXT_PUBLIC_USER_WEB_CSP_ENFORCE'];
+    jest.resetModules();
+    const { isUserMfaDeviceTrustEnabled } = await import(
+      './user-mfa-device-trust'
+    );
+    expect(isUserMfaDeviceTrustEnabled()).toBe(false);
+
+    process.env['NEXT_PUBLIC_USER_WEB_CSP_ENFORCE'] = 'true';
+    jest.resetModules();
+    const { isUserMfaDeviceTrustEnabled: enabledWithCsp } = await import(
+      './user-mfa-device-trust'
+    );
+    expect(enabledWithCsp()).toBe(true);
+  });
+});

--- a/apps/web/src/lib/user-mfa-device-trust-restore.spec.ts
+++ b/apps/web/src/lib/user-mfa-device-trust-restore.spec.ts
@@ -1,0 +1,423 @@
+import type { AbstrackSupabaseClient } from '@abstrack/supabase';
+import {
+  tryRestoreTrustedMfaSession,
+  USER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+} from './user-mfa-device-trust';
+
+jest.mock('@abstrack/supabase', () => {
+  const actual =
+    jest.requireActual<typeof import('@abstrack/supabase')>(
+      '@abstrack/supabase',
+    );
+  return {
+    ...actual,
+    getVerifiedAuthSession: jest.fn(async (client: AbstrackSupabaseClient) => {
+      const userResult = await client.auth.getUser();
+      if (userResult.error) {
+        return {
+          data: { user: null, session: null },
+          error: userResult.error,
+        };
+      }
+      const user = userResult.data.user;
+      if (!user) {
+        return { data: { user: null, session: null }, error: null };
+      }
+      const sessionResult = await client.auth.getSession();
+      if (sessionResult.error) {
+        return {
+          data: { user, session: null },
+          error: sessionResult.error,
+        };
+      }
+      const session = sessionResult.data.session;
+      if (!session) {
+        return { data: { user, session: null }, error: null };
+      }
+      return {
+        data: { user, session: { ...session, user } },
+        error: null,
+      };
+    }),
+  };
+});
+
+const prevTrustEnv = process.env['NEXT_PUBLIC_USER_MFA_DEVICE_TRUST'];
+const prevCspEnv = process.env['NEXT_PUBLIC_USER_WEB_CSP_ENFORCE'];
+const prevNodeEnv = process.env['NODE_ENV'];
+
+beforeAll(() => {
+  process.env['NEXT_PUBLIC_USER_MFA_DEVICE_TRUST'] = 'true';
+  process.env['NODE_ENV'] = 'development';
+  delete process.env['NEXT_PUBLIC_USER_WEB_CSP_ENFORCE'];
+});
+
+afterAll(() => {
+  if (prevTrustEnv === undefined) {
+    delete process.env['NEXT_PUBLIC_USER_MFA_DEVICE_TRUST'];
+  } else {
+    process.env['NEXT_PUBLIC_USER_MFA_DEVICE_TRUST'] = prevTrustEnv;
+  }
+  if (prevCspEnv === undefined) {
+    delete process.env['NEXT_PUBLIC_USER_WEB_CSP_ENFORCE'];
+  } else {
+    process.env['NEXT_PUBLIC_USER_WEB_CSP_ENFORCE'] = prevCspEnv;
+  }
+  if (prevNodeEnv === undefined) {
+    delete process.env['NODE_ENV'];
+  } else {
+    process.env['NODE_ENV'] = prevNodeEnv;
+  }
+});
+
+type BrowserClient = AbstrackSupabaseClient;
+
+function buildBundleJson(userId: string, trustedUntilMs: number) {
+  return JSON.stringify({
+    userId,
+    refresh_token: 'refresh',
+    access_token: 'access',
+    trustedUntilMs,
+  });
+}
+
+function prePasswordSession(id: string) {
+  return {
+    user: { id },
+    refresh_token: 'pre-refresh',
+    access_token: 'pre-access',
+  };
+}
+
+function mockGetUserForId(userId: string, callCount = 2) {
+  const getUser = jest.fn();
+  for (let i = 0; i < callCount; i++) {
+    getUser.mockResolvedValueOnce({
+      data: { user: { id: userId } },
+      error: null,
+    });
+  }
+  getUser.mockResolvedValue({ data: { user: { id: userId } }, error: null });
+  return getUser;
+}
+
+function mockGetUserOnce(id: string) {
+  return jest.fn().mockResolvedValue({
+    data: { user: { id } },
+    error: null,
+  });
+}
+
+describe('tryRestoreTrustedMfaSession', () => {
+  const userId = '00000000-0000-0000-0000-000000000042';
+
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns not_restored when no trust bundle exists', async () => {
+    const supabase = {
+      auth: {
+        getSession: jest.fn(),
+        refreshSession: jest.fn(),
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
+    expect(supabase.auth.refreshSession).not.toHaveBeenCalled();
+  });
+
+  it('returns not_restored and clears bundle when the trust window expired', async () => {
+    localStorage.setItem(
+      USER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() - 1_000),
+    );
+
+    const refreshSession = jest.fn();
+    const supabase = {
+      auth: { refreshSession },
+    } as unknown as BrowserClient;
+
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
+    expect(localStorage.getItem(USER_MFA_TRUST_BUNDLE_STORAGE_KEY)).toBeNull();
+    expect(refreshSession).not.toHaveBeenCalled();
+  });
+
+  it('returns restored when trust bundle applies and assurance is aal2', async () => {
+    localStorage.setItem(
+      USER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: {
+        session: prePasswordSession(userId),
+        user: { id: userId },
+      },
+      error: null,
+    });
+    const supabase = {
+      auth: {
+        getUser: mockGetUserForId(userId),
+        refreshSession,
+        setSession: jest.fn().mockResolvedValue({ error: null }),
+        signOut: jest.fn(),
+        getSession: jest
+          .fn()
+          .mockResolvedValueOnce({
+            data: { session: prePasswordSession(userId) },
+          })
+          .mockResolvedValueOnce({
+            data: { session: prePasswordSession(userId) },
+          }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+            error: null,
+            data: { currentLevel: 'aal2', nextLevel: 'aal2' },
+          }),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'restored' });
+    expect(refreshSession).toHaveBeenCalledWith({
+      refresh_token: 'refresh',
+    });
+  });
+
+  it('clears bundle and returns not_restored when stored bundle user id does not match', async () => {
+    localStorage.setItem(
+      USER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(
+        '99999999-9999-9999-9999-999999999999',
+        Date.now() + 60_000,
+      ),
+    );
+
+    const supabase = {
+      auth: {
+        getSession: jest.fn(),
+        refreshSession: jest.fn(),
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
+    expect(localStorage.getItem(USER_MFA_TRUST_BUNDLE_STORAGE_KEY)).toBeNull();
+    expect(supabase.auth.refreshSession).not.toHaveBeenCalled();
+  });
+
+  it('reverts to the password session when refreshSession fails', async () => {
+    localStorage.setItem(
+      USER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const refreshSession = jest.fn().mockResolvedValue({
+      data: { session: null, user: null },
+      error: { message: 'invalid refresh token' },
+    });
+    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
+    const supabase = {
+      auth: {
+        getUser: mockGetUserForId(userId),
+        refreshSession,
+        setSession,
+        signOut,
+        getSession: jest.fn().mockResolvedValueOnce({
+          error: null,
+          data: { session: prePasswordSession(userId) },
+        }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn(),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
+    expect(localStorage.getItem(USER_MFA_TRUST_BUNDLE_STORAGE_KEY)).toBeNull();
+    expect(setSession).toHaveBeenCalledWith({
+      refresh_token: 'pre-refresh',
+      access_token: 'pre-access',
+    });
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it('reverts when assurance is aal1 instead of aal2', async () => {
+    localStorage.setItem(
+      USER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
+    const supabase = {
+      auth: {
+        getUser: mockGetUserForId(userId),
+        refreshSession: jest.fn().mockResolvedValue({
+          data: {
+            session: prePasswordSession(userId),
+            user: { id: userId },
+          },
+          error: null,
+        }),
+        setSession,
+        signOut,
+        getSession: jest.fn().mockResolvedValueOnce({
+          data: { session: prePasswordSession(userId) },
+        }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn().mockResolvedValue({
+            error: null,
+            data: { currentLevel: 'aal1', nextLevel: 'aal2' },
+          }),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
+    expect(localStorage.getItem(USER_MFA_TRUST_BUNDLE_STORAGE_KEY)).toBeNull();
+    expect(setSession).toHaveBeenCalledWith({
+      refresh_token: 'pre-refresh',
+      access_token: 'pre-access',
+    });
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it('signs out when the initial getUser id does not match the expected user', async () => {
+    localStorage.setItem(
+      USER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const otherId = '99999999-9999-9999-9999-999999999999';
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+    const setSession = jest.fn();
+
+    const supabase = {
+      auth: {
+        getUser: mockGetUserOnce(otherId),
+        setSession,
+        signOut,
+        getSession: jest.fn(),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn(),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'signed_out' });
+    expect(localStorage.getItem(USER_MFA_TRUST_BUNDLE_STORAGE_KEY)).toBeNull();
+    expect(setSession).not.toHaveBeenCalled();
+    expect(signOut).toHaveBeenCalled();
+  });
+
+  it('reverts when restored session user id does not match after refresh', async () => {
+    localStorage.setItem(
+      USER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const otherId = '99999999-9999-9999-9999-999999999999';
+    const setSession = jest.fn().mockResolvedValue({ error: null });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
+    const getUser = jest
+      .fn()
+      .mockResolvedValueOnce({
+        data: { user: { id: userId } },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: { id: otherId } },
+        error: null,
+      });
+
+    const supabase = {
+      auth: {
+        getUser,
+        refreshSession: jest.fn().mockResolvedValue({
+          data: {
+            session: prePasswordSession(otherId),
+            user: { id: otherId },
+          },
+          error: null,
+        }),
+        setSession,
+        signOut,
+        getSession: jest.fn().mockResolvedValueOnce({
+          data: { session: prePasswordSession(userId) },
+        }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest.fn(),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'not_restored' });
+    expect(localStorage.getItem(USER_MFA_TRUST_BUNDLE_STORAGE_KEY)).toBeNull();
+    expect(setSession).toHaveBeenCalledWith({
+      refresh_token: 'pre-refresh',
+      access_token: 'pre-access',
+    });
+    expect(signOut).not.toHaveBeenCalled();
+  });
+
+  it('signs out when revert setSession fails after a restore failure', async () => {
+    localStorage.setItem(
+      USER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      buildBundleJson(userId, Date.now() + 60_000),
+    );
+
+    const setSession = jest.fn().mockResolvedValue({
+      error: { message: 'revert failed' },
+    });
+    const signOut = jest.fn().mockResolvedValue({ error: null });
+
+    const supabase = {
+      auth: {
+        getUser: mockGetUserForId(userId),
+        refreshSession: jest.fn().mockResolvedValue({
+          data: {
+            session: prePasswordSession(userId),
+            user: { id: userId },
+          },
+          error: null,
+        }),
+        setSession,
+        signOut,
+        getSession: jest.fn().mockResolvedValueOnce({
+          data: { session: prePasswordSession(userId) },
+        }),
+        mfa: {
+          getAuthenticatorAssuranceLevel: jest
+            .fn()
+            .mockResolvedValue({ error: new Error('network'), data: null }),
+        },
+      },
+    } as unknown as BrowserClient;
+
+    await expect(
+      tryRestoreTrustedMfaSession(supabase, userId),
+    ).resolves.toEqual({ status: 'signed_out' });
+    expect(signOut).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/user-mfa-device-trust.ts
+++ b/apps/web/src/lib/user-mfa-device-trust.ts
@@ -20,10 +20,15 @@
  *
  * RLS and MFA fail-closed rules remain authoritative for PHI; this module is UX-only.
  *
- * **Deploy gate:** Token persistence and restore are **on by default** when the env var is unset or
- * blank. Set it to **`true` or `1`** (case-insensitive) to enable explicitly, or **`false` or `0`**
- * to disable (no writes; reads scrub any existing bundle key). **Any other non-empty value is
- * treated as disabled** (fail-closed) so typos do not silently keep the feature on.
+ * **Deploy gate (fail-closed):** Device trust is **off** unless **`NEXT_PUBLIC_USER_MFA_DEVICE_TRUST`**
+ * is explicitly **`true` or `1`** (case-insensitive). Unset, blank, **`false`**, **`0`**, or any other
+ * value keeps the feature disabled and scrubs any stored bundle on read.
+ *
+ * **Production builds:** When trust is explicitly enabled, **`NEXT_PUBLIC_USER_WEB_CSP_ENFORCE`**
+ * must also be **`true` at build time** so enforced CSP ships before localStorage token bundles
+ * are allowed. Pair with **`USER_WEB_CSP_ENFORCE=true`** on the server/build for the CSP header
+ * (see `apps/web/next.config.js`). Development may enable trust without enforced CSP for local MFA
+ * testing; CSP defaults to Report-Only.
  *
  * @module user-device-trust
  */
@@ -66,11 +71,12 @@ export function getTrustedUntilMsForDuration(
 /**
  * Whether user MFA “trusted device” (localStorage token bundle) is allowed for this build.
  *
- * **Parsing (fail-closed for non-whitelisted values):**
- * - Unset, `null`, or empty/whitespace → **enabled** (default user UX).
- * - `false` or `0` (case-insensitive) → **disabled**.
- * - `true` or `1` (case-insensitive) → **enabled**.
- * - Any other non-empty string (e.g. `yes`) → **disabled** — avoids treating typos as “on”.
+ * **Parsing (fail-closed):**
+ * - Unset, `null`, empty/whitespace, **`false`**, **`0`**, or any other value → **disabled**.
+ * - **`true` or `1`** (case-insensitive) → **enabled** when CSP rules below pass.
+ *
+ * **Production (`NODE_ENV === 'production'`):** trust requires **`NEXT_PUBLIC_USER_WEB_CSP_ENFORCE`**
+ * **`true` at build time** in addition to the trust flag.
  *
  * @returns Whether device trust reads/writes are allowed for this process.
  *
@@ -80,26 +86,33 @@ export function getTrustedUntilMsForDuration(
  * and incorrectly fall back to the “unset” default — so per-environment disable would not apply.
  */
 export function isUserMfaDeviceTrustEnabled(): boolean {
-  let raw: string | undefined;
+  let trustRaw: string | undefined;
+  let cspEnforceRaw: string | undefined;
   try {
-    raw =
-      typeof process !== 'undefined' && process.env != null
-        ? process.env.NEXT_PUBLIC_USER_MFA_DEVICE_TRUST
-        : undefined;
+    if (typeof process !== 'undefined' && process.env != null) {
+      trustRaw = process.env.NEXT_PUBLIC_USER_MFA_DEVICE_TRUST;
+      cspEnforceRaw = process.env.NEXT_PUBLIC_USER_WEB_CSP_ENFORCE;
+    }
   } catch {
     return false;
   }
-  if (raw == null || String(raw).trim() === '') {
-    return true;
-  }
-  const v = String(raw).trim().toLowerCase();
-  if (v === 'false' || v === '0') {
+  if (trustRaw == null || String(trustRaw).trim() === '') {
     return false;
   }
-  if (v === 'true' || v === '1') {
-    return true;
+  const trustFlag = String(trustRaw).trim().toLowerCase();
+  if (trustFlag !== 'true' && trustFlag !== '1') {
+    return false;
   }
-  return false;
+  const isProduction =
+    typeof process !== 'undefined' && process.env?.NODE_ENV === 'production';
+  if (isProduction) {
+    return (
+      String(cspEnforceRaw ?? '')
+        .trim()
+        .toLowerCase() === 'true'
+    );
+  }
+  return true;
 }
 
 /**
@@ -587,9 +600,10 @@ export async function tryRestoreTrustedMfaSession(
 
 /**
  * Full sign-out: clears the MFA trust bundle and browser `sb-*` auth storage, then POSTs to
- * `/api/auth/logout` so the server revokes refresh tokens and clears auth cookies. Prefer this on
- * shared machines, after credential compromise, or whenever all sessions must end. Navigation happens
- * via the redirect response (this function does not return in normal browsers).
+ * `/api/auth/logout?scope=global` so the server revokes refresh tokens on all devices and clears
+ * auth cookies. Prefer this on shared machines, after credential compromise, or whenever all
+ * sessions must end. Navigation happens via the redirect response (this function does not return
+ * in normal browsers).
  */
 export function userSignOutEverywhere(): void {
   if (typeof document === 'undefined') {
@@ -603,7 +617,7 @@ export function userSignOutEverywhere(): void {
   }
   const form = document.createElement('form');
   form.method = 'POST';
-  form.action = '/api/auth/logout';
+  form.action = '/api/auth/logout?scope=global';
   form.setAttribute('aria-hidden', 'true');
   form.style.display = 'none';
   document.body.appendChild(form);

--- a/apps/web/src/lib/user-mfa-device-trust.ts
+++ b/apps/web/src/lib/user-mfa-device-trust.ts
@@ -30,7 +30,7 @@
  * (see `apps/web/next.config.js`). Development may enable trust without enforced CSP for local MFA
  * testing; CSP defaults to Report-Only.
  *
- * @module user-device-trust
+ * @module user-mfa-device-trust
  */
 
 import {

--- a/apps/web/src/lib/user-mfa-device-trust.ts
+++ b/apps/web/src/lib/user-mfa-device-trust.ts
@@ -1,0 +1,794 @@
+/**
+ * User MFA “trusted device” helpers — **browser `localStorage` only**.
+ *
+ * **XSS / token exposure (high impact on patient-data surfaces):** When the user opts in after
+ * successful TOTP verification, we persist a JSON bundle that includes Supabase **`refresh_token`**
+ * and **`access_token`**. Any successful XSS in this origin can read `localStorage`, exfiltrate those
+ * secrets, and mint sessions until tokens expire or are revoked—materially larger blast radius than
+ * the default Supabase session key alone.
+ *
+ * **Operational mitigations (required, not sufficient):** Ship a **strict Content-Security-Policy**
+ * (e.g. at the CDN / edge / host; include `connect-src` for your Supabase project and websocket
+ * endpoints), avoid inline script injection (`dangerouslySetInnerHTML`, unsanitized HTML), keep
+ * dependencies patched, and treat XSS prevention as part of the security boundary for this
+ * feature.
+ *
+ * **Preferred direction:** Replace this pattern with **server-managed** device trust (e.g.
+ * HttpOnly, `Secure`, `SameSite` cookie holding an opaque device id + server-side validation, or a
+ * short-lived scoped token exchanged only on the server). Documented at repo level in
+ * `docs/SECURITY_BASELINE.md`.
+ *
+ * RLS and MFA fail-closed rules remain authoritative for PHI; this module is UX-only.
+ *
+ * **Deploy gate:** Token persistence and restore are **on by default** when the env var is unset or
+ * blank. Set it to **`true` or `1`** (case-insensitive) to enable explicitly, or **`false` or `0`**
+ * to disable (no writes; reads scrub any existing bundle key). **Any other non-empty value is
+ * treated as disabled** (fail-closed) so typos do not silently keep the feature on.
+ *
+ * @module user-device-trust
+ */
+
+import {
+  getVerifiedAuthSession,
+  isAuthSessionMissingError,
+  type AbstrackSupabaseClient,
+  type Session,
+} from '@abstrack/supabase';
+
+type UserBrowserClient = AbstrackSupabaseClient;
+
+/**
+ * `localStorage` key for the user MFA device-trust bundle. **Bundle holds session
+ * secrets** — see module warning.
+ */
+export const USER_MFA_TRUST_BUNDLE_STORAGE_KEY =
+  'abstrack.user.mfaTrustBundle.v1';
+
+const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+/** User-selected window to skip TOTP on this browser after a successful MFA sign-in. */
+export type UserMfaDeviceTrustDuration = '30_days' | '1_year';
+
+/**
+ * Absolute expiry timestamp for a device-trust bundle from the chosen duration.
+ *
+ * @param duration - `30_days` or `1_year`.
+ * @returns Milliseconds since epoch when trust expires.
+ */
+export function getTrustedUntilMsForDuration(
+  duration: UserMfaDeviceTrustDuration,
+): number {
+  const windowMs = duration === '1_year' ? ONE_YEAR_MS : THIRTY_DAYS_MS;
+  return Date.now() + windowMs;
+}
+
+/**
+ * Whether user MFA “trusted device” (localStorage token bundle) is allowed for this build.
+ *
+ * **Parsing (fail-closed for non-whitelisted values):**
+ * - Unset, `null`, or empty/whitespace → **enabled** (default user UX).
+ * - `false` or `0` (case-insensitive) → **disabled**.
+ * - `true` or `1` (case-insensitive) → **enabled**.
+ * - Any other non-empty string (e.g. `yes`) → **disabled** — avoids treating typos as “on”.
+ *
+ * @returns Whether device trust reads/writes are allowed for this process.
+ *
+ * **Next.js client bundles:** `NEXT_PUBLIC_*` values are substituted at build time when the key is
+ * referenced as **`process.env.NEXT_PUBLIC_USER_MFA_DEVICE_TRUST`** (dot access). Bracket
+ * access (`process.env['…']`) is often **not** inlined, which can leave the runtime value missing
+ * and incorrectly fall back to the “unset” default — so per-environment disable would not apply.
+ */
+export function isUserMfaDeviceTrustEnabled(): boolean {
+  let raw: string | undefined;
+  try {
+    raw =
+      typeof process !== 'undefined' && process.env != null
+        ? process.env.NEXT_PUBLIC_USER_MFA_DEVICE_TRUST
+        : undefined;
+  } catch {
+    return false;
+  }
+  if (raw == null || String(raw).trim() === '') {
+    return true;
+  }
+  const v = String(raw).trim().toLowerCase();
+  if (v === 'false' || v === '0') {
+    return false;
+  }
+  if (v === 'true' || v === '1') {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Serialized trust bundle. **Contains long-lived session secrets** readable by any script on the
+ * origin—see module warning.
+ */
+export type UserMfaTrustBundle = {
+  userId: string;
+  /**
+   * Sign-in email for this account, used to correlate the bundle with the next login attempt (see
+   * {@link tryRestoreTrustedMfaSession} and `saveMfaTrustBundle` merge rules when `user.email` is
+   * absent on the session).
+   */
+  email?: string;
+  refresh_token: string;
+  access_token: string;
+  expires_at?: number;
+  /** Wall-clock time after which we stop attempting session restore (user must enter TOTP again). */
+  trustedUntilMs: number;
+};
+
+function isNonEmptyTrimmedString(value: unknown): value is string {
+  return typeof value === 'string' && value.trim() !== '';
+}
+
+/**
+ * Validates JSON parsed from {@link USER_MFA_TRUST_BUNDLE_STORAGE_KEY}. Rejects empty
+ * tokens, blank `userId`, non-finite `trustedUntilMs` / `expires_at`, and malformed shapes.
+ *
+ * @param parsed - Value from `JSON.parse`.
+ * @returns Whether the object is safe to use as a trust bundle.
+ */
+function isValidStoredTrustBundle(
+  parsed: unknown,
+): parsed is UserMfaTrustBundle {
+  if (parsed === null || typeof parsed !== 'object') {
+    return false;
+  }
+  const o = parsed as Record<string, unknown>;
+  if (
+    !isNonEmptyTrimmedString(o['userId']) ||
+    !isNonEmptyTrimmedString(o['refresh_token']) ||
+    !isNonEmptyTrimmedString(o['access_token'])
+  ) {
+    return false;
+  }
+  const trustedUntilMs = o['trustedUntilMs'];
+  if (typeof trustedUntilMs !== 'number' || !Number.isFinite(trustedUntilMs)) {
+    return false;
+  }
+  if (o['expires_at'] !== undefined) {
+    const exp = o['expires_at'];
+    if (typeof exp !== 'number' || !Number.isFinite(exp)) {
+      return false;
+    }
+  }
+  if (o['email'] !== undefined && !isNonEmptyTrimmedString(o['email'])) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Removes `sb-*-auth-token` keys from `localStorage` when present. The user browser client
+ * uses **`@supabase/ssr` cookie-backed sessions**; ending the session is done with
+ * `auth.signOut` or `POST /api/auth/logout`. This sweep still matters because the Supabase client
+ * may persist auth-related material under those keys in some cases, and {@link userSignOutEverywhere}
+ * pairs it with server logout so nothing session-like is left in browser storage for this origin.
+ * Swallows `localStorage` errors (blocked storage, privacy mode, quota).
+ */
+export function clearSupabaseBrowserAuthStorage(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    const toRemove: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const key = localStorage.key(i);
+      if (key && key.startsWith('sb-') && key.endsWith('-auth-token')) {
+        toRemove.push(key);
+      }
+    }
+    for (const key of toRemove) {
+      localStorage.removeItem(key);
+    }
+  } catch {
+    // `localStorage` can throw when blocked or in some privacy modes (see `theme-storage.ts`).
+  }
+}
+
+/**
+ * Reads the MFA trust bundle from storage. Corrupt, unparseable, or invalid payloads are removed
+ * so tokens are not left in `localStorage` indefinitely.
+ */
+function readBundle(): UserMfaTrustBundle | null {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  if (!isUserMfaDeviceTrustEnabled()) {
+    try {
+      window.localStorage.removeItem(USER_MFA_TRUST_BUNDLE_STORAGE_KEY);
+    } catch {
+      // Blocked storage — same as `clearMfaTrustBundle`.
+    }
+    return null;
+  }
+  let raw: string | null;
+  try {
+    raw = window.localStorage.getItem(USER_MFA_TRUST_BUNDLE_STORAGE_KEY);
+  } catch {
+    return null;
+  }
+  if (!raw) {
+    return null;
+  }
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    if (!isValidStoredTrustBundle(parsed)) {
+      clearMfaTrustBundle();
+      return null;
+    }
+    return parsed;
+  } catch {
+    clearMfaTrustBundle();
+    return null;
+  }
+}
+
+/**
+ * Reads the MFA trust bundle for callers that need metadata (e.g. `trustedUntilMs`) without
+ * duplicating storage logic.
+ *
+ * @returns Parsed bundle or `null`.
+ */
+export function readMfaTrustBundle(): UserMfaTrustBundle | null {
+  return readBundle();
+}
+
+/**
+ * Whether a non-expired MFA device-trust bundle exists for this user (soft sign-out path).
+ * Clears stored tokens when the bundle is **expired** or for a **different** user so session
+ * material is not left in `localStorage` after trust has lapsed or the account changed.
+ *
+ * @param userId - Authenticated user id from the current session, if any.
+ * @returns Whether a non-expired MFA device-trust bundle exists for this user.
+ */
+export function isUserMfaDeviceTrustActive(
+  userId: string | undefined,
+): boolean {
+  if (userId == null || userId === '') {
+    return false;
+  }
+  const bundle = readBundle();
+  if (bundle === null) {
+    return false;
+  }
+  if (bundle.userId !== userId) {
+    clearMfaTrustBundle();
+    return false;
+  }
+  if (bundle.trustedUntilMs <= Date.now()) {
+    clearMfaTrustBundle();
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Persists refresh/access tokens for a verified MFA session so this browser can restore AAL2
+ * within the trust window. **Only call after explicit user opt-in**; see module XSS warning.
+ *
+ * **`user.email` may be missing** on some Supabase session payloads (for example after
+ * `refreshSession` / token rotation). In that case, for the **same** `userId`, we **keep** the
+ * email already stored in the bundle so the next login can still correlate storage with the
+ * account (see Supabase refresh-token rotation docs).
+ *
+ * @param session - Active Supabase session after successful `mfa.verify`.
+ * @param trustedUntilMs - Absolute expiry for the trust window (must be finite).
+ */
+export function saveMfaTrustBundle(
+  session: Session,
+  trustedUntilMs: number,
+): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  if (!isUserMfaDeviceTrustEnabled()) {
+    return;
+  }
+  if (!Number.isFinite(trustedUntilMs)) {
+    return;
+  }
+  if (
+    session.refresh_token == null ||
+    session.refresh_token === '' ||
+    session.access_token == null ||
+    session.access_token === ''
+  ) {
+    return;
+  }
+  const emailRaw = session.user.email;
+  const emailFromSession =
+    typeof emailRaw === 'string' && emailRaw.trim() !== ''
+      ? emailRaw.trim()
+      : undefined;
+
+  const previous = readMfaTrustBundle();
+  const email =
+    emailFromSession ??
+    (previous?.userId === session.user.id &&
+    typeof previous.email === 'string' &&
+    previous.email.trim() !== ''
+      ? previous.email.trim()
+      : undefined);
+
+  const bundle: UserMfaTrustBundle = {
+    userId: session.user.id,
+    ...(email != null ? { email } : {}),
+    refresh_token: session.refresh_token,
+    access_token: session.access_token,
+    expires_at: session.expires_at,
+    trustedUntilMs,
+  };
+  try {
+    window.localStorage.setItem(
+      USER_MFA_TRUST_BUNDLE_STORAGE_KEY,
+      JSON.stringify(bundle),
+    );
+  } catch {
+    // Blocked or full storage; trust bundle is optional UX — session is already valid in memory.
+  }
+}
+
+/**
+ * Call from `onAuthStateChange` when `event === 'TOKEN_REFRESHED'`. Supabase **rotates refresh tokens**; the bundle written at MFA
+ * verify time would otherwise go stale, so the next sign-in’s {@link tryRestoreTrustedMfaSession}
+ * would fail and clear storage. Only updates the bundle when a trust row still exists for this user,
+ * the window has not expired, and **MFA assurance is AAL2** — so password-only (AAL1) sessions never
+ * overwrite a prior AAL2 bundle.
+ *
+ * **`readBundle()` does not drop expired rows** (only validates shape). If the stored bundle’s
+ * trust window has ended, or its `userId` does not match the refreshed session, clears the bundle so
+ * stale secrets are not retained until another code path runs.
+ *
+ * @param supabase - Browser Supabase client.
+ * @param session - Session from the auth callback (null clears nothing).
+ */
+export async function syncMfaTrustBundleAfterTokenRefresh(
+  supabase: UserBrowserClient,
+  session: Session | null,
+): Promise<void> {
+  if (typeof window === 'undefined' || session?.user?.id == null) {
+    return;
+  }
+  if (!isUserMfaDeviceTrustEnabled()) {
+    return;
+  }
+
+  const bundle = readBundle();
+  if (!bundle) {
+    return;
+  }
+  if (bundle.userId !== session.user.id) {
+    clearMfaTrustBundle();
+    return;
+  }
+  if (bundle.trustedUntilMs <= Date.now()) {
+    clearMfaTrustBundle();
+    return;
+  }
+  if (
+    session.refresh_token == null ||
+    session.refresh_token === '' ||
+    session.access_token == null ||
+    session.access_token === ''
+  ) {
+    return;
+  }
+
+  const assurance = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+  if (assurance.error || assurance.data.currentLevel !== 'aal2') {
+    return;
+  }
+
+  saveMfaTrustBundle(session, bundle.trustedUntilMs);
+}
+
+export function clearMfaTrustBundle(): void {
+  if (typeof window === 'undefined') {
+    return;
+  }
+  try {
+    window.localStorage.removeItem(USER_MFA_TRUST_BUNDLE_STORAGE_KEY);
+  } catch {
+    // Same environments as `readBundle` / theme storage.
+  }
+}
+
+/**
+ * After a failed trust-bundle restore, re-applies the password session’s tokens so the client is
+ * not left on a mismatched or half-applied session. If reversion fails or no tokens were
+ * captured, signs out.
+ *
+ * @param supabase - Browser Supabase client.
+ * @param preSessionTokens - Refresh/access pair from before `setSession(bundle)`, if any.
+ * @returns Whether the password session was re-applied (`reverted`) or the client was signed out.
+ */
+async function revertToPreRestoreSession(
+  supabase: UserBrowserClient,
+  preSessionTokens: { refresh_token: string; access_token: string } | null,
+): Promise<'reverted' | 'signed_out'> {
+  if (
+    preSessionTokens &&
+    preSessionTokens.refresh_token !== '' &&
+    preSessionTokens.access_token !== ''
+  ) {
+    const { error } = await supabase.auth.setSession({
+      refresh_token: preSessionTokens.refresh_token,
+      access_token: preSessionTokens.access_token,
+    });
+    if (!error) {
+      return 'reverted';
+    }
+  }
+  await supabase.auth.signOut();
+  return 'signed_out';
+}
+
+/**
+ * Clears the trust bundle after a failed apply step, reverts to the password session when possible,
+ * and maps {@link revertToPreRestoreSession}’s outcome to the public union.
+ */
+async function finishFailedBundleRestore(
+  supabase: UserBrowserClient,
+  preSessionTokens: { refresh_token: string; access_token: string } | null,
+): Promise<{ status: 'not_restored' } | { status: 'signed_out' }> {
+  clearMfaTrustBundle();
+  const revertOutcome = await revertToPreRestoreSession(
+    supabase,
+    preSessionTokens,
+  );
+  return revertOutcome === 'reverted'
+    ? { status: 'not_restored' }
+    : { status: 'signed_out' };
+}
+
+/**
+ * Outcome of {@link tryRestoreTrustedMfaSession}.
+ *
+ * - **`restored`**: AAL2 session was re-established from the trust bundle; caller may skip TOTP.
+ * - **`not_restored`**: No AAL2 restore (no/expired/invalid bundle, or restore failed but the
+ *   password session was re-applied). The user typically remains signed in at AAL1; caller should
+ *   continue MFA flow.
+ * - **`signed_out`**: Auth state was cleared during failure handling (e.g. unsafe mismatch,
+ *   missing session on pre-restore probes, or reversion to the password session failed).
+ *   Caller must not assume a session.
+ */
+export type TryRestoreTrustedMfaSessionResult =
+  | { status: 'restored' }
+  | { status: 'not_restored' }
+  | { status: 'signed_out' };
+
+/**
+ * After email/password sign-in, attempts to restore a prior AAL2 session from the trust bundle.
+ * **Security:** intentionally runs only after a successful password grant so `refreshSession` does
+ * not authenticate the browser before the user proves possession of the password.
+ * If the stored bundle’s `userId` does not match the current password session’s user, clears the
+ * bundle and returns (avoids keeping another user’s tokens after account switch).
+ * Restore uses `auth.refreshSession({ refresh_token })` with the stored refresh token, not
+ * `setSession({ access_token, refresh_token })` alone (see implementation comment).
+ * On failure (revoked or expired tokens, **session user mismatch** after restore, assurance error,
+ * **missing session** after a successful `getSession()` call, or session not at
+ * **aal2**), clears the bundle and restores the pre-restore
+ * password session (or signs out) so the client is not left authenticated as the wrong user. If the
+ * **initial** `getSession()` user id does not match `userId`, clears the bundle and **signs out**
+ * (there is no safe pre-restore token pair for the expected user).
+ *
+ * @param supabase - Browser Supabase client.
+ * @param userId - Authenticated user id from the new password session.
+ * @returns Discriminated result — see {@link TryRestoreTrustedMfaSessionResult}.
+ */
+export async function tryRestoreTrustedMfaSession(
+  supabase: UserBrowserClient,
+  userId: string,
+): Promise<TryRestoreTrustedMfaSessionResult> {
+  const bundle = readBundle();
+  if (!bundle) {
+    return { status: 'not_restored' };
+  }
+  if (bundle.userId !== userId) {
+    clearMfaTrustBundle();
+    return { status: 'not_restored' };
+  }
+  if (bundle.trustedUntilMs <= Date.now()) {
+    clearMfaTrustBundle();
+    return { status: 'not_restored' };
+  }
+
+  const preUserResult = await supabase.auth.getUser();
+  if (preUserResult.error) {
+    clearMfaTrustBundle();
+    if (isAuthSessionMissingError(preUserResult.error)) {
+      await supabase.auth.signOut();
+      return { status: 'signed_out' };
+    }
+    return { status: 'not_restored' };
+  }
+
+  if (preUserResult.data.user?.id !== userId) {
+    clearMfaTrustBundle();
+    await supabase.auth.signOut();
+    return { status: 'signed_out' };
+  }
+
+  const preSessionResult = await supabase.auth.getSession();
+  if (preSessionResult.error) {
+    clearMfaTrustBundle();
+    if (isAuthSessionMissingError(preSessionResult.error)) {
+      await supabase.auth.signOut();
+      return { status: 'signed_out' };
+    }
+    return { status: 'not_restored' };
+  }
+
+  const preRestoreSession = preSessionResult.data.session;
+  if (!preRestoreSession) {
+    clearMfaTrustBundle();
+    await supabase.auth.signOut();
+    return { status: 'signed_out' };
+  }
+
+  const preSessionTokens =
+    preRestoreSession.refresh_token &&
+    preRestoreSession.refresh_token !== '' &&
+    preRestoreSession.access_token &&
+    preRestoreSession.access_token !== ''
+      ? {
+          refresh_token: preRestoreSession.refresh_token,
+          access_token: preRestoreSession.access_token,
+        }
+      : null;
+
+  /**
+   * Always exchange the stored **refresh** token via the refresh endpoint — do not use
+   * `setSession({ access_token, refresh_token })` alone: if the access JWT is still within expiry,
+   * GoTrue **skips** `_callRefreshToken` and persists the **same** refresh token from the bundle.
+   * After normal use, Supabase may have rotated that refresh token, so the stored pair is stale and
+   * restore fails (and the bundle was cleared). `refreshSession({ refresh_token })` always refreshes.
+   */
+  const { data: refreshData, error: refreshError } =
+    await supabase.auth.refreshSession({
+      refresh_token: bundle.refresh_token,
+    });
+  if (refreshError || refreshData?.session == null) {
+    return finishFailedBundleRestore(supabase, preSessionTokens);
+  }
+
+  const refreshedUserResult = await supabase.auth.getUser();
+  if (
+    refreshedUserResult.error ||
+    refreshedUserResult.data.user?.id == null ||
+    refreshedUserResult.data.user.id !== userId
+  ) {
+    return finishFailedBundleRestore(supabase, preSessionTokens);
+  }
+
+  const assurance = await supabase.auth.mfa.getAuthenticatorAssuranceLevel();
+  if (assurance.error) {
+    return finishFailedBundleRestore(supabase, preSessionTokens);
+  }
+  if (assurance.data.currentLevel !== 'aal2') {
+    return finishFailedBundleRestore(supabase, preSessionTokens);
+  }
+
+  const { data: verified, error: verifiedError } =
+    await getVerifiedAuthSession(supabase);
+  if (verifiedError || verified.session == null) {
+    return finishFailedBundleRestore(supabase, preSessionTokens);
+  }
+
+  saveMfaTrustBundle(verified.session, bundle.trustedUntilMs);
+
+  return { status: 'restored' };
+}
+
+/**
+ * Full sign-out: clears the MFA trust bundle and browser `sb-*` auth storage, then POSTs to
+ * `/api/auth/logout` so the server revokes refresh tokens and clears auth cookies. Prefer this on
+ * shared machines, after credential compromise, or whenever all sessions must end. Navigation happens
+ * via the redirect response (this function does not return in normal browsers).
+ */
+export function userSignOutEverywhere(): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  clearMfaTrustBundle();
+  try {
+    clearSupabaseBrowserAuthStorage();
+  } catch {
+    // ignore
+  }
+  const form = document.createElement('form');
+  form.method = 'POST';
+  form.action = '/api/auth/logout';
+  form.setAttribute('aria-hidden', 'true');
+  form.style.display = 'none';
+  document.body.appendChild(form);
+  form.submit();
+}
+
+/**
+ * Reads `user.id` from persisted Supabase auth JSON in browser storage without calling
+ * `getSession()` (avoids relying on an unverified `session.user` from the client API).
+ *
+ * @param supabase - Browser Supabase client.
+ * @returns Non-empty user id, or `null` when storage is unavailable or unreadable.
+ */
+async function readUserIdFromPersistedAuthStorage(
+  supabase: UserBrowserClient,
+): Promise<string | null> {
+  const auth = supabase.auth as unknown as {
+    storage?: {
+      getItem: (key: string) => Promise<string | null> | string | null;
+    };
+    storageKey?: string;
+  };
+  const { storage, storageKey } = auth;
+  if (!storage?.getItem || !storageKey) {
+    return null;
+  }
+  try {
+    const raw = await storage.getItem(storageKey);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw) as { user?: { id?: unknown } };
+    const id = parsed.user?.id;
+    return typeof id === 'string' && id.trim() !== '' ? id.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolves the current user id for soft vs full sign-out when matching the MFA trust bundle.
+ * Prefers verified {@link AbstrackSupabaseClient.auth.getUser}; on failure, reads `user.id`
+ * from persisted auth storage when available, then `getSession()` only if storage is missing.
+ *
+ * @param supabase - Browser Supabase client.
+ * @returns User id string, or `null` when none can be resolved.
+ */
+async function resolveUserIdForMfaTrustSignOut(
+  supabase: UserBrowserClient,
+): Promise<string | null> {
+  const { data: userData, error: userError } = await supabase.auth.getUser();
+  if (!userError) {
+    const id = userData.user?.id;
+    return id != null && id !== '' ? id : null;
+  }
+  console.warn(
+    'userSignOut: getUser failed; reading user id from persisted auth storage for trust-bundle check',
+    userError,
+  );
+  const persistedId = await readUserIdFromPersistedAuthStorage(supabase);
+  if (persistedId != null) {
+    return persistedId;
+  }
+  const auth = supabase.auth as unknown as {
+    storage?: { getItem: (key: string) => unknown };
+    storageKey?: string;
+  };
+  if (auth.storage?.getItem && auth.storageKey) {
+    return null;
+  }
+  try {
+    const { data: sessionData, error: sessionError } =
+      await supabase.auth.getSession();
+    if (sessionError) {
+      return null;
+    }
+    const id = sessionData.session?.user?.id;
+    return id != null && id !== '' ? id : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Clears the browser auth session **without** calling GoTrue’s `POST /logout` endpoint.
+ *
+ * **`signOut({ scope: 'local' })` still revokes the current session’s refresh token on the server**
+ * (`GoTrueClient._signOut` → `admin.signOut(jwt, scope)`). The MFA trust bundle stores a copy of
+ * that refresh token; if it is revoked, `refreshSession` / restore fails on the next sign-in — the
+ * “same issue” loop users saw after “soft” logout.
+ *
+ * This mirrors the storage half of `GoTrueClient`’s private `_removeSession` (cookie chunks via
+ * `@supabase/ssr`), then navigation reloads the app with an empty session while the bundle’s token
+ * remains valid until natural expiry or {@link userSignOutEverywhere}.
+ *
+ * @param supabase - Browser Supabase client (`createBrowserClient`).
+ */
+async function clearBrowserSessionWithoutServerLogout(
+  supabase: UserBrowserClient,
+): Promise<void> {
+  const auth = supabase.auth as unknown as {
+    storage?: { removeItem: (key: string) => Promise<void> };
+    storageKey: string;
+    userStorage?: { removeItem: (key: string) => Promise<void> };
+  };
+  const { storage, storageKey, userStorage } = auth;
+  if (!storage?.removeItem || !storageKey) {
+    throw new Error('Supabase auth storage API unavailable for soft sign-out');
+  }
+  await storage.removeItem(storageKey);
+  await storage.removeItem(`${storageKey}-code-verifier`);
+  await storage.removeItem(`${storageKey}-user`);
+  if (userStorage?.removeItem) {
+    await userStorage.removeItem(`${storageKey}-user`);
+  }
+}
+
+/**
+ * Signs the user out. If MFA device trust is still valid, clears only **browser** session storage
+ * (no `POST /logout`) so the refresh token kept in the trust bundle stays valid for the next
+ * visit; then navigates to `/login`. Otherwise performs a full Supabase `signOut()` and clears the
+ * bundle. For a **full** server revoke while trust is active, use {@link userSignOutEverywhere}.
+ *
+ * If the soft session clear fails, falls back to {@link userSignOutEverywhere} in the browser.
+ *
+ * Navigation to `/login` via `location.assign` runs after soft clear or full sign-out when `window`
+ * is present.
+ *
+ * @param supabase - Browser Supabase client.
+ */
+export async function userSignOut(supabase: UserBrowserClient): Promise<void> {
+  const userId = await resolveUserIdForMfaTrustSignOut(supabase);
+  const bundle = readBundle();
+  const trustActiveForUser =
+    userId != null &&
+    bundle != null &&
+    bundle.userId === userId &&
+    bundle.trustedUntilMs > Date.now();
+
+  if (trustActiveForUser) {
+    try {
+      await clearBrowserSessionWithoutServerLogout(supabase);
+    } catch (err) {
+      console.error(
+        'userSignOut: soft session clear failed; falling back to full logout',
+        err,
+      );
+      if (typeof document !== 'undefined') {
+        userSignOutEverywhere();
+      } else {
+        console.error(
+          'userSignOut: cannot fall back to server logout without a document.',
+        );
+      }
+      return;
+    }
+    if (typeof window !== 'undefined') {
+      window.location.assign('/login');
+    }
+    return;
+  }
+
+  clearMfaTrustBundle();
+  const { error: signOutError } = await supabase.auth.signOut();
+  if (signOutError) {
+    if (typeof document !== 'undefined') {
+      userSignOutEverywhere();
+    } else {
+      console.error(
+        'userSignOut: sign-out failed; cannot fall back to server logout without a document.',
+        signOutError,
+      );
+    }
+    return;
+  }
+  if (typeof window !== 'undefined') {
+    window.location.assign('/login');
+  }
+}
+
+/**
+ * Default trust window (30 days) for callers that do not expose duration choice.
+ *
+ * @returns Milliseconds since epoch when trust expires.
+ */
+export function getTrustedUntilMsAfterVerification(): number {
+  return getTrustedUntilMsForDuration('30_days');
+}

--- a/apps/web/src/lib/user-mfa-device-trust.ts
+++ b/apps/web/src/lib/user-mfa-device-trust.ts
@@ -400,6 +400,29 @@ export async function syncMfaTrustBundleAfterTokenRefresh(
   saveMfaTrustBundle(session, bundle.trustedUntilMs);
 }
 
+/**
+ * Refreshes the browser session and syncs the MFA trust bundle when refresh tokens rotate.
+ *
+ * Prefer the {@link AuthProvider} `supabase` client so `onAuthStateChange('TOKEN_REFRESHED')`
+ * also runs; this helper explicitly syncs the bundle for call sites that refresh after
+ * `updateUser` (password change/revoke).
+ *
+ * @param supabase - Browser Supabase client (should be the AuthProvider instance).
+ * @returns Refresh error when `auth.refreshSession` fails.
+ */
+export async function refreshBrowserSessionAndSyncMfaTrustBundle(
+  supabase: UserBrowserClient,
+): Promise<{ error: Error | null }> {
+  const { data, error } = await supabase.auth.refreshSession();
+  if (error) {
+    return { error };
+  }
+  if (data.session) {
+    await syncMfaTrustBundleAfterTokenRefresh(supabase, data.session);
+  }
+  return { error: null };
+}
+
 export function clearMfaTrustBundle(): void {
   if (typeof window === 'undefined') {
     return;

--- a/apps/web/src/lib/user-password-sign-in.spec.ts
+++ b/apps/web/src/lib/user-password-sign-in.spec.ts
@@ -48,6 +48,20 @@ describe('clampAuthPasswordInput', () => {
       AUTH_PASSWORD_MAX_LENGTH,
     );
     expect(getAuthPasswordValidationError(clamped)).toBeNull();
+    expect(clamped).toBe('😀'.repeat(18));
+  });
+
+  it('drops whole astral symbols instead of leaving surrogate halves', () => {
+    const over = `${'a'.repeat(71)}😀`;
+    expect(getAuthPasswordUtf8ByteLength(over)).toBeGreaterThan(
+      AUTH_PASSWORD_MAX_LENGTH,
+    );
+
+    const clamped = clampAuthPasswordInput(over);
+
+    expect(clamped).toBe('a'.repeat(71));
+    expect(clamped).not.toContain('\uFFFD');
+    expect(getAuthPasswordUtf8ByteLength(clamped)).toBe(71);
   });
 });
 

--- a/apps/web/src/lib/user-password-sign-in.spec.ts
+++ b/apps/web/src/lib/user-password-sign-in.spec.ts
@@ -1,7 +1,10 @@
 import {
   AUTH_PASSWORD_MAX_LENGTH,
+  AUTH_PASSWORD_MIN_LENGTH,
   USER_PASSWORD_SET_USER_METADATA_KEY,
   buildRevokedPasswordPlaceholder,
+  getAuthPasswordUtf8ByteLength,
+  getAuthPasswordValidationError,
   userHasPasswordSignIn,
 } from './user-password-sign-in';
 
@@ -24,11 +27,36 @@ describe('userHasPasswordSignIn', () => {
   });
 });
 
+describe('getAuthPasswordUtf8ByteLength', () => {
+  it('counts UTF-8 bytes, not JavaScript string length', () => {
+    expect(getAuthPasswordUtf8ByteLength('a'.repeat(72))).toBe(72);
+    expect(getAuthPasswordUtf8ByteLength('é')).toBe(2);
+    expect(getAuthPasswordUtf8ByteLength('😀')).toBe(4);
+  });
+});
+
+describe('getAuthPasswordValidationError', () => {
+  it('returns null for an acceptable ASCII password', () => {
+    expect(getAuthPasswordValidationError('a'.repeat(12))).toBeNull();
+  });
+
+  it('rejects passwords shorter than the minimum', () => {
+    expect(getAuthPasswordValidationError('short')).toContain('at least');
+  });
+
+  it('rejects passwords longer than 72 UTF-8 bytes', () => {
+    expect(getAuthPasswordValidationError('😀'.repeat(19))).toContain('bytes');
+  });
+});
+
 describe('buildRevokedPasswordPlaceholder', () => {
   it('stays within the bcrypt / GoTrue password length limit', () => {
     const password = buildRevokedPasswordPlaceholder();
     expect(password.length).toBeLessThanOrEqual(AUTH_PASSWORD_MAX_LENGTH);
-    expect(password.length).toBeGreaterThanOrEqual(8);
+    expect(password.length).toBeGreaterThanOrEqual(AUTH_PASSWORD_MIN_LENGTH);
+    expect(getAuthPasswordUtf8ByteLength(password)).toBeLessThanOrEqual(
+      AUTH_PASSWORD_MAX_LENGTH,
+    );
     expect(password.startsWith('Abstrack-revoked-')).toBe(true);
     expect(password.endsWith('!9')).toBe(true);
   });

--- a/apps/web/src/lib/user-password-sign-in.spec.ts
+++ b/apps/web/src/lib/user-password-sign-in.spec.ts
@@ -3,6 +3,7 @@ import {
   AUTH_PASSWORD_MIN_LENGTH,
   USER_PASSWORD_SET_USER_METADATA_KEY,
   buildRevokedPasswordPlaceholder,
+  clampAuthPasswordInput,
   getAuthPasswordUtf8ByteLength,
   getAuthPasswordValidationError,
   userHasPasswordSignIn,
@@ -32,6 +33,21 @@ describe('getAuthPasswordUtf8ByteLength', () => {
     expect(getAuthPasswordUtf8ByteLength('a'.repeat(72))).toBe(72);
     expect(getAuthPasswordUtf8ByteLength('é')).toBe(2);
     expect(getAuthPasswordUtf8ByteLength('😀')).toBe(4);
+  });
+});
+
+describe('clampAuthPasswordInput', () => {
+  it('passes through values within the UTF-8 byte limit', () => {
+    expect(clampAuthPasswordInput('a'.repeat(72))).toBe('a'.repeat(72));
+    expect(clampAuthPasswordInput('😀'.repeat(18))).toBe('😀'.repeat(18));
+  });
+
+  it('truncates values that exceed 72 UTF-8 bytes', () => {
+    const clamped = clampAuthPasswordInput('😀'.repeat(19));
+    expect(getAuthPasswordUtf8ByteLength(clamped)).toBeLessThanOrEqual(
+      AUTH_PASSWORD_MAX_LENGTH,
+    );
+    expect(getAuthPasswordValidationError(clamped)).toBeNull();
   });
 });
 

--- a/apps/web/src/lib/user-password-sign-in.spec.ts
+++ b/apps/web/src/lib/user-password-sign-in.spec.ts
@@ -1,0 +1,18 @@
+import {
+  USER_PASSWORD_SET_USER_METADATA_KEY,
+  userHasPasswordSignIn,
+} from './user-password-sign-in';
+
+describe('userHasPasswordSignIn', () => {
+  it('returns true when metadata flag is set', () => {
+    expect(
+      userHasPasswordSignIn({
+        user_metadata: { [USER_PASSWORD_SET_USER_METADATA_KEY]: true },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when metadata flag is absent', () => {
+    expect(userHasPasswordSignIn({ user_metadata: {} })).toBe(false);
+  });
+});

--- a/apps/web/src/lib/user-password-sign-in.spec.ts
+++ b/apps/web/src/lib/user-password-sign-in.spec.ts
@@ -1,5 +1,7 @@
 import {
+  AUTH_PASSWORD_MAX_LENGTH,
   USER_PASSWORD_SET_USER_METADATA_KEY,
+  buildRevokedPasswordPlaceholder,
   userHasPasswordSignIn,
 } from './user-password-sign-in';
 
@@ -12,7 +14,22 @@ describe('userHasPasswordSignIn', () => {
     ).toBe(true);
   });
 
-  it('returns false when metadata flag is absent', () => {
+  it('returns false when metadata flag is absent or explicitly false', () => {
     expect(userHasPasswordSignIn({ user_metadata: {} })).toBe(false);
+    expect(
+      userHasPasswordSignIn({
+        user_metadata: { [USER_PASSWORD_SET_USER_METADATA_KEY]: false },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('buildRevokedPasswordPlaceholder', () => {
+  it('stays within the bcrypt / GoTrue password length limit', () => {
+    const password = buildRevokedPasswordPlaceholder();
+    expect(password.length).toBeLessThanOrEqual(AUTH_PASSWORD_MAX_LENGTH);
+    expect(password.length).toBeGreaterThanOrEqual(8);
+    expect(password.startsWith('Abstrack-revoked-')).toBe(true);
+    expect(password.endsWith('!9')).toBe(true);
   });
 });

--- a/apps/web/src/lib/user-password-sign-in.ts
+++ b/apps/web/src/lib/user-password-sign-in.ts
@@ -41,8 +41,13 @@ export function getAuthPasswordUtf8ByteLength(password: string): number {
 /**
  * Keeps password input within {@link AUTH_PASSWORD_MAX_LENGTH} UTF-8 bytes.
  *
- * HTML `maxLength` counts UTF-16 code units, so emoji and other non-ASCII text can
- * exceed the GoTrue/bcrypt byte limit while still under `maxLength`.
+ * GoTrue hashes passwords with bcrypt, which only uses the first 72 bytes of the
+ * password ([Supabase password security](https://supabase.com/docs/guides/auth/password-security)).
+ * HTML `maxLength` counts UTF-16 code units, so emoji and other non-ASCII text can exceed
+ * the byte limit while still under `maxLength`.
+ *
+ * Truncation removes whole Unicode code points from the end (via {@link Array.from}),
+ * never lone UTF-16 surrogates.
  *
  * @param value - Raw input from a password field.
  * @returns Value truncated to the byte limit when needed.
@@ -51,14 +56,15 @@ export function clampAuthPasswordInput(value: string): string {
   if (getAuthPasswordUtf8ByteLength(value) <= AUTH_PASSWORD_MAX_LENGTH) {
     return value;
   }
-  let clamped = value;
-  while (
-    clamped.length > 0 &&
-    getAuthPasswordUtf8ByteLength(clamped) > AUTH_PASSWORD_MAX_LENGTH
-  ) {
-    clamped = clamped.slice(0, -1);
+  const codePoints = Array.from(value);
+  while (codePoints.length > 0) {
+    const candidate = codePoints.join('');
+    if (getAuthPasswordUtf8ByteLength(candidate) <= AUTH_PASSWORD_MAX_LENGTH) {
+      return candidate;
+    }
+    codePoints.pop();
   }
-  return clamped;
+  return '';
 }
 
 /**

--- a/apps/web/src/lib/user-password-sign-in.ts
+++ b/apps/web/src/lib/user-password-sign-in.ts
@@ -7,7 +7,7 @@ type UserMetadataCarrier = {
 
 /**
  * True when this user saved a password (sign-up, settings, or password reset).
- * Magic-link–only accounts omit this flag.
+ * Magic-link–only accounts omit this flag unless explicitly revoked (`false`).
  *
  * @param user - Supabase Auth user (session or `getUser()`).
  * @returns Whether email/password sign-in is enabled for this account.
@@ -16,20 +16,36 @@ export function userHasPasswordSignIn(
   user: UserMetadataCarrier | null | undefined,
 ): boolean {
   const raw = user?.user_metadata?.[USER_PASSWORD_SET_USER_METADATA_KEY];
+  if (raw === false || raw === 'false') {
+    return false;
+  }
   return raw === true || raw === 'true';
 }
+
+/** GoTrue/bcrypt rejects passwords longer than 72 bytes. */
+export const AUTH_PASSWORD_MAX_LENGTH = 72;
+
+const REVOKED_PASSWORD_PREFIX = 'Abstrack-revoked-';
+const REVOKED_PASSWORD_SUFFIX = '!9';
 
 /**
  * Builds a cryptographically random password for revoking user-chosen credentials
  * while keeping the account active for magic-link sign-in.
  *
+ * Length stays within {@link AUTH_PASSWORD_MAX_LENGTH} (bcrypt limit).
+ *
  * @returns A password string suitable for `updateUser({ password })`.
  */
 export function buildRevokedPasswordPlaceholder(): string {
-  const bytes = new Uint8Array(32);
+  const fixedLength =
+    REVOKED_PASSWORD_PREFIX.length + REVOKED_PASSWORD_SUFFIX.length;
+  const maxRandomChars = AUTH_PASSWORD_MAX_LENGTH - fixedLength;
+  const randomByteCount = Math.floor(maxRandomChars / 2);
+
+  const bytes = new Uint8Array(randomByteCount);
   crypto.getRandomValues(bytes);
   const segment = Array.from(bytes, (b) =>
     b.toString(16).padStart(2, '0'),
   ).join('');
-  return `Abstrack-revoked-${segment}!9`;
+  return `${REVOKED_PASSWORD_PREFIX}${segment}${REVOKED_PASSWORD_SUFFIX}`;
 }

--- a/apps/web/src/lib/user-password-sign-in.ts
+++ b/apps/web/src/lib/user-password-sign-in.ts
@@ -46,25 +46,24 @@ export function getAuthPasswordUtf8ByteLength(password: string): number {
  * HTML `maxLength` counts UTF-16 code units, so emoji and other non-ASCII text can exceed
  * the byte limit while still under `maxLength`.
  *
- * Truncation removes whole Unicode code points from the end (via {@link Array.from}),
- * never lone UTF-16 surrogates.
+ * Truncation keeps a prefix of whole Unicode code points ({@link String} iteration),
+ * never lone UTF-16 surrogates. Runs in one pass over the input.
  *
  * @param value - Raw input from a password field.
  * @returns Value truncated to the byte limit when needed.
  */
 export function clampAuthPasswordInput(value: string): string {
-  if (getAuthPasswordUtf8ByteLength(value) <= AUTH_PASSWORD_MAX_LENGTH) {
-    return value;
-  }
-  const codePoints = Array.from(value);
-  while (codePoints.length > 0) {
-    const candidate = codePoints.join('');
-    if (getAuthPasswordUtf8ByteLength(candidate) <= AUTH_PASSWORD_MAX_LENGTH) {
-      return candidate;
+  let byteLength = 0;
+  let result = '';
+  for (const char of value) {
+    const charBytes = getAuthPasswordUtf8ByteLength(char);
+    if (byteLength + charBytes > AUTH_PASSWORD_MAX_LENGTH) {
+      break;
     }
-    codePoints.pop();
+    byteLength += charBytes;
+    result += char;
   }
-  return '';
+  return result;
 }
 
 /**

--- a/apps/web/src/lib/user-password-sign-in.ts
+++ b/apps/web/src/lib/user-password-sign-in.ts
@@ -22,8 +22,39 @@ export function userHasPasswordSignIn(
   return raw === true || raw === 'true';
 }
 
+/** Minimum password length enforced by GoTrue for sign-up / update flows. */
+export const AUTH_PASSWORD_MIN_LENGTH = 8;
+
 /** GoTrue/bcrypt rejects passwords longer than 72 bytes. */
 export const AUTH_PASSWORD_MAX_LENGTH = 72;
+
+/**
+ * UTF-8 byte length of a password (GoTrue/bcrypt limit is bytes, not JavaScript string length).
+ *
+ * @param password - Candidate password.
+ * @returns Encoded byte length.
+ */
+export function getAuthPasswordUtf8ByteLength(password: string): number {
+  return new TextEncoder().encode(password).length;
+}
+
+/**
+ * Client-side password rules before `auth.updateUser({ password })`.
+ *
+ * @param password - Candidate password.
+ * @returns User-visible error, or `null` when acceptable.
+ */
+export function getAuthPasswordValidationError(
+  password: string,
+): string | null {
+  if (password.length < AUTH_PASSWORD_MIN_LENGTH) {
+    return `Password must be at least ${AUTH_PASSWORD_MIN_LENGTH} characters.`;
+  }
+  if (getAuthPasswordUtf8ByteLength(password) > AUTH_PASSWORD_MAX_LENGTH) {
+    return `Password must be no more than ${AUTH_PASSWORD_MAX_LENGTH} bytes.`;
+  }
+  return null;
+}
 
 const REVOKED_PASSWORD_PREFIX = 'Abstrack-revoked-';
 const REVOKED_PASSWORD_SUFFIX = '!9';

--- a/apps/web/src/lib/user-password-sign-in.ts
+++ b/apps/web/src/lib/user-password-sign-in.ts
@@ -1,0 +1,35 @@
+/** `auth.users` metadata: set when a password is saved on user web (settings or `/update-password`). */
+export const USER_PASSWORD_SET_USER_METADATA_KEY = 'abstrack_password_set';
+
+type UserMetadataCarrier = {
+  user_metadata?: Record<string, unknown> | null;
+};
+
+/**
+ * True when this user saved a password (sign-up, settings, or password reset).
+ * Magic-link–only accounts omit this flag.
+ *
+ * @param user - Supabase Auth user (session or `getUser()`).
+ * @returns Whether email/password sign-in is enabled for this account.
+ */
+export function userHasPasswordSignIn(
+  user: UserMetadataCarrier | null | undefined,
+): boolean {
+  const raw = user?.user_metadata?.[USER_PASSWORD_SET_USER_METADATA_KEY];
+  return raw === true || raw === 'true';
+}
+
+/**
+ * Builds a cryptographically random password for revoking user-chosen credentials
+ * while keeping the account active for magic-link sign-in.
+ *
+ * @returns A password string suitable for `updateUser({ password })`.
+ */
+export function buildRevokedPasswordPlaceholder(): string {
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  const segment = Array.from(bytes, (b) =>
+    b.toString(16).padStart(2, '0'),
+  ).join('');
+  return `Abstrack-revoked-${segment}!9`;
+}

--- a/apps/web/src/lib/user-password-sign-in.ts
+++ b/apps/web/src/lib/user-password-sign-in.ts
@@ -39,6 +39,29 @@ export function getAuthPasswordUtf8ByteLength(password: string): number {
 }
 
 /**
+ * Keeps password input within {@link AUTH_PASSWORD_MAX_LENGTH} UTF-8 bytes.
+ *
+ * HTML `maxLength` counts UTF-16 code units, so emoji and other non-ASCII text can
+ * exceed the GoTrue/bcrypt byte limit while still under `maxLength`.
+ *
+ * @param value - Raw input from a password field.
+ * @returns Value truncated to the byte limit when needed.
+ */
+export function clampAuthPasswordInput(value: string): string {
+  if (getAuthPasswordUtf8ByteLength(value) <= AUTH_PASSWORD_MAX_LENGTH) {
+    return value;
+  }
+  let clamped = value;
+  while (
+    clamped.length > 0 &&
+    getAuthPasswordUtf8ByteLength(clamped) > AUTH_PASSWORD_MAX_LENGTH
+  ) {
+    clamped = clamped.slice(0, -1);
+  }
+  return clamped;
+}
+
+/**
  * Client-side password rules before `auth.updateUser({ password })`.
  *
  * @param password - Candidate password.

--- a/apps/web/src/lib/web-public-paths.spec.ts
+++ b/apps/web/src/lib/web-public-paths.spec.ts
@@ -24,7 +24,7 @@ describe('isPublicWebPath', () => {
     expect(isPublicWebPath('/dashboard')).toBe(false);
     expect(isPublicWebPath('/manage')).toBe(false);
     expect(isPublicWebPath('/insights')).toBe(false);
-    expect(isPublicWebPath('/settings/caretaker')).toBe(false);
+    expect(isPublicWebPath('/settings')).toBe(false);
   });
 
   it('returns false for lookalike paths that do not match a prefix boundary', () => {

--- a/apps/web/src/lib/web-sign-out-everywhere.ts
+++ b/apps/web/src/lib/web-sign-out-everywhere.ts
@@ -1,0 +1,17 @@
+/**
+ * Performs a full server sign-out via `POST /api/auth/logout` with `scope=global`, revoking
+ * refresh tokens on all devices. Navigation happens via the redirect response.
+ */
+export function webSignOutEverywhere(): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+  const form = document.createElement('form');
+  form.method = 'POST';
+  form.action = '/api/auth/logout?scope=global';
+  form.setAttribute('aria-hidden', 'true');
+  form.style.display = 'none';
+
+  document.body.appendChild(form);
+  form.submit();
+}

--- a/apps/web/src/lib/web-sign-out-everywhere.ts
+++ b/apps/web/src/lib/web-sign-out-everywhere.ts
@@ -1,3 +1,5 @@
+import { clearMfaTrustBundle } from '@/lib/user-mfa-device-trust';
+
 /**
  * Performs a full server sign-out via `POST /api/auth/logout` with `scope=global`, revoking
  * refresh tokens on all devices. Navigation happens via the redirect response.
@@ -6,6 +8,7 @@ export function webSignOutEverywhere(): void {
   if (typeof document === 'undefined') {
     return;
   }
+  clearMfaTrustBundle();
   const form = document.createElement('form');
   form.method = 'POST';
   form.action = '/api/auth/logout?scope=global';

--- a/apps/web/src/lib/web-sign-out-everywhere.ts
+++ b/apps/web/src/lib/web-sign-out-everywhere.ts
@@ -1,20 +1,10 @@
-import { clearMfaTrustBundle } from '@/lib/user-mfa-device-trust';
+import { userSignOutEverywhere } from '@/lib/user-mfa-device-trust';
 
 /**
  * Performs a full server sign-out via `POST /api/auth/logout` with `scope=global`, revoking
- * refresh tokens on all devices. Navigation happens via the redirect response.
+ * refresh tokens on all devices. Clears the MFA trust bundle and any `sb-*-auth-token` keys in
+ * browser storage on this origin before navigation. Navigation happens via the redirect response.
  */
 export function webSignOutEverywhere(): void {
-  if (typeof document === 'undefined') {
-    return;
-  }
-  clearMfaTrustBundle();
-  const form = document.createElement('form');
-  form.method = 'POST';
-  form.action = '/api/auth/logout?scope=global';
-  form.setAttribute('aria-hidden', 'true');
-  form.style.display = 'none';
-
-  document.body.appendChild(form);
-  form.submit();
+  userSignOutEverywhere();
 }

--- a/apps/web/src/proxy.spec.ts
+++ b/apps/web/src/proxy.spec.ts
@@ -229,44 +229,6 @@ describe('web auth proxy', () => {
     );
   });
 
-  it('redirects unauthenticated user from /settings/caretaker to /login', async () => {
-    createServerClientMock.mockImplementation(() =>
-      Promise.resolve({
-        auth: {
-          getUser: jest.fn(async () => ({ data: { user: null } })),
-        },
-      } as unknown as ServerClient),
-    );
-
-    const result = await proxy(makeRequest('/settings/caretaker'));
-
-    expect(result).toEqual(
-      expect.objectContaining({
-        type: 'redirect',
-        location: 'https://example.com/login',
-      }),
-    );
-  });
-
-  it('redirects unauthenticated user from /settings/practitioner to /login', async () => {
-    createServerClientMock.mockImplementation(() =>
-      Promise.resolve({
-        auth: {
-          getUser: jest.fn(async () => ({ data: { user: null } })),
-        },
-      } as unknown as ServerClient),
-    );
-
-    const result = await proxy(makeRequest('/settings/practitioner'));
-
-    expect(result).toEqual(
-      expect.objectContaining({
-        type: 'redirect',
-        location: 'https://example.com/login',
-      }),
-    );
-  });
-
   it('redirects unauthenticated user from preset routes to /login', async () => {
     createServerClientMock.mockImplementation(() =>
       Promise.resolve({

--- a/apps/web/tailwind.config.js
+++ b/apps/web/tailwind.config.js
@@ -51,6 +51,9 @@ module.exports = {
           'on-primary-solid':
             'rgb(var(--app-primary-on-solid) / <alpha-value>)',
           'primary-soft': 'rgb(var(--app-primary-soft) / <alpha-value>)',
+          'tab-active-bg': 'rgb(var(--app-tab-active-bg) / <alpha-value>)',
+          'tab-active-text': 'rgb(var(--app-tab-active-text) / <alpha-value>)',
+          'tab-active-ring': 'rgb(var(--app-tab-active-ring) / <alpha-value>)',
           ring: 'rgb(var(--app-ring) / <alpha-value>)',
         },
       },

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -118,6 +118,20 @@ This document summarizes the repository security posture, points to implementati
 - Preferred direction: **redesign** to server-managed device trust (opaque HttpOnly cookie + server validation, or short-lived scoped tokens exchanged only server-side)—not implemented in the current client-only bundle.
 - Status: **interim** client implementation; **RLS and MFA rules remain authoritative** for PHI—this path is not an additional server-side authorization layer.
 
+#### User web “trusted device” (browser storage — disabled by default)
+
+- Intent: optional patient/caretaker UX to skip TOTP on a later email/password sign-in within a chosen window (30 days or 1 year), after explicit opt-in post–MFA verification on [`UserLoginForm`](../apps/web/src/components/auth/UserLoginForm.tsx).
+- Implementation: [`apps/web/src/lib/user-mfa-device-trust.ts`](../apps/web/src/lib/user-mfa-device-trust.ts) — same **localStorage token bundle** risk as practitioner (see above).
+- **Deploy gate:** **`NEXT_PUBLIC_USER_MFA_DEVICE_TRUST=true` only** (unset/false → feature off). **Production** builds also require **`NEXT_PUBLIC_USER_WEB_CSP_ENFORCE=true`** at build time before trust is enabled.
+- Status: **off by default** until CSP is staged and both flags are set for a release.
+
+#### User web Content-Security-Policy (staged)
+
+- Intent: reduce XSS impact on user web (including optional trusted-device tokens) with **Report-Only first**, then enforce — same staged model as practitioner, separate config.
+- Implementation: [`apps/web/next.config.js`](../apps/web/next.config.js), [`apps/web/csp-config.js`](../apps/web/csp-config.js).
+- **Phase A (default):** `Content-Security-Policy-Report-Only`.
+- **Phase B:** set **`USER_WEB_CSP_ENFORCE=true`** at build/deploy time and **`NEXT_PUBLIC_USER_WEB_CSP_ENFORCE=true`** when enabling MFA device trust in production.
+
 #### Practitioner Content-Security-Policy (staged)
 
 - Intent: reduce XSS impact on the practitioner surface (including optional trusted-device tokens in `localStorage`) with a **strict, staged** CSP: report violations first, then enforce when noise is acceptable.
@@ -191,6 +205,8 @@ Core implementation artifacts:
 - `apps/mobile/src/app/screens/UpdatePasswordScreen.tsx`
 - `apps/web/src/lib/auth-provider.tsx`
 - `apps/web/src/app/dashboard/page.tsx`
+- `apps/web/src/lib/user-mfa-device-trust.ts` (user web trusted-device UX; **disabled by default**; see “User web trusted device” above)
+- `apps/web/next.config.js`, `apps/web/csp-config.js` (user web CSP; see “User web Content-Security-Policy” above)
 - `apps/practitioner/src/lib/practitioner-device-trust.ts` (trusted-device UX; see XSS warning in file and subsection above)
 - `apps/practitioner/next.config.js`, `apps/practitioner/csp-config.js` (practitioner CSP; see “Practitioner Content-Security-Policy” above)
 

--- a/docs/SUPABASE_CLOUD_DEVELOPER.md
+++ b/docs/SUPABASE_CLOUD_DEVELOPER.md
@@ -20,11 +20,11 @@ Follow **[AGENTS.md](../AGENTS.md)** (section **Correct flow for migrations and 
 
 ## Ground rules (read first)
 
-| Fact                                            | Implication                                                                                                               |
-| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
-| **Canonical DB is Supabase Cloud**              | `db push` applies `supabase/migrations/` to your hosted project (CLI on your laptop **and/or** GitHub Actions on `main`). |
-| **`supabase db reset` is local-only**           | It only affects a **Docker** database from `supabase db start` (your machine or CI). It does **not** reset cloud.         |
-| **`gen types typescript --linked` reads cloud** | It does not “read” new SQL from git until that SQL has been applied to cloud via **`db push`**.                           |
+| Fact                                            | Implication                                                                                                                                                                                                        |
+| ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Canonical DB is Supabase Cloud**              | `db push` applies `supabase/migrations/` to your hosted project (CLI on your laptop **and/or** GitHub Actions on `main`).                                                                                          |
+| **`supabase db reset`** (no flags)              | Local Docker only (`supabase start`). Use **`supabase db reset --linked`** to wipe and re-apply migrations on the **linked cloud** project (see [CLI](https://supabase.com/docs/reference/cli/supabase-db-reset)). |
+| **`gen types typescript --linked` reads cloud** | It does not “read” new SQL from git until that SQL has been applied to cloud via **`db push`**.                                                                                                                    |
 
 ---
 
@@ -449,7 +449,7 @@ Repository secrets are documented under **[DEV_SETUP.md → PowerSync sync confi
 
    **Critical review-phase rule:** while Sarah is still iterating on Copilot/PR review feedback, assume migrations have **not** been pushed yet and **modify existing migration file(s) only**. **Do not create new migration files during review iterations** unless Sarah explicitly asks.
 
-3. **Never imply `supabase db reset` affects cloud.** Local Docker only (or CI-only).
+3. **Do not confuse reset targets:** plain **`supabase db reset`** is local Docker only; **`supabase db reset --linked`** resets the linked cloud project.
 
 4. **Say explicitly** when she must use **her terminal** (CLI login, link, `db push`, `gen types`) vs what CI does after merge.
 

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -34,7 +34,9 @@ export {
 } from './lib/auth.js';
 export {
   ensurePatientProfileRow,
+  ensureProfileRow,
   isPostgresUniqueViolation,
+  type SelfServiceProfileRole,
 } from './lib/ensure-patient-profile.js';
 export {
   fetchProfileByUserId,

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -36,6 +36,8 @@ export {
   ensurePatientProfileRow,
   ensureProfileRow,
   isPostgresUniqueViolation,
+  type EnsureProfileRowFailure,
+  type EnsureProfileRowResult,
   type SelfServiceProfileRole,
 } from './lib/ensure-patient-profile.js';
 export {

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -33,6 +33,10 @@ export {
   updatePassword,
 } from './lib/auth.js';
 export {
+  ensurePatientProfileRow,
+  isPostgresUniqueViolation,
+} from './lib/ensure-patient-profile.js';
+export {
   fetchProfileByUserId,
   healthCheckProfilesLimit1,
 } from './lib/queries.js';

--- a/packages/supabase/src/lib/ensure-patient-profile.spec.ts
+++ b/packages/supabase/src/lib/ensure-patient-profile.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ensurePatientProfileRow,
+  isPostgresUniqueViolation,
+} from './ensure-patient-profile.js';
+
+describe('isPostgresUniqueViolation', () => {
+  it('detects code 23505', () => {
+    expect(isPostgresUniqueViolation({ code: '23505' })).toBe(true);
+    expect(isPostgresUniqueViolation({ code: '42501' })).toBe(false);
+  });
+});
+
+describe('ensurePatientProfileRow', () => {
+  it('returns ok when profile already exists', async () => {
+    const client = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: { id: 'u1' }, error: null }),
+          }),
+        }),
+      }),
+    } as never;
+
+    await expect(ensurePatientProfileRow(client, 'u1')).resolves.toEqual({
+      ok: true,
+    });
+  });
+
+  it('inserts patient profile when absent', async () => {
+    const insert = vi.fn(async () => ({ error: null }));
+    const client = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: null, error: null }),
+          }),
+        }),
+        insert,
+      }),
+    } as never;
+
+    const result = await ensurePatientProfileRow(client, 'u1');
+    expect(result).toEqual({ ok: true });
+    expect(insert).toHaveBeenCalledWith({ id: 'u1', app_role: 'patient' });
+  });
+});

--- a/packages/supabase/src/lib/ensure-patient-profile.spec.ts
+++ b/packages/supabase/src/lib/ensure-patient-profile.spec.ts
@@ -66,4 +66,53 @@ describe('ensureProfileRow', () => {
     expect(result).toEqual({ ok: true });
     expect(insert).toHaveBeenCalledWith({ id: 'u1', app_role: 'caretaker' });
   });
+
+  it('returns safe message and cause when profile read fails', async () => {
+    const client = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({
+              data: null,
+              error: {
+                message: 'permission denied for table profiles',
+                code: '42501',
+              },
+            }),
+          }),
+        }),
+      }),
+    } as never;
+
+    await expect(ensureProfileRow(client, 'u1', 'patient')).resolves.toEqual({
+      ok: false,
+      message: 'Unable to load your profile. Try again in a moment.',
+      cause: 'permission denied for table profiles',
+    });
+  });
+
+  it('returns safe message and cause when profile insert fails', async () => {
+    const client = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: null, error: null }),
+          }),
+        }),
+        insert: async () => ({
+          error: {
+            message: 'new row violates row-level security policy',
+            code: '42501',
+          },
+        }),
+      }),
+    } as never;
+
+    await expect(ensureProfileRow(client, 'u1', 'caretaker')).resolves.toEqual({
+      ok: false,
+      message:
+        'Unable to create your caretaker profile. Try again or contact support.',
+      cause: 'new row violates row-level security policy',
+    });
+  });
 });

--- a/packages/supabase/src/lib/ensure-patient-profile.spec.ts
+++ b/packages/supabase/src/lib/ensure-patient-profile.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   ensurePatientProfileRow,
+  ensureProfileRow,
   isPostgresUniqueViolation,
 } from './ensure-patient-profile.js';
 
@@ -44,5 +45,25 @@ describe('ensurePatientProfileRow', () => {
     const result = await ensurePatientProfileRow(client, 'u1');
     expect(result).toEqual({ ok: true });
     expect(insert).toHaveBeenCalledWith({ id: 'u1', app_role: 'patient' });
+  });
+});
+
+describe('ensureProfileRow', () => {
+  it('inserts caretaker profile when absent', async () => {
+    const insert = vi.fn(async () => ({ error: null }));
+    const client = {
+      from: () => ({
+        select: () => ({
+          eq: () => ({
+            maybeSingle: async () => ({ data: null, error: null }),
+          }),
+        }),
+        insert,
+      }),
+    } as never;
+
+    const result = await ensureProfileRow(client, 'u1', 'caretaker');
+    expect(result).toEqual({ ok: true });
+    expect(insert).toHaveBeenCalledWith({ id: 'u1', app_role: 'caretaker' });
   });
 });

--- a/packages/supabase/src/lib/ensure-patient-profile.ts
+++ b/packages/supabase/src/lib/ensure-patient-profile.ts
@@ -4,6 +4,34 @@ import type { AbstrackSupabaseClient } from './supabase-client-type.js';
 /** Roles a user may self-provision via signup or invite completion (not practitioner). */
 export type SelfServiceProfileRole = Extract<AppRole, 'patient' | 'caretaker'>;
 
+/** Result when {@link ensureProfileRow} cannot complete. */
+export type EnsureProfileRowFailure = {
+  ok: false;
+  /** Safe copy for UI; do not surface {@link cause} to end users. */
+  message: string;
+  /** Raw PostgREST/Postgres detail for logging or diagnostics. */
+  cause?: string;
+};
+
+/** @returns Outcome of ensuring a self-service profile row exists. */
+export type EnsureProfileRowResult = { ok: true } | EnsureProfileRowFailure;
+
+const PROFILE_READ_ERROR_MESSAGE =
+  'Unable to load your profile. Try again in a moment.';
+
+function profileInsertErrorMessage(appRole: SelfServiceProfileRole): string {
+  return appRole === 'caretaker'
+    ? 'Unable to create your caretaker profile. Try again or contact support.'
+    : 'Unable to create your profile. Try again or contact support.';
+}
+
+function postgrestErrorDetail(
+  err: { message?: string } | null,
+): string | undefined {
+  const trimmed = err?.message?.trim();
+  return trimmed === '' ? undefined : trimmed;
+}
+
 /** True when PostgREST reports a duplicate primary key (concurrent profile insert). */
 export function isPostgresUniqueViolation(
   err: { code?: string } | null | undefined,
@@ -26,7 +54,7 @@ export async function ensureProfileRow(
   client: AbstrackSupabaseClient,
   userId: string,
   appRole: SelfServiceProfileRole,
-): Promise<{ ok: true } | { ok: false; message: string }> {
+): Promise<EnsureProfileRowResult> {
   const trimmed = userId.trim();
   if (trimmed === '') {
     return { ok: false, message: 'Missing user id.' };
@@ -39,7 +67,11 @@ export async function ensureProfileRow(
     .maybeSingle();
 
   if (readErr) {
-    return { ok: false, message: readErr.message };
+    return {
+      ok: false,
+      message: PROFILE_READ_ERROR_MESSAGE,
+      cause: postgrestErrorDetail(readErr),
+    };
   }
   if (existing) {
     return { ok: true };
@@ -53,7 +85,11 @@ export async function ensureProfileRow(
   if (!insErr || isPostgresUniqueViolation(insErr)) {
     return { ok: true };
   }
-  return { ok: false, message: insErr.message };
+  return {
+    ok: false,
+    message: profileInsertErrorMessage(appRole),
+    cause: postgrestErrorDetail(insErr),
+  };
 }
 
 /**
@@ -66,6 +102,6 @@ export async function ensureProfileRow(
 export async function ensurePatientProfileRow(
   client: AbstrackSupabaseClient,
   userId: string,
-): Promise<{ ok: true } | { ok: false; message: string }> {
+): Promise<EnsureProfileRowResult> {
   return ensureProfileRow(client, userId, 'patient');
 }

--- a/packages/supabase/src/lib/ensure-patient-profile.ts
+++ b/packages/supabase/src/lib/ensure-patient-profile.ts
@@ -1,4 +1,8 @@
+import type { AppRole } from '@abstrack/types';
 import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+/** Roles a user may self-provision via signup or invite completion (not practitioner). */
+export type SelfServiceProfileRole = Extract<AppRole, 'patient' | 'caretaker'>;
 
 /** True when PostgREST reports a duplicate primary key (concurrent profile insert). */
 export function isPostgresUniqueViolation(
@@ -8,15 +12,20 @@ export function isPostgresUniqueViolation(
 }
 
 /**
- * Ensures a `public.profiles` row exists for a patient self-signup when absent.
+ * Ensures a `public.profiles` row exists with the given self-service role when absent.
+ *
+ * Does not change `app_role` when a row already exists — callers that require a specific
+ * role must verify `profiles.app_role` after this returns `{ ok: true }`.
  *
  * @param client - Supabase client with the user's session.
  * @param userId - `auth.users.id`.
+ * @param appRole - `patient` (self-signup) or `caretaker` (invite completion).
  * @returns Success or an error message.
  */
-export async function ensurePatientProfileRow(
+export async function ensureProfileRow(
   client: AbstrackSupabaseClient,
   userId: string,
+  appRole: SelfServiceProfileRole,
 ): Promise<{ ok: true } | { ok: false; message: string }> {
   const trimmed = userId.trim();
   if (trimmed === '') {
@@ -38,11 +47,25 @@ export async function ensurePatientProfileRow(
 
   const { error: insErr } = await client.from('profiles').insert({
     id: trimmed,
-    app_role: 'patient',
+    app_role: appRole,
   });
 
   if (!insErr || isPostgresUniqueViolation(insErr)) {
     return { ok: true };
   }
   return { ok: false, message: insErr.message };
+}
+
+/**
+ * Ensures a patient `public.profiles` row exists for self-signup when absent.
+ *
+ * @param client - Supabase client with the user's session.
+ * @param userId - `auth.users.id`.
+ * @returns Success or an error message.
+ */
+export async function ensurePatientProfileRow(
+  client: AbstrackSupabaseClient,
+  userId: string,
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  return ensureProfileRow(client, userId, 'patient');
 }

--- a/packages/supabase/src/lib/ensure-patient-profile.ts
+++ b/packages/supabase/src/lib/ensure-patient-profile.ts
@@ -1,0 +1,48 @@
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+/** True when PostgREST reports a duplicate primary key (concurrent profile insert). */
+export function isPostgresUniqueViolation(
+  err: { code?: string } | null | undefined,
+): boolean {
+  return err?.code === '23505';
+}
+
+/**
+ * Ensures a `public.profiles` row exists for a patient self-signup when absent.
+ *
+ * @param client - Supabase client with the user's session.
+ * @param userId - `auth.users.id`.
+ * @returns Success or an error message.
+ */
+export async function ensurePatientProfileRow(
+  client: AbstrackSupabaseClient,
+  userId: string,
+): Promise<{ ok: true } | { ok: false; message: string }> {
+  const trimmed = userId.trim();
+  if (trimmed === '') {
+    return { ok: false, message: 'Missing user id.' };
+  }
+
+  const { data: existing, error: readErr } = await client
+    .from('profiles')
+    .select('id')
+    .eq('id', trimmed)
+    .maybeSingle();
+
+  if (readErr) {
+    return { ok: false, message: readErr.message };
+  }
+  if (existing) {
+    return { ok: true };
+  }
+
+  const { error: insErr } = await client.from('profiles').insert({
+    id: trimmed,
+    app_role: 'patient',
+  });
+
+  if (!insErr || isPostgresUniqueViolation(insErr)) {
+    return { ok: true };
+  }
+  return { ok: false, message: insErr.message };
+}

--- a/packages/ui-web/src/lib/sidebar-provider-behavior.spec.ts
+++ b/packages/ui-web/src/lib/sidebar-provider-behavior.spec.ts
@@ -97,6 +97,19 @@ describe('shouldToggleSidebarFromKeyboard', () => {
     expect(shouldToggleSidebarFromKeyboard(event)).toBe(false);
   });
 
+  it('ignores keydown events without a key value', () => {
+    vi.stubGlobal('navigator', {
+      platform: 'Win32',
+      userAgent: 'Windows',
+    });
+    const event = dispatchKey({ ctrlKey: true });
+    Object.defineProperty(event, 'key', {
+      configurable: true,
+      value: undefined,
+    });
+    expect(shouldToggleSidebarFromKeyboard(event)).toBe(false);
+  });
+
   it('ignores the shortcut without a modifier', () => {
     const event = dispatchKey({ key: 'b' });
     expect(shouldToggleSidebarFromKeyboard(event)).toBe(false);

--- a/packages/ui-web/src/lib/sidebar-provider-behavior.ts
+++ b/packages/ui-web/src/lib/sidebar-provider-behavior.ts
@@ -118,7 +118,8 @@ export function shouldToggleSidebarFromKeyboard(event: KeyboardEvent): boolean {
   if (event.repeat) {
     return false;
   }
-  if (event.key.toLowerCase() !== SIDEBAR_KEYBOARD_SHORTCUT) {
+  const key = event.key;
+  if (!key || key.toLowerCase() !== SIDEBAR_KEYBOARD_SHORTCUT) {
     return false;
   }
   const isMac = isMacLikePlatform();

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -461,6 +461,9 @@ importers:
       next:
         specifier: ~16.0.1
         version: 16.0.11(@babel/core@7.29.0)(@playwright/test@1.58.2)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)(sass@1.97.3)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -480,6 +483,9 @@ importers:
         specifier: ^3.8.1
         version: 3.8.1(@types/react@19.1.17)(react-dom@19.1.0(react@19.1.0))(react-is@19.2.4)(react@19.1.0)(redux@5.0.1)
     devDependencies:
+      '@types/qrcode':
+        specifier: ^1.5.6
+        version: 1.5.6
       tailwindcss-animate:
         specifier: ^1.0.7
         version: 1.0.7(tailwindcss@3.4.3(ts-node@10.9.1(@swc/core@1.15.18(@swc/helpers@0.5.19))(@types/node@20.19.9)(typescript@5.9.3)))

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -204,7 +204,7 @@ web3 = 30
 enable_signup = true
 # If enabled, a user will be required to confirm any email change on both the old, and new email
 # addresses. If disabled, only the new email is required to confirm.
-double_confirm_changes = true
+double_confirm_changes = false
 # If enabled, users need to confirm their email address before signing in.
 enable_confirmations = false
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.

--- a/supabase/functions/patient-caretaker-access/index.ts
+++ b/supabase/functions/patient-caretaker-access/index.ts
@@ -516,7 +516,7 @@ async function sendCaretakerInviteEmailAndStamp(
   const { error: invMailErr } = await admin.auth.admin.inviteUserByEmail(
     normalizedTarget,
     {
-      data: { abstrack_caretaker_invite_id: inviteId },
+      data: { abstrack_caretaker_invite_id: inviteId, app_role: 'caretaker' },
       redirectTo,
     },
   );

--- a/supabase/functions/patient-practitioner-access/index.ts
+++ b/supabase/functions/patient-practitioner-access/index.ts
@@ -532,7 +532,10 @@ async function sendPractitionerInviteEmailAndStamp(
   const { error: invMailErr } = await admin.auth.admin.inviteUserByEmail(
     normalizedTarget,
     {
-      data: { abstrack_practitioner_invite_id: inviteId },
+      data: {
+        abstrack_practitioner_invite_id: inviteId,
+        app_role: 'practitioner',
+      },
       redirectTo,
     },
   );

--- a/supabase/migrations/20260524150000_public_schema_api_grants.sql
+++ b/supabase/migrations/20260524150000_public_schema_api_grants.sql
@@ -1,35 +1,69 @@
--- PostgREST / API roles need table and sequence privileges on objects created in migrations.
--- RLS alone is not sufficient: authenticated clients get 403 without GRANTs; service_role
--- (secret API key) gets 42501 without GRANTs even when RLS is bypassed (integration tests, Edge).
+-- PostgREST roles need explicit table/sequence privileges on existing objects.
+-- RLS enforces row access; missing GRANTs yield 403 (authenticated) or 42501 (service_role).
+--
+-- Fail-closed: no GRANT ALL, no ALTER DEFAULT PRIVILEGES (new tables stay closed until a
+-- migration grants them). Re-applies minimal access_log / chart_snapshots privileges so
+-- blanket grants from an earlier revision cannot widen them.
 
-GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
+GRANT USAGE ON SCHEMA public TO authenticated, service_role;
 
-GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO authenticated;
+-- Patient / caretaker / practitioner app data (RLS is authoritative).
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.profiles,
+  public.symptom_presets,
+  public.preset_symptoms,
+  public.health_marker_presets,
+  public.preset_health_markers,
+  public.episode_templates,
+  public.episodes,
+  public.episode_symptoms,
+  public.health_markers,
+  public.food_diary_entries,
+  public.episode_media,
+  public.practitioner_access,
+  public.caretaker_access,
+  public.practitioner_observation_notes,
+  public.practitioner_invites,
+  public.caretaker_invites TO authenticated;
 
-GRANT SELECT ON ALL TABLES IN SCHEMA public TO anon;
-
-GRANT ALL ON ALL TABLES IN SCHEMA public TO service_role;
-
+-- Sequences for serial/identity columns on the tables above (existing objects only).
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO authenticated;
 
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO anon;
+-- service_role: integration tests and Edge Functions (narrow table grants, not ALL).
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.profiles TO service_role;
 
-GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO service_role;
+GRANT SELECT ON TABLE public.symptom_presets,
+  public.preset_symptoms,
+  public.health_marker_presets,
+  public.preset_health_markers,
+  public.episode_templates,
+  public.episodes,
+  public.episode_symptoms,
+  public.health_markers,
+  public.food_diary_entries,
+  public.episode_media,
+  public.practitioner_observation_notes TO service_role;
 
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
+GRANT SELECT, INSERT, UPDATE ON TABLE public.practitioner_access,
+  public.caretaker_access TO service_role;
 
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT SELECT ON TABLES TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.practitioner_invites,
+  public.caretaker_invites TO service_role;
 
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT ALL ON TABLES TO service_role;
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO service_role;
 
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
+-- ---------------------------------------------------------------------------
+-- Restricted tables (must match 20260327130000_rls_policies.sql and 20260524130000_chart_snapshots.sql)
+-- ---------------------------------------------------------------------------
+REVOKE ALL ON TABLE public.access_log
+FROM PUBLIC, anon, authenticated, service_role;
 
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT USAGE, SELECT ON SEQUENCES TO anon;
+GRANT SELECT ON TABLE public.access_log TO authenticated;
 
-ALTER DEFAULT PRIVILEGES IN SCHEMA public
-  GRANT ALL ON SEQUENCES TO service_role;
+GRANT INSERT, SELECT ON TABLE public.access_log TO service_role;
+
+REVOKE ALL ON TABLE public.chart_snapshots
+FROM PUBLIC, anon, authenticated, service_role;
+
+GRANT SELECT, INSERT ON TABLE public.chart_snapshots TO authenticated;
+
+GRANT SELECT, INSERT ON TABLE public.chart_snapshots TO service_role;

--- a/supabase/migrations/20260524150000_public_schema_api_grants.sql
+++ b/supabase/migrations/20260524150000_public_schema_api_grants.sql
@@ -23,8 +23,8 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.profiles,
   public.caretaker_access,
   public.practitioner_observation_notes TO authenticated;
 
--- caretaker_invites / practitioner_invites: service_role + Edge Functions only (no authenticated
--- policies in 20260510120000 / 20260515180000). Do not grant PostgREST table access here.
+-- caretaker_invites / practitioner_invites: no authenticated grants (no authenticated RLS
+-- policies in 20260510120000 / 20260515180000). service_role grants for Edge Functions follow.
 
 -- No GRANT ON SEQUENCE: tables above use uuid PRIMARY KEY DEFAULT gen_random_uuid() (no serial/identity).
 
@@ -46,6 +46,7 @@ GRANT SELECT ON TABLE public.symptom_presets,
 GRANT SELECT, INSERT, UPDATE ON TABLE public.practitioner_access,
   public.caretaker_access TO service_role;
 
+-- Invite tables: service_role only (see comment above; not granted to authenticated).
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.practitioner_invites,
   public.caretaker_invites TO service_role;
 

--- a/supabase/migrations/20260524150000_public_schema_api_grants.sql
+++ b/supabase/migrations/20260524150000_public_schema_api_grants.sql
@@ -1,4 +1,4 @@
--- PostgREST roles need explicit table/sequence privileges on existing objects.
+-- PostgREST roles need explicit table privileges on existing objects.
 -- RLS enforces row access; missing GRANTs yield 403 (authenticated) or 42501 (service_role).
 --
 -- Fail-closed: no GRANT ALL, no ALTER DEFAULT PRIVILEGES (new tables stay closed until a
@@ -25,8 +25,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.profiles,
   public.practitioner_invites,
   public.caretaker_invites TO authenticated;
 
--- Sequences for serial/identity columns on the tables above (existing objects only).
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO authenticated;
+-- No GRANT ON SEQUENCE: tables above use uuid PRIMARY KEY DEFAULT gen_random_uuid() (no serial/identity).
 
 -- service_role: integration tests and Edge Functions (narrow table grants, not ALL).
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.profiles TO service_role;
@@ -48,8 +47,6 @@ GRANT SELECT, INSERT, UPDATE ON TABLE public.practitioner_access,
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.practitioner_invites,
   public.caretaker_invites TO service_role;
-
-GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO service_role;
 
 -- ---------------------------------------------------------------------------
 -- Restricted tables (must match 20260327130000_rls_policies.sql and 20260524130000_chart_snapshots.sql)

--- a/supabase/migrations/20260524150000_public_schema_api_grants.sql
+++ b/supabase/migrations/20260524150000_public_schema_api_grants.sql
@@ -1,0 +1,24 @@
+-- PostgREST roles need table/sequence privileges on objects created in migrations.
+-- RLS policies alone are not sufficient; without these GRANTs, authenticated clients receive 403.
+
+GRANT USAGE ON SCHEMA public TO anon, authenticated;
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO authenticated;
+
+GRANT SELECT ON ALL TABLES IN SCHEMA public TO anon;
+
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO authenticated;
+
+GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO anon;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT SELECT ON TABLES TO anon;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT USAGE, SELECT ON SEQUENCES TO anon;

--- a/supabase/migrations/20260524150000_public_schema_api_grants.sql
+++ b/supabase/migrations/20260524150000_public_schema_api_grants.sql
@@ -1,15 +1,20 @@
--- PostgREST roles need table/sequence privileges on objects created in migrations.
--- RLS policies alone are not sufficient; without these GRANTs, authenticated clients receive 403.
+-- PostgREST / API roles need table and sequence privileges on objects created in migrations.
+-- RLS alone is not sufficient: authenticated clients get 403 without GRANTs; service_role
+-- (secret API key) gets 42501 without GRANTs even when RLS is bypassed (integration tests, Edge).
 
-GRANT USAGE ON SCHEMA public TO anon, authenticated;
+GRANT USAGE ON SCHEMA public TO anon, authenticated, service_role;
 
 GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO authenticated;
 
 GRANT SELECT ON ALL TABLES IN SCHEMA public TO anon;
 
+GRANT ALL ON ALL TABLES IN SCHEMA public TO service_role;
+
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO authenticated;
 
 GRANT USAGE, SELECT ON ALL SEQUENCES IN SCHEMA public TO anon;
+
+GRANT ALL ON ALL SEQUENCES IN SCHEMA public TO service_role;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT SELECT, INSERT, UPDATE, DELETE ON TABLES TO authenticated;
@@ -18,7 +23,13 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT SELECT ON TABLES TO anon;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT ALL ON TABLES TO service_role;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT USAGE, SELECT ON SEQUENCES TO authenticated;
 
 ALTER DEFAULT PRIVILEGES IN SCHEMA public
   GRANT USAGE, SELECT ON SEQUENCES TO anon;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA public
+  GRANT ALL ON SEQUENCES TO service_role;

--- a/supabase/migrations/20260524150000_public_schema_api_grants.sql
+++ b/supabase/migrations/20260524150000_public_schema_api_grants.sql
@@ -21,9 +21,10 @@ GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.profiles,
   public.episode_media,
   public.practitioner_access,
   public.caretaker_access,
-  public.practitioner_observation_notes,
-  public.practitioner_invites,
-  public.caretaker_invites TO authenticated;
+  public.practitioner_observation_notes TO authenticated;
+
+-- caretaker_invites / practitioner_invites: service_role + Edge Functions only (no authenticated
+-- policies in 20260510120000 / 20260515180000). Do not grant PostgREST table access here.
 
 -- No GRANT ON SEQUENCE: tables above use uuid PRIMARY KEY DEFAULT gen_random_uuid() (no serial/identity).
 

--- a/supabase/migrations/20260524200000_profiles_handle_new_user_trigger.sql
+++ b/supabase/migrations/20260524200000_profiles_handle_new_user_trigger.sql
@@ -76,7 +76,7 @@ DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
 CREATE TRIGGER on_auth_user_created
   AFTER INSERT ON auth.users
   FOR EACH ROW
-  EXECUTE PROCEDURE public.handle_new_user ();
+  EXECUTE FUNCTION public.handle_new_user ();
 
 -- Backfill profiles for auth users created before this migration.
 INSERT INTO public.profiles (id, app_role)

--- a/supabase/migrations/20260524200000_profiles_handle_new_user_trigger.sql
+++ b/supabase/migrations/20260524200000_profiles_handle_new_user_trigger.sql
@@ -1,0 +1,104 @@
+-- Provision public.profiles when Supabase Auth creates auth.users (official pattern:
+-- https://supabase.com/docs/guides/auth/managing-user-data#using-triggers).
+--
+-- Edge Functions stamp `app_role` in user metadata at invite time; self-signup defaults to patient.
+-- Practitioner rows require profiles_enforce_app_role bypass via transaction-local flag (only set here).
+
+CREATE OR REPLACE FUNCTION public.profiles_enforce_app_role ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = pg_catalog, public, pg_temp
+  AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.app_role = 'practitioner'
+      AND NOT public.profiles_trusted_session_for_app_role ()
+      AND current_setting('abstrack.provisioning_profile_from_auth', TRUE) IS DISTINCT FROM 'true' THEN
+      RAISE EXCEPTION 'profiles.app_role practitioner requires a trusted path';
+    END IF;
+    RETURN NEW;
+  END IF;
+  IF TG_OP = 'UPDATE' THEN
+    IF OLD.app_role IS DISTINCT FROM NEW.app_role
+      AND NOT public.profiles_trusted_session_for_app_role () THEN
+      RAISE EXCEPTION 'profiles.app_role cannot be changed without a trusted path';
+    END IF;
+    RETURN NEW;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.handle_new_user ()
+  RETURNS TRIGGER
+  LANGUAGE plpgsql
+  SECURITY DEFINER
+  SET search_path = ''
+  AS $$
+DECLARE
+  v_role text;
+BEGIN
+  v_role := COALESCE(new.raw_user_meta_data ->> 'app_role', 'patient');
+  IF v_role NOT IN ('patient', 'caretaker', 'practitioner') THEN
+    v_role := 'patient';
+  END IF;
+
+  -- Require invite stamps for non-patient roles (blocks self-signup metadata spoofing).
+  IF v_role = 'practitioner'
+    AND nullif(trim(new.raw_user_meta_data ->> 'abstrack_practitioner_invite_id'), '') IS NULL THEN
+    v_role := 'patient';
+  ELSIF v_role = 'caretaker'
+    AND nullif(trim(new.raw_user_meta_data ->> 'abstrack_caretaker_invite_id'), '') IS NULL THEN
+    v_role := 'patient';
+  END IF;
+
+  IF v_role = 'practitioner' THEN
+    PERFORM set_config('abstrack.provisioning_profile_from_auth', 'true', TRUE);
+  END IF;
+
+  INSERT INTO public.profiles (id, app_role)
+    VALUES (new.id, v_role)
+  ON CONFLICT (id)
+    DO NOTHING;
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.handle_new_user () IS 'After insert on auth.users: creates profiles from invite-stamped app_role metadata (Edge Functions) or patient for self-signup.';
+
+REVOKE ALL ON FUNCTION public.handle_new_user ()
+FROM PUBLIC;
+
+DROP TRIGGER IF EXISTS on_auth_user_created ON auth.users;
+
+CREATE TRIGGER on_auth_user_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW
+  EXECUTE PROCEDURE public.handle_new_user ();
+
+-- Backfill profiles for auth users created before this migration.
+INSERT INTO public.profiles (id, app_role)
+SELECT
+  u.id,
+  CASE
+  WHEN COALESCE(u.raw_user_meta_data ->> 'app_role', 'patient') = 'practitioner'
+    AND nullif(trim(u.raw_user_meta_data ->> 'abstrack_practitioner_invite_id'), '') IS NOT NULL THEN
+    'practitioner'
+  WHEN COALESCE(u.raw_user_meta_data ->> 'app_role', 'patient') = 'caretaker'
+    AND nullif(trim(u.raw_user_meta_data ->> 'abstrack_caretaker_invite_id'), '') IS NOT NULL THEN
+    'caretaker'
+  ELSE
+    'patient'
+  END
+FROM
+  auth.users AS u
+WHERE
+  NOT EXISTS (
+    SELECT
+      1
+    FROM
+      public.profiles AS p
+    WHERE
+      p.id = u.id);

--- a/supabase/migrations/20260524200000_profiles_handle_new_user_trigger.sql
+++ b/supabase/migrations/20260524200000_profiles_handle_new_user_trigger.sql
@@ -30,6 +30,8 @@ BEGIN
 END;
 $$;
 
+COMMENT ON FUNCTION public.profiles_enforce_app_role () IS 'Blocks practitioner self-signup and arbitrary app_role changes unless session is trusted (service_role / postgres). On INSERT, also allows practitioner when transaction-local abstrack.provisioning_profile_from_auth is true (set only by public.handle_new_user during auth.users provisioning).';
+
 CREATE OR REPLACE FUNCTION public.handle_new_user ()
   RETURNS TRIGGER
   LANGUAGE plpgsql


### PR DESCRIPTION
Closes #204

## Summary

Adds a unified **Settings** page to user web (`/settings`) as the last sidebar item, replacing separate Caretaker and Practitioner nav links.

- **Account tab:** first/last name (stored as `profiles.display_name`), email change with Supabase confirmation flow, and sign-out-everywhere with confirmation dialog (clears MFA trust bundle and `sb-*-auth-token` localStorage keys before global logout)
- **Security tab:** add/change/revoke password (via `abstrack_password_set` metadata, 8–72 character client validation), optional TOTP enrollment and factor management
- **Invites tab (patients only):** caretaker and practitioner access UIs merged on one tab. Non-patients do not see this tab; `/settings?tab=invites` is sanitized to `/settings` once profile role is known

**Legacy URLs:** standalone `/settings/caretaker` and `/settings/practitioner` routes were removed with the nav consolidation. There are no Next.js redirects or middleware rewrites for those paths—authenticated users hitting the old URLs will get a 404. (No shipped users or bookmarks expected after DB reset.)

Also extends auth session context with `user_metadata`, supports global logout via `POST /api/auth/logout?scope=global`, sets password metadata on sign-up and `/update-password`, and adds focused unit tests for MFA message mappers and trusted-session restore.

## Test plan

- [ ] Sidebar shows **Settings** last; Caretaker/Practitioner links are gone
- [ ] **Account:** save name, request email change (confirm via inbox link), sign out everywhere (all sessions end)
- [ ] **Security:** add/change password (reject >72 chars client-side); revoke password (magic-link-only); enroll and remove TOTP
- [ ] **Invites (patient):** caretaker and practitioner invite flows still work on the Invites tab
- [ ] **Non-patient roles:** no Invites tab; visiting `/settings?tab=invites` replaces URL with `/settings` and shows Account
- [ ] **Legacy URLs:** `/settings/caretaker` and `/settings/practitioner` return 404 (expected)
- [ ] `pnpm exec nx test @abstrack/web` and `pnpm exec nx run @abstrack/web:build` pass