### PR TITLE
feat(practitioner): add account and security settings page

### DIFF
--- a/apps/practitioner/specs/index.spec.tsx
+++ b/apps/practitioner/specs/index.spec.tsx
@@ -47,11 +47,8 @@ function renderPage() {
 
 function expectPractitionerSignOutButton() {
   expect(screen.getByTestId('practitioner-sign-out')).toBeTruthy();
-  expect(screen.getByTestId('practitioner-sign-out-everywhere')).toBeTruthy();
   expect(screen.getByRole('button', { name: /^Log out$/i })).toBeTruthy();
-  expect(
-    screen.getByRole('button', { name: /^Sign out everywhere$/i }),
-  ).toBeTruthy();
+  expect(screen.queryByTestId('practitioner-sign-out-everywhere')).toBeNull();
 }
 
 const patientProfileRow: PractitionerSupabaseProfilesRow = {

--- a/apps/practitioner/specs/settings-page.spec.tsx
+++ b/apps/practitioner/specs/settings-page.spec.tsx
@@ -1,0 +1,292 @@
+import {
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+  within,
+} from '@testing-library/react';
+import { LiveAnnouncerProvider } from '@abstrack/ui/a11y-web';
+import type { Session } from '@abstrack/supabase';
+import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import { SettingsPage } from '../src/components/settings/SettingsPage';
+import { PRACTITIONER_APP_NAV_ITEMS } from '../src/lib/practitioner-nav-items';
+import { practitionerSignOutEverywhere } from '../src/lib/practitioner-device-trust';
+import { useAuth } from '../src/lib/auth-provider';
+import { PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY } from '../src/lib/practitioner-password-sign-in';
+
+jest.mock('../src/lib/auth-provider', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('@abstrack/supabase/browser', () => ({
+  getSupabaseBrowserClient: jest.fn(),
+}));
+
+jest.mock('../src/lib/practitioner-device-trust', () => ({
+  practitionerSignOutEverywhere: jest.fn(),
+}));
+
+jest.mock('../src/lib/practitioner-sign-out-pending', () => ({
+  isPractitionerSignOutTransition: jest.fn(() => false),
+}));
+
+const replaceMock = jest.fn();
+let mockSearchParams = new URLSearchParams();
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({ replace: replaceMock }),
+  useSearchParams: () => mockSearchParams,
+}));
+
+const mockedUseAuth = jest.mocked(useAuth);
+const mockedGetClient = jest.mocked(getSupabaseBrowserClient);
+const mockedSignOutEverywhere = jest.mocked(practitionerSignOutEverywhere);
+
+const USER_ID = '00000000-0000-0000-0000-000000000001';
+
+function ensureDialogElementPolyfill(): void {
+  HTMLDialogElement.prototype.showModal =
+    HTMLDialogElement.prototype.showModal ||
+    function showModal(this: HTMLDialogElement) {
+      this.open = true;
+    };
+  HTMLDialogElement.prototype.close =
+    HTMLDialogElement.prototype.close ||
+    function close(this: HTMLDialogElement) {
+      this.open = false;
+      this.dispatchEvent(new Event('close'));
+    };
+}
+
+function practitionerSession(
+  userMetadata: Record<string, unknown> = {},
+): Session {
+  return {
+    access_token: 'test-access-token',
+    refresh_token: 'test-refresh-token',
+    expires_in: 3600,
+    expires_at: undefined,
+    token_type: 'bearer',
+    user: {
+      id: USER_ID,
+      aud: 'authenticated',
+      role: 'authenticated',
+      email: 'practitioner@example.com',
+      app_metadata: {},
+      user_metadata: userMetadata,
+      created_at: '',
+    },
+  } as Session;
+}
+
+function createSupabaseMock(options?: {
+  passwordSet?: boolean;
+  displayName?: string | null;
+}) {
+  const updateUserMock = jest.fn().mockResolvedValue({ error: null });
+  const getUserMock = jest.fn().mockResolvedValue({
+    data: {
+      user: {
+        id: USER_ID,
+        email: 'practitioner@example.com',
+        user_metadata: options?.passwordSet
+          ? { [PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY]: true }
+          : {},
+      },
+    },
+    error: null,
+  });
+  const listFactorsMock = jest.fn().mockResolvedValue({
+    data: { totp: [] },
+    error: null,
+  });
+
+  const client = {
+    from: jest.fn(() => ({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          maybeSingle: jest.fn().mockResolvedValue({
+            data: { display_name: options?.displayName ?? 'Dr Jane Doe' },
+            error: null,
+          }),
+        }),
+      }),
+      update: jest.fn().mockReturnValue({
+        eq: jest.fn().mockResolvedValue({ error: null }),
+      }),
+    })),
+    auth: {
+      getUser: getUserMock,
+      updateUser: updateUserMock,
+      mfa: {
+        listFactors: listFactorsMock,
+      },
+    },
+  };
+
+  return { client, updateUserMock, getUserMock, listFactorsMock };
+}
+
+function renderSettingsPage() {
+  return render(
+    <LiveAnnouncerProvider>
+      <SettingsPage />
+    </LiveAnnouncerProvider>,
+  );
+}
+
+describe('PRACTITIONER_APP_NAV_ITEMS', () => {
+  it('includes Settings as the last sidebar link targeting /settings', () => {
+    const last = PRACTITIONER_APP_NAV_ITEMS.at(-1);
+    expect(last).toEqual(
+      expect.objectContaining({ href: '/settings', label: 'Settings' }),
+    );
+    expect(last?.match('/settings')).toBe(true);
+    expect(last?.match('/settings/security')).toBe(true);
+    expect(last?.match('/patients')).toBe(false);
+  });
+});
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    ensureDialogElementPolyfill();
+    replaceMock.mockClear();
+    mockedSignOutEverywhere.mockClear();
+    mockSearchParams = new URLSearchParams();
+    mockedUseAuth.mockReturnValue({
+      session: practitionerSession(),
+      loading: false,
+      profile: undefined,
+      profileError: null,
+      accessTokenClaims: null,
+      gate: { kind: 'ready' },
+    });
+    const { client } = createSupabaseMock();
+    mockedGetClient.mockReturnValue(
+      client as unknown as ReturnType<typeof getSupabaseBrowserClient>,
+    );
+  });
+
+  it('renders the account tab by default with name, email, and sessions sections', async () => {
+    renderSettingsPage();
+
+    expect(screen.getByRole('heading', { name: 'Settings' })).toBeTruthy();
+    expect(
+      screen
+        .getByRole('tab', { name: 'Account' })
+        .getAttribute('aria-selected'),
+    ).toBe('true');
+    expect(await screen.findByRole('heading', { name: 'Name' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Email' })).toBeTruthy();
+    expect(screen.getByRole('heading', { name: 'Sessions' })).toBeTruthy();
+  });
+
+  it('opens the security tab from the tab query string', async () => {
+    mockSearchParams = new URLSearchParams('tab=security');
+    renderSettingsPage();
+
+    expect(
+      screen
+        .getByRole('tab', { name: 'Security' })
+        .getAttribute('aria-selected'),
+    ).toBe('true');
+    expect(
+      await screen.findByRole('heading', { name: 'Add a password' }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('heading', {
+        name: 'Two-factor authentication (TOTP)',
+      }),
+    ).toBeTruthy();
+  });
+
+  it('updates the URL when the Security tab is selected', async () => {
+    renderSettingsPage();
+    await screen.findByRole('heading', { name: 'Name' });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Security' }));
+    expect(replaceMock).toHaveBeenCalledWith('/settings?tab=security', {
+      scroll: false,
+    });
+  });
+
+  it('clears the tab query when returning to Account', async () => {
+    mockSearchParams = new URLSearchParams('tab=security');
+    renderSettingsPage();
+    await screen.findByRole('heading', {
+      name: 'Two-factor authentication (TOTP)',
+    });
+
+    fireEvent.click(screen.getByRole('tab', { name: 'Account' }));
+    expect(replaceMock).toHaveBeenCalledWith('/settings', { scroll: false });
+  });
+
+  it('requests email change with a callback redirect to the account tab', async () => {
+    const { client, updateUserMock } = createSupabaseMock();
+    mockedGetClient.mockReturnValue(
+      client as unknown as ReturnType<typeof getSupabaseBrowserClient>,
+    );
+
+    renderSettingsPage();
+    await screen.findByRole('heading', { name: 'Name' });
+
+    fireEvent.change(screen.getByLabelText(/New email/i), {
+      target: { value: 'new@example.com' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /Send confirmation email/i }),
+    );
+
+    await waitFor(() => {
+      expect(updateUserMock).toHaveBeenCalledWith(
+        { email: 'new@example.com' },
+        expect.objectContaining({
+          emailRedirectTo: expect.stringContaining(
+            'next=%2Fsettings%3Ftab%3Daccount',
+          ),
+        }),
+      );
+    });
+  });
+
+  it('opens a confirmation dialog for sign out everywhere', async () => {
+    renderSettingsPage();
+    await screen.findByRole('heading', { name: 'Name' });
+
+    fireEvent.click(
+      screen.getByRole('button', { name: /Sign out everywhere/i }),
+    );
+
+    const dialog = screen.getByRole('dialog', { name: /Sign out everywhere/i });
+    expect(
+      within(dialog).getByText(/ends your ABStrack session/i),
+    ).toBeTruthy();
+  });
+
+  it('shows change-password UI when password sign-in is enabled', async () => {
+    mockSearchParams = new URLSearchParams('tab=security');
+    mockedUseAuth.mockReturnValue({
+      session: practitionerSession({
+        [PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY]: true,
+      }),
+      loading: false,
+      profile: undefined,
+      profileError: null,
+      accessTokenClaims: null,
+      gate: { kind: 'ready' },
+    });
+    const { client } = createSupabaseMock({ passwordSet: true });
+    mockedGetClient.mockReturnValue(
+      client as unknown as ReturnType<typeof getSupabaseBrowserClient>,
+    );
+
+    renderSettingsPage();
+
+    expect(
+      await screen.findByRole('heading', { name: 'Change password' }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole('button', { name: /Revoke password sign-in/i }),
+    ).toBeTruthy();
+  });
+});

--- a/apps/practitioner/src/app/api/auth/logout/route.spec.ts
+++ b/apps/practitioner/src/app/api/auth/logout/route.spec.ts
@@ -52,17 +52,24 @@ describe('POST /api/auth/logout', () => {
   });
 
   it('redirects and signs out when Origin matches', async () => {
+    const signOut = jest.fn().mockResolvedValue(undefined);
+    mockedCreate.mockReturnValue({
+      auth: { signOut },
+    } as never);
+
     const request = {
       url: 'https://practitioner.example.com/api/auth/logout',
       headers: new Headers({
         Origin: 'https://practitioner.example.com',
       }),
       cookies: { getAll: jest.fn(() => []) },
+      nextUrl: { searchParams: new URLSearchParams() },
     } as unknown as NextRequest;
 
     const response = await POST(request);
 
     expect(mockedCreate).toHaveBeenCalled();
+    expect(signOut).toHaveBeenCalledWith(undefined);
     expect(response).toEqual(
       expect.objectContaining({
         type: 'redirect',
@@ -70,5 +77,25 @@ describe('POST /api/auth/logout', () => {
         location: expect.stringContaining('/login'),
       }),
     );
+  });
+
+  it('passes global scope when requested', async () => {
+    const signOut = jest.fn().mockResolvedValue(undefined);
+    mockedCreate.mockReturnValue({
+      auth: { signOut },
+    } as never);
+
+    const request = {
+      url: 'https://practitioner.example.com/api/auth/logout?scope=global',
+      headers: new Headers({
+        Origin: 'https://practitioner.example.com',
+      }),
+      cookies: { getAll: jest.fn(() => []) },
+      nextUrl: { searchParams: new URLSearchParams('scope=global') },
+    } as unknown as NextRequest;
+
+    await POST(request);
+
+    expect(signOut).toHaveBeenCalledWith({ scope: 'global' });
   });
 });

--- a/apps/practitioner/src/app/api/auth/logout/route.ts
+++ b/apps/practitioner/src/app/api/auth/logout/route.ts
@@ -4,9 +4,9 @@ import { getSameOriginLogoutPostFailure } from '@/lib/same-origin-logout-post';
 
 /**
  * Signs out the current practitioner session and clears auth cookies (full Supabase sign-out).
- * Revokes refresh tokens server-side; the MFA “trusted device” bundle in `localStorage` may be
- * stale until the next sign-in attempt clears it. Prefer the in-app Log out control for trust-aware
- * sign-out when available.
+ * Supports optional `?scope=global` to revoke refresh tokens on all devices. The MFA “trusted
+ * device” bundle in `localStorage` may be stale until the next sign-in attempt clears it. Prefer
+ * the in-app Log out control for trust-aware sign-out when available.
  *
  * Rejects cross-site `POST` requests (same-origin / `Sec-Fetch-Site` / `Referer` checks) before
  * mutating session state, to mitigate CSRF-driven logouts.
@@ -37,6 +37,10 @@ export async function POST(request: NextRequest) {
     },
   });
 
-  await supabase.auth.signOut();
+  const scopeParam = request.nextUrl.searchParams.get('scope');
+  const scope = scopeParam === 'global' ? 'global' : undefined;
+
+  await supabase.auth.signOut(scope ? { scope } : undefined);
+
   return response;
 }

--- a/apps/practitioner/src/app/auth/callback/route.spec.ts
+++ b/apps/practitioner/src/app/auth/callback/route.spec.ts
@@ -78,11 +78,46 @@ describe('practitioner auth callback route', () => {
     );
   });
 
+  it('redirects successfully when code exchange fails but an existing session is valid', async () => {
+    const refreshSession = jest.fn(async () => ({
+      data: { session: {} },
+      error: null,
+    }));
+    createServerClientMock.mockReturnValue({
+      auth: {
+        exchangeCodeForSession: jest.fn(async () => ({
+          error: { message: 'invalid grant' },
+        })),
+        getUser: jest.fn(async () => ({
+          data: { user: { id: 'user-1' } },
+          error: null,
+        })),
+        refreshSession,
+      },
+    } as unknown as ServerClient);
+
+    const response = await GET(
+      makeRequest(
+        'https://example.com/auth/callback?code=abc&next=/settings?tab=account',
+      ),
+    );
+    const redirectUrl = new URL((response as { location: string }).location);
+
+    expect(refreshSession).toHaveBeenCalled();
+    expect(redirectUrl.pathname).toBe('/settings');
+    expect(redirectUrl.searchParams.get('tab')).toBe('account');
+    expect(redirectUrl.searchParams.get('error')).toBeNull();
+  });
+
   it('redirects with an error when session exchange fails', async () => {
     createServerClientMock.mockReturnValue({
       auth: {
         exchangeCodeForSession: jest.fn(async () => ({
           error: { message: 'invalid grant' },
+        })),
+        getUser: jest.fn(async () => ({
+          data: { user: null },
+          error: null,
         })),
       },
     } as unknown as ServerClient);

--- a/apps/practitioner/src/app/auth/callback/route.ts
+++ b/apps/practitioner/src/app/auth/callback/route.ts
@@ -20,6 +20,10 @@ function redirectWithError(
  * can attach session cookies. Implicit auth (`#access_token=…` only) is rewritten to
  * `/auth/callback/fragment` in `src/proxy.ts` (Next.js 16 proxy); this handler returns **400** if
  * it receives a request without `code` (e.g. direct hits without the proxy).
+ *
+ * When {@link AbstrackSupabaseClient.auth.exchangeCodeForSession} fails but the request already
+ * has a valid session (common after email-change verification), redirects to `next` without an
+ * `error` query param and refreshes the session so JWT claims match the updated user.
  */
 export async function GET(request: NextRequest) {
   const code = request.nextUrl.searchParams.get('code');
@@ -57,8 +61,19 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    const { error } = await supabase.auth.exchangeCodeForSession(code);
-    if (error) {
+    const { error: exchangeError } =
+      await supabase.auth.exchangeCodeForSession(code);
+    if (exchangeError) {
+      const {
+        data: { user },
+        error: userError,
+      } = await supabase.auth.getUser();
+      if (user && !userError) {
+        // Email change and similar flows can verify server-side while the PKCE code is
+        // already consumed or unnecessary when the browser still holds a valid session.
+        await supabase.auth.refreshSession();
+        return response;
+      }
       return redirectWithError(
         request,
         redirectPath,

--- a/apps/practitioner/src/app/global.css
+++ b/apps/practitioner/src/app/global.css
@@ -18,6 +18,10 @@
     --app-primary-on-solid: 255 255 255;
     --app-primary-soft: 219 234 254;
     --app-ring: 37 99 235;
+    /* Segmented tab lists (Settings): active pill bg + label must meet contrast in both themes. */
+    --app-tab-active-bg: 219 234 254;
+    --app-tab-active-text: 29 78 216;
+    --app-tab-active-ring: 29 78 216;
     --app-header-bg: rgba(255, 255, 255, 0.92);
     --app-sidebar-bg: rgba(255, 255, 255, 0.94);
     --app-header-border: rgba(226, 232, 240, 0.95);
@@ -46,6 +50,9 @@
     --app-primary-on-solid: 255 255 255;
     --app-primary-soft: 37 99 235;
     --app-ring: 147 197 253;
+    --app-tab-active-bg: 30 58 138;
+    --app-tab-active-text: 219 234 254;
+    --app-tab-active-ring: 147 197 253;
     --app-header-bg: rgba(15, 23, 42, 0.92);
     --app-sidebar-bg: rgba(15, 23, 42, 0.94);
     --app-header-border: rgba(51, 65, 85, 0.95);
@@ -76,6 +83,9 @@
       --app-primary-on-solid: 255 255 255;
       --app-primary-soft: 219 234 254;
       --app-ring: 30 64 175;
+      --app-tab-active-bg: 219 234 254;
+      --app-tab-active-text: 30 64 175;
+      --app-tab-active-ring: 30 64 175;
       --app-header-bg: rgba(255, 255, 255, 1);
       --app-sidebar-bg: rgba(255, 255, 255, 1);
       --app-header-border: rgba(15, 23, 42, 0.85);
@@ -98,6 +108,9 @@
       --app-primary-on-solid: 255 255 255;
       --app-primary-soft: 30 64 175;
       --app-ring: 250 204 21;
+      --app-tab-active-bg: 255 255 255;
+      --app-tab-active-text: 0 0 0;
+      --app-tab-active-ring: 250 204 21;
       --app-header-bg: rgba(0, 0, 0, 1);
       --app-sidebar-bg: rgba(0, 0, 0, 1);
       --app-header-border: rgba(255, 255, 255, 0.9);

--- a/apps/practitioner/src/app/settings/page.tsx
+++ b/apps/practitioner/src/app/settings/page.tsx
@@ -1,0 +1,28 @@
+import type { Metadata } from 'next';
+import { Suspense } from 'react';
+import { SettingsPage } from '@/components/settings/SettingsPage';
+
+export const metadata: Metadata = {
+  title: 'Settings | ABStrack Practitioner',
+  description:
+    'Account and security settings for healthcare practitioners on ABStrack.',
+};
+
+/**
+ * Settings hub for the practitioner app: account details and security controls.
+ *
+ * @returns Settings page wrapped in Suspense for search-param tabs.
+ */
+export default function SettingsRoutePage() {
+  return (
+    <Suspense
+      fallback={
+        <p className="text-sm text-app-muted" role="status">
+          Loading settings…
+        </p>
+      }
+    >
+      <SettingsPage />
+    </Suspense>
+  );
+}

--- a/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
+++ b/apps/practitioner/src/components/app-shell/PractitionerAppShell.tsx
@@ -46,7 +46,9 @@ export function PractitionerAppShell({ children }: PractitionerAppShellProps) {
     return <>{children}</>;
   }
 
-  if (loading || !session) {
+  // Keep sidebar/top nav mounted whenever a session exists. Profile reloads after token
+  // refresh must not strip chrome (user web never flips `loading` after bootstrap).
+  if (!session) {
     const minHeightClass = loading
       ? 'min-h-svh'
       : 'min-h-[calc(100svh-4.5rem)]';
@@ -86,7 +88,7 @@ export function PractitionerAppShell({ children }: PractitionerAppShellProps) {
           actions={<PractitionerSignOutButton />}
           sidebarTriggerAriaLabel="Open practitioner navigation menu"
           mobileSheetTitle="Account"
-          mobileSheetDescription="Signed-in account, sign out, and appearance settings."
+          mobileSheetDescription="Signed-in account, log out, and appearance settings."
           mobileMenuTriggerAriaLabel="Open account menu"
         />
       }

--- a/apps/practitioner/src/components/practitioner-sign-out-button.tsx
+++ b/apps/practitioner/src/components/practitioner-sign-out-button.tsx
@@ -5,10 +5,7 @@ import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { ACCOUNT_ACTIONS_SURFACE_CLASS } from '@abstrack/ui-web';
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { practitionerSignOut } from '@/lib/practitioner-device-trust';
-import {
-  clearPractitionerSignOutPending,
-  markPractitionerSignOutPending,
-} from '@/lib/practitioner-sign-out-pending';
+import { clearPractitionerSignOutPending } from '@/lib/practitioner-sign-out-pending';
 
 export type PractitionerSignOutButtonProps = {
   /** Visible button label for the default (session-aware) sign-out. */
@@ -51,7 +48,6 @@ export function PractitionerSignOutButton({
     }
     setError(null);
     setSigningOut(true);
-    markPractitionerSignOutPending();
     void practitionerSignOut(supabase)
       .catch((err: unknown) => {
         console.error('Practitioner sign out failed', err);

--- a/apps/practitioner/src/components/practitioner-sign-out-button.tsx
+++ b/apps/practitioner/src/components/practitioner-sign-out-button.tsx
@@ -4,11 +4,11 @@ import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
 import { useAnnounce } from '@abstrack/ui/a11y-web';
 import { ACCOUNT_ACTIONS_SURFACE_CLASS } from '@abstrack/ui-web';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { practitionerSignOut } from '@/lib/practitioner-device-trust';
 import {
-  isPractitionerMfaDeviceTrustActive,
-  practitionerSignOut,
-  practitionerSignOutEverywhere,
-} from '@/lib/practitioner-device-trust';
+  clearPractitionerSignOutPending,
+  markPractitionerSignOutPending,
+} from '@/lib/practitioner-sign-out-pending';
 
 export type PractitionerSignOutButtonProps = {
   /** Visible button label for the default (session-aware) sign-out. */
@@ -21,13 +21,11 @@ export type PractitionerSignOutButtonProps = {
 };
 
 /**
- * Practitioner sign-out: default action respects MFA device trust (soft local clear) when active;
- * secondary action performs full server sign-out via `POST /api/auth/logout`. Primary and secondary
- * buttons share {@link ACCOUNT_ACTIONS_SURFACE_CLASS} with user web top nav; pass `className` on the
- * primary control only to override.
+ * Practitioner sign-out: respects MFA device trust (soft local clear) when active, otherwise
+ * performs a full `signOut()`. Full sign-out on all devices lives in Settings.
  *
  * @param props - Labels and styling.
- * @returns Accessible sign-out controls and optional trust explanation.
+ * @returns Accessible sign-out control.
  */
 export function PractitionerSignOutButton({
   label = 'Log out',
@@ -37,11 +35,8 @@ export function PractitionerSignOutButton({
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
   const { announce } = useAnnounce();
   const [signingOut, setSigningOut] = useState(false);
-  /** True after choosing full server sign-out until navigation completes. */
-  const [signingOutEverywhere, setSigningOutEverywhere] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const mountedRef = useRef(true);
-  const [trustActive, setTrustActive] = useState(false);
 
   useEffect(() => {
     mountedRef.current = true;
@@ -50,48 +45,17 @@ export function PractitionerSignOutButton({
     };
   }, []);
 
-  useEffect(() => {
-    const sync = async () => {
-      try {
-        const {
-          data: { user },
-        } = await supabase.auth.getUser();
-        if (!mountedRef.current) {
-          return;
-        }
-        setTrustActive(isPractitionerMfaDeviceTrustActive(user?.id));
-      } catch (syncError) {
-        console.error(
-          'Practitioner sign-out button: session sync failed',
-          syncError,
-        );
-        if (!mountedRef.current) {
-          return;
-        }
-        setTrustActive(false);
-      }
-    };
-
-    void sync();
-
-    const {
-      data: { subscription },
-    } = supabase.auth.onAuthStateChange(() => {
-      void sync();
-    });
-
-    return () => subscription.unsubscribe();
-  }, [supabase]);
-
   const handleLocalSignOut = () => {
     if (signingOut) {
       return;
     }
     setError(null);
     setSigningOut(true);
+    markPractitionerSignOutPending();
     void practitionerSignOut(supabase)
       .catch((err: unknown) => {
         console.error('Practitioner sign out failed', err);
+        clearPractitionerSignOutPending();
         if (!mountedRef.current) {
           return;
         }
@@ -109,55 +73,18 @@ export function PractitionerSignOutButton({
       });
   };
 
-  const handleSignOutEverywhere = () => {
-    if (signingOut || signingOutEverywhere) {
-      return;
-    }
-    setError(null);
-    setSigningOutEverywhere(true);
-    announce('Signing out from all sessions.', { politeness: 'polite' });
-    practitionerSignOutEverywhere();
-  };
-
-  const busy = signingOut || signingOutEverywhere;
-
   return (
     <div className="inline-flex max-w-full flex-col gap-2">
-      {trustActive ? (
-        <p
-          id="practitioner-sign-out-trust-hint"
-          className="max-w-prose text-xs text-app-muted"
-        >
-          Device trust is on: &quot;{label}&quot; clears this browser session
-          without revoking the saved trust token so you can skip TOTP on the
-          next sign-in here. On a shared computer, use Sign out everywhere.
-        </p>
-      ) : null}
-      <div className="flex flex-wrap gap-2">
-        <button
-          type="button"
-          data-testid="practitioner-sign-out"
-          className={primaryClassName}
-          disabled={busy}
-          {...(busy ? { 'aria-busy': true as const } : {})}
-          aria-describedby={
-            trustActive ? 'practitioner-sign-out-trust-hint' : undefined
-          }
-          onClick={handleLocalSignOut}
-        >
-          {busy ? 'Signing out…' : label}
-        </button>
-        <button
-          type="button"
-          data-testid="practitioner-sign-out-everywhere"
-          className={ACCOUNT_ACTIONS_SURFACE_CLASS}
-          disabled={busy}
-          {...(signingOutEverywhere ? { 'aria-busy': true as const } : {})}
-          onClick={handleSignOutEverywhere}
-        >
-          {signingOutEverywhere ? 'Signing out…' : 'Sign out everywhere'}
-        </button>
-      </div>
+      <button
+        type="button"
+        data-testid="practitioner-sign-out"
+        className={primaryClassName}
+        disabled={signingOut}
+        {...(signingOut ? { 'aria-busy': true as const } : {})}
+        onClick={handleLocalSignOut}
+      >
+        {signingOut ? 'Signing out…' : label}
+      </button>
       {error ? (
         <p
           role="alert"

--- a/apps/practitioner/src/components/settings/SettingsPage.tsx
+++ b/apps/practitioner/src/components/settings/SettingsPage.tsx
@@ -1,0 +1,729 @@
+'use client';
+
+import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+  type KeyboardEvent,
+} from 'react';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { SettingsSecuritySection } from '@/components/settings/SettingsSecuritySection';
+import { useAuth } from '@/lib/auth-provider';
+import { practitionerSignOutEverywhere } from '@/lib/practitioner-device-trust';
+import { isPractitionerSignOutTransition } from '@/lib/practitioner-sign-out-pending';
+import {
+  PRACTITIONER_TITLE_USER_METADATA_KEY,
+  combinePractitionerNameFieldsIntoDisplayName,
+  readPractitionerTitleFromUserMetadata,
+  splitDisplayNameIntoPractitionerNameFields,
+} from '@/lib/practitioner-profile-display-name';
+import { readPendingEmailChange } from '@/lib/pending-email-change';
+import {
+  PRACTITIONER_SETTINGS_TAB_IDS,
+  type PractitionerSettingsTabId,
+  parsePractitionerSettingsTabId,
+} from '@/lib/settings-tabs';
+
+const SETTINGS_SURFACE_CLASS =
+  'rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8';
+
+const TAB_ORDER = PRACTITIONER_SETTINGS_TAB_IDS;
+
+/** How long the name-save confirmation stays visible before reverting. */
+const NAME_SAVE_FEEDBACK_MS = 3_000;
+
+function tabClass(active: boolean): string {
+  return active
+    ? 'inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full bg-app-tab-active-bg px-4 py-2 text-sm font-semibold text-app-tab-active-text shadow-sm ring-1 ring-app-tab-active-ring/25'
+    : 'inline-flex min-h-[44px] flex-1 items-center justify-center rounded-full px-4 py-2 text-sm font-medium text-app-muted transition hover:bg-[var(--app-nav-hover-bg)] hover:text-app-ink';
+}
+
+/**
+ * Account and security settings for the practitioner web app.
+ *
+ * @returns Settings hub with tabbed sections.
+ */
+export function SettingsPage() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const formId = useId();
+  const { announce } = useAnnounce();
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const { session, loading: authLoading } = useAuth();
+
+  const tabFromUrl = parsePractitionerSettingsTabId(searchParams.get('tab'));
+  const [activeTab, setActiveTab] =
+    useState<PractitionerSettingsTabId>(tabFromUrl);
+  const [signOutEverywhereOpen, setSignOutEverywhereOpen] = useState(false);
+  const [securitySectionMounted, setSecuritySectionMounted] = useState(false);
+
+  const [profileLoading, setProfileLoading] = useState(true);
+  const [title, setTitle] = useState('');
+  const [firstName, setFirstName] = useState('');
+  const [lastName, setLastName] = useState('');
+  const [nameSubmitting, setNameSubmitting] = useState(false);
+  const [nameSavedVisible, setNameSavedVisible] = useState(false);
+  const [nameError, setNameError] = useState<string | null>(null);
+  const nameSavedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+
+  const [currentEmail, setCurrentEmail] = useState('');
+  const [newEmail, setNewEmail] = useState('');
+  const [emailSubmitting, setEmailSubmitting] = useState(false);
+  const [emailError, setEmailError] = useState<string | null>(null);
+  const [pendingEmailChange, setPendingEmailChange] = useState<string | null>(
+    null,
+  );
+  const [showEmailChangeForm, setShowEmailChangeForm] = useState(true);
+
+  const tabButtonRefs = useRef<
+    Partial<Record<PractitionerSettingsTabId, HTMLButtonElement>>
+  >({});
+  const authInitiallyResolvedRef = useRef(false);
+  const loadedProfileUserIdRef = useRef<string | null>(null);
+  const nameFormDirtyRef = useRef(false);
+  const tabId = (tab: PractitionerSettingsTabId) =>
+    `${formId}-settings-tab-${tab}`;
+  const panelId = (tab: PractitionerSettingsTabId) =>
+    `${formId}-settings-panel-${tab}`;
+
+  useEffect(() => {
+    if (activeTab === 'security') {
+      setSecuritySectionMounted(true);
+    }
+  }, [activeTab]);
+
+  useEffect(() => {
+    if (!authLoading) {
+      authInitiallyResolvedRef.current = true;
+    }
+  }, [authLoading]);
+
+  useEffect(() => {
+    setActiveTab(tabFromUrl);
+  }, [tabFromUrl]);
+
+  const setTab = useCallback(
+    (tab: PractitionerSettingsTabId) => {
+      setActiveTab(tab);
+      const params = new URLSearchParams(searchParams.toString());
+      if (tab === 'account') {
+        params.delete('tab');
+      } else {
+        params.set('tab', tab);
+      }
+      const qs = params.toString();
+      router.replace(qs ? `/settings?${qs}` : '/settings', { scroll: false });
+    },
+    [router, searchParams],
+  );
+
+  const loadProfile = useCallback(async () => {
+    const userId = session?.user?.id;
+    if (!userId) {
+      setProfileLoading(false);
+      loadedProfileUserIdRef.current = null;
+      nameFormDirtyRef.current = false;
+      return;
+    }
+
+    const isInitialLoadForUser = loadedProfileUserIdRef.current !== userId;
+    if (!isInitialLoadForUser) {
+      return;
+    }
+
+    nameFormDirtyRef.current = false;
+    setProfileLoading(true);
+    setNameError(null);
+
+    const [{ data, error }, { data: userData, error: userError }] =
+      await Promise.all([
+        supabase
+          .from('profiles')
+          .select('display_name')
+          .eq('id', userId)
+          .maybeSingle(),
+        supabase.auth.getUser(),
+      ]);
+
+    if (error) {
+      setNameError('Unable to load your profile. Try again in a moment.');
+      setProfileLoading(false);
+      return;
+    }
+    if (userError) {
+      setNameError(
+        'Unable to load your account details. Try again in a moment.',
+      );
+      setProfileLoading(false);
+      return;
+    }
+    if (data == null) {
+      setNameError(
+        'Your account is missing a profile record. Sign out and complete your invite link again, or contact support.',
+      );
+      setProfileLoading(false);
+      return;
+    }
+    if (!nameFormDirtyRef.current) {
+      const titleFromMetadata = readPractitionerTitleFromUserMetadata(
+        userData.user,
+      );
+      const names = splitDisplayNameIntoPractitionerNameFields(
+        data?.display_name,
+        titleFromMetadata,
+      );
+      setTitle(names.title);
+      setFirstName(names.firstName);
+      setLastName(names.lastName);
+    }
+    setCurrentEmail(session.user.email ?? '');
+    loadedProfileUserIdRef.current = userId;
+    setProfileLoading(false);
+  }, [session?.user?.email, session?.user?.id, supabase]);
+
+  useEffect(() => {
+    if (authLoading) {
+      return;
+    }
+    void loadProfile();
+  }, [authLoading, loadProfile, session?.user?.id]);
+
+  useEffect(() => {
+    if (authLoading || !session?.user?.id) {
+      return;
+    }
+    setCurrentEmail(session.user.email ?? '');
+  }, [authLoading, session?.user?.email, session?.user?.id]);
+
+  useEffect(() => {
+    if (authLoading || !session?.user?.id) {
+      return;
+    }
+    void supabase.auth.getUser().then(({ data: { user } }) => {
+      const pending = readPendingEmailChange(user);
+      if (pending) {
+        setPendingEmailChange(pending);
+        setShowEmailChangeForm(false);
+      }
+    });
+  }, [authLoading, session?.user?.id, supabase]);
+
+  useEffect(() => {
+    if (!pendingEmailChange) {
+      return;
+    }
+    const normalizedCurrent = currentEmail.trim().toLowerCase();
+    if (
+      normalizedCurrent !== '' &&
+      normalizedCurrent === pendingEmailChange.trim().toLowerCase()
+    ) {
+      setPendingEmailChange(null);
+      setShowEmailChangeForm(true);
+    }
+  }, [currentEmail, pendingEmailChange]);
+
+  useEffect(() => {
+    return () => {
+      if (nameSavedTimeoutRef.current) {
+        clearTimeout(nameSavedTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const clearNameSaveFeedback = useCallback(() => {
+    if (nameSavedTimeoutRef.current) {
+      clearTimeout(nameSavedTimeoutRef.current);
+      nameSavedTimeoutRef.current = null;
+    }
+    setNameSavedVisible(false);
+  }, []);
+
+  const showNameSaveFeedback = useCallback(() => {
+    clearNameSaveFeedback();
+    setNameSavedVisible(true);
+    nameSavedTimeoutRef.current = setTimeout(() => {
+      setNameSavedVisible(false);
+      nameSavedTimeoutRef.current = null;
+    }, NAME_SAVE_FEEDBACK_MS);
+  }, [clearNameSaveFeedback]);
+
+  const onNameSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!session?.user?.id) {
+      return;
+    }
+    setNameSubmitting(true);
+    setNameError(null);
+    clearNameSaveFeedback();
+    const displayName = combinePractitionerNameFieldsIntoDisplayName({
+      title,
+      firstName,
+      lastName,
+    });
+    const trimmedTitle = title.trim();
+    const [{ error: profileError }, { error: metadataError }] =
+      await Promise.all([
+        supabase
+          .from('profiles')
+          .update({ display_name: displayName })
+          .eq('id', session.user.id),
+        supabase.auth.updateUser({
+          data: {
+            [PRACTITIONER_TITLE_USER_METADATA_KEY]: trimmedTitle || null,
+          },
+        }),
+      ]);
+    setNameSubmitting(false);
+    if (profileError || metadataError) {
+      setNameError('Unable to save your name. Try again.');
+      announce('Unable to save your name.', { politeness: 'assertive' });
+      return;
+    }
+    nameFormDirtyRef.current = false;
+    showNameSaveFeedback();
+    announce('Name saved.', { politeness: 'polite' });
+  };
+
+  const onEmailSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!session) {
+      return;
+    }
+    const trimmed = newEmail.trim().toLowerCase();
+    if (!trimmed) {
+      setEmailError('Enter a new email address.');
+      return;
+    }
+    if (trimmed === (session.user.email ?? '').trim().toLowerCase()) {
+      setEmailError('That is already your email address.');
+      return;
+    }
+    setEmailSubmitting(true);
+    setEmailError(null);
+    const nextPath = '/settings?tab=account';
+    const emailRedirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(nextPath)}`;
+    const { error } = await supabase.auth.updateUser(
+      { email: trimmed },
+      { emailRedirectTo },
+    );
+    setEmailSubmitting(false);
+    if (error) {
+      setEmailError(error.message);
+      announce(error.message, { politeness: 'assertive' });
+      return;
+    }
+    setPendingEmailChange(trimmed);
+    setShowEmailChangeForm(false);
+    setNewEmail('');
+    const msg = `Confirmation email sent to ${trimmed}. Open the link in that message to finish changing your email.`;
+    announce(msg, { politeness: 'polite' });
+  };
+
+  const onTabKeyDown = useCallback(
+    (
+      event: KeyboardEvent<HTMLButtonElement>,
+      current: PractitionerSettingsTabId,
+    ) => {
+      const currentIndex = TAB_ORDER.indexOf(current);
+      if (currentIndex < 0) {
+        return;
+      }
+      let nextIndex = currentIndex;
+      if (event.key === 'ArrowRight') {
+        nextIndex = (currentIndex + 1) % TAB_ORDER.length;
+      } else if (event.key === 'ArrowLeft') {
+        nextIndex = (currentIndex - 1 + TAB_ORDER.length) % TAB_ORDER.length;
+      } else if (event.key === 'Home') {
+        nextIndex = 0;
+      } else if (event.key === 'End') {
+        nextIndex = TAB_ORDER.length - 1;
+      } else {
+        return;
+      }
+      event.preventDefault();
+      const target = TAB_ORDER[nextIndex];
+      if (!target) {
+        return;
+      }
+      setTab(target);
+      tabButtonRefs.current[target]?.focus();
+    },
+    [setTab],
+  );
+
+  if (authLoading && !authInitiallyResolvedRef.current) {
+    return (
+      <p className="text-sm text-app-muted" role="status">
+        Loading settings…
+      </p>
+    );
+  }
+
+  if (!session) {
+    if (isPractitionerSignOutTransition(session)) {
+      return (
+        <p className="text-sm text-app-muted" role="status">
+          Signing out…
+        </p>
+      );
+    }
+    return (
+      <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+        You must be signed in to open settings.
+      </p>
+    );
+  }
+
+  const tabLabels: Record<PractitionerSettingsTabId, string> = {
+    account: 'Account',
+    security: 'Security',
+  };
+
+  return (
+    <div className="mx-auto w-full max-w-2xl space-y-8">
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight text-app-ink">
+          Settings
+        </h1>
+        <p className="mt-2 text-sm text-app-muted">
+          Manage your practitioner account and security preferences.
+        </p>
+      </div>
+
+      <div
+        role="tablist"
+        aria-label="Settings sections"
+        className="flex flex-wrap gap-2 rounded-2xl border border-app-border/90 bg-app-surface/80 p-2 shadow-sm dark:border-app-border-dark/90 dark:bg-app-surface-dark/60"
+      >
+        {TAB_ORDER.map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            role="tab"
+            id={tabId(tab)}
+            aria-controls={panelId(tab)}
+            aria-selected={activeTab === tab ? 'true' : 'false'}
+            tabIndex={activeTab === tab ? 0 : -1}
+            className={tabClass(activeTab === tab)}
+            ref={(node) => {
+              tabButtonRefs.current[tab] = node ?? undefined;
+            }}
+            onKeyDown={(event) => onTabKeyDown(event, tab)}
+            onClick={() => setTab(tab)}
+          >
+            {tabLabels[tab]}
+          </button>
+        ))}
+      </div>
+
+      <div
+        role="tabpanel"
+        id={panelId('account')}
+        aria-labelledby={tabId('account')}
+        hidden={activeTab !== 'account'}
+        tabIndex={0}
+        className="space-y-8 outline-none"
+      >
+        {activeTab === 'account' ? (
+          <>
+            <section
+              aria-labelledby={`${formId}-name-heading`}
+              className={SETTINGS_SURFACE_CLASS}
+            >
+              <h2
+                id={`${formId}-name-heading`}
+                className="text-lg font-semibold text-app-ink"
+              >
+                Name
+              </h2>
+              <p className="mt-2 text-sm text-app-muted">
+                Your name may appear when patients view who has access to their
+                health data.
+              </p>
+              {profileLoading ? (
+                <p className="mt-4 text-sm text-app-muted" role="status">
+                  Loading profile…
+                </p>
+              ) : (
+                <form
+                  className="mt-6 grid gap-4 sm:grid-cols-2"
+                  onSubmit={(e) => {
+                    void onNameSubmit(e);
+                  }}
+                  noValidate
+                >
+                  <div className="space-y-2 sm:col-span-2">
+                    <label
+                      htmlFor={`${formId}-title`}
+                      className="text-sm font-medium text-app-ink"
+                    >
+                      Title
+                    </label>
+                    <input
+                      id={`${formId}-title`}
+                      type="text"
+                      autoComplete="honorific-prefix"
+                      value={title}
+                      onChange={(e) => {
+                        nameFormDirtyRef.current = true;
+                        clearNameSaveFeedback();
+                        setTitle(e.target.value);
+                      }}
+                      className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring sm:max-w-xs"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label
+                      htmlFor={`${formId}-first-name`}
+                      className="text-sm font-medium text-app-ink"
+                    >
+                      First name
+                    </label>
+                    <input
+                      id={`${formId}-first-name`}
+                      type="text"
+                      autoComplete="given-name"
+                      value={firstName}
+                      onChange={(e) => {
+                        nameFormDirtyRef.current = true;
+                        clearNameSaveFeedback();
+                        setFirstName(e.target.value);
+                      }}
+                      className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                    />
+                  </div>
+                  <div className="space-y-2">
+                    <label
+                      htmlFor={`${formId}-last-name`}
+                      className="text-sm font-medium text-app-ink"
+                    >
+                      Last name
+                    </label>
+                    <input
+                      id={`${formId}-last-name`}
+                      type="text"
+                      autoComplete="family-name"
+                      value={lastName}
+                      onChange={(e) => {
+                        nameFormDirtyRef.current = true;
+                        clearNameSaveFeedback();
+                        setLastName(e.target.value);
+                      }}
+                      className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                    />
+                  </div>
+                  {nameError ? (
+                    <p
+                      role="alert"
+                      className="sm:col-span-2 text-sm text-red-700 dark:text-red-300"
+                    >
+                      {nameError}
+                    </p>
+                  ) : null}
+                  <div className="sm:col-span-2">
+                    <button
+                      type="submit"
+                      disabled={nameSubmitting}
+                      aria-live="polite"
+                      className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      {nameSubmitting
+                        ? 'Saving…'
+                        : nameSavedVisible
+                          ? 'Saved'
+                          : 'Save name'}
+                    </button>
+                  </div>
+                </form>
+              )}
+            </section>
+
+            <section
+              aria-labelledby={`${formId}-email-heading`}
+              className={SETTINGS_SURFACE_CLASS}
+            >
+              <h2
+                id={`${formId}-email-heading`}
+                className="text-lg font-semibold text-app-ink"
+              >
+                Email
+              </h2>
+              <p className="mt-2 text-sm text-app-muted">
+                {pendingEmailChange ? (
+                  <>
+                    Your sign-in email is still{' '}
+                    <span className="font-medium text-app-ink">
+                      {currentEmail || 'Not set'}
+                    </span>
+                    . Finish confirming{' '}
+                    <span className="font-medium text-app-ink">
+                      {pendingEmailChange}
+                    </span>{' '}
+                    using the link we emailed to that address.
+                  </>
+                ) : (
+                  <>
+                    Current address:{' '}
+                    <span className="font-medium text-app-ink">
+                      {currentEmail || 'Not set'}
+                    </span>
+                    . We will send a confirmation link to your new address
+                    before the change takes effect.
+                  </>
+                )}
+              </p>
+              {pendingEmailChange ? (
+                <div
+                  className="mt-6 space-y-4"
+                  role="status"
+                  aria-labelledby={`${formId}-email-pending-heading`}
+                >
+                  <div className="rounded-xl border border-app-border/80 bg-app-bg p-4">
+                    <h3
+                      id={`${formId}-email-pending-heading`}
+                      className="text-sm font-semibold text-app-ink"
+                    >
+                      Email change pending
+                    </h3>
+                    <dl className="mt-3 space-y-2 text-sm">
+                      <div>
+                        <dt className="text-app-muted">Current address</dt>
+                        <dd className="font-medium text-app-ink">
+                          {currentEmail || 'Not set'}
+                        </dd>
+                      </div>
+                      <div>
+                        <dt className="text-app-muted">Changing to</dt>
+                        <dd className="font-medium text-app-ink">
+                          {pendingEmailChange}
+                        </dd>
+                      </div>
+                    </dl>
+                    <p className="mt-3 text-sm text-app-muted">
+                      We sent a confirmation link to{' '}
+                      <span className="font-medium text-app-ink">
+                        {pendingEmailChange}
+                      </span>
+                      . Open that message to finish the change.
+                    </p>
+                  </div>
+                  {!showEmailChangeForm ? (
+                    <button
+                      type="button"
+                      className="min-h-[44px] rounded-full border border-app-border px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                      onClick={() => {
+                        setShowEmailChangeForm(true);
+                        setEmailError(null);
+                      }}
+                    >
+                      Use a different address
+                    </button>
+                  ) : null}
+                </div>
+              ) : null}
+              {!pendingEmailChange || showEmailChangeForm ? (
+                <form
+                  className="mt-6 space-y-4"
+                  onSubmit={(e) => {
+                    void onEmailSubmit(e);
+                  }}
+                  noValidate
+                >
+                  <div className="space-y-2">
+                    <label
+                      htmlFor={`${formId}-new-email`}
+                      className="text-sm font-medium text-app-ink"
+                    >
+                      New email
+                    </label>
+                    <input
+                      id={`${formId}-new-email`}
+                      type="email"
+                      autoComplete="email"
+                      value={newEmail}
+                      onChange={(e) => setNewEmail(e.target.value)}
+                      className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+                    />
+                  </div>
+                  {emailError ? (
+                    <p
+                      role="alert"
+                      className="text-sm text-red-700 dark:text-red-300"
+                    >
+                      {emailError}
+                    </p>
+                  ) : null}
+                  <button
+                    type="submit"
+                    disabled={emailSubmitting}
+                    className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                  >
+                    {emailSubmitting ? 'Sending…' : 'Send confirmation email'}
+                  </button>
+                </form>
+              ) : null}
+            </section>
+
+            <section
+              aria-labelledby={`${formId}-sessions-heading`}
+              className={SETTINGS_SURFACE_CLASS}
+            >
+              <h2
+                id={`${formId}-sessions-heading`}
+                className="text-lg font-semibold text-app-ink"
+              >
+                Sessions
+              </h2>
+              <p className="mt-2 text-sm text-app-muted">
+                Sign out on every device where you are signed in to ABStrack.
+                Use this on a shared computer or if you think someone else may
+                have access to your account.
+              </p>
+              <button
+                type="button"
+                className="mt-4 min-h-[44px] rounded-full bg-red-600 px-5 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg dark:bg-red-700 dark:hover:bg-red-600"
+                onClick={() => setSignOutEverywhereOpen(true)}
+              >
+                Sign out everywhere
+              </button>
+            </section>
+          </>
+        ) : null}
+      </div>
+
+      <div
+        role="tabpanel"
+        id={panelId('security')}
+        aria-labelledby={tabId('security')}
+        hidden={activeTab !== 'security'}
+        tabIndex={0}
+        className="outline-none"
+      >
+        {securitySectionMounted ? <SettingsSecuritySection /> : null}
+      </div>
+
+      <ConfirmDialog
+        open={signOutEverywhereOpen}
+        title="Sign out everywhere?"
+        description="This ends your ABStrack session on this browser and signs you out on all other devices. You will need to sign in again everywhere."
+        confirmLabel="Sign out everywhere"
+        cancelLabel="Cancel"
+        confirmBusyLabel="Signing out…"
+        onConfirm={() => {
+          announce('Signing out from all sessions.', { politeness: 'polite' });
+          practitionerSignOutEverywhere();
+          return undefined;
+        }}
+        onClose={() => setSignOutEverywhereOpen(false)}
+      />
+    </div>
+  );
+}

--- a/apps/practitioner/src/components/settings/SettingsPage.tsx
+++ b/apps/practitioner/src/components/settings/SettingsPage.tsx
@@ -61,7 +61,9 @@ export function SettingsPage() {
   const [activeTab, setActiveTab] =
     useState<PractitionerSettingsTabId>(tabFromUrl);
   const [signOutEverywhereOpen, setSignOutEverywhereOpen] = useState(false);
-  const [securitySectionMounted, setSecuritySectionMounted] = useState(false);
+  const [securitySectionMounted, setSecuritySectionMounted] = useState(
+    tabFromUrl === 'security',
+  );
 
   const [profileLoading, setProfileLoading] = useState(true);
   const [title, setTitle] = useState('');
@@ -190,11 +192,11 @@ export function SettingsPage() {
   }, [session?.user?.email, session?.user?.id, supabase]);
 
   useEffect(() => {
-    if (authLoading) {
+    if (authLoading || activeTab !== 'account') {
       return;
     }
     void loadProfile();
-  }, [authLoading, loadProfile, session?.user?.id]);
+  }, [activeTab, authLoading, loadProfile, session?.user?.id]);
 
   useEffect(() => {
     if (authLoading || !session?.user?.id) {
@@ -308,6 +310,9 @@ export function SettingsPage() {
       nameFormDirtyRef.current = false;
       showNameSaveFeedback();
       announce('Name saved.', { politeness: 'polite' });
+    } catch {
+      setNameError('Unable to save your name. Try again.');
+      announce('Unable to save your name.', { politeness: 'assertive' });
     } finally {
       setNameSubmitting(false);
     }
@@ -331,21 +336,28 @@ export function SettingsPage() {
     setEmailError(null);
     const nextPath = '/settings?tab=account';
     const emailRedirectTo = `${window.location.origin}/auth/callback?next=${encodeURIComponent(nextPath)}`;
-    const { error } = await supabase.auth.updateUser(
-      { email: trimmed },
-      { emailRedirectTo },
-    );
-    setEmailSubmitting(false);
-    if (error) {
-      setEmailError(error.message);
-      announce(error.message, { politeness: 'assertive' });
-      return;
+    try {
+      const { error } = await supabase.auth.updateUser(
+        { email: trimmed },
+        { emailRedirectTo },
+      );
+      if (error) {
+        setEmailError(error.message);
+        announce(error.message, { politeness: 'assertive' });
+        return;
+      }
+      setPendingEmailChange(trimmed);
+      setShowEmailChangeForm(false);
+      setNewEmail('');
+      const msg = `Confirmation email sent to ${trimmed}. Open the link in that message to finish changing your email.`;
+      announce(msg, { politeness: 'polite' });
+    } catch {
+      const msg = 'Unable to send the confirmation email. Try again.';
+      setEmailError(msg);
+      announce(msg, { politeness: 'assertive' });
+    } finally {
+      setEmailSubmitting(false);
     }
-    setPendingEmailChange(trimmed);
-    setShowEmailChangeForm(false);
-    setNewEmail('');
-    const msg = `Confirmation email sent to ${trimmed}. Open the link in that message to finish changing your email.`;
-    announce(msg, { politeness: 'polite' });
   };
 
   const onTabKeyDown = useCallback(

--- a/apps/practitioner/src/components/settings/SettingsPage.tsx
+++ b/apps/practitioner/src/components/settings/SettingsPage.tsx
@@ -269,27 +269,48 @@ export function SettingsPage() {
       lastName,
     });
     const trimmedTitle = title.trim();
-    const [{ error: profileError }, { error: metadataError }] =
-      await Promise.all([
-        supabase
-          .from('profiles')
-          .update({ display_name: displayName })
-          .eq('id', session.user.id),
-        supabase.auth.updateUser({
+    const previousTitle = readPractitionerTitleFromUserMetadata(session.user);
+
+    try {
+      const { error: metadataError } = await supabase.auth.updateUser({
+        data: {
+          [PRACTITIONER_TITLE_USER_METADATA_KEY]: trimmedTitle || null,
+        },
+      });
+      if (metadataError) {
+        setNameError('Unable to save your name. Try again.');
+        announce('Unable to save your name.', { politeness: 'assertive' });
+        return;
+      }
+
+      const { error: profileError } = await supabase
+        .from('profiles')
+        .update({ display_name: displayName })
+        .eq('id', session.user.id);
+
+      if (profileError) {
+        const { error: rollbackError } = await supabase.auth.updateUser({
           data: {
-            [PRACTITIONER_TITLE_USER_METADATA_KEY]: trimmedTitle || null,
+            [PRACTITIONER_TITLE_USER_METADATA_KEY]: previousTitle || null,
           },
-        }),
-      ]);
-    setNameSubmitting(false);
-    if (profileError || metadataError) {
-      setNameError('Unable to save your name. Try again.');
-      announce('Unable to save your name.', { politeness: 'assertive' });
-      return;
+        });
+        if (rollbackError) {
+          console.error(
+            'Failed to roll back practitioner title metadata after profile update failed',
+            rollbackError,
+          );
+        }
+        setNameError('Unable to save your name. Try again.');
+        announce('Unable to save your name.', { politeness: 'assertive' });
+        return;
+      }
+
+      nameFormDirtyRef.current = false;
+      showNameSaveFeedback();
+      announce('Name saved.', { politeness: 'polite' });
+    } finally {
+      setNameSubmitting(false);
     }
-    nameFormDirtyRef.current = false;
-    showNameSaveFeedback();
-    announce('Name saved.', { politeness: 'polite' });
   };
 
   const onEmailSubmit = async (event: React.FormEvent) => {

--- a/apps/practitioner/src/components/settings/SettingsSecuritySection.tsx
+++ b/apps/practitioner/src/components/settings/SettingsSecuritySection.tsx
@@ -158,6 +158,7 @@ export function SettingsSecuritySection() {
       setPasswordSavedVisible(true);
       passwordSavedTimeoutRef.current = setTimeout(() => {
         setPasswordSavedVisible(false);
+        setPasswordSuccessMessage(null);
         passwordSavedTimeoutRef.current = null;
       }, PASSWORD_SAVE_FEEDBACK_MS);
     },

--- a/apps/practitioner/src/components/settings/SettingsSecuritySection.tsx
+++ b/apps/practitioner/src/components/settings/SettingsSecuritySection.tsx
@@ -1,0 +1,757 @@
+'use client';
+
+import { getSupabaseBrowserClient } from '@abstrack/supabase/browser';
+import { useAnnounce } from '@abstrack/ui/a11y-web';
+import {
+  useCallback,
+  useEffect,
+  useId,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { ConfirmDialog } from '@/components/ConfirmDialog';
+import { useAuth } from '@/lib/auth-provider';
+import {
+  isUnenrollAlreadyGoneError,
+  looksLikeTotpSetupPayload,
+  mapMfaUnenrollErrorToUserMessage,
+  mapMfaVerifyErrorToUserMessage,
+  normalizeTotpCode,
+} from '@/lib/mfa-user-messages';
+import { refreshPractitionerSessionAndSyncMfaTrustBundle } from '@/lib/practitioner-device-trust';
+import { isPractitionerSignOutTransition } from '@/lib/practitioner-sign-out-pending';
+import {
+  AUTH_PASSWORD_MAX_LENGTH,
+  AUTH_PASSWORD_MIN_LENGTH,
+  PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY,
+  buildRevokedPasswordPlaceholder,
+  clampAuthPasswordInput,
+  getAuthPasswordValidationError,
+  practitionerUserHasPasswordSignIn,
+} from '@/lib/practitioner-password-sign-in';
+
+type TotpEnrollment = {
+  id: string;
+  qrCodeImageSrc: string;
+  secret: string;
+  friendlyName: string;
+};
+
+type VerifiedTotpFactor = {
+  id: string;
+  friendlyName: string;
+};
+
+function getTotpIssuer(): string {
+  return process.env.NEXT_PUBLIC_APP_NAME?.trim() || 'ABStrack';
+}
+
+function buildOtpauthUriFromSecret(secret: string, account: string): string {
+  const issuer = getTotpIssuer();
+  const labelAccount = account.trim() || 'practitioner';
+  const pathLabel = `${encodeURIComponent(issuer)}:${encodeURIComponent(labelAccount)}`;
+  const url = new URL(`otpauth://totp/${pathLabel}`);
+  url.searchParams.set('secret', secret);
+  url.searchParams.set('issuer', issuer);
+  url.searchParams.set('algorithm', 'SHA1');
+  url.searchParams.set('digits', '6');
+  url.searchParams.set('period', '30');
+  return url.toString();
+}
+
+async function otpauthUriToQrPngDataUrl(otpauthUri: string): Promise<string> {
+  const { toDataURL } = await import('qrcode');
+  return toDataURL(otpauthUri, {
+    errorCorrectionLevel: 'H',
+    margin: 4,
+    width: 320,
+    color: { dark: '#000000', light: '#ffffff' },
+  });
+}
+
+const SETTINGS_SURFACE_CLASS =
+  'rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8';
+
+const PASSWORD_STATUS_SUCCESS_CLASS =
+  'rounded border border-blue-200 bg-blue-50 p-4 text-sm text-blue-800 dark:border-blue-800/60 dark:bg-blue-950/35 dark:text-blue-200';
+
+/** How long password-save confirmation stays visible before reverting. */
+const PASSWORD_SAVE_FEEDBACK_MS = 3_000;
+
+/**
+ * Security settings for practitioners: password add/change/revoke and TOTP enrollment.
+ *
+ * @returns Security section for the practitioner settings page.
+ */
+export function SettingsSecuritySection() {
+  const formId = useId();
+  const { announce } = useAnnounce();
+  const supabase = useMemo(() => getSupabaseBrowserClient(), []);
+  const { session, loading: authLoading } = useAuth();
+
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordSubmitting, setPasswordSubmitting] = useState(false);
+  const [passwordError, setPasswordError] = useState<string | null>(null);
+  const [passwordSuccessMessage, setPasswordSuccessMessage] = useState<
+    string | null
+  >(null);
+  const [passwordSavedVisible, setPasswordSavedVisible] = useState(false);
+  const [passwordSignInOverride, setPasswordSignInOverride] = useState<
+    boolean | null
+  >(null);
+  const passwordSavedTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(
+    null,
+  );
+  /** Avoid full-section loading flash when auth/profile reloads after password save. */
+  const authInitiallyResolvedRef = useRef(false);
+  const [revokeOpen, setRevokeOpen] = useState(false);
+  const [revokeError, setRevokeError] = useState<string | null>(null);
+
+  const [mfaLoading, setMfaLoading] = useState(true);
+  const [verifiedFactors, setVerifiedFactors] = useState<VerifiedTotpFactor[]>(
+    [],
+  );
+  const [enrollment, setEnrollment] = useState<TotpEnrollment | null>(null);
+  const [isEnrolling, setIsEnrolling] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [isCanceling, setIsCanceling] = useState(false);
+  const [verifyCode, setVerifyCode] = useState('');
+  const [verifyFailureMessage, setVerifyFailureMessage] = useState<
+    string | null
+  >(null);
+  const [mfaStatusMessage, setMfaStatusMessage] = useState<string | null>(null);
+  const [unenrollFactorId, setUnenrollFactorId] = useState<string | null>(null);
+  const [unenrollError, setUnenrollError] = useState<string | null>(null);
+
+  const hasPassword =
+    passwordSignInOverride ?? practitionerUserHasPasswordSignIn(session?.user);
+
+  useEffect(() => {
+    if (!authLoading) {
+      authInitiallyResolvedRef.current = true;
+    }
+  }, [authLoading]);
+
+  useEffect(() => {
+    return () => {
+      if (passwordSavedTimeoutRef.current) {
+        clearTimeout(passwordSavedTimeoutRef.current);
+      }
+    };
+  }, []);
+
+  const clearPasswordSaveFeedback = useCallback(() => {
+    if (passwordSavedTimeoutRef.current) {
+      clearTimeout(passwordSavedTimeoutRef.current);
+      passwordSavedTimeoutRef.current = null;
+    }
+    setPasswordSavedVisible(false);
+    setPasswordSuccessMessage(null);
+  }, []);
+
+  const showPasswordSaveFeedback = useCallback(
+    (message: string) => {
+      clearPasswordSaveFeedback();
+      setPasswordSuccessMessage(message);
+      setPasswordSavedVisible(true);
+      passwordSavedTimeoutRef.current = setTimeout(() => {
+        setPasswordSavedVisible(false);
+        passwordSavedTimeoutRef.current = null;
+      }, PASSWORD_SAVE_FEEDBACK_MS);
+    },
+    [clearPasswordSaveFeedback],
+  );
+
+  const refreshMfaState = useCallback(async () => {
+    const factorsResult = await supabase.auth.mfa.listFactors();
+    if (factorsResult.error) {
+      throw factorsResult.error;
+    }
+    setVerifiedFactors(
+      factorsResult.data.totp
+        .filter((f) => f.status === 'verified')
+        .map((f) => ({
+          id: f.id,
+          friendlyName: f.friendly_name ?? 'Authenticator',
+        })),
+    );
+  }, [supabase]);
+
+  useEffect(() => {
+    if (authLoading || !session) {
+      return;
+    }
+    const load = async () => {
+      setMfaLoading(true);
+      try {
+        await refreshMfaState();
+      } catch (error) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Unable to load two-factor status.';
+        setMfaStatusMessage(message);
+        announce(message, { politeness: 'assertive' });
+      } finally {
+        setMfaLoading(false);
+      }
+    };
+    void load();
+  }, [authLoading, session, refreshMfaState, announce]);
+
+  const onPasswordSubmit = async (event: React.FormEvent) => {
+    event.preventDefault();
+    if (!session) {
+      return;
+    }
+    const passwordValidationError = getAuthPasswordValidationError(password);
+    if (passwordValidationError) {
+      setPasswordError(passwordValidationError);
+      return;
+    }
+    if (password !== confirmPassword) {
+      setPasswordError('Passwords do not match.');
+      return;
+    }
+    setPasswordSubmitting(true);
+    setPasswordError(null);
+    clearPasswordSaveFeedback();
+    const wasPasswordUser = hasPassword;
+    try {
+      const { error } = await supabase.auth.updateUser({
+        password,
+        data: { [PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY]: true },
+      });
+      if (error) {
+        setPasswordError(error.message);
+        announce(error.message, { politeness: 'assertive' });
+        return;
+      }
+      setPassword('');
+      setConfirmPassword('');
+      setPasswordSignInOverride(true);
+      const { error: refreshError } =
+        await refreshPractitionerSessionAndSyncMfaTrustBundle(supabase);
+      if (refreshError) {
+        console.error('refreshSession after password update', refreshError);
+      }
+      const msg = wasPasswordUser
+        ? 'Password updated.'
+        : 'Password added. You can sign in with your email and password.';
+      showPasswordSaveFeedback(msg);
+      announce(msg, { politeness: 'polite' });
+    } catch {
+      const msg = 'Unable to update password. Try again.';
+      setPasswordError(msg);
+      announce(msg, { politeness: 'assertive' });
+    } finally {
+      setPasswordSubmitting(false);
+    }
+  };
+
+  const onRevokePassword = async () => {
+    if (!session) {
+      return false;
+    }
+    setRevokeError(null);
+    try {
+      const { error } = await supabase.auth.updateUser({
+        password: buildRevokedPasswordPlaceholder(),
+        data: { [PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY]: false },
+      });
+      if (error) {
+        const msg = error.message;
+        setRevokeError(msg);
+        announce(msg, { politeness: 'assertive' });
+        return false;
+      }
+      setPassword('');
+      setConfirmPassword('');
+      setPasswordSignInOverride(false);
+      const { error: refreshError } =
+        await refreshPractitionerSessionAndSyncMfaTrustBundle(supabase);
+      if (refreshError) {
+        console.error('refreshSession after password revoke', refreshError);
+      }
+      const msg =
+        'Password sign-in disabled. Use magic links from email to sign in.';
+      showPasswordSaveFeedback(msg);
+      announce(msg, { politeness: 'polite' });
+      return undefined;
+    } catch {
+      const msg = 'Unable to revoke password. Try again.';
+      setRevokeError(msg);
+      announce(msg, { politeness: 'assertive' });
+      return false;
+    }
+  };
+
+  const startEnrollment = async () => {
+    if (!session) {
+      return;
+    }
+    setIsEnrolling(true);
+    setMfaStatusMessage(null);
+    setVerifyFailureMessage(null);
+    try {
+      const { data, error } = await supabase.auth.mfa.enroll({
+        factorType: 'totp',
+        friendlyName: `Practitioner device ${new Date().toISOString()}`,
+      });
+      if (error) {
+        throw error;
+      }
+      const account = session.user.email ?? 'practitioner';
+      const otpauthUri = buildOtpauthUriFromSecret(data.totp.secret, account);
+      const qrCodeImageSrc = await otpauthUriToQrPngDataUrl(otpauthUri);
+      setEnrollment({
+        id: data.id,
+        qrCodeImageSrc,
+        secret: data.totp.secret,
+        friendlyName: data.friendly_name ?? 'Authenticator',
+      });
+      const msg =
+        'Scan the QR code with your authenticator app, then enter the six-digit code.';
+      setMfaStatusMessage(msg);
+      announce(msg, { politeness: 'polite' });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Unable to start two-factor enrollment.';
+      setMfaStatusMessage(message);
+      announce(message, { politeness: 'assertive' });
+    } finally {
+      setIsEnrolling(false);
+    }
+  };
+
+  const verifyEnrollment = async () => {
+    if (!enrollment || !session) {
+      return;
+    }
+    setIsVerifying(true);
+    setVerifyFailureMessage(null);
+    if (!/^\d{6}$/.test(verifyCode)) {
+      const msg =
+        'Enter exactly six digits from your authenticator, not a setup link.';
+      setVerifyFailureMessage(msg);
+      announce(msg, { politeness: 'assertive' });
+      setIsVerifying(false);
+      return;
+    }
+    try {
+      const challenge = await supabase.auth.mfa.challenge({
+        factorId: enrollment.id,
+      });
+      if (challenge.error) {
+        throw challenge.error;
+      }
+      const verify = await supabase.auth.mfa.verify({
+        factorId: enrollment.id,
+        challengeId: challenge.data.id,
+        code: verifyCode,
+      });
+      if (verify.error) {
+        throw verify.error;
+      }
+      setVerifyCode('');
+      setEnrollment(null);
+      await refreshMfaState();
+      const msg = 'Two-factor authentication is enabled.';
+      setMfaStatusMessage(msg);
+      announce(msg, { politeness: 'polite' });
+    } catch (error) {
+      const message = mapMfaVerifyErrorToUserMessage(error);
+      setVerifyFailureMessage(message);
+      announce(message, { politeness: 'assertive' });
+    } finally {
+      setIsVerifying(false);
+    }
+  };
+
+  const cancelEnrollment = async () => {
+    if (!enrollment) {
+      return;
+    }
+    setIsCanceling(true);
+    try {
+      const { error } = await supabase.auth.mfa.unenroll({
+        factorId: enrollment.id,
+      });
+      if (error && !isUnenrollAlreadyGoneError(error)) {
+        const message = mapMfaUnenrollErrorToUserMessage(error);
+        setMfaStatusMessage(message);
+        announce(message, { politeness: 'assertive' });
+        return;
+      }
+      setEnrollment(null);
+      setVerifyCode('');
+      setVerifyFailureMessage(null);
+      await refreshMfaState();
+      announce('Two-factor setup canceled.', { politeness: 'polite' });
+    } catch {
+      const message =
+        'Unable to cancel two-factor setup. Check your connection and try again.';
+      setMfaStatusMessage(message);
+      announce(message, { politeness: 'assertive' });
+    } finally {
+      setIsCanceling(false);
+    }
+  };
+
+  const onUnenrollFactor = async () => {
+    if (!unenrollFactorId) {
+      return false;
+    }
+    setUnenrollError(null);
+    try {
+      const { error } = await supabase.auth.mfa.unenroll({
+        factorId: unenrollFactorId,
+      });
+      if (error && !isUnenrollAlreadyGoneError(error)) {
+        const msg = mapMfaUnenrollErrorToUserMessage(error);
+        setUnenrollError(msg);
+        announce(msg, { politeness: 'assertive' });
+        return false;
+      }
+      await refreshMfaState();
+      announce('Authenticator removed.', { politeness: 'polite' });
+      return undefined;
+    } catch {
+      const msg = 'Unable to remove authenticator. Try again.';
+      setUnenrollError(msg);
+      announce(msg, { politeness: 'assertive' });
+      return false;
+    }
+  };
+
+  if (authLoading && !authInitiallyResolvedRef.current) {
+    return (
+      <p className="text-sm text-app-muted" role="status">
+        Loading security settings…
+      </p>
+    );
+  }
+
+  if (!session) {
+    if (isPractitionerSignOutTransition(session)) {
+      return (
+        <p className="text-sm text-app-muted" role="status">
+          Signing out…
+        </p>
+      );
+    }
+    return (
+      <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+        You must be signed in to manage security settings.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <section
+        aria-labelledby={`${formId}-password-heading`}
+        className={SETTINGS_SURFACE_CLASS}
+      >
+        <h2
+          id={`${formId}-password-heading`}
+          className="text-lg font-semibold text-app-ink"
+        >
+          {hasPassword ? 'Change password' : 'Add a password'}
+        </h2>
+        <p className="mt-2 text-sm text-app-muted">
+          {hasPassword
+            ? 'Update the password you use for email sign-in.'
+            : 'You currently sign in with magic links from email. Add a password if you want email and password sign-in too.'}{' '}
+          Passwords must be at least {AUTH_PASSWORD_MIN_LENGTH} characters and
+          no more than {AUTH_PASSWORD_MAX_LENGTH} bytes.
+        </p>
+        {passwordSuccessMessage ? (
+          <div
+            className={`mt-4 ${PASSWORD_STATUS_SUCCESS_CLASS}`}
+            role="status"
+            aria-live="polite"
+          >
+            {passwordSuccessMessage}
+          </div>
+        ) : null}
+        <form
+          className="mt-6 space-y-4"
+          onSubmit={(e) => {
+            void onPasswordSubmit(e);
+          }}
+          noValidate
+        >
+          <div className="space-y-2">
+            <label
+              htmlFor={`${formId}-new-password`}
+              className="text-sm font-medium text-app-ink"
+            >
+              {hasPassword ? 'New password' : 'Password'}
+            </label>
+            <input
+              id={`${formId}-new-password`}
+              type="password"
+              autoComplete="new-password"
+              value={password}
+              onChange={(e) => {
+                clearPasswordSaveFeedback();
+                setPasswordError(null);
+                setPassword(clampAuthPasswordInput(e.target.value));
+              }}
+              className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+            />
+          </div>
+          <div className="space-y-2">
+            <label
+              htmlFor={`${formId}-confirm-password`}
+              className="text-sm font-medium text-app-ink"
+            >
+              Confirm password
+            </label>
+            <input
+              id={`${formId}-confirm-password`}
+              type="password"
+              autoComplete="new-password"
+              value={confirmPassword}
+              onChange={(e) => {
+                clearPasswordSaveFeedback();
+                setPasswordError(null);
+                setConfirmPassword(clampAuthPasswordInput(e.target.value));
+              }}
+              className="mt-1 block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+            />
+          </div>
+          {passwordError ? (
+            <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+              {passwordError}
+            </p>
+          ) : null}
+          <button
+            type="submit"
+            disabled={passwordSubmitting}
+            aria-live="polite"
+            className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {passwordSubmitting
+              ? 'Saving…'
+              : passwordSavedVisible
+                ? 'Saved'
+                : hasPassword
+                  ? 'Update password'
+                  : 'Add password'}
+          </button>
+        </form>
+        {hasPassword ? (
+          <div className="mt-6 border-t border-app-border/80 pt-6">
+            <h3 className="text-sm font-semibold text-app-ink">
+              Use magic links only
+            </h3>
+            <p className="mt-2 text-sm text-app-muted">
+              Remove password sign-in and rely on magic links from email. You
+              will need a new invite or magic link to sign in after revoking.
+            </p>
+            <button
+              type="button"
+              className="mt-4 min-h-[44px] rounded-full border border-app-border px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-bg focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+              onClick={() => {
+                setRevokeError(null);
+                setRevokeOpen(true);
+              }}
+            >
+              Revoke password sign-in
+            </button>
+          </div>
+        ) : null}
+      </section>
+
+      <section
+        aria-labelledby={`${formId}-totp-heading`}
+        className={SETTINGS_SURFACE_CLASS}
+      >
+        <h2
+          id={`${formId}-totp-heading`}
+          className="text-lg font-semibold text-app-ink"
+        >
+          Two-factor authentication (TOTP)
+        </h2>
+        <p className="mt-2 text-sm text-app-muted">
+          {hasPassword
+            ? 'Required when you sign in with a password before you can view patient data. Enroll an authenticator app and enter a code when signing in.'
+            : 'Optional when you sign in with magic links only. Add an authenticator for an extra sign-in step.'}{' '}
+          You can enroll multiple factors as a backup.
+        </p>
+        {mfaStatusMessage ? (
+          <p className="mt-3 text-sm text-app-muted" role="status">
+            {mfaStatusMessage}
+          </p>
+        ) : null}
+        {mfaLoading ? (
+          <p className="mt-4 text-sm text-app-muted" role="status">
+            Loading two-factor status…
+          </p>
+        ) : (
+          <>
+            <p className="mt-4 text-sm text-app-ink">
+              {verifiedFactors.length > 0
+                ? `${verifiedFactors.length} verified authenticator${verifiedFactors.length === 1 ? '' : 's'} enrolled.`
+                : 'No authenticator enrolled yet.'}
+            </p>
+            {verifiedFactors.length > 0 ? (
+              <ul className="mt-4 space-y-2">
+                {verifiedFactors.map((factor) => (
+                  <li
+                    key={factor.id}
+                    className="flex flex-wrap items-center justify-between gap-2 rounded-xl border border-app-border/80 bg-app-bg px-4 py-3"
+                  >
+                    <span className="text-sm text-app-ink">
+                      {factor.friendlyName}
+                    </span>
+                    <button
+                      type="button"
+                      className="min-h-[44px] rounded-full border border-app-border px-4 text-sm font-semibold text-app-ink shadow-sm transition hover:bg-app-surface focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg"
+                      onClick={() => {
+                        setUnenrollError(null);
+                        setUnenrollFactorId(factor.id);
+                      }}
+                    >
+                      Remove
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+            {!enrollment ? (
+              <button
+                type="button"
+                disabled={isEnrolling}
+                className="mt-4 min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm transition hover:opacity-95 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-60"
+                onClick={() => void startEnrollment()}
+              >
+                {isEnrolling ? 'Starting…' : 'Set up authenticator'}
+              </button>
+            ) : null}
+          </>
+        )}
+        {enrollment ? (
+          <div className="mt-6 space-y-4 border-t border-app-border/80 pt-6">
+            <div className="inline-block rounded-lg border border-app-border bg-white p-4">
+              <img
+                src={enrollment.qrCodeImageSrc}
+                alt="TOTP enrollment QR code"
+                width={320}
+                height={320}
+                className="block h-auto max-h-[min(80vw,20rem)] w-auto max-w-full"
+              />
+            </div>
+            <p className="text-sm text-app-muted">
+              Setup key:{' '}
+              <code className="rounded bg-app-bg px-1 py-0.5 text-app-ink">
+                {enrollment.secret}
+              </code>
+            </p>
+            <label
+              htmlFor={`${formId}-totp-code`}
+              className="block text-sm font-medium text-app-ink"
+            >
+              Six-digit code
+            </label>
+            <input
+              id={`${formId}-totp-code`}
+              inputMode="numeric"
+              autoComplete="one-time-code"
+              maxLength={6}
+              value={verifyCode}
+              onChange={(event) => {
+                const raw = event.target.value;
+                if (looksLikeTotpSetupPayload(raw)) {
+                  setVerifyCode('');
+                  const msg =
+                    'Enter only the six-digit code from your authenticator.';
+                  setVerifyFailureMessage(msg);
+                  announce(msg, { politeness: 'assertive' });
+                  return;
+                }
+                setVerifyFailureMessage(null);
+                setVerifyCode(normalizeTotpCode(raw));
+              }}
+              className="block w-full min-h-[44px] rounded-md border border-app-border bg-app-bg px-3 py-2 text-app-ink shadow-sm focus:border-app-primary focus:outline-none focus:ring-2 focus:ring-app-ring"
+            />
+            {verifyFailureMessage ? (
+              <p
+                role="alert"
+                className="text-sm text-red-700 dark:text-red-300"
+              >
+                {verifyFailureMessage}
+              </p>
+            ) : null}
+            <div className="flex flex-wrap gap-2">
+              <button
+                type="button"
+                disabled={
+                  isVerifying || isCanceling || !/^\d{6}$/.test(verifyCode)
+                }
+                className="min-h-[44px] rounded-full bg-app-primary-solid px-5 text-sm font-semibold text-app-on-primary-solid shadow-sm disabled:cursor-not-allowed disabled:opacity-60"
+                onClick={() => void verifyEnrollment()}
+              >
+                {isVerifying ? 'Verifying…' : 'Verify and enable'}
+              </button>
+              <button
+                type="button"
+                disabled={isVerifying || isCanceling}
+                className="min-h-[44px] rounded-full border border-app-border px-4 text-sm font-semibold text-app-ink shadow-sm"
+                onClick={() => void cancelEnrollment()}
+              >
+                {isCanceling ? 'Canceling…' : 'Cancel setup'}
+              </button>
+            </div>
+          </div>
+        ) : null}
+      </section>
+
+      <ConfirmDialog
+        open={revokeOpen}
+        title="Revoke password sign-in?"
+        description="You will no longer be able to sign in with your email and password. Use magic links from email instead. This does not sign you out of your current session."
+        confirmLabel="Revoke password"
+        cancelLabel="Keep password"
+        confirmBusyLabel="Revoking…"
+        onConfirm={() => onRevokePassword()}
+        onClose={() => {
+          setRevokeOpen(false);
+          setRevokeError(null);
+        }}
+      >
+        {revokeError ? (
+          <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+            {revokeError}
+          </p>
+        ) : null}
+      </ConfirmDialog>
+
+      <ConfirmDialog
+        open={unenrollFactorId != null}
+        title="Remove authenticator?"
+        description="You will need this device or another enrolled authenticator to complete two-factor sign-in when it is required for your account."
+        confirmLabel="Remove"
+        cancelLabel="Keep"
+        confirmBusyLabel="Removing…"
+        onConfirm={() => onUnenrollFactor()}
+        onClose={() => {
+          setUnenrollFactorId(null);
+          setUnenrollError(null);
+        }}
+      >
+        {unenrollError ? (
+          <p role="alert" className="text-sm text-red-700 dark:text-red-300">
+            {unenrollError}
+          </p>
+        ) : null}
+      </ConfirmDialog>
+    </div>
+  );
+}

--- a/apps/practitioner/src/lib/auth-provider.spec.tsx
+++ b/apps/practitioner/src/lib/auth-provider.spec.tsx
@@ -461,4 +461,55 @@ describe('AuthProvider', () => {
 
     expect(signOutMock).toHaveBeenCalled();
   });
+
+  it('does not set loading when TOKEN_REFRESHED rotates access_token after profile is loaded', async () => {
+    const session = makeSession('practitioner-1');
+    const rotatedSession = {
+      ...session,
+      access_token: 'rotated-access-token',
+    };
+
+    getVerifiedAuthSessionMock
+      .mockResolvedValueOnce({
+        data: { user: null, session: null },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: session.user, session },
+        error: null,
+      })
+      .mockResolvedValueOnce({
+        data: { user: rotatedSession.user, session: rotatedSession },
+        error: null,
+      });
+
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(readAuthState().loading).toBe(false);
+    });
+
+    act(() => {
+      authStateChangeHandler?.('SIGNED_IN');
+    });
+
+    await waitFor(() => {
+      expect(readAuthState().userId).toBe('practitioner-1');
+    });
+
+    act(() => {
+      authStateChangeHandler?.('TOKEN_REFRESHED');
+    });
+
+    await waitFor(() => {
+      expect(getVerifiedAuthSessionMock).toHaveBeenCalledTimes(3);
+    });
+
+    expect(readAuthState().loading).toBe(false);
+    expect(readAuthState().userId).toBe('practitioner-1');
+  });
 });

--- a/apps/practitioner/src/lib/auth-provider.tsx
+++ b/apps/practitioner/src/lib/auth-provider.tsx
@@ -34,7 +34,8 @@ type AuthStateChangeEvent = Parameters<
 interface AuthContextType {
   session: Session | null;
   /**
-   * True while initial auth is resolving or, when signed in, while the profile row is loading.
+   * True while initial auth is resolving or, when signed in, while the profile row is loading
+   * for the first time for this user. Token rotation alone must not set this (see profile effect).
    */
   loading: boolean;
   /** Own profile row: undefined = not loaded yet; null = no row or load failed without error object. */
@@ -349,12 +350,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     return () => {
       cancelled = true;
     };
-  }, [
-    session?.user?.id,
-    session?.access_token,
-    pendingInviteMetadataId,
-    supabase,
-  ]);
+  }, [session?.user?.id, pendingInviteMetadataId, supabase]);
 
   const value = useMemo(
     () => ({

--- a/apps/practitioner/src/lib/pending-email-change.ts
+++ b/apps/practitioner/src/lib/pending-email-change.ts
@@ -1,0 +1,18 @@
+/**
+ * Reads GoTrue `new_email` when an address change awaits confirmation via
+ * {@link AbstrackSupabaseClient.auth.updateUser} (Supabase `email_change` template).
+ *
+ * @param user - Auth user from `getUser()` / session.
+ * @returns Normalized pending address, or `null` when none is set.
+ */
+export function readPendingEmailChange(user: unknown): string | null {
+  if (!user || typeof user !== 'object') {
+    return null;
+  }
+  const raw = (user as { new_email?: unknown }).new_email;
+  if (typeof raw !== 'string') {
+    return null;
+  }
+  const trimmed = raw.trim().toLowerCase();
+  return trimmed === '' ? null : trimmed;
+}

--- a/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.spec.ts
@@ -1091,6 +1091,9 @@ describe('practitionerSignOutEverywhere', () => {
       buildBundleJson(userId, Date.now() + 60_000),
     );
     localStorage.setItem('sb-proj-auth-token', '{"refresh":true}');
+    const appendChildSpy = jest
+      .spyOn(document.body, 'appendChild')
+      .mockImplementation((node) => node);
 
     practitionerSignOutEverywhere();
 
@@ -1099,6 +1102,10 @@ describe('practitionerSignOutEverywhere', () => {
     ).toBeNull();
     expect(localStorage.getItem('sb-proj-auth-token')).toBeNull();
     expect(submitSpy).toHaveBeenCalledTimes(1);
+    const form = appendChildSpy.mock.calls[0]?.[0] as HTMLFormElement;
+    expect(form.action).toContain('/api/auth/logout?scope=global');
+
+    appendChildSpy.mockRestore();
   });
 });
 

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -35,6 +35,8 @@ import {
   type Session,
 } from '@abstrack/supabase';
 
+import { markPractitionerSignOutPending } from './practitioner-sign-out-pending';
+
 type PractitionerBrowserClient = AbstrackSupabaseClient;
 
 /**
@@ -332,6 +334,25 @@ export function saveMfaTrustBundle(
  * @param supabase - Browser Supabase client.
  * @param session - Session from the auth callback (null clears nothing).
  */
+/**
+ * Refreshes the browser session and syncs the MFA trust bundle when tokens rotate.
+ *
+ * @param supabase - Browser Supabase client.
+ * @returns Refresh error when `refreshSession` fails.
+ */
+export async function refreshPractitionerSessionAndSyncMfaTrustBundle(
+  supabase: PractitionerBrowserClient,
+): Promise<{ error: Error | null }> {
+  const { data, error } = await supabase.auth.refreshSession();
+  if (error) {
+    return { error };
+  }
+  if (data.session) {
+    await syncMfaTrustBundleAfterTokenRefresh(supabase, data.session);
+  }
+  return { error: null };
+}
+
 export async function syncMfaTrustBundleAfterTokenRefresh(
   supabase: PractitionerBrowserClient,
   session: Session | null,
@@ -580,6 +601,7 @@ export function practitionerSignOutEverywhere(): void {
   if (typeof document === 'undefined') {
     return;
   }
+  markPractitionerSignOutPending();
   clearMfaTrustBundle();
   try {
     clearSupabaseBrowserAuthStorage();
@@ -588,7 +610,7 @@ export function practitionerSignOutEverywhere(): void {
   }
   const form = document.createElement('form');
   form.method = 'POST';
-  form.action = '/api/auth/logout';
+  form.action = '/api/auth/logout?scope=global';
   form.setAttribute('aria-hidden', 'true');
   form.style.display = 'none';
   document.body.appendChild(form);
@@ -722,6 +744,7 @@ async function clearBrowserSessionWithoutServerLogout(
 export async function practitionerSignOut(
   supabase: PractitionerBrowserClient,
 ): Promise<void> {
+  markPractitionerSignOutPending();
   const userId = await resolveUserIdForMfaTrustSignOut(supabase);
   const bundle = readBundle();
   const trustActiveForUser =

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -321,21 +321,11 @@ export function saveMfaTrustBundle(
 }
 
 /**
- * Call from `onAuthStateChange` when `event === 'TOKEN_REFRESHED'`. Supabase **rotates refresh tokens**; the bundle written at MFA
- * verify time would otherwise go stale, so the next sign-in’s {@link tryRestoreTrustedMfaSession}
- * would fail and clear storage. Only updates the bundle when a trust row still exists for this user,
- * the window has not expired, and **MFA assurance is AAL2** — so password-only (AAL1) sessions never
- * overwrite a prior AAL2 bundle.
+ * Refreshes the browser session and syncs the MFA trust bundle when refresh tokens rotate.
  *
- * **`readBundle()` does not drop expired rows** (only validates shape). If the stored bundle’s
- * trust window has ended, or its `userId` does not match the refreshed session, clears the bundle so
- * stale secrets are not retained until another code path runs.
- *
- * @param supabase - Browser Supabase client.
- * @param session - Session from the auth callback (null clears nothing).
- */
-/**
- * Refreshes the browser session and syncs the MFA trust bundle when tokens rotate.
+ * Use after `updateUser` (password change/revoke) so the trust bundle stays aligned with rotated
+ * tokens; {@link syncMfaTrustBundleAfterTokenRefresh} also runs from `onAuthStateChange`
+ * when `event === 'TOKEN_REFRESHED'`.
  *
  * @param supabase - Browser Supabase client.
  * @returns Refresh error when `refreshSession` fails.
@@ -353,6 +343,20 @@ export async function refreshPractitionerSessionAndSyncMfaTrustBundle(
   return { error: null };
 }
 
+/**
+ * Call from `onAuthStateChange` when `event === 'TOKEN_REFRESHED'`. Supabase **rotates refresh tokens**; the bundle written at MFA
+ * verify time would otherwise go stale, so the next sign-in’s {@link tryRestoreTrustedMfaSession}
+ * would fail and clear storage. Only updates the bundle when a trust row still exists for this user,
+ * the window has not expired, and **MFA assurance is AAL2** — so password-only (AAL1) sessions never
+ * overwrite a prior AAL2 bundle.
+ *
+ * **`readBundle()` does not drop expired rows** (only validates shape). If the stored bundle’s
+ * trust window has ended, or its `userId` does not match the refreshed session, clears the bundle so
+ * stale secrets are not retained until another code path runs.
+ *
+ * @param supabase - Browser Supabase client.
+ * @param session - Session from the auth callback (null clears nothing).
+ */
 export async function syncMfaTrustBundleAfterTokenRefresh(
   supabase: PractitionerBrowserClient,
   session: Session | null,

--- a/apps/practitioner/src/lib/practitioner-nav-items.ts
+++ b/apps/practitioner/src/lib/practitioner-nav-items.ts
@@ -14,4 +14,9 @@ export const PRACTITIONER_APP_NAV_ITEMS: AppSideNavItem[] = [
     label: 'Patients',
     match: (path) => path === '/patients' || path.startsWith('/patients/'),
   },
+  {
+    href: '/settings',
+    label: 'Settings',
+    match: (path) => path === '/settings' || path.startsWith('/settings/'),
+  },
 ];

--- a/apps/practitioner/src/lib/practitioner-password-sign-in.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-password-sign-in.spec.ts
@@ -1,0 +1,114 @@
+import { TextEncoder } from 'node:util';
+import {
+  AUTH_PASSWORD_MAX_LENGTH,
+  AUTH_PASSWORD_MIN_LENGTH,
+  PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY,
+  buildRevokedPasswordPlaceholder,
+  clampAuthPasswordInput,
+  getAuthPasswordUtf8ByteLength,
+  getAuthPasswordValidationError,
+  practitionerUserHasPasswordSignIn,
+} from './practitioner-password-sign-in';
+
+if (typeof globalThis.TextEncoder === 'undefined') {
+  globalThis.TextEncoder = TextEncoder as typeof globalThis.TextEncoder;
+}
+
+describe('practitionerUserHasPasswordSignIn', () => {
+  it('returns true when metadata flag is set', () => {
+    expect(
+      practitionerUserHasPasswordSignIn({
+        user_metadata: { [PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY]: true },
+      }),
+    ).toBe(true);
+    expect(
+      practitionerUserHasPasswordSignIn({
+        user_metadata: {
+          [PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY]: 'true',
+        },
+      }),
+    ).toBe(true);
+  });
+
+  it('returns false when metadata flag is absent or explicitly false', () => {
+    expect(practitionerUserHasPasswordSignIn({ user_metadata: {} })).toBe(
+      false,
+    );
+    expect(
+      practitionerUserHasPasswordSignIn({
+        user_metadata: { [PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY]: false },
+      }),
+    ).toBe(false);
+    expect(
+      practitionerUserHasPasswordSignIn({
+        user_metadata: {
+          [PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY]: 'false',
+        },
+      }),
+    ).toBe(false);
+  });
+});
+
+describe('getAuthPasswordUtf8ByteLength', () => {
+  it('counts UTF-8 bytes, not JavaScript string length', () => {
+    expect(getAuthPasswordUtf8ByteLength('a'.repeat(72))).toBe(72);
+    expect(getAuthPasswordUtf8ByteLength('é')).toBe(2);
+    expect(getAuthPasswordUtf8ByteLength('😀')).toBe(4);
+  });
+});
+
+describe('clampAuthPasswordInput', () => {
+  it('passes through values within the UTF-8 byte limit', () => {
+    expect(clampAuthPasswordInput('a'.repeat(72))).toBe('a'.repeat(72));
+    expect(clampAuthPasswordInput('😀'.repeat(18))).toBe('😀'.repeat(18));
+  });
+
+  it('truncates values that exceed 72 UTF-8 bytes', () => {
+    const clamped = clampAuthPasswordInput('😀'.repeat(19));
+    expect(getAuthPasswordUtf8ByteLength(clamped)).toBeLessThanOrEqual(
+      AUTH_PASSWORD_MAX_LENGTH,
+    );
+    expect(getAuthPasswordValidationError(clamped)).toBeNull();
+    expect(clamped).toBe('😀'.repeat(18));
+  });
+
+  it('drops whole astral symbols instead of leaving surrogate halves', () => {
+    const over = `${'a'.repeat(71)}😀`;
+    expect(getAuthPasswordUtf8ByteLength(over)).toBeGreaterThan(
+      AUTH_PASSWORD_MAX_LENGTH,
+    );
+
+    const clamped = clampAuthPasswordInput(over);
+
+    expect(clamped).toBe('a'.repeat(71));
+    expect(clamped).not.toContain('\uFFFD');
+    expect(getAuthPasswordUtf8ByteLength(clamped)).toBe(71);
+  });
+});
+
+describe('getAuthPasswordValidationError', () => {
+  it('returns null for an acceptable ASCII password', () => {
+    expect(getAuthPasswordValidationError('a'.repeat(12))).toBeNull();
+  });
+
+  it('rejects passwords shorter than the minimum', () => {
+    expect(getAuthPasswordValidationError('short')).toContain('at least');
+  });
+
+  it('rejects passwords longer than 72 UTF-8 bytes', () => {
+    expect(getAuthPasswordValidationError('😀'.repeat(19))).toContain('bytes');
+  });
+});
+
+describe('buildRevokedPasswordPlaceholder', () => {
+  it('stays within the bcrypt / GoTrue password length limit', () => {
+    const password = buildRevokedPasswordPlaceholder();
+    expect(password.length).toBeLessThanOrEqual(AUTH_PASSWORD_MAX_LENGTH);
+    expect(password.length).toBeGreaterThanOrEqual(AUTH_PASSWORD_MIN_LENGTH);
+    expect(getAuthPasswordUtf8ByteLength(password)).toBeLessThanOrEqual(
+      AUTH_PASSWORD_MAX_LENGTH,
+    );
+    expect(password.startsWith('Abstrack-revoked-')).toBe(true);
+    expect(password.endsWith('!9')).toBe(true);
+  });
+});

--- a/apps/practitioner/src/lib/practitioner-password-sign-in.ts
+++ b/apps/practitioner/src/lib/practitioner-password-sign-in.ts
@@ -17,5 +17,85 @@ export function practitionerUserHasPasswordSignIn(
 ): boolean {
   const raw =
     user?.user_metadata?.[PRACTITIONER_PASSWORD_SET_USER_METADATA_KEY];
+  if (raw === false || raw === 'false') {
+    return false;
+  }
   return raw === true || raw === 'true';
+}
+
+/** Minimum password length enforced by GoTrue for sign-up / update flows. */
+export const AUTH_PASSWORD_MIN_LENGTH = 8;
+
+/** GoTrue/bcrypt rejects passwords longer than 72 bytes. */
+export const AUTH_PASSWORD_MAX_LENGTH = 72;
+
+/**
+ * UTF-8 byte length of a password (GoTrue/bcrypt limit is bytes, not JavaScript string length).
+ *
+ * @param password - Candidate password.
+ * @returns Encoded byte length.
+ */
+export function getAuthPasswordUtf8ByteLength(password: string): number {
+  return new TextEncoder().encode(password).length;
+}
+
+/**
+ * Keeps password input within {@link AUTH_PASSWORD_MAX_LENGTH} UTF-8 bytes.
+ *
+ * @param value - Raw input from a password field.
+ * @returns Value truncated to the byte limit when needed.
+ */
+export function clampAuthPasswordInput(value: string): string {
+  let byteLength = 0;
+  let result = '';
+  for (const char of value) {
+    const charBytes = getAuthPasswordUtf8ByteLength(char);
+    if (byteLength + charBytes > AUTH_PASSWORD_MAX_LENGTH) {
+      break;
+    }
+    byteLength += charBytes;
+    result += char;
+  }
+  return result;
+}
+
+/**
+ * Client-side password rules before `auth.updateUser({ password })`.
+ *
+ * @param password - Candidate password.
+ * @returns User-visible error, or `null` when acceptable.
+ */
+export function getAuthPasswordValidationError(
+  password: string,
+): string | null {
+  if (password.length < AUTH_PASSWORD_MIN_LENGTH) {
+    return `Password must be at least ${AUTH_PASSWORD_MIN_LENGTH} characters.`;
+  }
+  if (getAuthPasswordUtf8ByteLength(password) > AUTH_PASSWORD_MAX_LENGTH) {
+    return `Password must be no more than ${AUTH_PASSWORD_MAX_LENGTH} bytes.`;
+  }
+  return null;
+}
+
+const REVOKED_PASSWORD_PREFIX = 'Abstrack-revoked-';
+const REVOKED_PASSWORD_SUFFIX = '!9';
+
+/**
+ * Builds a cryptographically random password for revoking user-chosen credentials
+ * while keeping the account active for magic-link sign-in.
+ *
+ * @returns A password string suitable for `updateUser({ password })`.
+ */
+export function buildRevokedPasswordPlaceholder(): string {
+  const fixedLength =
+    REVOKED_PASSWORD_PREFIX.length + REVOKED_PASSWORD_SUFFIX.length;
+  const maxRandomChars = AUTH_PASSWORD_MAX_LENGTH - fixedLength;
+  const randomByteCount = Math.floor(maxRandomChars / 2);
+
+  const bytes = new Uint8Array(randomByteCount);
+  crypto.getRandomValues(bytes);
+  const segment = Array.from(bytes, (b) =>
+    b.toString(16).padStart(2, '0'),
+  ).join('');
+  return `${REVOKED_PASSWORD_PREFIX}${segment}${REVOKED_PASSWORD_SUFFIX}`;
 }

--- a/apps/practitioner/src/lib/practitioner-profile-display-name.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-profile-display-name.spec.ts
@@ -1,0 +1,34 @@
+import {
+  combinePractitionerNameFieldsIntoDisplayName,
+  splitDisplayNameIntoPractitionerNameFields,
+} from './practitioner-profile-display-name';
+
+describe('practitioner-profile-display-name', () => {
+  it('combines title and name fields into display name', () => {
+    expect(
+      combinePractitionerNameFieldsIntoDisplayName({
+        title: 'Dr',
+        firstName: 'Jane',
+        lastName: 'Smith',
+      }),
+    ).toBe('Dr Jane Smith');
+  });
+
+  it('splits display name using stored title metadata', () => {
+    expect(
+      splitDisplayNameIntoPractitionerNameFields('Dr Jane Smith', 'Dr'),
+    ).toEqual({
+      title: 'Dr',
+      firstName: 'Jane',
+      lastName: 'Smith',
+    });
+  });
+
+  it('returns empty fields when display name is unset', () => {
+    expect(splitDisplayNameIntoPractitionerNameFields(null, null)).toEqual({
+      title: '',
+      firstName: '',
+      lastName: '',
+    });
+  });
+});

--- a/apps/practitioner/src/lib/practitioner-profile-display-name.ts
+++ b/apps/practitioner/src/lib/practitioner-profile-display-name.ts
@@ -1,0 +1,82 @@
+/** `auth.users` metadata: professional title or honorific (for example Dr, Prof). */
+export const PRACTITIONER_TITLE_USER_METADATA_KEY =
+  'abstrack_practitioner_title';
+
+type UserMetadataCarrier = {
+  user_metadata?: Record<string, unknown> | null;
+};
+
+export type PractitionerProfileNameFields = {
+  title: string;
+  firstName: string;
+  lastName: string;
+};
+
+/**
+ * Reads the practitioner title from Auth user metadata.
+ *
+ * @param user - Supabase Auth user (session or `getUser()`).
+ * @returns Trimmed title, or an empty string when unset.
+ */
+export function readPractitionerTitleFromUserMetadata(
+  user: UserMetadataCarrier | null | undefined,
+): string {
+  const raw = user?.user_metadata?.[PRACTITIONER_TITLE_USER_METADATA_KEY];
+  return typeof raw === 'string' ? raw.trim() : '';
+}
+
+/**
+ * Splits `profiles.display_name` into title, first, and last name fields for settings forms.
+ * Uses stored title metadata when present; otherwise treats the full display name as first/last only.
+ *
+ * @param displayName - Stored profile display name.
+ * @param titleFromMetadata - Title from {@link readPractitionerTitleFromUserMetadata}.
+ * @returns Editable title and name fields.
+ */
+export function splitDisplayNameIntoPractitionerNameFields(
+  displayName: string | null | undefined,
+  titleFromMetadata: string | null | undefined,
+): PractitionerProfileNameFields {
+  const storedTitle = titleFromMetadata?.trim() ?? '';
+  const trimmed = displayName?.trim() ?? '';
+
+  if (trimmed === '') {
+    return { title: storedTitle, firstName: '', lastName: '' };
+  }
+
+  if (storedTitle !== '') {
+    let remainder = trimmed;
+    const lowerDisplay = trimmed.toLowerCase();
+    const lowerTitle = storedTitle.toLowerCase();
+    if (lowerDisplay.startsWith(`${lowerTitle} `)) {
+      remainder = trimmed.slice(storedTitle.length).trimStart();
+    } else if (lowerDisplay === lowerTitle) {
+      remainder = '';
+    }
+    const parts = remainder.split(/\s+/).filter(Boolean);
+    const firstName = parts[0] ?? '';
+    const lastName = parts.slice(1).join(' ');
+    return { title: storedTitle, firstName, lastName };
+  }
+
+  const parts = trimmed.split(/\s+/);
+  const firstName = parts[0] ?? '';
+  const lastName = parts.slice(1).join(' ');
+  return { title: '', firstName, lastName };
+}
+
+/**
+ * Combines title and name fields into the single `profiles.display_name` value shown to patients.
+ *
+ * @param fields - Form title and name values.
+ * @returns Trimmed display name, or `null` when all fields are empty.
+ */
+export function combinePractitionerNameFieldsIntoDisplayName(
+  fields: PractitionerProfileNameFields,
+): string | null {
+  const title = fields.title.trim();
+  const firstName = fields.firstName.trim();
+  const lastName = fields.lastName.trim();
+  const combined = [title, firstName, lastName].filter(Boolean).join(' ');
+  return combined === '' ? null : combined;
+}

--- a/apps/practitioner/src/lib/practitioner-public-paths.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-public-paths.spec.ts
@@ -17,5 +17,6 @@ describe('isPublicPractitionerPath', () => {
     expect(isPublicPractitionerPath('/')).toBe(false);
     expect(isPublicPractitionerPath('/patients')).toBe(false);
     expect(isPublicPractitionerPath('/patients/abc')).toBe(false);
+    expect(isPublicPractitionerPath('/settings')).toBe(false);
   });
 });

--- a/apps/practitioner/src/lib/practitioner-sign-out-pending.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-sign-out-pending.spec.ts
@@ -1,0 +1,28 @@
+import {
+  clearPractitionerSignOutPending,
+  isPractitionerSignOutPending,
+  isPractitionerSignOutTransition,
+  markPractitionerSignOutPending,
+} from './practitioner-sign-out-pending';
+
+describe('practitioner sign-out pending', () => {
+  beforeEach(() => {
+    clearPractitionerSignOutPending();
+  });
+
+  it('marks, detects, and clears the pending flag', () => {
+    expect(isPractitionerSignOutPending()).toBe(false);
+    markPractitionerSignOutPending();
+    expect(isPractitionerSignOutPending()).toBe(true);
+    clearPractitionerSignOutPending();
+    expect(isPractitionerSignOutPending()).toBe(false);
+  });
+
+  it('treats missing session with pending flag as a sign-out transition', () => {
+    markPractitionerSignOutPending();
+    expect(isPractitionerSignOutTransition(null)).toBe(true);
+    expect(isPractitionerSignOutTransition({ user: { id: 'user-1' } })).toBe(
+      false,
+    );
+  });
+});

--- a/apps/practitioner/src/lib/practitioner-sign-out-pending.ts
+++ b/apps/practitioner/src/lib/practitioner-sign-out-pending.ts
@@ -1,0 +1,34 @@
+/** In-memory flag for the current page load while logout clears auth before navigation. */
+let practitionerSignOutPending = false;
+
+/**
+ * Marks an in-progress practitioner sign-out so protected pages can avoid flashing
+ * signed-out error copy when the app shell remounts before redirect.
+ */
+export function markPractitionerSignOutPending(): void {
+  practitionerSignOutPending = true;
+}
+
+/**
+ * @returns Whether a practitioner sign-out was initiated in this tab and navigation has not finished.
+ */
+export function isPractitionerSignOutPending(): boolean {
+  return practitionerSignOutPending;
+}
+
+/** Clears the pending sign-out flag when logout fails and the user stays on the page. */
+export function clearPractitionerSignOutPending(): void {
+  practitionerSignOutPending = false;
+}
+
+/**
+ * True when the UI should show a signing-out state instead of a signed-out guard.
+ *
+ * @param session - Current auth session from {@link useAuth}.
+ * @returns Whether logout is in progress for this tab.
+ */
+export function isPractitionerSignOutTransition(
+  session: { user: { id: string } } | null,
+): boolean {
+  return session == null && isPractitionerSignOutPending();
+}

--- a/apps/practitioner/src/lib/settings-tabs.spec.ts
+++ b/apps/practitioner/src/lib/settings-tabs.spec.ts
@@ -8,5 +8,6 @@ describe('settings-tabs', () => {
 
   it('parses security tab', () => {
     expect(parsePractitionerSettingsTabId('security')).toBe('security');
+    expect(parsePractitionerSettingsTabId('account')).toBe('account');
   });
 });

--- a/apps/practitioner/src/lib/settings-tabs.spec.ts
+++ b/apps/practitioner/src/lib/settings-tabs.spec.ts
@@ -1,0 +1,12 @@
+import { parsePractitionerSettingsTabId } from './settings-tabs';
+
+describe('settings-tabs', () => {
+  it('defaults to account for missing or invalid tab', () => {
+    expect(parsePractitionerSettingsTabId(null)).toBe('account');
+    expect(parsePractitionerSettingsTabId('invites')).toBe('account');
+  });
+
+  it('parses security tab', () => {
+    expect(parsePractitionerSettingsTabId('security')).toBe('security');
+  });
+});

--- a/apps/practitioner/src/lib/settings-tabs.ts
+++ b/apps/practitioner/src/lib/settings-tabs.ts
@@ -1,0 +1,19 @@
+export const PRACTITIONER_SETTINGS_TAB_IDS = ['account', 'security'] as const;
+
+export type PractitionerSettingsTabId =
+  (typeof PRACTITIONER_SETTINGS_TAB_IDS)[number];
+
+/**
+ * Parses a practitioner settings tab id from a query string value.
+ *
+ * @param raw - Raw `tab` search param.
+ * @returns A valid tab id, or `account` when missing/invalid.
+ */
+export function parsePractitionerSettingsTabId(
+  raw: string | null,
+): PractitionerSettingsTabId {
+  if (raw === 'security') {
+    return raw;
+  }
+  return 'account';
+}

--- a/apps/practitioner/src/lib/settings-tabs.ts
+++ b/apps/practitioner/src/lib/settings-tabs.ts
@@ -3,6 +3,12 @@ export const PRACTITIONER_SETTINGS_TAB_IDS = ['account', 'security'] as const;
 export type PractitionerSettingsTabId =
   (typeof PRACTITIONER_SETTINGS_TAB_IDS)[number];
 
+function isPractitionerSettingsTabId(
+  raw: string,
+): raw is PractitionerSettingsTabId {
+  return (PRACTITIONER_SETTINGS_TAB_IDS as readonly string[]).includes(raw);
+}
+
 /**
  * Parses a practitioner settings tab id from a query string value.
  *
@@ -12,7 +18,7 @@ export type PractitionerSettingsTabId =
 export function parsePractitionerSettingsTabId(
   raw: string | null,
 ): PractitionerSettingsTabId {
-  if (raw === 'security') {
+  if (raw != null && isPractitionerSettingsTabId(raw)) {
     return raw;
   }
   return 'account';

--- a/apps/practitioner/tailwind.config.js
+++ b/apps/practitioner/tailwind.config.js
@@ -50,6 +50,9 @@ module.exports = {
           'on-primary-solid':
             'rgb(var(--app-primary-on-solid) / <alpha-value>)',
           'primary-soft': 'rgb(var(--app-primary-soft) / <alpha-value>)',
+          'tab-active-bg': 'rgb(var(--app-tab-active-bg) / <alpha-value>)',
+          'tab-active-text': 'rgb(var(--app-tab-active-text) / <alpha-value>)',
+          'tab-active-ring': 'rgb(var(--app-tab-active-ring) / <alpha-value>)',
           ring: 'rgb(var(--app-ring) / <alpha-value>)',
         },
       },


### PR DESCRIPTION
Closes #210

## Summary

- Adds `/settings` to the practitioner app with **Account** and **Security** tabs, linked as the last item in the sidebar.
- **Account:** edit name (title, first, last) into `profiles.display_name`, request email change with confirmation flow, and **Sign out everywhere** (moved from the top nav; top nav keeps trust-aware **Log out** only).
- **Security:** add/change/revoke password sign-in and manage TOTP enrollment, aligned with user web patterns.
- Fixes practitioner auth/settings polish: email-change callback accepts an existing session when the PKCE code is already consumed (matches web), auth provider no longer flashes loading on token refresh after password save, settings tab active styling tokens added, and logout avoids a brief “must be signed in” error while redirecting.

## Test plan

- [ ] Open **Settings** from the sidebar; confirm Account and Security tabs match user web styling (active tab pill).
- [ ] Update name fields and confirm `display_name` persists after reload.
- [ ] Request an email change, click the confirmation link, and confirm redirect to `/settings?tab=account` without an invalid-link error and updated email shown.
- [ ] Add/change password on Security tab; confirm no full-page reload flash and success feedback.
- [ ] Enroll/remove TOTP; confirm MFA step-up still works on login.
- [ ] Use **Log out** from the top nav on Settings; confirm no error flash before redirect to `/login`.
- [ ] Use **Sign out everywhere** on Account tab; confirm global logout and re-login required on all devices.
- [ ] Run `pnpm practitioner:test` and `pnpm practitioner:build`.