### PR TITLE
feat(mobile): redesign home dashboard and secondary navigation

### DIFF
--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import NetInfo from '@react-native-community/netinfo';
 import type { NetInfoState } from '@react-native-community/netinfo';
-import { ActionSheetIOS, AppState, Linking } from 'react-native';
+import { AppState, Linking } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import type { AbstrackSupabaseClient, Session } from '@abstrack/supabase';
 
@@ -19,6 +19,8 @@ import * as mobileNetinfo from '../lib/network/mobile-device-netinfo';
 type MobileAuthGetSessionResult = Awaited<
   ReturnType<typeof getMobileAuthSessionSafe>
 >;
+
+const mockShowActionSheetWithOptions = jest.fn();
 
 jest.mock('@abstrack/supabase', () => {
   const actual =
@@ -54,6 +56,15 @@ jest.mock('../lib/caretaker-invite-complete', () => ({
   completeCaretakerInviteAfterAuth: jest.fn(async () => ({ ok: true })),
 }));
 
+jest.mock('@expo/react-native-action-sheet', () => ({
+  __esModule: true,
+  ActionSheetProvider: ({ children }: { children: React.ReactNode }) =>
+    children,
+  useActionSheet: () => ({
+    showActionSheetWithOptions: mockShowActionSheetWithOptions,
+  }),
+}));
+
 const ENV_KEYS = [
   'EXPO_PUBLIC_SUPABASE_URL',
   'EXPO_PUBLIC_SUPABASE_PUBLISHABLE_KEY',
@@ -77,6 +88,7 @@ const makeMockClient = () => ({
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockShowActionSheetWithOptions.mockReset();
 
   for (const key of ENV_KEYS) {
     snapshot[key] = process.env[key];
@@ -854,24 +866,18 @@ describe('mobile auth state sync', () => {
 
     jest.mocked(SecureStore.getItemAsync).mockResolvedValue('false');
     jest.mocked(getMobileSupabaseClient).mockReturnValue(mockClient);
-    const actionSheetSpy = jest
-      .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
-      .mockImplementation((_options, onSelect) => {
-        onSelect?.(1);
-      });
+    mockShowActionSheetWithOptions.mockImplementation((_options, onSelect) => {
+      onSelect?.(1);
+    });
 
-    try {
-      const { findByText, findByLabelText } = render(<App />);
+    const { findByText, findByLabelText } = render(<App />);
 
-      await findByText('Episode logging');
-      fireEvent.press(await findByLabelText('Open app menu'));
+    await findByText('Episode logging');
+    fireEvent.press(await findByLabelText('Open app menu'));
 
-      expect(
-        await findByLabelText('Require re-authentication on app open'),
-      ).toBeTruthy();
-    } finally {
-      actionSheetSpy.mockRestore();
-    }
+    expect(
+      await findByLabelText('Require re-authentication on app open'),
+    ).toBeTruthy();
   });
 
   test('enforces re-auth when app returns to foreground and preference is enabled', async () => {

--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -860,15 +860,18 @@ describe('mobile auth state sync', () => {
         onSelect?.(1);
       });
 
-    const { findByText, findByLabelText } = render(<App />);
+    try {
+      const { findByText, findByLabelText } = render(<App />);
 
-    await findByText('Episode logging');
-    fireEvent.press(await findByLabelText('Open app menu'));
+      await findByText('Episode logging');
+      fireEvent.press(await findByLabelText('Open app menu'));
 
-    expect(
-      await findByLabelText('Require re-authentication on app open'),
-    ).toBeTruthy();
-    actionSheetSpy.mockRestore();
+      expect(
+        await findByLabelText('Require re-authentication on app open'),
+      ).toBeTruthy();
+    } finally {
+      actionSheetSpy.mockRestore();
+    }
   });
 
   test('enforces re-auth when app returns to foreground and preference is enabled', async () => {

--- a/apps/mobile/src/app/App.spec.tsx
+++ b/apps/mobile/src/app/App.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { act, fireEvent, render, waitFor } from '@testing-library/react-native';
 import NetInfo from '@react-native-community/netinfo';
 import type { NetInfoState } from '@react-native-community/netinfo';
-import { AppState, Linking } from 'react-native';
+import { ActionSheetIOS, AppState, Linking } from 'react-native';
 import * as SecureStore from 'expo-secure-store';
 import type { AbstrackSupabaseClient, Session } from '@abstrack/supabase';
 
@@ -219,7 +219,7 @@ describe('mobile auth state sync', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('Welcome to ABStrack')).toBeTruthy();
+      expect(getByText('Episode logging')).toBeTruthy();
     });
 
     await act(async () => {
@@ -264,7 +264,7 @@ describe('mobile auth state sync', () => {
     });
 
     await waitFor(() => {
-      expect(getByText('Welcome to ABStrack')).toBeTruthy();
+      expect(getByText('Episode logging')).toBeTruthy();
     });
 
     await act(async () => {
@@ -273,7 +273,7 @@ describe('mobile auth state sync', () => {
 
     await waitFor(() => {
       expect(getByText('Login')).toBeTruthy();
-      expect(queryByText('Welcome to ABStrack')).toBeNull();
+      expect(queryByText('Episode logging')).toBeNull();
     });
   });
 
@@ -568,7 +568,7 @@ describe('mobile auth state sync', () => {
 
     const { findByText } = render(<App />);
 
-    expect(await findByText('You are signed in.')).toBeTruthy();
+    expect(await findByText('Episode logging')).toBeTruthy();
     expect(signOut).not.toHaveBeenCalled();
   });
 
@@ -697,7 +697,7 @@ describe('mobile auth state sync', () => {
     try {
       const { findByText, findByLabelText, findByTestId } = render(<App />);
 
-      expect(await findByText('Welcome to ABStrack')).toBeTruthy();
+      expect(await findByText('Episode logging')).toBeTruthy();
 
       fireEvent.press(await findByLabelText('Symptom presets'));
       expect(await findByTestId('symptom-preset-list-screen')).toBeTruthy();
@@ -809,7 +809,7 @@ describe('mobile auth state sync', () => {
         <App />,
       );
 
-      await findByText('Welcome to ABStrack');
+      await findByText('Episode logging');
 
       // Wait for Home to leave the active-episode probe spinner, then the start CTA (not resume).
       await waitFor(() => {
@@ -854,15 +854,21 @@ describe('mobile auth state sync', () => {
 
     jest.mocked(SecureStore.getItemAsync).mockResolvedValue('false');
     jest.mocked(getMobileSupabaseClient).mockReturnValue(mockClient);
+    const actionSheetSpy = jest
+      .spyOn(ActionSheetIOS, 'showActionSheetWithOptions')
+      .mockImplementation((_options, onSelect) => {
+        onSelect?.(1);
+      });
 
     const { findByText, findByLabelText } = render(<App />);
 
-    const settingsButton = await findByText('Settings');
-    fireEvent.press(settingsButton);
+    await findByText('Episode logging');
+    fireEvent.press(await findByLabelText('Open app menu'));
 
     expect(
       await findByLabelText('Require re-authentication on app open'),
     ).toBeTruthy();
+    actionSheetSpy.mockRestore();
   });
 
   test('enforces re-auth when app returns to foreground and preference is enabled', async () => {
@@ -922,7 +928,7 @@ describe('mobile auth state sync', () => {
 
     const { findByText } = render(<App />);
 
-    expect(await findByText('You are signed in.')).toBeTruthy();
+    expect(await findByText('Episode logging')).toBeTruthy();
     expect(signOut).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -1018,7 +1024,7 @@ describe('mobile auth state sync', () => {
 
     const { findByText } = render(<App />);
 
-    expect(await findByText('You are signed in.')).toBeTruthy();
+    expect(await findByText('Episode logging')).toBeTruthy();
     expect(signOut).not.toHaveBeenCalled();
 
     await act(async () => {
@@ -1153,7 +1159,7 @@ describe('mobile auth state sync', () => {
 
     const { findByText } = render(<App />);
 
-    expect(await findByText('You are signed in.')).toBeTruthy();
+    expect(await findByText('Episode logging')).toBeTruthy();
     expect(signOut).not.toHaveBeenCalled();
     expect(warnSpy).toHaveBeenCalled();
 
@@ -1197,7 +1203,7 @@ describe('mobile auth state sync', () => {
 
     const { findByText } = render(<App />);
 
-    expect(await findByText('You are signed in.')).toBeTruthy();
+    expect(await findByText('Episode logging')).toBeTruthy();
     expect(warnSpy).toHaveBeenCalled();
 
     warnSpy.mockRestore();

--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -34,6 +34,7 @@ import { EpisodeStartScreen } from './screens/EpisodeStartScreen';
 import { FoodDiaryEntryScreen } from './screens/FoodDiaryEntryScreen';
 import { StandaloneHealthMarkersScreen } from './screens/StandaloneHealthMarkersScreen';
 import { HealthMarkerPromptScreen } from './screens/HealthMarkerPromptScreen';
+import { ManageScreen } from './screens/ManageScreen';
 import { SymptomPromptScreen } from './screens/SymptomPromptScreen';
 import { SettingsScreen } from './screens/SettingsScreen';
 import { SignupScreen } from './screens/SignupScreen';
@@ -708,6 +709,11 @@ function AppBootstrap() {
                     title: 'Health markers',
                     headerBackTitle: 'Home',
                   }}
+                />
+                <MainStack.Screen
+                  name="Manage"
+                  component={ManageScreen}
+                  options={{ title: 'Manage' }}
                 />
                 <MainStack.Screen
                   name="Settings"

--- a/apps/mobile/src/app/components/AppNavigationShell.tsx
+++ b/apps/mobile/src/app/components/AppNavigationShell.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { NavigationShell } from '@abstrack/ui/native';
 import { useAppTheme } from '../theme/AppThemeContext';
@@ -8,6 +8,8 @@ import { nw } from '../theme/app-nativewind-classes';
 export type AppNavigationShellProps = {
   /** Visible screen title; header semantics come from {@link NavigationShell}'s header container. */
   title: string;
+  /** Optional trailing header action, such as the authenticated menu button. */
+  headerAction?: React.ReactNode;
   children: React.ReactNode;
 };
 
@@ -21,6 +23,7 @@ export type AppNavigationShellProps = {
  */
 export function AppNavigationShell({
   title,
+  headerAction,
   children,
 }: AppNavigationShellProps) {
   const { colors } = useAppTheme();
@@ -38,12 +41,16 @@ export function AppNavigationShell({
         }}
         mainStyle={{ flex: 1, backgroundColor: colors.bg }}
         header={
-          <Text
-            className={`text-xl font-semibold ${nw.textInk}`}
-            maxFontSizeMultiplier={2}
-          >
-            {title}
-          </Text>
+          <View className="flex-row items-center justify-between gap-3">
+            <Text
+              className={`min-w-0 flex-1 text-xl font-semibold ${nw.textInk}`}
+              maxFontSizeMultiplier={2}
+              numberOfLines={1}
+            >
+              {title}
+            </Text>
+            {headerAction ? <View>{headerAction}</View> : null}
+          </View>
         }
       >
         {children}

--- a/apps/mobile/src/app/components/AppSecondaryMenuButton.tsx
+++ b/apps/mobile/src/app/components/AppSecondaryMenuButton.tsx
@@ -1,0 +1,82 @@
+import React, { useCallback } from 'react';
+import { Platform, Pressable } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useActionSheet } from '@expo/react-native-action-sheet';
+import { Ionicons } from '@expo/vector-icons';
+import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import { useAppTheme } from '../theme/AppThemeContext';
+
+export type AppSecondaryMenuButtonProps = {
+  /** Opens the standalone Manage screen. */
+  onGoToManage: () => void;
+  /** Opens the standalone Settings screen. */
+  onGoToSettings: () => void;
+};
+
+/**
+ * Header action that opens the app's secondary navigation menu in a native action sheet.
+ *
+ * @param props - Secondary destination callbacks.
+ * @returns Pressable icon button for authenticated mobile screens.
+ */
+export function AppSecondaryMenuButton({
+  onGoToManage,
+  onGoToSettings,
+}: AppSecondaryMenuButtonProps) {
+  const { colors } = useAppTheme();
+  const insets = useSafeAreaInsets();
+  const { showActionSheetWithOptions } = useActionSheet();
+
+  const openMenu = useCallback(() => {
+    const options = ['Manage', 'Settings', 'Cancel'];
+    const cancelButtonIndex = options.length - 1;
+    const androidBottomPad =
+      Platform.OS === 'android' ? Math.max(insets.bottom, 24) : 0;
+
+    showActionSheetWithOptions(
+      {
+        title: 'Menu',
+        options,
+        cancelButtonIndex,
+        ...(androidBottomPad > 0
+          ? { containerStyle: { paddingBottom: androidBottomPad } }
+          : {}),
+      },
+      (selectedIndex?: number) => {
+        if (selectedIndex === 0) {
+          onGoToManage();
+          return;
+        }
+        if (selectedIndex === 1) {
+          onGoToSettings();
+        }
+      },
+    );
+  }, [insets.bottom, onGoToManage, onGoToSettings, showActionSheetWithOptions]);
+
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel="Open app menu"
+      accessibilityHint="Opens navigation for Manage and Settings."
+      onPress={openMenu}
+      hitSlop={8}
+      style={({ pressed }) => ({
+        minWidth: COMFORTABLE_TOUCH_TARGET_DP,
+        minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+        alignItems: 'center',
+        justifyContent: 'center',
+        borderRadius: COMFORTABLE_TOUCH_TARGET_DP / 2,
+        opacity: pressed ? 0.72 : 1,
+      })}
+    >
+      <Ionicons
+        name="ellipsis-horizontal"
+        size={22}
+        color={colors.ink}
+        accessibilityElementsHidden
+        importantForAccessibility="no"
+      />
+    </Pressable>
+  );
+}

--- a/apps/mobile/src/app/components/HomeDashboardActionCard.tsx
+++ b/apps/mobile/src/app/components/HomeDashboardActionCard.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import { useAppTheme } from '../theme/AppThemeContext';
+import { nw } from '../theme/app-nativewind-classes';
+
+export type HomeDashboardActionCardProps = {
+  /** Visible card heading. */
+  heading: string;
+  /** Supporting copy under the heading. */
+  description: string;
+  /** Primary button label. */
+  ctaLabel: string;
+  /** Spoken label for the primary button. */
+  ctaAccessibilityLabel: string;
+  /** Runs the primary action. */
+  onPress: () => void;
+};
+
+/**
+ * Neutral dashboard card for Home shortcuts such as standalone health markers and food diary.
+ *
+ * @param props - Card copy and primary action.
+ * @returns Rounded surface with a single primary CTA.
+ */
+export function HomeDashboardActionCard({
+  heading,
+  description,
+  ctaLabel,
+  ctaAccessibilityLabel,
+  onPress,
+}: HomeDashboardActionCardProps) {
+  const { colors } = useAppTheme();
+
+  return (
+    <View className={`mb-4 gap-3 rounded-xl p-4 ${nw.card} ${nw.cardShadow}`}>
+      <View className="gap-1">
+        <Text className={`text-lg font-semibold ${nw.textInk}`}>{heading}</Text>
+        <Text className={`text-sm leading-5 ${nw.textMuted}`}>
+          {description}
+        </Text>
+      </View>
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel={ctaAccessibilityLabel}
+        onPress={onPress}
+        className={`min-h-[52px] items-center justify-center rounded-xl px-4 ${nw.btnPrimary}`}
+        style={{ backgroundColor: colors.primary }}
+      >
+        <Text
+          className={`text-center text-base font-semibold ${nw.textOnPrimary}`}
+        >
+          {ctaLabel}
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
+++ b/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
@@ -1,0 +1,131 @@
+import React from 'react';
+import { Pressable, Text, View } from 'react-native';
+import type { EpisodeRow } from '@abstrack/types';
+import { formatEpisodeDurationSimple } from '@abstrack/types';
+import { useAppTheme } from '../theme/AppThemeContext';
+import { nw } from '../theme/app-nativewind-classes';
+
+function episodeSummaryLine(
+  ep: Pick<EpisodeRow, 'episode_type' | 'episode_label'>,
+) {
+  const label = ep.episode_label?.trim();
+  return label ? `${ep.episode_type} - ${label}` : ep.episode_type;
+}
+
+function formatInstant(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) {
+    return iso.trim() === '' ? '-' : iso;
+  }
+  return date.toLocaleString(undefined, {
+    dateStyle: 'medium',
+    timeStyle: 'short',
+  });
+}
+
+export type HomeRecentEpisodesCardProps = {
+  /** Recent ended episodes to preview. */
+  episodes: EpisodeRow[];
+  /** Shows a loading state while Home determines what to show. */
+  loading: boolean;
+  /** Error or status message when the preview cannot be fully loaded. */
+  message: string | null;
+  /** Opens the full Manage episodes screen. */
+  onViewAllEpisodes: () => void;
+};
+
+/**
+ * Home-card preview of the patient's most recent ended episodes.
+ *
+ * @param props - Episode preview data and CTA.
+ * @returns Card with loading, empty, error, and preview states.
+ */
+export function HomeRecentEpisodesCard({
+  episodes,
+  loading,
+  message,
+  onViewAllEpisodes,
+}: HomeRecentEpisodesCardProps) {
+  const { colors } = useAppTheme();
+
+  return (
+    <View className={`gap-3 rounded-xl p-4 ${nw.card} ${nw.cardShadow}`}>
+      <View className="gap-1">
+        <Text className={`text-lg font-semibold ${nw.textInk}`}>
+          Recent episodes
+        </Text>
+        <Text className={`text-sm leading-5 ${nw.textMuted}`}>
+          Your latest ended episodes. Open Manage for the full history and
+          filters.
+        </Text>
+      </View>
+
+      {loading ? (
+        <Text
+          className={`text-sm ${nw.textMuted}`}
+          accessibilityLiveRegion="polite"
+        >
+          Loading recent episodes...
+        </Text>
+      ) : null}
+
+      {!loading && message ? (
+        <Text
+          className={`text-sm ${message.startsWith('Showing ') ? nw.textMuted : nw.textError}`}
+          accessibilityRole={
+            message.startsWith('Showing ') ? undefined : 'alert'
+          }
+        >
+          {message}
+        </Text>
+      ) : null}
+
+      {!loading && episodes.length === 0 && !message ? (
+        <Text
+          className={`rounded-xl border border-dashed p-4 text-sm ${nw.textMuted} ${nw.card}`}
+        >
+          No ended episodes yet. Start an episode when you are ready to log
+          symptoms.
+        </Text>
+      ) : null}
+
+      {!loading && episodes.length > 0 ? (
+        <View className="gap-3" accessibilityRole="list">
+          {episodes.map((episode) => (
+            <View
+              key={episode.id}
+              className={`rounded-xl border px-4 py-3 ${nw.card}`}
+              accessibilityRole="none"
+            >
+              <Text className={`text-base font-semibold ${nw.textInk}`}>
+                {episodeSummaryLine(episode)}
+              </Text>
+              <Text className={`mt-2 text-sm ${nw.textMuted}`}>
+                Ended {episode.ended_at ? formatInstant(episode.ended_at) : '-'}
+              </Text>
+              <Text className={`text-sm ${nw.textMuted}`}>
+                Duration{' '}
+                {formatEpisodeDurationSimple(
+                  episode.started_at,
+                  episode.ended_at,
+                ) ?? '-'}
+              </Text>
+            </View>
+          ))}
+        </View>
+      ) : null}
+
+      <Pressable
+        accessibilityRole="button"
+        accessibilityLabel="View all episodes"
+        onPress={onViewAllEpisodes}
+        className={`min-h-[48px] items-center justify-center rounded-xl border px-4 py-3 ${nw.card}`}
+        style={{ borderColor: colors.border, backgroundColor: colors.surface }}
+      >
+        <Text className={`text-center text-sm font-semibold ${nw.textInk}`}>
+          View all episodes
+        </Text>
+      </Pressable>
+    </View>
+  );
+}

--- a/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
+++ b/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
@@ -23,6 +23,13 @@ function formatInstant(iso: string): string {
   });
 }
 
+// React Native docs support `listitem`, but this repo's current types/linting still lag behind.
+// Remove this cast once the accessibility tooling catches up and accepts the role directly.
+const ACCESSIBILITY_ROLE_LISTITEM =
+  'listitem' as unknown as React.ComponentProps<
+    typeof View
+  >['accessibilityRole'];
+
 export type HomeRecentEpisodesCardProps = {
   /** Recent ended episodes to preview. */
   episodes: EpisodeRow[];
@@ -96,7 +103,7 @@ export function HomeRecentEpisodesCard({
             <View
               key={episode.id}
               className={`rounded-xl border px-4 py-3 ${nw.card}`}
-              accessibilityRole="none"
+              accessibilityRole={ACCESSIBILITY_ROLE_LISTITEM}
             >
               <Text className={`text-base font-semibold ${nw.textInk}`}>
                 {episodeSummaryLine(episode)}

--- a/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
+++ b/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
@@ -30,6 +30,8 @@ export type HomeRecentEpisodesCardProps = {
   loading: boolean;
   /** Error or status message when the preview cannot be fully loaded. */
   message: string | null;
+  /** Visual + accessibility treatment for the optional message. */
+  messageTone?: 'info' | 'error';
   /** Opens the full Manage episodes screen. */
   onViewAllEpisodes: () => void;
 };
@@ -44,6 +46,7 @@ export function HomeRecentEpisodesCard({
   episodes,
   loading,
   message,
+  messageTone = 'error',
   onViewAllEpisodes,
 }: HomeRecentEpisodesCardProps) {
   const { colors } = useAppTheme();
@@ -71,10 +74,8 @@ export function HomeRecentEpisodesCard({
 
       {!loading && message ? (
         <Text
-          className={`text-sm ${message.startsWith('Showing ') ? nw.textMuted : nw.textError}`}
-          accessibilityRole={
-            message.startsWith('Showing ') ? undefined : 'alert'
-          }
+          className={`text-sm ${messageTone === 'info' ? nw.textMuted : nw.textError}`}
+          accessibilityRole={messageTone === 'error' ? 'alert' : undefined}
         >
           {message}
         </Text>

--- a/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
+++ b/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
@@ -15,7 +15,7 @@ function episodeSummaryLine(
 function formatInstant(iso: string): string {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) {
-    return iso.trim() === '' ? '-' : iso;
+    return iso.trim() === '' ? '—' : iso;
   }
   return date.toLocaleString(undefined, {
     dateStyle: 'medium',
@@ -101,14 +101,14 @@ export function HomeRecentEpisodesCard({
                 {episodeSummaryLine(episode)}
               </Text>
               <Text className={`mt-2 text-sm ${nw.textMuted}`}>
-                Ended {episode.ended_at ? formatInstant(episode.ended_at) : '-'}
+                Ended {episode.ended_at ? formatInstant(episode.ended_at) : '—'}
               </Text>
               <Text className={`text-sm ${nw.textMuted}`}>
                 Duration{' '}
                 {formatEpisodeDurationSimple(
                   episode.started_at,
                   episode.ended_at,
-                ) ?? '-'}
+                ) ?? '—'}
               </Text>
             </View>
           ))}

--- a/apps/mobile/src/app/navigation/EpisodeTemplatesNavigator.tsx
+++ b/apps/mobile/src/app/navigation/EpisodeTemplatesNavigator.tsx
@@ -1,10 +1,18 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { AppSecondaryMenuButton } from '../components/AppSecondaryMenuButton';
 import { EpisodeTemplateCreateScreen } from '../screens/EpisodeTemplateCreateScreen';
 import { EpisodeTemplateEditorScreen } from '../screens/EpisodeTemplateEditorScreen';
 import { EpisodeTemplateListScreen } from '../screens/EpisodeTemplateListScreen';
 import { useAppTheme } from '../theme/AppThemeContext';
-import type { EpisodeTemplatesStackParamList } from './types';
+import type {
+  EpisodeTemplatesStackParamList,
+  MainStackParamList,
+  MainTabParamList,
+} from './types';
 
 const Stack = createNativeStackNavigator<EpisodeTemplatesStackParamList>();
 
@@ -15,6 +23,25 @@ const Stack = createNativeStackNavigator<EpisodeTemplatesStackParamList>();
  */
 export function EpisodeTemplatesNavigator() {
   const { colors } = useAppTheme();
+  const tabNavigation =
+    useNavigation<
+      BottomTabNavigationProp<MainTabParamList, 'EpisodeTemplates'>
+    >();
+  const stackNavigation =
+    tabNavigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
+  if (stackNavigation == null) {
+    throw new Error(
+      'EpisodeTemplatesNavigator: expected native stack parent for app menu.',
+    );
+  }
+
+  const openManage = useCallback(() => {
+    stackNavigation.navigate('Manage');
+  }, [stackNavigation]);
+
+  const openSettings = useCallback(() => {
+    stackNavigation.navigate('Settings');
+  }, [stackNavigation]);
 
   const screenOptions = useMemo(
     () => ({
@@ -26,12 +53,25 @@ export function EpisodeTemplatesNavigator() {
     [colors],
   );
 
+  const listScreenOptions = useMemo(
+    () => ({
+      title: 'Episode templates',
+      headerRight: () => (
+        <AppSecondaryMenuButton
+          onGoToManage={openManage}
+          onGoToSettings={openSettings}
+        />
+      ),
+    }),
+    [openManage, openSettings],
+  );
+
   return (
     <Stack.Navigator screenOptions={screenOptions}>
       <Stack.Screen
         name="EpisodeTemplateList"
         component={EpisodeTemplateListScreen}
-        options={{ title: 'Episode templates' }}
+        options={listScreenOptions}
       />
       <Stack.Screen
         name="EpisodeTemplateCreate"

--- a/apps/mobile/src/app/navigation/HealthMarkerPresetsNavigator.tsx
+++ b/apps/mobile/src/app/navigation/HealthMarkerPresetsNavigator.tsx
@@ -1,10 +1,18 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { AppSecondaryMenuButton } from '../components/AppSecondaryMenuButton';
 import { HealthMarkerPresetCreateScreen } from '../screens/HealthMarkerPresetCreateScreen';
 import { HealthMarkerPresetEditorScreen } from '../screens/HealthMarkerPresetEditorScreen';
 import { HealthMarkerPresetListScreen } from '../screens/HealthMarkerPresetListScreen';
 import { useAppTheme } from '../theme/AppThemeContext';
-import type { HealthMarkerPresetsStackParamList } from './types';
+import type {
+  HealthMarkerPresetsStackParamList,
+  MainStackParamList,
+  MainTabParamList,
+} from './types';
 
 const Stack = createNativeStackNavigator<HealthMarkerPresetsStackParamList>();
 
@@ -15,6 +23,25 @@ const Stack = createNativeStackNavigator<HealthMarkerPresetsStackParamList>();
  */
 export function HealthMarkerPresetsNavigator() {
   const { colors } = useAppTheme();
+  const tabNavigation =
+    useNavigation<
+      BottomTabNavigationProp<MainTabParamList, 'HealthMarkerPresets'>
+    >();
+  const stackNavigation =
+    tabNavigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
+  if (stackNavigation == null) {
+    throw new Error(
+      'HealthMarkerPresetsNavigator: expected native stack parent for app menu.',
+    );
+  }
+
+  const openManage = useCallback(() => {
+    stackNavigation.navigate('Manage');
+  }, [stackNavigation]);
+
+  const openSettings = useCallback(() => {
+    stackNavigation.navigate('Settings');
+  }, [stackNavigation]);
 
   const screenOptions = useMemo(
     () => ({
@@ -26,12 +53,25 @@ export function HealthMarkerPresetsNavigator() {
     [colors],
   );
 
+  const listScreenOptions = useMemo(
+    () => ({
+      title: 'Health marker presets',
+      headerRight: () => (
+        <AppSecondaryMenuButton
+          onGoToManage={openManage}
+          onGoToSettings={openSettings}
+        />
+      ),
+    }),
+    [openManage, openSettings],
+  );
+
   return (
     <Stack.Navigator screenOptions={screenOptions}>
       <Stack.Screen
         name="HealthMarkerPresetList"
         component={HealthMarkerPresetListScreen}
-        options={{ title: 'Health marker presets' }}
+        options={listScreenOptions}
       />
       <Stack.Screen
         name="HealthMarkerPresetCreate"

--- a/apps/mobile/src/app/navigation/MainTabNavigator.tsx
+++ b/apps/mobile/src/app/navigation/MainTabNavigator.tsx
@@ -5,10 +5,12 @@ import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { Ionicons } from '@expo/vector-icons';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import type { ActiveEpisodeHomeSummary } from '../components/episode-flow/EpisodeStartHomeCta';
+import { AppSecondaryMenuButton } from '../components/AppSecondaryMenuButton';
 import { HomeScreen } from '../screens/HomeScreen';
-import { ManageScreen } from '../screens/ManageScreen';
+import { InsightsScreen } from '../screens/InsightsScreen';
 import { EpisodeTemplatesNavigator } from './EpisodeTemplatesNavigator';
 import { HealthMarkerPresetsNavigator } from './HealthMarkerPresetsNavigator';
 import { SymptomPresetsNavigator } from './SymptomPresetsNavigator';
@@ -20,13 +22,14 @@ import type { MainStackParamList, MainTabParamList } from './types';
 const Tab = createBottomTabNavigator<MainTabParamList>();
 
 /**
- * Home tab lives under {@link MainStackParamList} `MainTabs`; opens stack `Settings`.
+ * Bottom tabs live under {@link MainStackParamList} `MainTabs`; stack screens such as `Manage` and
+ * `Settings` are opened from tab roots via the parent native stack.
  * Invariant: tab navigator is always nested in that stack — missing parent is a programmer error.
  *
- * @param navigation - Home tab navigation object.
+ * @param navigation - Any main-tab navigation object.
  */
-function navigateFromHomeTabToSettings(
-  navigation: BottomTabNavigationProp<MainTabParamList, 'Home'>,
+function navigateFromTabToSettings(
+  navigation: BottomTabNavigationProp<MainTabParamList>,
 ) {
   const stackNavigation =
     navigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
@@ -36,6 +39,20 @@ function navigateFromHomeTabToSettings(
     );
   }
   stackNavigation.navigate('Settings');
+}
+
+function navigateFromTabToManage(
+  navigation: BottomTabNavigationProp<MainTabParamList>,
+  params?: MainStackParamList['Manage'],
+) {
+  const stackNavigation =
+    navigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
+  if (stackNavigation == null) {
+    throw new Error(
+      'MainTabNavigator: expected native stack parent (MainStack) to open Manage.',
+    );
+  }
+  stackNavigation.navigate('Manage', params);
 }
 
 function navigateFromHomeTabToEpisodeStart(
@@ -131,8 +148,18 @@ function HomeTab() {
     useNavigation<BottomTabNavigationProp<MainTabParamList, 'Home'>>();
   return (
     <HomeScreen
-      onGoToSettings={() => {
-        navigateFromHomeTabToSettings(navigation);
+      headerAction={
+        <AppSecondaryMenuButton
+          onGoToManage={() => {
+            navigateFromTabToManage(navigation);
+          }}
+          onGoToSettings={() => {
+            navigateFromTabToSettings(navigation);
+          }}
+        />
+      }
+      onGoToManageEpisodes={() => {
+        navigateFromTabToManage(navigation, { initialSegment: 'episodes' });
       }}
       onGoToFoodDiary={() => {
         navigateFromHomeTabToFoodDiary(navigation);
@@ -151,6 +178,30 @@ function HomeTab() {
 }
 
 /**
+ * Placeholder Insights tab until the mobile charting experience ships.
+ *
+ * @returns Insights tab UI.
+ */
+function InsightsTab() {
+  const navigation =
+    useNavigation<BottomTabNavigationProp<MainTabParamList, 'Insights'>>();
+  return (
+    <InsightsScreen
+      headerAction={
+        <AppSecondaryMenuButton
+          onGoToManage={() => {
+            navigateFromTabToManage(navigation);
+          }}
+          onGoToSettings={() => {
+            navigateFromTabToSettings(navigation);
+          }}
+        />
+      }
+    />
+  );
+}
+
+/**
  * Primary signed-in navigation: home plus preset entry points with a bottom tab bar sized for
  * comfortable touch targets.
  *
@@ -158,6 +209,9 @@ function HomeTab() {
  */
 export function MainTabNavigator() {
   const { colors } = useAppTheme();
+  const { bottom } = useSafeAreaInsets();
+  const tabBarBottomPadding = 6 + bottom;
+  const tabBarMinHeight = COMFORTABLE_TOUCH_TARGET_DP + 28 + bottom;
 
   return (
     <EpisodeTemplatesDraftProvider>
@@ -170,8 +224,8 @@ export function MainTabNavigator() {
           tabBarShowLabel: true,
           tabBarStyle: {
             paddingTop: 4,
-            paddingBottom: 6,
-            minHeight: COMFORTABLE_TOUCH_TARGET_DP + 28,
+            paddingBottom: tabBarBottomPadding,
+            minHeight: tabBarMinHeight,
             backgroundColor: colors.surface,
             borderTopColor: colors.border,
             borderTopWidth: StyleSheet.hairlineWidth,
@@ -194,6 +248,15 @@ export function MainTabNavigator() {
             tabBarLabel: 'Home',
             tabBarAccessibilityLabel: 'Home',
             tabBarIcon: tabBarIonIcon('home-outline'),
+          }}
+        />
+        <Tab.Screen
+          name="Insights"
+          component={InsightsTab}
+          options={{
+            tabBarLabel: 'Insights',
+            tabBarAccessibilityLabel: 'Insights',
+            tabBarIcon: tabBarIonIcon('stats-chart-outline'),
           }}
         />
         <Tab.Screen
@@ -221,15 +284,6 @@ export function MainTabNavigator() {
             tabBarLabel: 'Templates',
             tabBarAccessibilityLabel: 'Episode templates',
             tabBarIcon: tabBarIonIcon('layers-outline'),
-          }}
-        />
-        <Tab.Screen
-          name="Manage"
-          component={ManageScreen}
-          options={{
-            tabBarLabel: 'Manage',
-            tabBarAccessibilityLabel: 'Manage records',
-            tabBarIcon: tabBarIonIcon('albums-outline'),
           }}
         />
       </Tab.Navigator>

--- a/apps/mobile/src/app/navigation/SymptomPresetsNavigator.tsx
+++ b/apps/mobile/src/app/navigation/SymptomPresetsNavigator.tsx
@@ -1,10 +1,18 @@
-import React, { useMemo } from 'react';
+import React, { useCallback, useMemo } from 'react';
+import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
+import { useNavigation } from '@react-navigation/native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import { AppSecondaryMenuButton } from '../components/AppSecondaryMenuButton';
 import { SymptomPresetCreateScreen } from '../screens/SymptomPresetCreateScreen';
 import { SymptomPresetEditorScreen } from '../screens/SymptomPresetEditorScreen';
 import { SymptomPresetListScreen } from '../screens/SymptomPresetListScreen';
 import { useAppTheme } from '../theme/AppThemeContext';
-import type { SymptomPresetsStackParamList } from './types';
+import type {
+  MainStackParamList,
+  MainTabParamList,
+  SymptomPresetsStackParamList,
+} from './types';
 
 const Stack = createNativeStackNavigator<SymptomPresetsStackParamList>();
 
@@ -15,6 +23,25 @@ const Stack = createNativeStackNavigator<SymptomPresetsStackParamList>();
  */
 export function SymptomPresetsNavigator() {
   const { colors } = useAppTheme();
+  const tabNavigation =
+    useNavigation<
+      BottomTabNavigationProp<MainTabParamList, 'SymptomPresets'>
+    >();
+  const stackNavigation =
+    tabNavigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
+  if (stackNavigation == null) {
+    throw new Error(
+      'SymptomPresetsNavigator: expected native stack parent for app menu.',
+    );
+  }
+
+  const openManage = useCallback(() => {
+    stackNavigation.navigate('Manage');
+  }, [stackNavigation]);
+
+  const openSettings = useCallback(() => {
+    stackNavigation.navigate('Settings');
+  }, [stackNavigation]);
 
   const screenOptions = useMemo(
     () => ({
@@ -26,12 +53,25 @@ export function SymptomPresetsNavigator() {
     [colors],
   );
 
+  const listScreenOptions = useMemo(
+    () => ({
+      title: 'Symptom presets',
+      headerRight: () => (
+        <AppSecondaryMenuButton
+          onGoToManage={openManage}
+          onGoToSettings={openSettings}
+        />
+      ),
+    }),
+    [openManage, openSettings],
+  );
+
   return (
     <Stack.Navigator screenOptions={screenOptions}>
       <Stack.Screen
         name="SymptomPresetList"
         component={SymptomPresetListScreen}
-        options={{ title: 'Symptom presets' }}
+        options={listScreenOptions}
       />
       <Stack.Screen
         name="SymptomPresetCreate"

--- a/apps/mobile/src/app/navigation/types.ts
+++ b/apps/mobile/src/app/navigation/types.ts
@@ -25,18 +25,17 @@ export type EpisodeTemplatesStackParamList = {
   EpisodeTemplateEdit: { templateId: string };
 };
 
-/** Optional deep-link into the Manage tab (e.g. Settings shortcut). */
-export type ManageTabParams = {
+/** Optional deep-link into the Manage screen (e.g. Home / Settings shortcut). */
+export type ManageScreenParams = {
   initialSegment?: 'episodes' | 'health' | 'food';
 };
 
 export type MainTabParamList = {
   Home: undefined;
+  Insights: undefined;
   SymptomPresets: undefined;
   HealthMarkerPresets: undefined;
   EpisodeTemplates: undefined;
-  /** Episodes, standalone health markers, and standalone food diary management. */
-  Manage: ManageTabParams | undefined;
 };
 
 export type MainStackParamList = {
@@ -67,5 +66,7 @@ export type MainStackParamList = {
   };
   /** Log vitals from a preset without an episode (`episode_id` null on saved rows). */
   StandaloneHealthMarkers: undefined;
+  /** Episodes, standalone health markers, and standalone food diary management. */
+  Manage: ManageScreenParams | undefined;
   Settings: undefined;
 };

--- a/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
+++ b/apps/mobile/src/app/screens/EpisodesManagementPanel.tsx
@@ -88,7 +88,7 @@ export type EpisodesManagementPanelProps = {
   navigation: EpisodesManagementNav;
   /**
    * `standalone`: full screen with {@link ScreenShell} and page title (tests / legacy).
-   * `embedded`: body only for the Manage tab.
+   * `embedded`: body only for the Manage screen.
    */
   variant?: 'standalone' | 'embedded';
   /** Inclusive lower bound on `ended_at` for completed history (ISO timestamptz). */

--- a/apps/mobile/src/app/screens/EpisodesScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodesScreen.tsx
@@ -6,7 +6,7 @@ import {
 } from './EpisodesManagementPanel';
 
 /**
- * @deprecated Episodes are opened from the Manage tab; this wrapper remains for test compatibility
+ * @deprecated Episodes are opened from Manage; this wrapper remains for test compatibility
  *   with existing `EpisodesScreen` specs.
  *
  * @returns Standalone episode management screen.

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -526,28 +526,41 @@ export function HomeScreen({
     ? psEpisodeSnap.completedLoading
     : recentEpisodesLoading;
 
-  const recentEpisodesMessage = useMemo(() => {
+  const recentEpisodesFeedback = useMemo(() => {
     if (replicaMirrorHomeReads) {
       if (
         psEpisodeSnap.completedQueryError &&
         !psEpisodeSnap.completedLoading &&
         recentEpisodesDisplay.length === 0
       ) {
-        return `Could not read recent episodes from this device. ${userFacingSyncHealthBridgeOrClientError(
-          psEpisodeSnap.completedQueryError,
-        )}`;
+        return {
+          message: `Could not read recent episodes from this device. ${userFacingSyncHealthBridgeOrClientError(
+            psEpisodeSnap.completedQueryError,
+          )}`,
+          tone: 'error' as const,
+        };
       }
-      return null;
+      return { message: null, tone: null };
     }
     if (showRecentDeviceFallback) {
-      return recentEpisodesSkippedOffline
-        ? 'Showing recent episodes saved on this device while you are offline.'
-        : 'Showing recent episodes saved on this device.';
+      return {
+        message: recentEpisodesSkippedOffline
+          ? 'Showing recent episodes saved on this device while you are offline.'
+          : 'Showing recent episodes saved on this device.',
+        tone: 'info' as const,
+      };
     }
     if (recentEpisodesSkippedOffline) {
-      return 'Connect or wait for network reachability to load recent episodes.';
+      return {
+        message:
+          'Connect or wait for network reachability to load recent episodes.',
+        tone: 'error' as const,
+      };
     }
-    return recentEpisodesError;
+    return {
+      message: recentEpisodesError,
+      tone: recentEpisodesError ? ('error' as const) : null,
+    };
   }, [
     psEpisodeSnap.completedLoading,
     psEpisodeSnap.completedQueryError,
@@ -625,7 +638,8 @@ export function HomeScreen({
         <HomeRecentEpisodesCard
           episodes={recentEpisodesDisplay}
           loading={recentEpisodesCardLoading}
-          message={recentEpisodesMessage}
+          message={recentEpisodesFeedback.message}
+          messageTone={recentEpisodesFeedback.tone ?? undefined}
           onViewAllEpisodes={onGoToManageEpisodes}
         />
       </ScrollView>

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -330,6 +330,7 @@ export function HomeScreen({
   loadNetworkResumeEpisodeRef.current = loadNetworkResumeEpisode;
   const loadRecentEpisodesRef = useRef(loadRecentEpisodes);
   loadRecentEpisodesRef.current = loadRecentEpisodes;
+  const authStateLoadCancelRef = useRef<{ cancelled: boolean } | null>(null);
   const psActiveEpisodeQueryErrorRef = useRef<Error | undefined>(undefined);
   psActiveEpisodeQueryErrorRef.current = psEpisodeSnap.activeQueryError;
 
@@ -369,16 +370,22 @@ export function HomeScreen({
     if (replicaMirrorHomeReads) {
       return;
     }
+    const cancel = { cancelled: false };
+    authStateLoadCancelRef.current = cancel;
     const supabase = getMobileSupabaseClient();
     const {
       data: { subscription },
     } = supabase.auth.onAuthStateChange((event) => {
       if (event === 'SIGNED_IN' || event === 'SIGNED_OUT') {
-        void loadNetworkResumeEpisode();
-        void loadRecentEpisodes();
+        void loadNetworkResumeEpisode(cancel);
+        void loadRecentEpisodes(cancel);
       }
     });
     return () => {
+      cancel.cancelled = true;
+      if (authStateLoadCancelRef.current === cancel) {
+        authStateLoadCancelRef.current = null;
+      }
       subscription.unsubscribe();
     };
   }, [loadNetworkResumeEpisode, loadRecentEpisodes, replicaMirrorHomeReads]);

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -330,7 +330,6 @@ export function HomeScreen({
   loadNetworkResumeEpisodeRef.current = loadNetworkResumeEpisode;
   const loadRecentEpisodesRef = useRef(loadRecentEpisodes);
   loadRecentEpisodesRef.current = loadRecentEpisodes;
-  const authStateLoadCancelRef = useRef<{ cancelled: boolean } | null>(null);
   const psActiveEpisodeQueryErrorRef = useRef<Error | undefined>(undefined);
   psActiveEpisodeQueryErrorRef.current = psEpisodeSnap.activeQueryError;
 
@@ -371,7 +370,6 @@ export function HomeScreen({
       return;
     }
     const cancel = { cancelled: false };
-    authStateLoadCancelRef.current = cancel;
     const supabase = getMobileSupabaseClient();
     const {
       data: { subscription },
@@ -383,9 +381,6 @@ export function HomeScreen({
     });
     return () => {
       cancel.cancelled = true;
-      if (authStateLoadCancelRef.current === cancel) {
-        authStateLoadCancelRef.current = null;
-      }
       subscription.unsubscribe();
     };
   }, [loadNetworkResumeEpisode, loadRecentEpisodes, replicaMirrorHomeReads]);

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -169,8 +169,8 @@ export function HomeScreen({
       }
       if (!stale()) {
         setNetworkResumeSkippedOffline(false);
+        setNetworkResumeLoading(true);
       }
-      setNetworkResumeLoading(true);
       try {
         const mobileSupabase = getMobileSupabaseClient();
         const {

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -82,8 +82,9 @@ export function HomeScreen({
   const [networkResumeLoading, setNetworkResumeLoading] = useState(false);
   /**
    * True when the last network-resume attempt bailed before calling Supabase because NetInfo
-   * reported explicit offline. While PowerSync is configured but the replica is not mirror-ready,
-   * we must not treat a null resume row as authoritative (empty replica + no fetch).
+   * did not confirm usable internet (`false` or `null`). While PowerSync is configured but the
+   * replica is not mirror-ready, we must not treat a null resume row as authoritative
+   * (empty replica + no fetch).
    */
   const [networkResumeSkippedOffline, setNetworkResumeSkippedOffline] =
     useState(false);
@@ -159,7 +160,7 @@ export function HomeScreen({
         return;
       }
       const connected = await fetchMobileDeviceIsConnected();
-      if (connected === false) {
+      if (connected !== true) {
         if (!stale()) {
           setNetworkResumeSkippedOffline(true);
           setNetworkResumeLoading(false);
@@ -233,7 +234,7 @@ export function HomeScreen({
       }
 
       const connected = await fetchMobileDeviceIsConnected();
-      if (connected === false) {
+      if (connected !== true) {
         if (!stale()) {
           setRecentEpisodes([]);
           setRecentEpisodesLoading(false);
@@ -532,7 +533,9 @@ export function HomeScreen({
         !psEpisodeSnap.completedLoading &&
         recentEpisodesDisplay.length === 0
       ) {
-        return `Could not read recent episodes from this device. ${psEpisodeSnap.completedQueryError.message}`;
+        return `Could not read recent episodes from this device. ${userFacingSyncHealthBridgeOrClientError(
+          psEpisodeSnap.completedQueryError,
+        )}`;
       }
       return null;
     }
@@ -542,7 +545,7 @@ export function HomeScreen({
         : 'Showing recent episodes saved on this device.';
     }
     if (recentEpisodesSkippedOffline) {
-      return 'Connect to load recent episodes.';
+      return 'Connect or wait for network reachability to load recent episodes.';
     }
     return recentEpisodesError;
   }, [

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -5,76 +5,77 @@ import React, {
   useRef,
   useState,
 } from 'react';
-import {
-  Pressable,
-  RefreshControl,
-  ScrollView,
-  Text,
-  View,
-} from 'react-native';
+import { RefreshControl, ScrollView, Text, View } from 'react-native';
 import { useFocusEffect } from '@react-navigation/native';
 import type { EpisodeRow } from '@abstrack/types';
 import {
   getActiveEpisodeForUser,
-  healthCheckProfilesLimit1,
-  signOut,
+  listCompletedEpisodesForUser,
 } from '@abstrack/supabase';
 import { useMobilePhiSubjectUserContext } from '../../lib/auth/use-mobile-phi-subject-user-context';
-import { PowerSyncActiveEpisodeSubscription } from '../../lib/powersync/PowerSyncActiveEpisodeSubscription';
+import { fetchMobileDeviceIsConnected } from '../../lib/network/mobile-device-netinfo';
+import {
+  PowerSyncEpisodeReadSubscriptions,
+  type PowerSyncEpisodeReadSnapshots,
+} from '../../lib/powersync/PowerSyncEpisodeReadSubscriptions';
 import {
   powerSyncOfflineReplicaReadsEnabled,
   powerSyncReplicaSqliteReady,
   usePowerSyncBridgeState,
 } from '../../lib/powersync/PowerSyncSessionBridge';
 import { usePullToResyncPowerSync } from '../../lib/powersync/use-pull-to-resync-powersync';
-import { fetchMobileDeviceIsConnected } from '../../lib/network/mobile-device-netinfo';
-import { useMobileDeviceNetworkConnected } from '../../lib/network/use-mobile-device-network-connected';
 import {
   getMobileAuthSessionSafe,
   getMobileSupabaseClient,
 } from '../../lib/supabase-wiring';
-import { mapAuthError } from '../auth-helpers';
+import { AppNavigationShell } from '../components/AppNavigationShell';
+import { HomeDashboardActionCard } from '../components/HomeDashboardActionCard';
+import { HomeRecentEpisodesCard } from '../components/HomeRecentEpisodesCard';
 import {
   EpisodeStartHomeCta,
   episodeRowToActiveHomeSummary,
   type ActiveEpisodeHomeSummary,
 } from '../components/episode-flow/EpisodeStartHomeCta';
-import { AppNavigationShell } from '../components/AppNavigationShell';
 import { userFacingSyncHealthBridgeOrClientError } from '../components/sync-health-footer-user-messages';
 import { useAppTheme } from '../theme/AppThemeContext';
 import { nw } from '../theme/app-nativewind-classes';
 
-interface HealthCheckResult {
-  success: boolean;
-  message: string;
-  error?: string;
-}
+const HOME_RECENT_EPISODES_LIMIT = 3;
+
+const EMPTY_POWER_SYNC_EPISODE_SNAP: PowerSyncEpisodeReadSnapshots = {
+  activeEpisode: null,
+  activeLoading: false,
+  activeQueryError: undefined,
+  completedEpisodes: [],
+  completedLoading: false,
+  completedQueryError: undefined,
+};
 
 type HomeScreenProps = {
-  onGoToSettings: () => void;
+  headerAction?: React.ReactNode;
+  onGoToManageEpisodes: () => void;
   onGoToFoodDiary: () => void;
   onGoToStandaloneHealthMarkers: () => void;
   onStartEpisode: () => void;
   onResumeEpisode: (episode: ActiveEpisodeHomeSummary) => void;
 };
 
+/**
+ * Mobile dashboard surface for the signed-in user: episode logging, standalone logging shortcuts,
+ * and a short recent-episodes preview.
+ *
+ * @param props - Header action plus primary Home navigation callbacks.
+ * @returns Home dashboard content.
+ */
 export function HomeScreen({
-  onGoToSettings,
+  headerAction,
+  onGoToManageEpisodes,
   onGoToFoodDiary,
   onGoToStandaloneHealthMarkers,
   onStartEpisode,
   onResumeEpisode,
 }: HomeScreenProps) {
   const { colors } = useAppTheme();
-  const isTestEnv =
-    typeof process !== 'undefined' && process.env.NODE_ENV === 'test';
-  const showHealthCheck = __DEV__ && !isTestEnv;
-  const isMountedRef = useRef(true);
-  const [signOutBusy, setSignOutBusy] = useState(false);
-  const [signOutError, setSignOutError] = useState<string | null>(null);
-  const [healthCheck, setHealthCheck] = useState<HealthCheckResult | null>(
-    null,
-  );
   /** When `EXPO_PUBLIC_POWERSYNC_URL` is unset only: online Supabase resume row (see README). */
   const [networkResumeEpisode, setNetworkResumeEpisode] =
     useState<ActiveEpisodeHomeSummary | null>(null);
@@ -86,6 +87,13 @@ export function HomeScreen({
    */
   const [networkResumeSkippedOffline, setNetworkResumeSkippedOffline] =
     useState(false);
+  const [recentEpisodes, setRecentEpisodes] = useState<EpisodeRow[]>([]);
+  const [recentEpisodesLoading, setRecentEpisodesLoading] = useState(false);
+  const [recentEpisodesError, setRecentEpisodesError] = useState<string | null>(
+    null,
+  );
+  const [recentEpisodesSkippedOffline, setRecentEpisodesSkippedOffline] =
+    useState(false);
 
   const {
     authUserId,
@@ -94,32 +102,28 @@ export function HomeScreen({
     errorMessage: phiSubjectError,
     refresh: refreshPhiSubject,
   } = useMobilePhiSubjectUserContext();
-  const { isConnected: deviceNetConnected } = useMobileDeviceNetworkConnected();
   const psBridge = usePowerSyncBridgeState();
   const replicaMirrorHomeReads = useMemo(
     () => powerSyncOfflineReplicaReadsEnabled(psBridge),
     [psBridge],
   );
-  const [psEpisodeSnap, setPsEpisodeSnap] = useState<{
-    episode: EpisodeRow | null;
-    isLoading: boolean;
-    error: Error | undefined;
-  }>({ episode: null, isLoading: false, error: undefined });
+  const [psEpisodeSnap, setPsEpisodeSnap] =
+    useState<PowerSyncEpisodeReadSnapshots>(EMPTY_POWER_SYNC_EPISODE_SNAP);
 
   useEffect(() => {
-    if (!psBridge.database) {
-      setPsEpisodeSnap({
-        episode: null,
-        isLoading: false,
-        error: undefined,
-      });
+    if (!psBridge.database || !psBridge.localSqliteInitialized) {
+      setPsEpisodeSnap(EMPTY_POWER_SYNC_EPISODE_SNAP);
     }
-  }, [psBridge.database]);
+  }, [psBridge.database, psBridge.localSqliteInitialized]);
 
   useEffect(() => {
     setNetworkResumeEpisode(null);
     setNetworkResumeLoading(false);
     setNetworkResumeSkippedOffline(false);
+    setRecentEpisodes([]);
+    setRecentEpisodesLoading(false);
+    setRecentEpisodesError(null);
+    setRecentEpisodesSkippedOffline(false);
   }, [phiSubjectUserId]);
 
   useEffect(() => {
@@ -127,6 +131,10 @@ export function HomeScreen({
       setNetworkResumeEpisode(null);
       setNetworkResumeLoading(false);
       setNetworkResumeSkippedOffline(false);
+      setRecentEpisodes([]);
+      setRecentEpisodesLoading(false);
+      setRecentEpisodesError(null);
+      setRecentEpisodesSkippedOffline(false);
     }
   }, [replicaMirrorHomeReads]);
 
@@ -202,9 +210,98 @@ export function HomeScreen({
     [phiSubjectUserId, replicaMirrorHomeReads],
   );
 
+  const loadRecentEpisodes = useCallback(
+    async (cancel?: { cancelled: boolean }) => {
+      const stale = () => cancel?.cancelled === true;
+      if (!phiSubjectUserId) {
+        if (!stale()) {
+          setRecentEpisodes([]);
+          setRecentEpisodesLoading(false);
+          setRecentEpisodesError(null);
+          setRecentEpisodesSkippedOffline(false);
+        }
+        return;
+      }
+      if (replicaMirrorHomeReads) {
+        if (!stale()) {
+          setRecentEpisodes([]);
+          setRecentEpisodesLoading(false);
+          setRecentEpisodesError(null);
+          setRecentEpisodesSkippedOffline(false);
+        }
+        return;
+      }
+
+      const connected = await fetchMobileDeviceIsConnected();
+      if (connected === false) {
+        if (!stale()) {
+          setRecentEpisodes([]);
+          setRecentEpisodesLoading(false);
+          setRecentEpisodesError(null);
+          setRecentEpisodesSkippedOffline(true);
+        }
+        return;
+      }
+
+      if (!stale()) {
+        setRecentEpisodesLoading(true);
+        setRecentEpisodesError(null);
+        setRecentEpisodesSkippedOffline(false);
+      }
+
+      try {
+        const {
+          data: { session },
+          error: sessionError,
+        } = await getMobileAuthSessionSafe();
+        if (stale()) {
+          return;
+        }
+        if (sessionError || !session?.user?.id) {
+          setRecentEpisodes([]);
+          return;
+        }
+
+        const mobileSupabase = getMobileSupabaseClient();
+        const result = await listCompletedEpisodesForUser(
+          mobileSupabase,
+          phiSubjectUserId,
+          {
+            limit: HOME_RECENT_EPISODES_LIMIT,
+            offset: 0,
+          },
+        );
+        if (stale()) {
+          return;
+        }
+        if (!result.ok) {
+          setRecentEpisodes([]);
+          setRecentEpisodesError(result.error.message);
+          return;
+        }
+        setRecentEpisodes(result.data);
+        setRecentEpisodesError(null);
+      } catch {
+        if (!stale()) {
+          setRecentEpisodes([]);
+          setRecentEpisodesError('Unable to load recent episodes.');
+        }
+      } finally {
+        if (!stale()) {
+          setRecentEpisodesLoading(false);
+        }
+      }
+    },
+    [phiSubjectUserId, replicaMirrorHomeReads],
+  );
+
   /** When the watched SQLite query fails, fetch Supabase resume as a fallback (same user, online). */
   useEffect(() => {
-    if (!phiSubjectUserId || !replicaMirrorHomeReads || !psEpisodeSnap.error) {
+    if (
+      !phiSubjectUserId ||
+      !replicaMirrorHomeReads ||
+      !psEpisodeSnap.activeQueryError
+    ) {
       return;
     }
     const cancel = { cancelled: false };
@@ -215,63 +312,56 @@ export function HomeScreen({
   }, [
     phiSubjectUserId,
     replicaMirrorHomeReads,
-    psEpisodeSnap.error,
+    psEpisodeSnap.activeQueryError,
     loadNetworkResumeEpisode,
   ]);
 
   /** Drop stale online fallback once local reads work again. */
   useEffect(() => {
-    if (!replicaMirrorHomeReads || psEpisodeSnap.error) {
+    if (!replicaMirrorHomeReads || psEpisodeSnap.activeQueryError) {
       return;
     }
     setNetworkResumeEpisode(null);
     setNetworkResumeLoading(false);
     setNetworkResumeSkippedOffline(false);
-  }, [replicaMirrorHomeReads, psEpisodeSnap.error]);
+  }, [replicaMirrorHomeReads, psEpisodeSnap.activeQueryError]);
 
   const loadNetworkResumeEpisodeRef = useRef(loadNetworkResumeEpisode);
   loadNetworkResumeEpisodeRef.current = loadNetworkResumeEpisode;
-  const psEpisodeQueryErrorRef = useRef<Error | undefined>(undefined);
-  psEpisodeQueryErrorRef.current = psEpisodeSnap.error;
-  const runDevHealthCheckRef = useRef<() => Promise<void>>(() =>
-    Promise.resolve(),
-  );
+  const loadRecentEpisodesRef = useRef(loadRecentEpisodes);
+  loadRecentEpisodesRef.current = loadRecentEpisodes;
+  const psActiveEpisodeQueryErrorRef = useRef<Error | undefined>(undefined);
+  psActiveEpisodeQueryErrorRef.current = psEpisodeSnap.activeQueryError;
 
   const { refreshing: syncPullRefreshing, onRefresh: onSyncPullRefresh } =
     usePullToResyncPowerSync(() => {
       void loadNetworkResumeEpisodeRef.current(undefined, {
-        bypassReplicaMirrorGate: Boolean(psEpisodeQueryErrorRef.current),
+        bypassReplicaMirrorGate: Boolean(psActiveEpisodeQueryErrorRef.current),
       });
-      void runDevHealthCheckRef.current();
+      void loadRecentEpisodesRef.current();
       refreshPhiSubject();
     });
 
   useFocusEffect(
     useCallback(() => {
-      if (showHealthCheck) {
-        void runDevHealthCheckRef.current();
-      }
-      if (!authUserId) {
-        return;
-      }
-      const bypass = replicaMirrorHomeReads && Boolean(psEpisodeSnap.error);
-      if (replicaMirrorHomeReads && !bypass) {
-        return;
-      }
       const cancel = { cancelled: false };
-      void loadNetworkResumeEpisode(
-        cancel,
-        bypass ? { bypassReplicaMirrorGate: true } : undefined,
-      );
+      const bypass =
+        replicaMirrorHomeReads && Boolean(psEpisodeSnap.activeQueryError);
+      if (!replicaMirrorHomeReads || bypass) {
+        void loadNetworkResumeEpisode(
+          cancel,
+          bypass ? { bypassReplicaMirrorGate: true } : undefined,
+        );
+      }
+      void loadRecentEpisodes(cancel);
       return () => {
         cancel.cancelled = true;
       };
     }, [
-      showHealthCheck,
       loadNetworkResumeEpisode,
+      loadRecentEpisodes,
       replicaMirrorHomeReads,
-      authUserId,
-      psEpisodeSnap.error,
+      psEpisodeSnap.activeQueryError,
     ]),
   );
 
@@ -285,12 +375,13 @@ export function HomeScreen({
     } = supabase.auth.onAuthStateChange((event) => {
       if (event === 'SIGNED_IN' || event === 'SIGNED_OUT') {
         void loadNetworkResumeEpisode();
+        void loadRecentEpisodes();
       }
     });
     return () => {
       subscription.unsubscribe();
     };
-  }, [loadNetworkResumeEpisode, replicaMirrorHomeReads]);
+  }, [loadNetworkResumeEpisode, loadRecentEpisodes, replicaMirrorHomeReads]);
 
   /**
    * Episode CTA loading: with PowerSync configured, wait on SQLite **only** while init/connect may
@@ -330,7 +421,7 @@ export function HomeScreen({
         return true;
       }
       if (replicaMirrorHomeReads) {
-        if (psEpisodeSnap.error) {
+        if (psEpisodeSnap.activeQueryError) {
           return networkResumeLoading || networkResumeSkippedOffline;
         }
         return !psBridge.firstSyncCompleted && psBridge.syncConnecting;
@@ -357,7 +448,7 @@ export function HomeScreen({
     psBridge.syncConnecting,
     psBridge.syncError,
     replicaMirrorHomeReads,
-    psEpisodeSnap.error,
+    psEpisodeSnap.activeQueryError,
     networkResumeLoading,
     networkResumeSkippedOffline,
   ]);
@@ -367,10 +458,10 @@ export function HomeScreen({
       return null;
     }
     if (replicaMirrorHomeReads) {
-      if (psEpisodeSnap.error) {
+      if (psEpisodeSnap.activeQueryError) {
         return networkResumeEpisode;
       }
-      const row = psEpisodeSnap.episode;
+      const row = psEpisodeSnap.activeEpisode;
       if (!row) {
         return null;
       }
@@ -378,141 +469,97 @@ export function HomeScreen({
     }
     if (
       powerSyncReplicaSqliteReady(psBridge) &&
-      !psEpisodeSnap.error &&
+      !psEpisodeSnap.activeQueryError &&
       networkResumeEpisode == null &&
-      psEpisodeSnap.episode != null
+      psEpisodeSnap.activeEpisode != null
     ) {
-      return episodeRowToActiveHomeSummary(psEpisodeSnap.episode);
+      return episodeRowToActiveHomeSummary(psEpisodeSnap.activeEpisode);
     }
     return networkResumeEpisode;
   }, [
     phiSubjectUserId,
     phiSubjectError,
     replicaMirrorHomeReads,
-    psEpisodeSnap.episode,
-    psEpisodeSnap.error,
+    psEpisodeSnap.activeEpisode,
+    psEpisodeSnap.activeQueryError,
     networkResumeEpisode,
     psBridge,
   ]);
 
   const activeEpisodeQueryError = useMemo(() => {
-    if (!replicaMirrorHomeReads || !psEpisodeSnap.error) {
+    if (!replicaMirrorHomeReads || !psEpisodeSnap.activeQueryError) {
       return null;
     }
     if (activeEpisodeLoading || homeActiveEpisode) {
       return null;
     }
-    return `Could not read episode status from the copy stored on this device. ${userFacingSyncHealthBridgeOrClientError(psEpisodeSnap.error)}`;
+    return `Could not read episode status from the copy stored on this device. ${userFacingSyncHealthBridgeOrClientError(
+      psEpisodeSnap.activeQueryError,
+    )}`;
   }, [
     replicaMirrorHomeReads,
-    psEpisodeSnap.error,
+    psEpisodeSnap.activeQueryError,
     activeEpisodeLoading,
     homeActiveEpisode,
   ]);
 
-  const runDevHealthCheck = useCallback(async () => {
-    if (!showHealthCheck) {
-      return;
-    }
-    try {
-      const mobileSupabase = getMobileSupabaseClient();
-      const {
-        data: { user },
-        error: userError,
-      } = await mobileSupabase.auth.getUser();
+  const recentEpisodesFromDevice = useMemo(() => {
+    return psEpisodeSnap.completedEpisodes.slice(0, HOME_RECENT_EPISODES_LIMIT);
+  }, [psEpisodeSnap.completedEpisodes]);
 
-      if (userError || !user) {
-        if (isMountedRef.current) {
-          setHealthCheck({
-            success: false,
-            message: 'Health check failed',
-            error: userError?.message ?? 'No authenticated user found',
-          });
-        }
-        return;
+  const showRecentDeviceFallback =
+    !replicaMirrorHomeReads &&
+    (recentEpisodesError != null || recentEpisodesSkippedOffline) &&
+    !psEpisodeSnap.completedQueryError &&
+    recentEpisodesFromDevice.length > 0;
+
+  const recentEpisodesDisplay = showRecentDeviceFallback
+    ? recentEpisodesFromDevice
+    : replicaMirrorHomeReads
+      ? recentEpisodesFromDevice
+      : recentEpisodes;
+
+  const recentEpisodesCardLoading = replicaMirrorHomeReads
+    ? psEpisodeSnap.completedLoading
+    : recentEpisodesLoading;
+
+  const recentEpisodesMessage = useMemo(() => {
+    if (replicaMirrorHomeReads) {
+      if (
+        psEpisodeSnap.completedQueryError &&
+        !psEpisodeSnap.completedLoading &&
+        recentEpisodesDisplay.length === 0
+      ) {
+        return `Could not read recent episodes from this device. ${psEpisodeSnap.completedQueryError.message}`;
       }
-
-      const result = await healthCheckProfilesLimit1(mobileSupabase);
-
-      if (result.error) {
-        if (isMountedRef.current) {
-          setHealthCheck({
-            success: false,
-            message: 'Health check failed',
-            error: result.error.message,
-          });
-        }
-      } else {
-        if (isMountedRef.current) {
-          setHealthCheck({
-            success: true,
-            message:
-              'Health check passed: authenticated user found and profiles query executed without API error (empty rows may still indicate no profile or restrictive RLS).',
-          });
-        }
-      }
-    } catch (err) {
-      // getSession may still attempt a token refresh offline; suppress network errors silently.
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      const isNetworkError =
-        message.includes('Network request failed') ||
-        message.includes('Failed to fetch');
-      if (isMountedRef.current && !isNetworkError) {
-        setHealthCheck({
-          success: false,
-          message: 'Health check error',
-          error: message,
-        });
-      }
+      return null;
     }
-  }, [showHealthCheck]);
-
-  runDevHealthCheckRef.current = runDevHealthCheck;
-
-  useEffect(() => {
-    isMountedRef.current = true;
-
-    if (!showHealthCheck) {
-      return () => {
-        isMountedRef.current = false;
-      };
+    if (showRecentDeviceFallback) {
+      return recentEpisodesSkippedOffline
+        ? 'Showing recent episodes saved on this device while you are offline.'
+        : 'Showing recent episodes saved on this device.';
     }
-
-    void runDevHealthCheck();
-
-    return () => {
-      isMountedRef.current = false;
-    };
-  }, [showHealthCheck, deviceNetConnected, runDevHealthCheck]);
-
-  const handleSignOut = async () => {
-    const mobileSupabase = getMobileSupabaseClient();
-    setSignOutBusy(true);
-    setSignOutError(null);
-
-    try {
-      const { error } = await signOut(mobileSupabase);
-
-      if (error) {
-        setSignOutError(mapAuthError(error.message));
-      }
-    } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : 'Unexpected authentication error';
-      setSignOutError(mapAuthError(message));
-    } finally {
-      setSignOutBusy(false);
+    if (recentEpisodesSkippedOffline) {
+      return 'Connect to load recent episodes.';
     }
-  };
+    return recentEpisodesError;
+  }, [
+    psEpisodeSnap.completedLoading,
+    psEpisodeSnap.completedQueryError,
+    recentEpisodesDisplay.length,
+    recentEpisodesError,
+    recentEpisodesSkippedOffline,
+    replicaMirrorHomeReads,
+    showRecentDeviceFallback,
+  ]);
 
   return (
-    <AppNavigationShell title="Home">
+    <AppNavigationShell title="Home" headerAction={headerAction}>
       {powerSyncReplicaSqliteReady(psBridge) ? (
-        <PowerSyncActiveEpisodeSubscription
+        <PowerSyncEpisodeReadSubscriptions
           userId={phiSubjectError ? null : phiSubjectUserId}
-          onChange={setPsEpisodeSnap}
+          completedEpisodesFetchLimit={HOME_RECENT_EPISODES_LIMIT}
+          onSnapshots={setPsEpisodeSnap}
         />
       ) : null}
       <ScrollView
@@ -521,7 +568,6 @@ export function HomeScreen({
           flexGrow: 1,
           padding: 16,
           paddingBottom: 24,
-          justifyContent: 'flex-start',
         }}
         keyboardShouldPersistTaps="handled"
         refreshControl={
@@ -535,7 +581,7 @@ export function HomeScreen({
       >
         {phiSubjectError ? (
           <View
-            className={`mb-3 rounded-xl border border-app-border bg-app-surface p-4 dark:border-app-border-dark dark:bg-app-surface-dark`}
+            className={`mb-4 rounded-xl border border-app-border bg-app-surface p-4 dark:border-app-border-dark dark:bg-app-surface-dark`}
             accessibilityRole="alert"
           >
             <Text className={`text-base font-semibold ${nw.textInk}`}>
@@ -546,6 +592,7 @@ export function HomeScreen({
             </Text>
           </View>
         ) : null}
+
         <EpisodeStartHomeCta
           onStartEpisode={onStartEpisode}
           onResumeEpisode={onResumeEpisode}
@@ -554,123 +601,28 @@ export function HomeScreen({
           activeEpisodeQueryError={activeEpisodeQueryError}
         />
 
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Add food diary entry"
-          onPress={onGoToFoodDiary}
-          className={`mb-1 min-h-[48px] justify-center rounded-xl border border-app-border bg-app-surface px-4 py-3 dark:border-app-border-dark dark:bg-app-surface-dark`}
-        >
-          <Text
-            className={`text-center text-base font-semibold ${nw.textPrimary}`}
-            maxFontSizeMultiplier={2}
-          >
-            Food diary
-          </Text>
-        </Pressable>
-        <Pressable
-          accessibilityRole="button"
-          accessibilityLabel="Log health markers without an episode"
+        <HomeDashboardActionCard
+          heading="Health markers"
+          description="Log vitals and wellness markers outside an episode using your saved presets."
+          ctaLabel="Log health markers"
+          ctaAccessibilityLabel="Log health markers without an episode"
           onPress={onGoToStandaloneHealthMarkers}
-          className={`mb-1 min-h-[48px] justify-center rounded-xl border border-app-border bg-app-surface px-4 py-3 dark:border-app-border-dark dark:bg-app-surface-dark`}
-        >
-          <Text
-            className={`text-center text-base font-semibold ${nw.textPrimary}`}
-            maxFontSizeMultiplier={2}
-          >
-            Health markers
-          </Text>
-        </Pressable>
+        />
 
-        <View className={`gap-3 rounded-xl p-4 ${nw.card} ${nw.cardShadow}`}>
-          <Text
-            className={`text-[22px] font-semibold ${nw.textInk}`}
-            testID="main-home-title"
-          >
-            Welcome to ABStrack
-          </Text>
+        <HomeDashboardActionCard
+          heading="Food diary"
+          description="Record meals and notes on their own, or link them later to an episode."
+          ctaLabel="Add a food diary entry"
+          ctaAccessibilityLabel="Add a food diary entry"
+          onPress={onGoToFoodDiary}
+        />
 
-          {showHealthCheck && healthCheck && (
-            <View
-              className={`my-3 rounded-lg p-3 ${
-                healthCheck.success
-                  ? nw.healthSuccessPanel
-                  : nw.healthFailurePanel
-              }`}
-            >
-              <Text
-                className={`mb-1 text-sm font-semibold ${
-                  healthCheck.success
-                    ? nw.healthSuccessTitle
-                    : nw.healthFailureTitle
-                }`}
-              >
-                {healthCheck.success
-                  ? '✓ Health Check Passed'
-                  : '✗ Health Check Failed'}
-              </Text>
-              <Text
-                className={`text-xs ${
-                  healthCheck.success
-                    ? nw.healthSuccessBody
-                    : nw.healthFailureBody
-                }`}
-              >
-                {healthCheck.message}
-              </Text>
-              {healthCheck.error && (
-                <Text
-                  className={`mt-2 font-mono text-[10px] ${
-                    healthCheck.success
-                      ? nw.healthSuccessBody
-                      : nw.healthFailureBody
-                  }`}
-                >
-                  Error: {healthCheck.error}
-                </Text>
-              )}
-            </View>
-          )}
-
-          <Text className={`text-base ${nw.textMuted}`}>
-            You are signed in.
-          </Text>
-          {signOutError ? (
-            <Text
-              className={`text-sm ${nw.textError}`}
-              accessibilityRole="alert"
-            >
-              {signOutError}
-            </Text>
-          ) : null}
-          <View className="h-2" />
-
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel="Go to settings"
-            onPress={onGoToSettings}
-            className={`min-h-[52px] items-center justify-center rounded-[10px] px-4 ${nw.btnSecondary}`}
-          >
-            <Text
-              className={`text-center text-[17px] font-semibold ${nw.textPrimary}`}
-            >
-              Settings
-            </Text>
-          </Pressable>
-
-          <View className="h-2" />
-
-          <Pressable
-            accessibilityRole="button"
-            accessibilityLabel={signOutBusy ? 'Signing out...' : 'Sign out'}
-            onPress={handleSignOut}
-            disabled={signOutBusy}
-            className={`min-h-[52px] items-center justify-center rounded-[10px] px-4 ${nw.btnPrimary} ${signOutBusy ? 'opacity-60' : ''}`}
-          >
-            <Text className={`text-lg font-bold ${nw.textOnPrimary}`}>
-              {signOutBusy ? 'Signing out...' : 'Sign out'}
-            </Text>
-          </Pressable>
-        </View>
+        <HomeRecentEpisodesCard
+          episodes={recentEpisodesDisplay}
+          loading={recentEpisodesCardLoading}
+          message={recentEpisodesMessage}
+          onViewAllEpisodes={onGoToManageEpisodes}
+        />
       </ScrollView>
     </AppNavigationShell>
   );

--- a/apps/mobile/src/app/screens/HomeScreen.tsx
+++ b/apps/mobile/src/app/screens/HomeScreen.tsx
@@ -95,6 +95,7 @@ export function HomeScreen({
   );
   const [recentEpisodesSkippedOffline, setRecentEpisodesSkippedOffline] =
     useState(false);
+  const isMountedRef = useRef(true);
 
   const {
     authUserId,
@@ -110,6 +111,13 @@ export function HomeScreen({
   );
   const [psEpisodeSnap, setPsEpisodeSnap] =
     useState<PowerSyncEpisodeReadSnapshots>(EMPTY_POWER_SYNC_EPISODE_SNAP);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
 
   useEffect(() => {
     if (!psBridge.database || !psBridge.localSqliteInitialized) {
@@ -144,7 +152,8 @@ export function HomeScreen({
       cancel?: { cancelled: boolean },
       options?: { bypassReplicaMirrorGate?: boolean },
     ) => {
-      const stale = () => cancel?.cancelled === true;
+      const stale = () =>
+        cancel?.cancelled === true || isMountedRef.current === false;
       if (!phiSubjectUserId) {
         if (!stale()) {
           setNetworkResumeLoading(false);
@@ -213,7 +222,8 @@ export function HomeScreen({
 
   const loadRecentEpisodes = useCallback(
     async (cancel?: { cancelled: boolean }) => {
-      const stale = () => cancel?.cancelled === true;
+      const stale = () =>
+        cancel?.cancelled === true || isMountedRef.current === false;
       if (!phiSubjectUserId) {
         if (!stale()) {
           setRecentEpisodes([]);

--- a/apps/mobile/src/app/screens/InsightsScreen.tsx
+++ b/apps/mobile/src/app/screens/InsightsScreen.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ScrollView, Text, View } from 'react-native';
+import { AppNavigationShell } from '../components/AppNavigationShell';
+import { nw } from '../theme/app-nativewind-classes';
+
+export type InsightsScreenProps = {
+  /** Optional trailing header action, such as the app menu button. */
+  headerAction?: React.ReactNode;
+};
+
+/**
+ * Placeholder root for the future mobile Insights experience.
+ *
+ * @param props - Optional authenticated header action.
+ * @returns Temporary tab content while mobile insights are being designed.
+ */
+export function InsightsScreen({ headerAction }: InsightsScreenProps) {
+  return (
+    <AppNavigationShell title="Insights" headerAction={headerAction}>
+      <ScrollView
+        className="flex-1"
+        contentContainerStyle={{ flexGrow: 1, padding: 16, paddingBottom: 24 }}
+      >
+        <View className={`gap-3 rounded-xl p-4 ${nw.card} ${nw.cardShadow}`}>
+          <Text className={`text-lg font-semibold ${nw.textInk}`}>
+            Insights are coming to mobile
+          </Text>
+          <Text className={`text-base ${nw.textMuted}`}>
+            This tab is reserved for charts, trends, and shared summaries. For
+            now, use Home to log entries and Manage to review your history.
+          </Text>
+        </View>
+      </ScrollView>
+    </AppNavigationShell>
+  );
+}

--- a/apps/mobile/src/app/screens/ManageScreen.tsx
+++ b/apps/mobile/src/app/screens/ManageScreen.tsx
@@ -21,7 +21,6 @@ import {
   useNavigation,
   useRoute,
 } from '@react-navigation/native';
-import type { BottomTabNavigationProp } from '@react-navigation/bottom-tabs';
 import type { RouteProp } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import type { FoodDiaryEntryRow, HealthMarkerRow } from '@abstrack/types';
@@ -40,7 +39,7 @@ import {
 import { getMobileSupabaseClient } from '../../lib/supabase-wiring';
 import { useMobilePhiSubjectUserContext } from '../../lib/auth/use-mobile-phi-subject-user-context';
 import { ScreenShell } from '../components/ScreenShell';
-import type { MainStackParamList, MainTabParamList } from '../navigation/types';
+import type { MainStackParamList } from '../navigation/types';
 import { useAppTheme } from '../theme/AppThemeContext';
 import { nw } from '../theme/app-nativewind-classes';
 import {
@@ -116,19 +115,12 @@ function healthMarkerValueLine(row: HealthMarkerRow): string {
 /**
  * Consolidated management: episodes, standalone health markers, and standalone food diary rows.
  *
- * @returns Manage tab root screen.
+ * @returns Manage screen content.
  */
 export function ManageScreen() {
-  const tabNavigation =
-    useNavigation<BottomTabNavigationProp<MainTabParamList, 'Manage'>>();
-  const stackNavigation =
-    tabNavigation.getParent<NativeStackNavigationProp<MainStackParamList>>();
-  if (!stackNavigation) {
-    throw new Error(
-      'ManageScreen: expected native stack parent for episode flows.',
-    );
-  }
-  const route = useRoute<RouteProp<MainTabParamList, 'Manage'>>();
+  const navigation =
+    useNavigation<NativeStackNavigationProp<MainStackParamList, 'Manage'>>();
+  const route = useRoute<RouteProp<MainStackParamList, 'Manage'>>();
   const initialSegment = route.params?.initialSegment;
   const { colors } = useAppTheme();
 
@@ -154,8 +146,8 @@ export function ManageScreen() {
     }
     setSegment(requested);
     // Consume one-shot deep-link params so subsequent navigations can retarget segment.
-    tabNavigation.setParams({ initialSegment: undefined });
-  }, [initialSegment, tabNavigation]);
+    navigation.setParams({ initialSegment: undefined });
+  }, [initialSegment, navigation]);
 
   const episodeDateBounds = useMemo(() => {
     if (!filterDay) {
@@ -310,7 +302,7 @@ export function ManageScreen() {
         <View className="min-h-0 flex-1">
           {segment === 'episodes' ? (
             <EpisodesManagementPanel
-              navigation={stackNavigation as EpisodesManagementNav}
+              navigation={navigation as EpisodesManagementNav}
               variant="embedded"
               endedAtOrAfter={episodeDateBounds.endedAtOrAfter}
               endedAtOrBefore={episodeDateBounds.endedAtOrBefore}

--- a/apps/mobile/src/app/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/app/screens/SettingsScreen.tsx
@@ -1023,7 +1023,7 @@ export function SettingsScreen() {
 
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel="Open Manage on episodes"
+            accessibilityLabel="Open Manage episodes"
             onPress={() =>
               navigation.navigate('Manage', { initialSegment: 'episodes' })
             }

--- a/apps/mobile/src/app/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/app/screens/SettingsScreen.tsx
@@ -938,17 +938,21 @@ export function SettingsScreen() {
 
     try {
       const { error } = await signOut(mobileSupabase);
-      if (error) {
+      if (isMountedRef.current && error) {
         setSignOutError(mapAuthError(error.message));
       }
     } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : 'Unexpected authentication error';
-      setSignOutError(mapAuthError(message));
+      if (isMountedRef.current) {
+        const message =
+          error instanceof Error
+            ? error.message
+            : 'Unexpected authentication error';
+        setSignOutError(mapAuthError(message));
+      }
     } finally {
-      setSignOutBusy(false);
+      if (isMountedRef.current) {
+        setSignOutBusy(false);
+      }
     }
   };
 

--- a/apps/mobile/src/app/screens/SettingsScreen.tsx
+++ b/apps/mobile/src/app/screens/SettingsScreen.tsx
@@ -12,10 +12,12 @@ import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { announce } from '@abstrack/ui/native';
+import { signOut } from '@abstrack/supabase';
 import {
   getRequireReauthOnOpenPreference,
   setRequireReauthOnOpenPreference,
 } from '../reauth-preference';
+import { mapAuthError } from '../auth-helpers';
 import { ScreenShell } from '../components/ScreenShell';
 import {
   formatPowerSyncReplicaDiagnosticsMessage,
@@ -46,7 +48,10 @@ import {
   isMissingPublishableKeyForPractitionerEdge,
   resolvePatientPractitionerAccessUrl,
 } from '../../lib/patient-practitioner-edge-api';
-import { getMobileAuthSessionSafe } from '../../lib/supabase-wiring';
+import {
+  getMobileAuthSessionSafe,
+  getMobileSupabaseClient,
+} from '../../lib/supabase-wiring';
 
 const THEME_OPTIONS: {
   value: ThemePreference;
@@ -101,6 +106,11 @@ type PractitionerPendingInviteDto = {
 
 const caretakerInputClassName = `min-h-[52px] rounded-lg px-3 py-2.5 text-base ${nw.input}`;
 
+/**
+ * User settings, account actions, and caretaker / practitioner access management for mobile.
+ *
+ * @returns Settings content.
+ */
 export function SettingsScreen() {
   const navigation =
     useNavigation<NativeStackNavigationProp<MainStackParamList>>();
@@ -115,6 +125,8 @@ export function SettingsScreen() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const [themeError, setThemeError] = useState<string | null>(null);
   const [themeSaving, setThemeSaving] = useState(false);
+  const [signOutBusy, setSignOutBusy] = useState(false);
+  const [signOutError, setSignOutError] = useState<string | null>(null);
   const powerSyncBridge = usePowerSyncBridgeState();
   const [powerSyncDiagBusy, setPowerSyncDiagBusy] = useState(false);
   const [caretakerGrant, setCaretakerGrant] = useState<
@@ -919,6 +931,27 @@ export function SettingsScreen() {
     }
   };
 
+  const handleSignOut = async () => {
+    const mobileSupabase = getMobileSupabaseClient();
+    setSignOutBusy(true);
+    setSignOutError(null);
+
+    try {
+      const { error } = await signOut(mobileSupabase);
+      if (error) {
+        setSignOutError(mapAuthError(error.message));
+      }
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Unexpected authentication error';
+      setSignOutError(mapAuthError(message));
+    } finally {
+      setSignOutBusy(false);
+    }
+  };
+
   return (
     <ScreenShell contentAlign="stretch">
       <ScrollView
@@ -986,12 +1019,9 @@ export function SettingsScreen() {
 
           <Pressable
             accessibilityRole="button"
-            accessibilityLabel="Open manage tab on episodes"
+            accessibilityLabel="Open Manage on episodes"
             onPress={() =>
-              navigation.navigate('MainTabs', {
-                screen: 'Manage',
-                params: { initialSegment: 'episodes' },
-              })
+              navigation.navigate('Manage', { initialSegment: 'episodes' })
             }
             className={`min-h-[52px] justify-center rounded-xl border border-app-border bg-app-surface px-4 py-3 dark:border-app-border-dark dark:bg-app-surface-dark`}
           >
@@ -999,10 +1029,43 @@ export function SettingsScreen() {
               Manage episodes
             </Text>
             <Text className={`mt-0.5 text-sm ${nw.textMuted}`}>
-              Open the Manage tab to review episode history and resume an
-              in-progress episode.
+              Open Manage to review episode history and resume an in-progress
+              episode.
             </Text>
           </Pressable>
+
+          <View className="my-2 h-px bg-app-border dark:bg-app-border-dark" />
+
+          <View className="gap-2" accessibilityLabel="Account">
+            <Text className={`text-base font-semibold ${nw.textInk}`}>
+              Account
+            </Text>
+            <Text className={`text-base ${nw.textMuted}`}>
+              Sign out of this device when you are finished.
+            </Text>
+            {signOutError ? (
+              <Text
+                className={`text-sm ${nw.textError}`}
+                accessibilityRole="alert"
+              >
+                {signOutError}
+              </Text>
+            ) : null}
+            <Pressable
+              accessibilityRole="button"
+              accessibilityLabel={signOutBusy ? 'Signing out...' : 'Sign out'}
+              accessibilityState={{ disabled: signOutBusy }}
+              disabled={signOutBusy}
+              onPress={() => void handleSignOut()}
+              className={`min-h-[52px] items-center justify-center rounded-xl px-4 ${nw.btnPrimary} ${signOutBusy ? 'opacity-60' : ''}`}
+            >
+              <Text
+                className={`text-center text-base font-semibold ${nw.textOnPrimary}`}
+              >
+                {signOutBusy ? 'Signing out...' : 'Sign out'}
+              </Text>
+            </Pressable>
+          </View>
 
           <View className="my-2 h-px bg-app-border dark:bg-app-border-dark" />
 

--- a/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
+++ b/apps/mobile/src/lib/auth/use-mobile-phi-subject-user-context.ts
@@ -30,8 +30,8 @@ export type MobilePhiSubjectUserContextState = {
  * In-flight {@link resolveMobilePhiSubjectUserContext} results are ignored when a **new** resolve
  * starts (each `runResolve` call increments a generation counter first) or when the hook
  * **unmounts** (a final increment drops any still-pending completion). Replica readiness
- * (`database` + `localSqliteInitialized`) and `authUserId` changes recreate `runResolve` and
- * re-run the primary effect, which invokes it again; the first-sync effect may invoke it once when
+ * (`database` + `localSqliteInitialized`) recreates `runResolve`, and `authUserId` changes re-run
+ * the primary effect so resolution happens again; the first-sync effect may invoke it once when
  * `firstSyncCompleted` becomes true. Each new resolve clears `phiSubjectUserId` and `profileAppRole` before
  * awaiting the resolver so consumers that do not gate every read on `loading` cannot briefly use a
  * stale PHI subject after an account switch or replica re-scope. Resolution still runs when `authUserId` is null: on cold starts where
@@ -86,7 +86,7 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
     setPhiSubjectUserId(result.data.phiSubjectUserId);
     setProfileAppRole(result.data.profileAppRole);
     setErrorMessage(null);
-  }, [authUserId, dbForPhi]);
+  }, [dbForPhi]);
 
   /**
    * Invalidate in-flight resolves only on real unmount. Do not bump `genRef` from other effect
@@ -102,7 +102,7 @@ export function useMobilePhiSubjectUserContext(): MobilePhiSubjectUserContextSta
 
   useEffect(() => {
     void runResolve();
-  }, [runResolve]);
+  }, [authUserId, runResolve]);
 
   const firstSyncHandledRef = useRef(false);
   useEffect(() => {


### PR DESCRIPTION
Closes #216

## Summary
- redesign the mobile Home tab to mirror the web dashboard with episode logging, health markers, food diary, and recent episodes cards
- replace the bottom-tab `Manage` destination with `Insights`, add a top-right secondary menu for `Manage` and `Settings`, and move sign out into `Settings`
- update mobile navigation/tests to match the new flow, including the temporary mobile `Insights` placeholder and related cleanup

## Test plan
- [x] `pnpm mobile:lint`
- [x] `pnpm mobile:typecheck`
- [x] `pnpm mobile:test`