### PR TITLE
feat(insights): add overview-first patient and practitioner insights dashboards

### DIFF
--- a/apps/practitioner/next.config.js
+++ b/apps/practitioner/next.config.js
@@ -45,6 +45,7 @@ const nextConfig = {
   ],
   webpack: (config) => {
     const supabaseSrc = path.join(__dirname, '../../packages/supabase/src');
+    const uiSrc = path.join(__dirname, '../../packages/ui/src');
     const uiWebSrc = path.join(__dirname, '../../packages/ui-web/src');
     config.resolve.alias = {
       ...config.resolve.alias,
@@ -58,6 +59,9 @@ const nextConfig = {
       '@abstrack/supabase/server': path.join(supabaseSrc, 'server.ts'),
       '@abstrack/supabase/native': path.join(supabaseSrc, 'native.ts'),
       '@abstrack/supabase/admin': path.join(supabaseSrc, 'admin.ts'),
+      '@abstrack/ui$': path.join(uiSrc, 'index.ts'),
+      '@abstrack/ui/a11y-web': path.join(uiSrc, 'a11y-web.ts'),
+      '@abstrack/ui/insights-web': path.join(uiSrc, 'insights-web.ts'),
       '@abstrack/ui-web$': path.join(uiWebSrc, 'index.ts'),
       '@abstrack/ui-web/sidebar': path.join(uiWebSrc, 'components/sidebar.tsx'),
     };

--- a/apps/practitioner/specs/patient-detail-insights.spec.tsx
+++ b/apps/practitioner/specs/patient-detail-insights.spec.tsx
@@ -238,6 +238,10 @@ describe('PractitionerPatientDetailPage insights tab', () => {
       expect.anything(),
       expect.objectContaining({ p_user_id: PATIENT_ID }),
     );
+    expect(getSymptomFrequencyMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ p_user_id: PATIENT_ID }),
+    );
     expect(getUserChartManifestMock).not.toHaveBeenCalledWith(
       expect.anything(),
       PRACTITIONER_USER_ID,

--- a/apps/practitioner/specs/patient-detail-insights.spec.tsx
+++ b/apps/practitioner/specs/patient-detail-insights.spec.tsx
@@ -11,7 +11,11 @@ import type { ChartManifestRow } from '@abstrack/ui/insights-web';
 import {
   CHART_SNAPSHOT_PRACTITIONER_NOTE_MAX_LENGTH,
   getChartSeries,
+  getEpisodeStartHourDistribution,
+  getEpisodeSummary,
+  getEpisodeWeekCounts,
   getUserChartManifest,
+  getSymptomFrequency,
   shareChartSnapshot,
 } from '@abstrack/supabase';
 import { PractitionerPatientDetailPage } from '../src/app/patients/[patientId]/practitioner-patient-detail-page';
@@ -67,6 +71,10 @@ jest.mock('@abstrack/supabase', () => {
       listPractitionerObservationNotesForPatient(...args),
     getUserChartManifest: jest.fn(),
     getChartSeries: jest.fn(),
+    getEpisodeSummary: jest.fn(),
+    getEpisodeWeekCounts: jest.fn(),
+    getSymptomFrequency: jest.fn(),
+    getEpisodeStartHourDistribution: jest.fn(),
     shareChartSnapshot: jest.fn(),
   };
 });
@@ -77,6 +85,19 @@ const getUserChartManifestMock = getUserChartManifest as jest.MockedFunction<
 const getChartSeriesMock = getChartSeries as jest.MockedFunction<
   typeof getChartSeries
 >;
+const getEpisodeSummaryMock = getEpisodeSummary as jest.MockedFunction<
+  typeof getEpisodeSummary
+>;
+const getEpisodeWeekCountsMock = getEpisodeWeekCounts as jest.MockedFunction<
+  typeof getEpisodeWeekCounts
+>;
+const getSymptomFrequencyMock = getSymptomFrequency as jest.MockedFunction<
+  typeof getSymptomFrequency
+>;
+const getEpisodeStartHourDistributionMock =
+  getEpisodeStartHourDistribution as jest.MockedFunction<
+    typeof getEpisodeStartHourDistribution
+  >;
 const shareChartSnapshotMock = shareChartSnapshot as jest.MockedFunction<
   typeof shareChartSnapshot
 >;
@@ -168,6 +189,30 @@ describe('PractitionerPatientDetailPage insights tab', () => {
         },
       ],
     });
+    getEpisodeSummaryMock.mockResolvedValue({
+      ok: true,
+      data: {
+        total_episode_count: 5,
+        abs_episode_count: 1,
+        other_episode_count: 4,
+        average_episodes_per_week: 1.2,
+        longest_episode_free_streak_days: 6,
+        current_episode_free_streak_days: 2,
+        average_episode_duration_hours: 10.4,
+      },
+    });
+    getEpisodeWeekCountsMock.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+    getSymptomFrequencyMock.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+    getEpisodeStartHourDistributionMock.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
     shareChartSnapshotMock.mockResolvedValue({ ok: true, data: SNAPSHOT_ID });
   });
 
@@ -176,11 +221,22 @@ describe('PractitionerPatientDetailPage insights tab', () => {
     await screen.findByText('Alex Kim');
     await openInsightsTab();
 
+    expect(
+      await screen.findByTestId('insights-summary-section'),
+    ).toBeInTheDocument();
     await waitFor(() =>
       expect(getUserChartManifestMock).toHaveBeenCalledWith(
         expect.anything(),
         PATIENT_ID,
       ),
+    );
+    expect(getEpisodeSummaryMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ p_user_id: PATIENT_ID }),
+    );
+    expect(getEpisodeWeekCountsMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ p_user_id: PATIENT_ID }),
     );
     expect(getUserChartManifestMock).not.toHaveBeenCalledWith(
       expect.anything(),

--- a/apps/practitioner/specs/patient-detail-insights.spec.tsx
+++ b/apps/practitioner/specs/patient-detail-insights.spec.tsx
@@ -11,11 +11,8 @@ import type { ChartManifestRow } from '@abstrack/ui/insights-web';
 import {
   CHART_SNAPSHOT_PRACTITIONER_NOTE_MAX_LENGTH,
   getChartSeries,
-  getEpisodeStartHourDistribution,
-  getEpisodeSummary,
-  getEpisodeWeekCounts,
   getUserChartManifest,
-  getSymptomFrequency,
+  loadEpisodeInsightsOverview,
   shareChartSnapshot,
 } from '@abstrack/supabase';
 import { PractitionerPatientDetailPage } from '../src/app/patients/[patientId]/practitioner-patient-detail-page';
@@ -71,10 +68,7 @@ jest.mock('@abstrack/supabase', () => {
       listPractitionerObservationNotesForPatient(...args),
     getUserChartManifest: jest.fn(),
     getChartSeries: jest.fn(),
-    getEpisodeSummary: jest.fn(),
-    getEpisodeWeekCounts: jest.fn(),
-    getSymptomFrequency: jest.fn(),
-    getEpisodeStartHourDistribution: jest.fn(),
+    loadEpisodeInsightsOverview: jest.fn(),
     shareChartSnapshot: jest.fn(),
   };
 });
@@ -85,18 +79,9 @@ const getUserChartManifestMock = getUserChartManifest as jest.MockedFunction<
 const getChartSeriesMock = getChartSeries as jest.MockedFunction<
   typeof getChartSeries
 >;
-const getEpisodeSummaryMock = getEpisodeSummary as jest.MockedFunction<
-  typeof getEpisodeSummary
->;
-const getEpisodeWeekCountsMock = getEpisodeWeekCounts as jest.MockedFunction<
-  typeof getEpisodeWeekCounts
->;
-const getSymptomFrequencyMock = getSymptomFrequency as jest.MockedFunction<
-  typeof getSymptomFrequency
->;
-const getEpisodeStartHourDistributionMock =
-  getEpisodeStartHourDistribution as jest.MockedFunction<
-    typeof getEpisodeStartHourDistribution
+const loadEpisodeInsightsOverviewMock =
+  loadEpisodeInsightsOverview as jest.MockedFunction<
+    typeof loadEpisodeInsightsOverview
   >;
 const shareChartSnapshotMock = shareChartSnapshot as jest.MockedFunction<
   typeof shareChartSnapshot
@@ -189,29 +174,22 @@ describe('PractitionerPatientDetailPage insights tab', () => {
         },
       ],
     });
-    getEpisodeSummaryMock.mockResolvedValue({
+    loadEpisodeInsightsOverviewMock.mockResolvedValue({
       ok: true,
       data: {
-        total_episode_count: 5,
-        abs_episode_count: 1,
-        other_episode_count: 4,
-        average_episodes_per_week: 1.2,
-        longest_episode_free_streak_days: 6,
-        current_episode_free_streak_days: 2,
-        average_episode_duration_hours: 10.4,
+        summary: {
+          total_episode_count: 5,
+          abs_episode_count: 1,
+          other_episode_count: 4,
+          average_episodes_per_week: 1.2,
+          longest_episode_free_streak_days: 6,
+          current_episode_free_streak_days: 2,
+          average_episode_duration_hours: 10.4,
+        },
+        weekCounts: [],
+        symptomFrequencies: [],
+        startHourDistribution: [],
       },
-    });
-    getEpisodeWeekCountsMock.mockResolvedValue({
-      ok: true,
-      data: [],
-    });
-    getSymptomFrequencyMock.mockResolvedValue({
-      ok: true,
-      data: [],
-    });
-    getEpisodeStartHourDistributionMock.mockResolvedValue({
-      ok: true,
-      data: [],
     });
     shareChartSnapshotMock.mockResolvedValue({ ok: true, data: SNAPSHOT_ID });
   });
@@ -230,15 +208,7 @@ describe('PractitionerPatientDetailPage insights tab', () => {
         PATIENT_ID,
       ),
     );
-    expect(getEpisodeSummaryMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ p_user_id: PATIENT_ID }),
-    );
-    expect(getEpisodeWeekCountsMock).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ p_user_id: PATIENT_ID }),
-    );
-    expect(getSymptomFrequencyMock).toHaveBeenCalledWith(
+    expect(loadEpisodeInsightsOverviewMock).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ p_user_id: PATIENT_ID }),
     );

--- a/apps/practitioner/specs/test-support/mock-insights-web.tsx
+++ b/apps/practitioner/specs/test-support/mock-insights-web.tsx
@@ -51,11 +51,7 @@ export function InsightSeriesPicker({
   manifest,
   value,
   onChange,
-}: {
-  manifest: ChartManifestRow[];
-  value: SelectedSeries[];
-  onChange: (next: SelectedSeries[]) => void;
-}) {
+}: InsightSeriesPickerProps) {
   return (
     <div>
       <button

--- a/apps/practitioner/specs/test-support/mock-insights-web.tsx
+++ b/apps/practitioner/specs/test-support/mock-insights-web.tsx
@@ -114,3 +114,21 @@ export function InsightDateRangePicker({
 export function InsightComposedChart() {
   return <div data-testid="composed-chart" />;
 }
+
+export function InsightsSummarySection({
+  summary,
+  loading,
+  error,
+}: {
+  summary: { total_episode_count: number } | null;
+  loading?: boolean;
+  error?: string | null;
+}) {
+  return (
+    <div data-testid="insights-summary-section">
+      {loading ? <p role="status">Overview loading</p> : null}
+      {error ? <p role="alert">{error}</p> : null}
+      <p>{summary?.total_episode_count ?? 0} overview episodes</p>
+    </div>
+  );
+}

--- a/apps/practitioner/src/components/practitioner-patient-insights-panel.tsx
+++ b/apps/practitioner/src/components/practitioner-patient-insights-panel.tsx
@@ -12,9 +12,17 @@ import { chartManifestSeriesDisplayLabel } from '@abstrack/types';
 import {
   CHART_SNAPSHOT_PRACTITIONER_NOTE_MAX_LENGTH,
   getChartSeries,
+  getEpisodeStartHourDistribution,
+  getEpisodeSummary,
+  getEpisodeWeekCounts,
   getUserChartManifest,
+  getSymptomFrequency,
   shareChartSnapshot,
   type AbstrackSupabaseClient,
+  type EpisodeStartHourDistributionRow,
+  type EpisodeSummaryRow,
+  type EpisodeWeekCountRow,
+  type SymptomFrequencyRow,
   type UserChartManifestSeries,
 } from '@abstrack/supabase';
 import {
@@ -22,6 +30,7 @@ import {
   InsightDateRangePicker,
   filterChartableManifestRows,
   InsightSeriesPicker,
+  InsightsSummarySection,
   pivotChartSeriesBucketRows,
   reconcileSelectedSeriesWithManifest,
   type ChartManifestRow,
@@ -82,6 +91,7 @@ export function PractitionerPatientInsightsPanel({
   supabase,
 }: PractitionerPatientInsightsPanelProps) {
   const { announce } = useAnnounce();
+  const dateRangeHeadingId = useId();
   const filtersHeadingId = useId();
   const chartOptionsHeadingId = useId();
   const bucketGroupId = useId();
@@ -108,12 +118,25 @@ export function PractitionerPatientInsightsPanel({
     ReturnType<typeof pivotChartSeriesBucketRows>
   >([]);
   const [chartError, setChartError] = useState<string | null>(null);
+  const [overviewLoading, setOverviewLoading] = useState(false);
+  const [overviewError, setOverviewError] = useState<string | null>(null);
+  const [overviewSummary, setOverviewSummary] =
+    useState<EpisodeSummaryRow | null>(null);
+  const [overviewWeekCounts, setOverviewWeekCounts] = useState<
+    EpisodeWeekCountRow[]
+  >([]);
+  const [overviewSymptomFrequencies, setOverviewSymptomFrequencies] = useState<
+    SymptomFrequencyRow[]
+  >([]);
+  const [overviewStartHourDistribution, setOverviewStartHourDistribution] =
+    useState<EpisodeStartHourDistributionRow[]>([]);
 
   const [shareDialogOpen, setShareDialogOpen] = useState(false);
   const [shareNote, setShareNote] = useState('');
 
   const manifestLoadGenRef = useRef(0);
   const chartLoadGenRef = useRef(0);
+  const overviewLoadGenRef = useRef(0);
   const patientUserIdRef = useRef(patientUserId);
   patientUserIdRef.current = patientUserId;
   const selectionOwnerUserIdRef = useRef<string | null>(null);
@@ -121,6 +144,7 @@ export function PractitionerPatientInsightsPanel({
   const invalidateInsightsLoads = useCallback(() => {
     manifestLoadGenRef.current += 1;
     chartLoadGenRef.current += 1;
+    overviewLoadGenRef.current += 1;
   }, []);
 
   const resetInsightsPatientState = useCallback(() => {
@@ -129,6 +153,12 @@ export function PractitionerPatientInsightsPanel({
     setChartLoading(false);
     setChartRows([]);
     setChartError(null);
+    setOverviewLoading(false);
+    setOverviewError(null);
+    setOverviewSummary(null);
+    setOverviewWeekCounts([]);
+    setOverviewSymptomFrequencies([]);
+    setOverviewStartHourDistribution([]);
     setShareDialogOpen(false);
     setShareNote('');
   }, []);
@@ -196,6 +226,83 @@ export function PractitionerPatientInsightsPanel({
     announce('Chart options loaded.', { politeness: 'polite' });
   }, [announce, patientUserId, supabase]);
 
+  const loadOverview = useCallback(async () => {
+    const requestedUserId = patientUserId;
+    const generation = ++overviewLoadGenRef.current;
+    const { p_from, p_to } = insightDateRangeToRpcBounds(dateRange);
+    setOverviewLoading(true);
+    setOverviewError(null);
+
+    const [
+      summaryResult,
+      weekCountsResult,
+      symptomFrequencyResult,
+      startHourDistributionResult,
+    ] = await Promise.all([
+      getEpisodeSummary(supabase, {
+        p_user_id: requestedUserId,
+        p_from,
+        p_to,
+        p_timezone: chartTimeZone,
+      }),
+      getEpisodeWeekCounts(supabase, {
+        p_user_id: requestedUserId,
+        p_from,
+        p_to,
+        p_timezone: chartTimeZone,
+      }),
+      getSymptomFrequency(supabase, {
+        p_user_id: requestedUserId,
+        p_from,
+        p_to,
+      }),
+      getEpisodeStartHourDistribution(supabase, {
+        p_user_id: requestedUserId,
+        p_from,
+        p_to,
+        p_timezone: chartTimeZone,
+      }),
+    ]);
+
+    if (
+      generation !== overviewLoadGenRef.current ||
+      requestedUserId !== patientUserIdRef.current
+    ) {
+      return;
+    }
+
+    setOverviewLoading(false);
+
+    if (
+      !summaryResult.ok ||
+      !weekCountsResult.ok ||
+      !symptomFrequencyResult.ok ||
+      !startHourDistributionResult.ok
+    ) {
+      const message =
+        (!summaryResult.ok && summaryResult.error.message) ||
+        (!weekCountsResult.ok && weekCountsResult.error.message) ||
+        (!symptomFrequencyResult.ok && symptomFrequencyResult.error.message) ||
+        (!startHourDistributionResult.ok &&
+          startHourDistributionResult.error.message) ||
+        'Unknown error.';
+      setOverviewSummary(null);
+      setOverviewWeekCounts([]);
+      setOverviewSymptomFrequencies([]);
+      setOverviewStartHourDistribution([]);
+      setOverviewError(message);
+      announce(`Could not load overview insights. ${message}`, {
+        politeness: 'assertive',
+      });
+      return;
+    }
+
+    setOverviewSummary(summaryResult.data);
+    setOverviewWeekCounts(weekCountsResult.data);
+    setOverviewSymptomFrequencies(symptomFrequencyResult.data);
+    setOverviewStartHourDistribution(startHourDistributionResult.data);
+  }, [announce, chartTimeZone, dateRange, patientUserId, supabase]);
+
   useEffect(() => {
     invalidateInsightsLoads();
     resetInsightsPatientState();
@@ -210,6 +317,14 @@ export function PractitionerPatientInsightsPanel({
     patientUserId,
     resetInsightsPatientState,
   ]);
+
+  useEffect(() => {
+    void loadOverview();
+
+    return () => {
+      overviewLoadGenRef.current += 1;
+    };
+  }, [loadOverview]);
 
   const loadChartSeries = useCallback(async () => {
     if (series.length === 0) {
@@ -332,122 +447,162 @@ export function PractitionerPatientInsightsPanel({
 
   return (
     <div className="space-y-8">
-      {manifestLoading ? (
-        <p className="text-sm text-app-muted" role="status">
-          Loading chart options…
+      <section
+        aria-labelledby={dateRangeHeadingId}
+        className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+      >
+        <h2
+          id={dateRangeHeadingId}
+          className="text-lg font-semibold text-app-ink"
+        >
+          Time period
+        </h2>
+        <p className="mt-1 text-sm text-app-muted">
+          The patient overview and custom chart stay aligned to this selected
+          range.
         </p>
-      ) : null}
+        <div className="mt-6">
+          <InsightDateRangePicker value={dateRange} onChange={setDateRange} />
+        </div>
+      </section>
 
-      {manifestError ? (
-        <p className="text-sm text-red-700 dark:text-red-300" role="alert">
-          {manifestError}
-        </p>
-      ) : null}
+      <InsightsSummarySection
+        dateRange={dateRange}
+        timeZone={chartTimeZone}
+        summary={overviewSummary}
+        weekCounts={overviewWeekCounts}
+        symptomFrequencies={overviewSymptomFrequencies}
+        startHourDistribution={overviewStartHourDistribution}
+        loading={overviewLoading}
+        error={overviewError}
+      />
 
-      {manifestIsEmpty ? (
-        <p className="text-sm text-app-muted" role="status">
-          {EMPTY_MANIFEST_MESSAGE}
-        </p>
-      ) : null}
-
-      {!manifestLoading && !manifestError && chartableManifest.length > 0 ? (
-        <section aria-labelledby={filtersHeadingId} className="space-y-6">
-          <h2 id={filtersHeadingId} className="sr-only">
-            Chart filters
-          </h2>
-
-          <div
-            className="space-y-6 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
-            aria-labelledby={chartOptionsHeadingId}
+      <section aria-labelledby={filtersHeadingId} className="space-y-6">
+        <div className="space-y-1">
+          <h2
+            id={filtersHeadingId}
+            className="text-xl font-semibold tracking-tight text-app-ink"
           >
-            <h3
-              id={chartOptionsHeadingId}
-              className="text-lg font-semibold text-app-ink"
-            >
-              What to chart
-            </h3>
-            <InsightSeriesPicker
-              manifest={manifest}
-              value={series}
-              onChange={handleSeriesChange}
-            />
-            <InsightDateRangePicker value={dateRange} onChange={setDateRange} />
-          </div>
+            Custom exploration
+          </h2>
+          <p className="text-sm text-app-muted">
+            Drill into a trend from the overview, then share the chart view you
+            want the patient to notice.
+          </p>
+        </div>
 
-          {showChartSection ? (
-            <section
-              aria-labelledby="practitioner-insights-chart-heading"
-              className="space-y-4 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+        {manifestLoading ? (
+          <p className="text-sm text-app-muted" role="status">
+            Loading chart options…
+          </p>
+        ) : null}
+
+        {manifestError ? (
+          <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+            {manifestError}
+          </p>
+        ) : null}
+
+        {manifestIsEmpty ? (
+          <p className="text-sm text-app-muted" role="status">
+            {EMPTY_MANIFEST_MESSAGE}
+          </p>
+        ) : null}
+
+        {!manifestLoading && !manifestError && chartableManifest.length > 0 ? (
+          <>
+            <div
+              className="space-y-6 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+              aria-labelledby={chartOptionsHeadingId}
             >
               <h3
-                id="practitioner-insights-chart-heading"
+                id={chartOptionsHeadingId}
                 className="text-lg font-semibold text-app-ink"
               >
-                Chart
+                Choose data series
               </h3>
+              <InsightSeriesPicker
+                manifest={manifest}
+                value={series}
+                onChange={handleSeriesChange}
+              />
+            </div>
 
-              <div
-                role="group"
-                aria-labelledby={bucketGroupId}
-                className="flex flex-wrap gap-2"
+            {showChartSection ? (
+              <section
+                aria-labelledby="practitioner-insights-chart-heading"
+                className="space-y-4 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
               >
-                <span id={bucketGroupId} className="sr-only">
-                  Group chart by
-                </span>
-                {BUCKET_OPTIONS.map(({ value, label }) => {
-                  const selected = bucket === value;
-                  return (
-                    <button
-                      key={value}
-                      type="button"
-                      aria-pressed={selected}
-                      className={
-                        selected
-                          ? 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-primary-solid px-4 text-base font-semibold text-app-on-primary-solid shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
-                          : 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
-                      }
-                      onClick={() => setBucket(value)}
-                    >
-                      {label}
-                    </button>
-                  );
-                })}
-              </div>
-
-              {chartError ? (
-                <p
-                  className="text-sm text-red-700 dark:text-red-300"
-                  role="alert"
+                <h3
+                  id="practitioner-insights-chart-heading"
+                  className="text-lg font-semibold text-app-ink"
                 >
-                  {chartError}
-                </p>
-              ) : (
-                <InsightComposedChart
-                  series={series}
-                  data={chartRows}
-                  bucket={bucket}
-                  loading={chartLoading}
-                  summary={chartSummary}
-                  patientTimeZone={chartTimeZone}
-                  showPatientTimeZoneNote
-                  patientTimeZoneNoteUsesPatientLocal={false}
-                />
-              )}
+                  Explore chart
+                </h3>
 
-              <div className="pt-2">
-                <button
-                  type="button"
-                  className="inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-50"
-                  disabled={chartLoading || Boolean(chartError)}
-                  onClick={() => setShareDialogOpen(true)}
+                <div
+                  role="group"
+                  aria-labelledby={bucketGroupId}
+                  className="flex flex-wrap gap-2"
                 >
-                  Share with patient
-                </button>
-              </div>
-            </section>
-          ) : null}
-        </section>
-      ) : null}
+                  <span id={bucketGroupId} className="sr-only">
+                    Group chart by
+                  </span>
+                  {BUCKET_OPTIONS.map(({ value, label }) => {
+                    const selected = bucket === value;
+                    return (
+                      <button
+                        key={value}
+                        type="button"
+                        aria-pressed={selected ? 'true' : 'false'}
+                        className={
+                          selected
+                            ? 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-primary-solid px-4 text-base font-semibold text-app-on-primary-solid shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
+                            : 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
+                        }
+                        onClick={() => setBucket(value)}
+                      >
+                        {label}
+                      </button>
+                    );
+                  })}
+                </div>
+
+                {chartError ? (
+                  <p
+                    className="text-sm text-red-700 dark:text-red-300"
+                    role="alert"
+                  >
+                    {chartError}
+                  </p>
+                ) : (
+                  <InsightComposedChart
+                    series={series}
+                    data={chartRows}
+                    bucket={bucket}
+                    loading={chartLoading}
+                    summary={chartSummary}
+                    patientTimeZone={chartTimeZone}
+                    showPatientTimeZoneNote
+                    patientTimeZoneNoteUsesPatientLocal={false}
+                  />
+                )}
+
+                <div className="pt-2">
+                  <button
+                    type="button"
+                    className="inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg disabled:cursor-not-allowed disabled:opacity-50"
+                    disabled={chartLoading || Boolean(chartError)}
+                    onClick={() => setShareDialogOpen(true)}
+                  >
+                    Share with patient
+                  </button>
+                </div>
+              </section>
+            ) : null}
+          </>
+        ) : null}
+      </section>
 
       <ConfirmDialog
         open={shareDialogOpen}

--- a/apps/practitioner/src/components/practitioner-patient-insights-panel.tsx
+++ b/apps/practitioner/src/components/practitioner-patient-insights-panel.tsx
@@ -255,6 +255,7 @@ export function PractitionerPatientInsightsPanel({
         p_user_id: requestedUserId,
         p_from,
         p_to,
+        p_timezone: chartTimeZone,
       }),
       getEpisodeStartHourDistribution(supabase, {
         p_user_id: requestedUserId,
@@ -525,6 +526,7 @@ export function PractitionerPatientInsightsPanel({
                 manifest={manifest}
                 value={series}
                 onChange={handleSeriesChange}
+                timeZone={chartTimeZone}
               />
             </div>
 

--- a/apps/practitioner/src/components/practitioner-patient-insights-panel.tsx
+++ b/apps/practitioner/src/components/practitioner-patient-insights-panel.tsx
@@ -12,11 +12,8 @@ import { chartManifestSeriesDisplayLabel } from '@abstrack/types';
 import {
   CHART_SNAPSHOT_PRACTITIONER_NOTE_MAX_LENGTH,
   getChartSeries,
-  getEpisodeStartHourDistribution,
-  getEpisodeSummary,
-  getEpisodeWeekCounts,
   getUserChartManifest,
-  getSymptomFrequency,
+  loadEpisodeInsightsOverview,
   shareChartSnapshot,
   type AbstrackSupabaseClient,
   type EpisodeStartHourDistributionRow,
@@ -233,37 +230,12 @@ export function PractitionerPatientInsightsPanel({
     setOverviewLoading(true);
     setOverviewError(null);
 
-    const [
-      summaryResult,
-      weekCountsResult,
-      symptomFrequencyResult,
-      startHourDistributionResult,
-    ] = await Promise.all([
-      getEpisodeSummary(supabase, {
-        p_user_id: requestedUserId,
-        p_from,
-        p_to,
-        p_timezone: chartTimeZone,
-      }),
-      getEpisodeWeekCounts(supabase, {
-        p_user_id: requestedUserId,
-        p_from,
-        p_to,
-        p_timezone: chartTimeZone,
-      }),
-      getSymptomFrequency(supabase, {
-        p_user_id: requestedUserId,
-        p_from,
-        p_to,
-        p_timezone: chartTimeZone,
-      }),
-      getEpisodeStartHourDistribution(supabase, {
-        p_user_id: requestedUserId,
-        p_from,
-        p_to,
-        p_timezone: chartTimeZone,
-      }),
-    ]);
+    const overviewResult = await loadEpisodeInsightsOverview(supabase, {
+      p_user_id: requestedUserId,
+      p_from,
+      p_to,
+      p_timezone: chartTimeZone,
+    });
 
     if (
       generation !== overviewLoadGenRef.current ||
@@ -274,19 +246,8 @@ export function PractitionerPatientInsightsPanel({
 
     setOverviewLoading(false);
 
-    if (
-      !summaryResult.ok ||
-      !weekCountsResult.ok ||
-      !symptomFrequencyResult.ok ||
-      !startHourDistributionResult.ok
-    ) {
-      const message =
-        (!summaryResult.ok && summaryResult.error.message) ||
-        (!weekCountsResult.ok && weekCountsResult.error.message) ||
-        (!symptomFrequencyResult.ok && symptomFrequencyResult.error.message) ||
-        (!startHourDistributionResult.ok &&
-          startHourDistributionResult.error.message) ||
-        'Unknown error.';
+    if (!overviewResult.ok) {
+      const message = overviewResult.error.message || 'Unknown error.';
       setOverviewSummary(null);
       setOverviewWeekCounts([]);
       setOverviewSymptomFrequencies([]);
@@ -298,10 +259,10 @@ export function PractitionerPatientInsightsPanel({
       return;
     }
 
-    setOverviewSummary(summaryResult.data);
-    setOverviewWeekCounts(weekCountsResult.data);
-    setOverviewSymptomFrequencies(symptomFrequencyResult.data);
-    setOverviewStartHourDistribution(startHourDistributionResult.data);
+    setOverviewSummary(overviewResult.data.summary);
+    setOverviewWeekCounts(overviewResult.data.weekCounts);
+    setOverviewSymptomFrequencies(overviewResult.data.symptomFrequencies);
+    setOverviewStartHourDistribution(overviewResult.data.startHourDistribution);
   }, [announce, chartTimeZone, dateRange, patientUserId, supabase]);
 
   useEffect(() => {

--- a/apps/web/next.config.js
+++ b/apps/web/next.config.js
@@ -88,6 +88,7 @@ const nextConfig = {
   ],
   webpack: (config) => {
     const supabaseSrc = path.join(__dirname, '../../packages/supabase/src');
+    const uiSrc = path.join(__dirname, '../../packages/ui/src');
     const uiWebSrc = path.join(__dirname, '../../packages/ui-web/src');
     config.resolve.alias = {
       ...config.resolve.alias,
@@ -105,6 +106,9 @@ const nextConfig = {
       '@abstrack/supabase/server': path.join(supabaseSrc, 'server.ts'),
       '@abstrack/supabase/native': path.join(supabaseSrc, 'native.ts'),
       '@abstrack/supabase/admin': path.join(supabaseSrc, 'admin.ts'),
+      '@abstrack/ui$': path.join(uiSrc, 'index.ts'),
+      '@abstrack/ui/a11y-web': path.join(uiSrc, 'a11y-web.ts'),
+      '@abstrack/ui/insights-web': path.join(uiSrc, 'insights-web.ts'),
       '@abstrack/ui-web$': path.join(uiWebSrc, 'index.ts'),
       '@abstrack/ui-web/sidebar': path.join(uiWebSrc, 'components/sidebar.tsx'),
     };

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -15,12 +15,9 @@ import type {
 } from '@abstrack/ui';
 import {
   getChartSeries,
-  getEpisodeStartHourDistribution,
-  getEpisodeSummary,
-  getEpisodeWeekCounts,
   getUserChartManifest,
-  getSymptomFrequency,
   listUnseenChartSnapshotsForPatient,
+  loadEpisodeInsightsOverview,
   markChartSnapshotSeen,
 } from '@abstrack/supabase';
 import {
@@ -71,10 +68,7 @@ jest.mock('../../../lib/supabase/browser-client', () => ({
 jest.mock('@abstrack/supabase', () => ({
   getUserChartManifest: jest.fn(),
   getChartSeries: jest.fn(),
-  getEpisodeSummary: jest.fn(),
-  getEpisodeWeekCounts: jest.fn(),
-  getSymptomFrequency: jest.fn(),
-  getEpisodeStartHourDistribution: jest.fn(),
+  loadEpisodeInsightsOverview: jest.fn(),
   listUnseenChartSnapshotsForPatient: jest.fn(),
   markChartSnapshotSeen: jest.fn(),
 }));
@@ -209,18 +203,9 @@ const getUserChartManifestMock = getUserChartManifest as jest.MockedFunction<
 const getChartSeriesMock = getChartSeries as jest.MockedFunction<
   typeof getChartSeries
 >;
-const getEpisodeSummaryMock = getEpisodeSummary as jest.MockedFunction<
-  typeof getEpisodeSummary
->;
-const getEpisodeWeekCountsMock = getEpisodeWeekCounts as jest.MockedFunction<
-  typeof getEpisodeWeekCounts
->;
-const getSymptomFrequencyMock = getSymptomFrequency as jest.MockedFunction<
-  typeof getSymptomFrequency
->;
-const getEpisodeStartHourDistributionMock =
-  getEpisodeStartHourDistribution as jest.MockedFunction<
-    typeof getEpisodeStartHourDistribution
+const loadEpisodeInsightsOverviewMock =
+  loadEpisodeInsightsOverview as jest.MockedFunction<
+    typeof loadEpisodeInsightsOverview
   >;
 const listUnseenChartSnapshotsForPatientMock =
   listUnseenChartSnapshotsForPatient as jest.MockedFunction<
@@ -290,29 +275,22 @@ describe('InsightsClient', () => {
         },
       ],
     });
-    getEpisodeSummaryMock.mockResolvedValue({
+    loadEpisodeInsightsOverviewMock.mockResolvedValue({
       ok: true,
       data: {
-        total_episode_count: 5,
-        abs_episode_count: 1,
-        other_episode_count: 4,
-        average_episodes_per_week: 1.2,
-        longest_episode_free_streak_days: 6,
-        current_episode_free_streak_days: 2,
-        average_episode_duration_hours: 10.4,
+        summary: {
+          total_episode_count: 5,
+          abs_episode_count: 1,
+          other_episode_count: 4,
+          average_episodes_per_week: 1.2,
+          longest_episode_free_streak_days: 6,
+          current_episode_free_streak_days: 2,
+          average_episode_duration_hours: 10.4,
+        },
+        weekCounts: [],
+        symptomFrequencies: [],
+        startHourDistribution: [],
       },
-    });
-    getEpisodeWeekCountsMock.mockResolvedValue({
-      ok: true,
-      data: [],
-    });
-    getSymptomFrequencyMock.mockResolvedValue({
-      ok: true,
-      data: [],
-    });
-    getEpisodeStartHourDistributionMock.mockResolvedValue({
-      ok: true,
-      data: [],
     });
     listUnseenChartSnapshotsForPatientMock.mockResolvedValue({
       ok: true,
@@ -710,7 +688,7 @@ describe('InsightsClient', () => {
     });
 
     await waitFor(() => {
-      expect(getEpisodeSummaryMock).toHaveBeenLastCalledWith(
+      expect(loadEpisodeInsightsOverviewMock).toHaveBeenLastCalledWith(
         expect.anything(),
         expect.objectContaining({
           p_from: SHARED_SNAPSHOT.date_from,
@@ -719,30 +697,6 @@ describe('InsightsClient', () => {
         }),
       );
     });
-    expect(getEpisodeWeekCountsMock).toHaveBeenLastCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        p_from: SHARED_SNAPSHOT.date_from,
-        p_to: SHARED_SNAPSHOT.date_to,
-        p_timezone: 'America/New_York',
-      }),
-    );
-    expect(getSymptomFrequencyMock).toHaveBeenLastCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        p_from: SHARED_SNAPSHOT.date_from,
-        p_to: SHARED_SNAPSHOT.date_to,
-        p_timezone: 'America/New_York',
-      }),
-    );
-    expect(getEpisodeStartHourDistributionMock).toHaveBeenLastCalledWith(
-      expect.anything(),
-      expect.objectContaining({
-        p_from: SHARED_SNAPSHOT.date_from,
-        p_to: SHARED_SNAPSHOT.date_to,
-        p_timezone: 'America/New_York',
-      }),
-    );
 
     await waitFor(() => {
       expect(markChartSnapshotSeenMock).toHaveBeenCalledWith(

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -727,6 +727,14 @@ describe('InsightsClient', () => {
         p_timezone: 'America/New_York',
       }),
     );
+    expect(getSymptomFrequencyMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        p_from: SHARED_SNAPSHOT.date_from,
+        p_to: SHARED_SNAPSHOT.date_to,
+        p_timezone: 'America/New_York',
+      }),
+    );
     expect(getEpisodeStartHourDistributionMock).toHaveBeenLastCalledWith(
       expect.anything(),
       expect.objectContaining({

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -710,6 +710,33 @@ describe('InsightsClient', () => {
     });
 
     await waitFor(() => {
+      expect(getEpisodeSummaryMock).toHaveBeenLastCalledWith(
+        expect.anything(),
+        expect.objectContaining({
+          p_from: SHARED_SNAPSHOT.date_from,
+          p_to: SHARED_SNAPSHOT.date_to,
+          p_timezone: 'America/New_York',
+        }),
+      );
+    });
+    expect(getEpisodeWeekCountsMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        p_from: SHARED_SNAPSHOT.date_from,
+        p_to: SHARED_SNAPSHOT.date_to,
+        p_timezone: 'America/New_York',
+      }),
+    );
+    expect(getEpisodeStartHourDistributionMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        p_from: SHARED_SNAPSHOT.date_from,
+        p_to: SHARED_SNAPSHOT.date_to,
+        p_timezone: 'America/New_York',
+      }),
+    );
+
+    await waitFor(() => {
       expect(markChartSnapshotSeenMock).toHaveBeenCalledWith(
         expect.anything(),
         SHARED_SNAPSHOT_ID,

--- a/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.spec.tsx
@@ -15,7 +15,11 @@ import type {
 } from '@abstrack/ui';
 import {
   getChartSeries,
+  getEpisodeStartHourDistribution,
+  getEpisodeSummary,
+  getEpisodeWeekCounts,
   getUserChartManifest,
+  getSymptomFrequency,
   listUnseenChartSnapshotsForPatient,
   markChartSnapshotSeen,
 } from '@abstrack/supabase';
@@ -67,6 +71,10 @@ jest.mock('../../../lib/supabase/browser-client', () => ({
 jest.mock('@abstrack/supabase', () => ({
   getUserChartManifest: jest.fn(),
   getChartSeries: jest.fn(),
+  getEpisodeSummary: jest.fn(),
+  getEpisodeWeekCounts: jest.fn(),
+  getSymptomFrequency: jest.fn(),
+  getEpisodeStartHourDistribution: jest.fn(),
   listUnseenChartSnapshotsForPatient: jest.fn(),
   markChartSnapshotSeen: jest.fn(),
 }));
@@ -177,6 +185,21 @@ jest.mock('@abstrack/ui', () => {
         {loading ? <p role="status">Chart loading</p> : null}
       </div>
     ),
+    InsightsSummarySection: ({
+      summary,
+      loading,
+      error,
+    }: {
+      summary: { total_episode_count: number } | null;
+      loading: boolean;
+      error?: string | null;
+    }) => (
+      <div data-testid="insights-summary-section">
+        {loading ? <p role="status">Overview loading</p> : null}
+        {error ? <p role="alert">{error}</p> : null}
+        <p>{summary?.total_episode_count ?? 0} overview episodes</p>
+      </div>
+    ),
   };
 });
 
@@ -186,6 +209,19 @@ const getUserChartManifestMock = getUserChartManifest as jest.MockedFunction<
 const getChartSeriesMock = getChartSeries as jest.MockedFunction<
   typeof getChartSeries
 >;
+const getEpisodeSummaryMock = getEpisodeSummary as jest.MockedFunction<
+  typeof getEpisodeSummary
+>;
+const getEpisodeWeekCountsMock = getEpisodeWeekCounts as jest.MockedFunction<
+  typeof getEpisodeWeekCounts
+>;
+const getSymptomFrequencyMock = getSymptomFrequency as jest.MockedFunction<
+  typeof getSymptomFrequency
+>;
+const getEpisodeStartHourDistributionMock =
+  getEpisodeStartHourDistribution as jest.MockedFunction<
+    typeof getEpisodeStartHourDistribution
+  >;
 const listUnseenChartSnapshotsForPatientMock =
   listUnseenChartSnapshotsForPatient as jest.MockedFunction<
     typeof listUnseenChartSnapshotsForPatient
@@ -254,6 +290,30 @@ describe('InsightsClient', () => {
         },
       ],
     });
+    getEpisodeSummaryMock.mockResolvedValue({
+      ok: true,
+      data: {
+        total_episode_count: 5,
+        abs_episode_count: 1,
+        other_episode_count: 4,
+        average_episodes_per_week: 1.2,
+        longest_episode_free_streak_days: 6,
+        current_episode_free_streak_days: 2,
+        average_episode_duration_hours: 10.4,
+      },
+    });
+    getEpisodeWeekCountsMock.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+    getSymptomFrequencyMock.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
+    getEpisodeStartHourDistributionMock.mockResolvedValue({
+      ok: true,
+      data: [],
+    });
     listUnseenChartSnapshotsForPatientMock.mockResolvedValue({
       ok: true,
       data: [],
@@ -283,6 +343,9 @@ describe('InsightsClient', () => {
 
     renderInsights();
 
+    expect(
+      await screen.findByTestId('insights-summary-section'),
+    ).toBeInTheDocument();
     expect(
       await screen.findByText(
         'No data to chart yet. Log some episodes or health markers to get started.',
@@ -316,7 +379,9 @@ describe('InsightsClient', () => {
         'No data to chart yet. Log some episodes or health markers to get started.',
       ),
     ).toBeInTheDocument();
-    expect(screen.queryByTestId('date-range-picker')).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: 'Select first series' }),
+    ).not.toBeInTheDocument();
     expect(getChartSeriesMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -342,6 +342,7 @@ export function InsightsClient() {
         p_user_id: requestedUserId,
         p_from,
         p_to,
+        p_timezone: overviewTimeZone,
       }),
       getEpisodeStartHourDistribution(supabase, {
         p_user_id: requestedUserId,
@@ -733,6 +734,7 @@ export function InsightsClient() {
                   manifest={manifest}
                   value={series}
                   onChange={handleSeriesChange}
+                  timeZone={activeChartTimeZone}
                 />
               </div>
 

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -312,7 +312,10 @@ export function InsightsClient() {
 
     const requestedUserId = phiSubjectUserId;
     const generation = ++overviewLoadGenRef.current;
-    const { p_from, p_to } = insightDateRangeToRpcBounds(dateRange);
+    const rpcOverride = chartRpcBoundsOverrideRef.current;
+    const { p_from, p_to } =
+      rpcOverride ?? insightDateRangeToRpcBounds(dateRange);
+    const overviewTimeZone = rpcOverride?.p_timezone ?? activeChartTimeZone;
     setOverviewLoading(true);
     setOverviewError(null);
 
@@ -327,13 +330,13 @@ export function InsightsClient() {
         p_user_id: requestedUserId,
         p_from,
         p_to,
-        p_timezone: chartTimeZone,
+        p_timezone: overviewTimeZone,
       }),
       getEpisodeWeekCounts(supabase, {
         p_user_id: requestedUserId,
         p_from,
         p_to,
-        p_timezone: chartTimeZone,
+        p_timezone: overviewTimeZone,
       }),
       getSymptomFrequency(supabase, {
         p_user_id: requestedUserId,
@@ -344,7 +347,7 @@ export function InsightsClient() {
         p_user_id: requestedUserId,
         p_from,
         p_to,
-        p_timezone: chartTimeZone,
+        p_timezone: overviewTimeZone,
       }),
     ]);
 
@@ -385,7 +388,7 @@ export function InsightsClient() {
     setOverviewWeekCounts(weekCountsResult.data);
     setOverviewSymptomFrequencies(symptomFrequencyResult.data);
     setOverviewStartHourDistribution(startHourDistributionResult.data);
-  }, [announce, chartTimeZone, dateRange, phiSubjectUserId]);
+  }, [activeChartTimeZone, announce, dateRange, phiSubjectUserId]);
 
   useEffect(() => {
     if (viewingOwnInsights && phiScopeReady) {
@@ -669,7 +672,7 @@ export function InsightsClient() {
       {phiScopeReady ? (
         <InsightsSummarySection
           dateRange={dateRange}
-          timeZone={chartTimeZone}
+          timeZone={activeChartTimeZone}
           summary={overviewSummary}
           weekCounts={overviewWeekCounts}
           symptomFrequencies={overviewSymptomFrequencies}

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -11,10 +11,18 @@ import {
 import { chartManifestSeriesDisplayLabel } from '@abstrack/types';
 import {
   getChartSeries,
+  getEpisodeStartHourDistribution,
+  getEpisodeSummary,
+  getEpisodeWeekCounts,
   getUserChartManifest,
+  getSymptomFrequency,
   listUnseenChartSnapshotsForPatient,
   markChartSnapshotSeen,
   type ChartSnapshotRow,
+  type EpisodeStartHourDistributionRow,
+  type EpisodeSummaryRow,
+  type EpisodeWeekCountRow,
+  type SymptomFrequencyRow,
   type UserChartManifestSeries,
 } from '@abstrack/supabase';
 import {
@@ -22,6 +30,7 @@ import {
   InsightDateRangePicker,
   filterChartableManifestRows,
   InsightSeriesPicker,
+  InsightsSummarySection,
   pivotChartSeriesBucketRows,
   reconcileSelectedSeriesWithManifest,
   type ChartManifestRow,
@@ -73,6 +82,7 @@ function manifestToChartRows(
  */
 export function InsightsClient() {
   const { announce } = useAnnounce();
+  const dateRangeHeadingId = useId();
   const filtersHeadingId = useId();
   const chartOptionsHeadingId = useId();
   const bucketGroupId = useId();
@@ -113,6 +123,18 @@ export function InsightsClient() {
     ReturnType<typeof pivotChartSeriesBucketRows>
   >([]);
   const [chartError, setChartError] = useState<string | null>(null);
+  const [overviewLoading, setOverviewLoading] = useState(false);
+  const [overviewError, setOverviewError] = useState<string | null>(null);
+  const [overviewSummary, setOverviewSummary] =
+    useState<EpisodeSummaryRow | null>(null);
+  const [overviewWeekCounts, setOverviewWeekCounts] = useState<
+    EpisodeWeekCountRow[]
+  >([]);
+  const [overviewSymptomFrequencies, setOverviewSymptomFrequencies] = useState<
+    SymptomFrequencyRow[]
+  >([]);
+  const [overviewStartHourDistribution, setOverviewStartHourDistribution] =
+    useState<EpisodeStartHourDistributionRow[]>([]);
 
   const [unseenSnapshots, setUnseenSnapshots] = useState<ChartSnapshotRow[]>(
     [],
@@ -125,6 +147,7 @@ export function InsightsClient() {
 
   const manifestLoadGenRef = useRef(0);
   const chartLoadGenRef = useRef(0);
+  const overviewLoadGenRef = useRef(0);
   const unseenSnapshotsLoadGenRef = useRef(0);
   const pendingSeenSnapshotIdRef = useRef<string | null>(null);
   /** Snapshot RPC bounds + timezone; set synchronously before series state updates. */
@@ -142,6 +165,7 @@ export function InsightsClient() {
   const invalidateInsightsLoads = useCallback(() => {
     manifestLoadGenRef.current += 1;
     chartLoadGenRef.current += 1;
+    overviewLoadGenRef.current += 1;
   }, []);
 
   const resetInsightsPatientState = useCallback(() => {
@@ -154,6 +178,12 @@ export function InsightsClient() {
     setChartError(null);
     setSharedSnapshotNote(null);
     setSharedSnapshotChartTimeZone(null);
+    setOverviewLoading(false);
+    setOverviewError(null);
+    setOverviewSummary(null);
+    setOverviewWeekCounts([]);
+    setOverviewSymptomFrequencies([]);
+    setOverviewStartHourDistribution([]);
   }, []);
 
   const handleSeriesChange = useCallback(
@@ -275,6 +305,88 @@ export function InsightsClient() {
     announce('Chart options loaded.', { politeness: 'polite' });
   }, [announce, phiSubjectUserId]);
 
+  const loadOverview = useCallback(async () => {
+    if (phiSubjectUserId == null) {
+      return;
+    }
+
+    const requestedUserId = phiSubjectUserId;
+    const generation = ++overviewLoadGenRef.current;
+    const { p_from, p_to } = insightDateRangeToRpcBounds(dateRange);
+    setOverviewLoading(true);
+    setOverviewError(null);
+
+    const supabase = createBrowserClient();
+    const [
+      summaryResult,
+      weekCountsResult,
+      symptomFrequencyResult,
+      startHourDistributionResult,
+    ] = await Promise.all([
+      getEpisodeSummary(supabase, {
+        p_user_id: requestedUserId,
+        p_from,
+        p_to,
+        p_timezone: chartTimeZone,
+      }),
+      getEpisodeWeekCounts(supabase, {
+        p_user_id: requestedUserId,
+        p_from,
+        p_to,
+        p_timezone: chartTimeZone,
+      }),
+      getSymptomFrequency(supabase, {
+        p_user_id: requestedUserId,
+        p_from,
+        p_to,
+      }),
+      getEpisodeStartHourDistribution(supabase, {
+        p_user_id: requestedUserId,
+        p_from,
+        p_to,
+        p_timezone: chartTimeZone,
+      }),
+    ]);
+
+    if (
+      generation !== overviewLoadGenRef.current ||
+      requestedUserId !== phiSubjectUserIdRef.current
+    ) {
+      return;
+    }
+
+    setOverviewLoading(false);
+
+    if (
+      !summaryResult.ok ||
+      !weekCountsResult.ok ||
+      !symptomFrequencyResult.ok ||
+      !startHourDistributionResult.ok
+    ) {
+      const message =
+        (!summaryResult.ok && summaryResult.error.message) ||
+        (!weekCountsResult.ok && weekCountsResult.error.message) ||
+        (!symptomFrequencyResult.ok && symptomFrequencyResult.error.message) ||
+        (!startHourDistributionResult.ok &&
+          startHourDistributionResult.error.message) ||
+        'Unknown error.';
+      setOverviewSummary(null);
+      setOverviewWeekCounts([]);
+      setOverviewSymptomFrequencies([]);
+      setOverviewStartHourDistribution([]);
+      setOverviewError(message);
+      announce(`Could not load overview insights. ${message}`, {
+        politeness: 'assertive',
+      });
+      return;
+    }
+
+    setOverviewSummary(summaryResult.data);
+    setOverviewWeekCounts(weekCountsResult.data);
+    setOverviewSymptomFrequencies(symptomFrequencyResult.data);
+    setOverviewStartHourDistribution(startHourDistributionResult.data);
+  }, [announce, chartTimeZone, dateRange, phiSubjectUserId]);
+
   useEffect(() => {
     if (viewingOwnInsights && phiScopeReady) {
       void loadUnseenSnapshots();
@@ -314,6 +426,40 @@ export function InsightsClient() {
     phiSubjectUserId,
     resetInsightsPatientState,
   ]);
+
+  useEffect(() => {
+    overviewLoadGenRef.current += 1;
+
+    if (phiScopeLoading) {
+      setOverviewLoading(true);
+      setOverviewError(null);
+      setOverviewSummary(null);
+      setOverviewWeekCounts([]);
+      setOverviewSymptomFrequencies([]);
+      setOverviewStartHourDistribution([]);
+      return () => {
+        overviewLoadGenRef.current += 1;
+      };
+    }
+
+    if (phiSubjectUserId == null || phiScopeError) {
+      setOverviewLoading(false);
+      setOverviewError(null);
+      setOverviewSummary(null);
+      setOverviewWeekCounts([]);
+      setOverviewSymptomFrequencies([]);
+      setOverviewStartHourDistribution([]);
+      return () => {
+        overviewLoadGenRef.current += 1;
+      };
+    }
+
+    void loadOverview();
+
+    return () => {
+      overviewLoadGenRef.current += 1;
+    };
+  }, [loadOverview, phiScopeError, phiScopeLoading, phiSubjectUserId]);
 
   const loadChartSeries = useCallback(async () => {
     if (phiSubjectUserId == null || series.length === 0) {
@@ -496,134 +642,179 @@ export function InsightsClient() {
         </div>
       ) : null}
 
-      {manifestLoading ? (
-        <p className="text-sm text-app-muted" role="status">
-          Loading chart options…
-        </p>
-      ) : null}
-
-      {manifestError ? (
-        <p className="text-sm text-red-700 dark:text-red-300" role="alert">
-          {manifestError}
-        </p>
-      ) : null}
-
-      {manifestIsEmpty ? (
-        <p className="text-sm text-app-muted" role="status">
-          {EMPTY_MANIFEST_MESSAGE}
-        </p>
-      ) : null}
-
-      {phiScopeReady &&
-      !manifestLoading &&
-      !manifestError &&
-      chartableManifest.length > 0 ? (
-        <section aria-labelledby={filtersHeadingId} className="space-y-6">
-          <h2 id={filtersHeadingId} className="sr-only">
-            Chart filters
-          </h2>
-
-          <div
-            className="space-y-6 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
-            aria-labelledby={chartOptionsHeadingId}
+      {phiScopeReady ? (
+        <section
+          aria-labelledby={dateRangeHeadingId}
+          className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+        >
+          <h2
+            id={dateRangeHeadingId}
+            className="text-lg font-semibold text-app-ink"
           >
-            <h3
-              id={chartOptionsHeadingId}
-              className="text-lg font-semibold text-app-ink"
-            >
-              What to chart
-            </h3>
-            <InsightSeriesPicker
-              manifest={manifest}
-              value={series}
-              onChange={handleSeriesChange}
-            />
+            Time period
+          </h2>
+          <p className="mt-1 text-sm text-app-muted">
+            The overview and custom chart below stay in sync with this selected
+            range.
+          </p>
+          <div className="mt-6">
             <InsightDateRangePicker
               value={dateRange}
               onChange={handleDateRangeChange}
             />
           </div>
+        </section>
+      ) : null}
 
-          {showChartSection ? (
-            <section
-              aria-labelledby="insights-chart-heading"
-              className="space-y-4 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+      {phiScopeReady ? (
+        <InsightsSummarySection
+          dateRange={dateRange}
+          timeZone={chartTimeZone}
+          summary={overviewSummary}
+          weekCounts={overviewWeekCounts}
+          symptomFrequencies={overviewSymptomFrequencies}
+          startHourDistribution={overviewStartHourDistribution}
+          loading={overviewLoading}
+          error={overviewError}
+        />
+      ) : null}
+
+      {phiScopeReady ? (
+        <section aria-labelledby={filtersHeadingId} className="space-y-6">
+          <div className="space-y-1">
+            <h2
+              id={filtersHeadingId}
+              className="text-xl font-semibold tracking-tight text-app-ink"
             >
-              <h3
-                id="insights-chart-heading"
-                className="text-lg font-semibold text-app-ink"
-              >
-                Chart
-              </h3>
+              Custom exploration
+            </h2>
+            <p className="text-sm text-app-muted">
+              Use the chart builder to dig into a pattern from the overview or a
+              chart your practitioner shared.
+            </p>
+          </div>
 
-              {sharedSnapshotNote ? (
-                <div
-                  className="rounded-lg border border-app-border bg-app-bg/80 px-4 py-3 text-sm text-app-ink"
-                  role="note"
-                >
-                  <p className="font-medium text-app-ink">
-                    Note from your practitioner
-                  </p>
-                  <p className="mt-1 whitespace-pre-wrap text-app-muted">
-                    {sharedSnapshotNote}
-                  </p>
-                </div>
-              ) : null}
+          {manifestLoading ? (
+            <p className="text-sm text-app-muted" role="status">
+              Loading chart options…
+            </p>
+          ) : null}
 
+          {manifestError ? (
+            <p className="text-sm text-red-700 dark:text-red-300" role="alert">
+              {manifestError}
+            </p>
+          ) : null}
+
+          {manifestIsEmpty ? (
+            <p className="text-sm text-app-muted" role="status">
+              {EMPTY_MANIFEST_MESSAGE}
+            </p>
+          ) : null}
+
+          {!manifestLoading &&
+          !manifestError &&
+          chartableManifest.length > 0 ? (
+            <>
               <div
-                role="group"
-                aria-labelledby={bucketGroupId}
-                className="flex flex-wrap gap-2"
+                className="space-y-6 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
+                aria-labelledby={chartOptionsHeadingId}
               >
-                <span id={bucketGroupId} className="sr-only">
-                  Group chart by
-                </span>
-                {BUCKET_OPTIONS.map(({ value, label }) => {
-                  const selected = bucket === value;
-                  return (
-                    <button
-                      key={value}
-                      type="button"
-                      aria-pressed={selected}
-                      className={
-                        selected
-                          ? 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-primary-solid px-4 text-base font-semibold text-app-on-primary-solid shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
-                          : 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
-                      }
-                      onClick={() => handleBucketChange(value)}
-                    >
-                      {label}
-                    </button>
-                  );
-                })}
+                <h3
+                  id={chartOptionsHeadingId}
+                  className="text-lg font-semibold text-app-ink"
+                >
+                  Choose data series
+                </h3>
+                <InsightSeriesPicker
+                  manifest={manifest}
+                  value={series}
+                  onChange={handleSeriesChange}
+                />
               </div>
 
-              {chartError ? (
-                <p
-                  className="text-sm text-red-700 dark:text-red-300"
-                  role="alert"
+              {showChartSection ? (
+                <section
+                  aria-labelledby="insights-chart-heading"
+                  className="space-y-4 rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)] sm:p-8"
                 >
-                  {chartError}
-                </p>
-              ) : (
-                <InsightComposedChart
-                  series={series}
-                  data={chartRows}
-                  bucket={bucket}
-                  loading={chartLoading}
-                  summary={chartSummary}
-                  patientTimeZone={activeChartTimeZone}
-                  showPatientTimeZoneNote={
-                    showPatientTimeZoneNote || showSharedChartTimeZoneNote
-                  }
-                  patientTimeZoneNoteVariant={
-                    showSharedChartTimeZoneNote
-                      ? 'practitionerShared'
-                      : 'browser'
-                  }
-                />
-              )}
-            </section>
+                  <h3
+                    id="insights-chart-heading"
+                    className="text-lg font-semibold text-app-ink"
+                  >
+                    Explore chart
+                  </h3>
+
+                  {sharedSnapshotNote ? (
+                    <div
+                      className="rounded-lg border border-app-border bg-app-bg/80 px-4 py-3 text-sm text-app-ink"
+                      role="note"
+                    >
+                      <p className="font-medium text-app-ink">
+                        Note from your practitioner
+                      </p>
+                      <p className="mt-1 whitespace-pre-wrap text-app-muted">
+                        {sharedSnapshotNote}
+                      </p>
+                    </div>
+                  ) : null}
+
+                  <div
+                    role="group"
+                    aria-labelledby={bucketGroupId}
+                    className="flex flex-wrap gap-2"
+                  >
+                    <span id={bucketGroupId} className="sr-only">
+                      Group chart by
+                    </span>
+                    {BUCKET_OPTIONS.map(({ value, label }) => {
+                      const selected = bucket === value;
+                      return (
+                        <button
+                          key={value}
+                          type="button"
+                          aria-pressed={selected ? 'true' : 'false'}
+                          className={
+                            selected
+                              ? 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-primary-solid px-4 text-base font-semibold text-app-on-primary-solid shadow-sm outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
+                              : 'inline-flex min-h-11 items-center justify-center rounded-lg border border-app-border bg-app-surface px-4 text-base font-semibold text-app-ink shadow-sm transition hover:bg-[var(--app-nav-hover-bg)] outline-none focus-visible:ring-2 focus-visible:ring-app-ring focus-visible:ring-offset-2 focus-visible:ring-offset-app-bg'
+                          }
+                          onClick={() => handleBucketChange(value)}
+                        >
+                          {label}
+                        </button>
+                      );
+                    })}
+                  </div>
+
+                  {chartError ? (
+                    <p
+                      className="text-sm text-red-700 dark:text-red-300"
+                      role="alert"
+                    >
+                      {chartError}
+                    </p>
+                  ) : (
+                    <InsightComposedChart
+                      series={series}
+                      data={chartRows}
+                      bucket={bucket}
+                      loading={chartLoading}
+                      summary={chartSummary}
+                      patientTimeZone={activeChartTimeZone}
+                      showPatientTimeZoneNote={
+                        showPatientTimeZoneNote || showSharedChartTimeZoneNote
+                      }
+                      patientTimeZoneNoteVariant={
+                        showSharedChartTimeZoneNote
+                          ? 'practitionerShared'
+                          : 'browser'
+                      }
+                    />
+                  )}
+                </section>
+              ) : null}
+            </>
           ) : null}
         </section>
       ) : null}

--- a/apps/web/src/app/(app)/insights/InsightsClient.tsx
+++ b/apps/web/src/app/(app)/insights/InsightsClient.tsx
@@ -11,12 +11,9 @@ import {
 import { chartManifestSeriesDisplayLabel } from '@abstrack/types';
 import {
   getChartSeries,
-  getEpisodeStartHourDistribution,
-  getEpisodeSummary,
-  getEpisodeWeekCounts,
   getUserChartManifest,
-  getSymptomFrequency,
   listUnseenChartSnapshotsForPatient,
+  loadEpisodeInsightsOverview,
   markChartSnapshotSeen,
   type ChartSnapshotRow,
   type EpisodeStartHourDistributionRow,
@@ -320,37 +317,12 @@ export function InsightsClient() {
     setOverviewError(null);
 
     const supabase = createBrowserClient();
-    const [
-      summaryResult,
-      weekCountsResult,
-      symptomFrequencyResult,
-      startHourDistributionResult,
-    ] = await Promise.all([
-      getEpisodeSummary(supabase, {
-        p_user_id: requestedUserId,
-        p_from,
-        p_to,
-        p_timezone: overviewTimeZone,
-      }),
-      getEpisodeWeekCounts(supabase, {
-        p_user_id: requestedUserId,
-        p_from,
-        p_to,
-        p_timezone: overviewTimeZone,
-      }),
-      getSymptomFrequency(supabase, {
-        p_user_id: requestedUserId,
-        p_from,
-        p_to,
-        p_timezone: overviewTimeZone,
-      }),
-      getEpisodeStartHourDistribution(supabase, {
-        p_user_id: requestedUserId,
-        p_from,
-        p_to,
-        p_timezone: overviewTimeZone,
-      }),
-    ]);
+    const overviewResult = await loadEpisodeInsightsOverview(supabase, {
+      p_user_id: requestedUserId,
+      p_from,
+      p_to,
+      p_timezone: overviewTimeZone,
+    });
 
     if (
       generation !== overviewLoadGenRef.current ||
@@ -361,19 +333,8 @@ export function InsightsClient() {
 
     setOverviewLoading(false);
 
-    if (
-      !summaryResult.ok ||
-      !weekCountsResult.ok ||
-      !symptomFrequencyResult.ok ||
-      !startHourDistributionResult.ok
-    ) {
-      const message =
-        (!summaryResult.ok && summaryResult.error.message) ||
-        (!weekCountsResult.ok && weekCountsResult.error.message) ||
-        (!symptomFrequencyResult.ok && symptomFrequencyResult.error.message) ||
-        (!startHourDistributionResult.ok &&
-          startHourDistributionResult.error.message) ||
-        'Unknown error.';
+    if (!overviewResult.ok) {
+      const message = overviewResult.error.message || 'Unknown error.';
       setOverviewSummary(null);
       setOverviewWeekCounts([]);
       setOverviewSymptomFrequencies([]);
@@ -385,10 +346,10 @@ export function InsightsClient() {
       return;
     }
 
-    setOverviewSummary(summaryResult.data);
-    setOverviewWeekCounts(weekCountsResult.data);
-    setOverviewSymptomFrequencies(symptomFrequencyResult.data);
-    setOverviewStartHourDistribution(startHourDistributionResult.data);
+    setOverviewSummary(overviewResult.data.summary);
+    setOverviewWeekCounts(overviewResult.data.weekCounts);
+    setOverviewSymptomFrequencies(overviewResult.data.symptomFrequencies);
+    setOverviewStartHourDistribution(overviewResult.data.startHourDistribution);
   }, [activeChartTimeZone, announce, dateRange, phiSubjectUserId]);
 
   useEffect(() => {

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -215,6 +215,19 @@ export type {
 } from './lib/chart-series-query.js';
 export { getChartSeries } from './lib/chart-series-query.js';
 export type {
+  EpisodeInsightsRangeParams,
+  EpisodeStartHourDistributionRow,
+  EpisodeSummaryRow,
+  EpisodeWeekCountRow,
+  SymptomFrequencyRow,
+} from './lib/episode-insights-query.js';
+export {
+  getEpisodeStartHourDistribution,
+  getEpisodeSummary,
+  getEpisodeWeekCounts,
+  getSymptomFrequency,
+} from './lib/episode-insights-query.js';
+export type {
   ChartSnapshotRow,
   ChartSnapshotSeriesDefinition,
   ShareChartSnapshotParams,

--- a/packages/supabase/src/index.ts
+++ b/packages/supabase/src/index.ts
@@ -215,6 +215,7 @@ export type {
 } from './lib/chart-series-query.js';
 export { getChartSeries } from './lib/chart-series-query.js';
 export type {
+  EpisodeInsightsOverviewData,
   EpisodeInsightsRangeParams,
   EpisodeStartHourDistributionRow,
   EpisodeSummaryRow,
@@ -226,6 +227,7 @@ export {
   getEpisodeSummary,
   getEpisodeWeekCounts,
   getSymptomFrequency,
+  loadEpisodeInsightsOverview,
 } from './lib/episode-insights-query.js';
 export type {
   ChartSnapshotRow,

--- a/packages/supabase/src/lib/database.types.ts
+++ b/packages/supabase/src/lib/database.types.ts
@@ -787,6 +787,61 @@ export type Database = {
           value_min: number
         }[]
       }
+      get_episode_start_hour_distribution: {
+        Args: {
+          p_from: string
+          p_timezone: string
+          p_to: string
+          p_user_id: string
+        }
+        Returns: {
+          episode_count: number
+          episode_type: string
+          hour_of_day: number
+        }[]
+      }
+      get_episode_summary: {
+        Args: {
+          p_from: string
+          p_timezone: string
+          p_to: string
+          p_user_id: string
+        }
+        Returns: {
+          abs_episode_count: number
+          average_episode_duration_hours: number
+          average_episodes_per_week: number
+          current_episode_free_streak_days: number
+          longest_episode_free_streak_days: number
+          other_episode_count: number
+          total_episode_count: number
+        }[]
+      }
+      get_episode_week_counts: {
+        Args: {
+          p_from: string
+          p_timezone: string
+          p_to: string
+          p_user_id: string
+        }
+        Returns: {
+          episode_count: number
+          episode_type: string
+          week_start: string
+        }[]
+      }
+      get_symptom_frequency: {
+        Args: {
+          p_from: string
+          p_timezone: string
+          p_to: string
+          p_user_id: string
+        }
+        Returns: {
+          occurrence_count: number
+          symptom_name: string
+        }[]
+      }
       get_user_chart_manifest: {
         Args: { p_user_id: string }
         Returns: {

--- a/packages/supabase/src/lib/episode-insights-query.spec.ts
+++ b/packages/supabase/src/lib/episode-insights-query.spec.ts
@@ -117,6 +117,24 @@ describe('episode insights query wrappers', () => {
     expect(result).toEqual({ ok: true, data: rows });
   });
 
+  it('coalesces null row sets to empty arrays', async () => {
+    const client = rpcClient(null);
+
+    const weekCountsResult = await getEpisodeWeekCounts(client, RANGE_PARAMS);
+    const symptomResult = await getSymptomFrequency(client, RANGE_PARAMS);
+
+    expect(weekCountsResult).toEqual({ ok: true, data: [] });
+    expect(symptomResult).toEqual({ ok: true, data: [] });
+  });
+
+  it('returns null when get_episode_summary returns no rows', async () => {
+    const client = rpcClient(null);
+
+    const result = await getEpisodeSummary(client, RANGE_PARAMS);
+
+    expect(result).toEqual({ ok: true, data: null });
+  });
+
   it('maps rpc errors to PresetDataError', async () => {
     const client = rpcClient(null, {
       message: 'permission denied for function get_episode_summary',

--- a/packages/supabase/src/lib/episode-insights-query.spec.ts
+++ b/packages/supabase/src/lib/episode-insights-query.spec.ts
@@ -7,8 +7,10 @@ import {
   getEpisodeSummary,
   getEpisodeWeekCounts,
   getSymptomFrequency,
+  loadEpisodeInsightsOverview,
   type EpisodeInsightsRangeParams,
   type EpisodeStartHourDistributionRow,
+  type EpisodeInsightsOverviewData,
   type EpisodeSummaryRow,
   type EpisodeWeekCountRow,
   type SymptomFrequencyRow,
@@ -25,6 +27,18 @@ const RANGE_PARAMS: EpisodeInsightsRangeParams = {
 
 function rpcClient(data: unknown, error: unknown = null) {
   const rpc = vi.fn(async () => ({ data, error }));
+  return {
+    rpc,
+  } as unknown as AbstrackSupabaseClient;
+}
+
+function rpcClientByFunction(
+  responses: Record<string, { data: unknown; error?: unknown }>,
+) {
+  const rpc = vi.fn(async (fn: string) => {
+    const response = responses[fn] ?? { data: null, error: null };
+    return { data: response.data, error: response.error ?? null };
+  });
   return {
     rpc,
   } as unknown as AbstrackSupabaseClient;
@@ -133,6 +147,104 @@ describe('episode insights query wrappers', () => {
     const result = await getEpisodeSummary(client, RANGE_PARAMS);
 
     expect(result).toEqual({ ok: true, data: null });
+  });
+
+  it('loads the combined overview payload across all overview RPCs', async () => {
+    const summaryRows: EpisodeSummaryRow[] = [
+      {
+        total_episode_count: 3,
+        abs_episode_count: 1,
+        other_episode_count: 2,
+        average_episodes_per_week: 1.5,
+        longest_episode_free_streak_days: 6,
+        current_episode_free_streak_days: 4,
+        average_episode_duration_hours: 9.5,
+      },
+    ];
+    const weekCountRows: EpisodeWeekCountRow[] = [
+      {
+        week_start: '2026-01-05T05:00:00.000Z',
+        episode_type: 'Other',
+        episode_count: 2,
+      },
+    ];
+    const symptomRows: SymptomFrequencyRow[] = [
+      {
+        symptom_name: 'Nausea',
+        occurrence_count: 12,
+      },
+    ];
+    const startHourRows: EpisodeStartHourDistributionRow[] = [
+      {
+        hour_of_day: 4,
+        episode_type: 'Other',
+        episode_count: 7,
+      },
+    ];
+    const client = rpcClientByFunction({
+      get_episode_summary: { data: summaryRows },
+      get_episode_week_counts: { data: weekCountRows },
+      get_symptom_frequency: { data: symptomRows },
+      get_episode_start_hour_distribution: { data: startHourRows },
+    });
+
+    const result = await loadEpisodeInsightsOverview(client, RANGE_PARAMS);
+
+    expect(client.rpc).toHaveBeenNthCalledWith(
+      1,
+      'get_episode_summary',
+      RANGE_PARAMS,
+    );
+    expect(client.rpc).toHaveBeenNthCalledWith(
+      2,
+      'get_episode_week_counts',
+      RANGE_PARAMS,
+    );
+    expect(client.rpc).toHaveBeenNthCalledWith(
+      3,
+      'get_symptom_frequency',
+      RANGE_PARAMS,
+    );
+    expect(client.rpc).toHaveBeenNthCalledWith(
+      4,
+      'get_episode_start_hour_distribution',
+      RANGE_PARAMS,
+    );
+    expect(result).toEqual({
+      ok: true,
+      data: {
+        summary: summaryRows[0],
+        weekCounts: weekCountRows,
+        symptomFrequencies: symptomRows,
+        startHourDistribution: startHourRows,
+      } satisfies EpisodeInsightsOverviewData,
+    });
+  });
+
+  it('returns the first overview RPC error when a combined load fails', async () => {
+    const client = rpcClientByFunction({
+      get_episode_summary: { data: [] },
+      get_episode_week_counts: {
+        data: null,
+        error: {
+          code: '42501',
+          message: 'permission denied for function get_episode_week_counts',
+        },
+      },
+      get_symptom_frequency: { data: [] },
+      get_episode_start_hour_distribution: { data: [] },
+    });
+
+    const result = await loadEpisodeInsightsOverview(client, RANGE_PARAMS);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error).toBeInstanceOf(PresetDataError);
+    expect(result.error.code).toBe('permission_denied');
+    expect(result.error.message).toBe('You do not have permission to do that.');
   });
 
   it('maps rpc errors to PresetDataError', async () => {

--- a/packages/supabase/src/lib/episode-insights-query.spec.ts
+++ b/packages/supabase/src/lib/episode-insights-query.spec.ts
@@ -1,0 +1,133 @@
+import type { Uuid } from '@abstrack/types';
+import { describe, expect, it, vi } from 'vitest';
+import { PresetDataError } from './preset-data-error.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+import {
+  getEpisodeStartHourDistribution,
+  getEpisodeSummary,
+  getEpisodeWeekCounts,
+  getSymptomFrequency,
+  type EpisodeInsightsRangeParams,
+  type EpisodeStartHourDistributionRow,
+  type EpisodeSummaryRow,
+  type EpisodeWeekCountRow,
+  type SymptomFrequencyRow,
+} from './episode-insights-query.js';
+
+const USER_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' as Uuid;
+
+const RANGE_PARAMS: EpisodeInsightsRangeParams = {
+  p_user_id: USER_ID,
+  p_from: '2026-01-01T00:00:00.000Z',
+  p_to: '2026-03-01T00:00:00.000Z',
+  p_timezone: 'America/New_York',
+};
+
+function rpcClient(data: unknown, error: unknown = null) {
+  const rpc = vi.fn(async () => ({ data, error }));
+  return {
+    rpc,
+  } as unknown as AbstrackSupabaseClient;
+}
+
+describe('episode insights query wrappers', () => {
+  it('calls get_episode_summary with the selected range and timezone', async () => {
+    const rows: EpisodeSummaryRow[] = [
+      {
+        total_episode_count: 3,
+        abs_episode_count: 1,
+        other_episode_count: 2,
+        average_episodes_per_week: 1.5,
+        longest_episode_free_streak_days: 6,
+        current_episode_free_streak_days: 4,
+        average_episode_duration_hours: 9.5,
+      },
+    ];
+    const client = rpcClient(rows);
+
+    const result = await getEpisodeSummary(client, RANGE_PARAMS);
+
+    expect(client.rpc).toHaveBeenCalledWith(
+      'get_episode_summary',
+      RANGE_PARAMS,
+    );
+    expect(result).toEqual({ ok: true, data: rows[0] });
+  });
+
+  it('calls get_episode_week_counts and returns rows unchanged', async () => {
+    const rows: EpisodeWeekCountRow[] = [
+      {
+        week_start: '2026-01-05T05:00:00.000Z',
+        episode_type: 'Other',
+        episode_count: 2,
+      },
+    ];
+    const client = rpcClient(rows);
+
+    const result = await getEpisodeWeekCounts(client, RANGE_PARAMS);
+
+    expect(client.rpc).toHaveBeenCalledWith(
+      'get_episode_week_counts',
+      RANGE_PARAMS,
+    );
+    expect(result).toEqual({ ok: true, data: rows });
+  });
+
+  it('calls get_episode_start_hour_distribution and returns rows unchanged', async () => {
+    const rows: EpisodeStartHourDistributionRow[] = [
+      {
+        hour_of_day: 4,
+        episode_type: 'Other',
+        episode_count: 7,
+      },
+    ];
+    const client = rpcClient(rows);
+
+    const result = await getEpisodeStartHourDistribution(client, RANGE_PARAMS);
+
+    expect(client.rpc).toHaveBeenCalledWith(
+      'get_episode_start_hour_distribution',
+      RANGE_PARAMS,
+    );
+    expect(result).toEqual({ ok: true, data: rows });
+  });
+
+  it('calls get_symptom_frequency without timezone and returns rows unchanged', async () => {
+    const rows: SymptomFrequencyRow[] = [
+      {
+        symptom_name: 'Nausea',
+        occurrence_count: 12,
+      },
+    ];
+    const client = rpcClient(rows);
+
+    const result = await getSymptomFrequency(client, {
+      p_user_id: RANGE_PARAMS.p_user_id,
+      p_from: RANGE_PARAMS.p_from,
+      p_to: RANGE_PARAMS.p_to,
+    });
+
+    expect(client.rpc).toHaveBeenCalledWith('get_symptom_frequency', {
+      p_user_id: RANGE_PARAMS.p_user_id,
+      p_from: RANGE_PARAMS.p_from,
+      p_to: RANGE_PARAMS.p_to,
+    });
+    expect(result).toEqual({ ok: true, data: rows });
+  });
+
+  it('maps rpc errors to PresetDataError', async () => {
+    const client = rpcClient(null, {
+      message: 'permission denied for function get_episode_summary',
+    });
+
+    const result = await getEpisodeSummary(client, RANGE_PARAMS);
+
+    expect(result.ok).toBe(false);
+    if (result.ok) {
+      return;
+    }
+
+    expect(result.error).toBeInstanceOf(PresetDataError);
+    expect(result.error.code).toBe('permission_denied');
+  });
+});

--- a/packages/supabase/src/lib/episode-insights-query.spec.ts
+++ b/packages/supabase/src/lib/episode-insights-query.spec.ts
@@ -92,7 +92,7 @@ describe('episode insights query wrappers', () => {
     expect(result).toEqual({ ok: true, data: rows });
   });
 
-  it('calls get_symptom_frequency without timezone and returns rows unchanged', async () => {
+  it('calls get_symptom_frequency with timezone and returns rows unchanged', async () => {
     const rows: SymptomFrequencyRow[] = [
       {
         symptom_name: 'Nausea',
@@ -105,12 +105,14 @@ describe('episode insights query wrappers', () => {
       p_user_id: RANGE_PARAMS.p_user_id,
       p_from: RANGE_PARAMS.p_from,
       p_to: RANGE_PARAMS.p_to,
+      p_timezone: RANGE_PARAMS.p_timezone,
     });
 
     expect(client.rpc).toHaveBeenCalledWith('get_symptom_frequency', {
       p_user_id: RANGE_PARAMS.p_user_id,
       p_from: RANGE_PARAMS.p_from,
       p_to: RANGE_PARAMS.p_to,
+      p_timezone: RANGE_PARAMS.p_timezone,
     });
     expect(result).toEqual({ ok: true, data: rows });
   });

--- a/packages/supabase/src/lib/episode-insights-query.ts
+++ b/packages/supabase/src/lib/episode-insights-query.ts
@@ -163,12 +163,12 @@ export async function getEpisodeStartHourDistribution(
  * Loads symptom counts for episode symptoms recorded in the selected period.
  *
  * @param client - Supabase client with the caller JWT.
- * @param params - User and selected period bounds (`p_to` exclusive).
+ * @param params - User, selected period bounds (`p_to` exclusive), and IANA timezone for range validation.
  * @returns Symptom counts ordered from most to least frequent.
  */
 export async function getSymptomFrequency(
   client: AbstrackSupabaseClient,
-  params: Pick<EpisodeInsightsRangeParams, 'p_user_id' | 'p_from' | 'p_to'>,
+  params: EpisodeInsightsRangeParams,
 ): Promise<PresetDataResult<SymptomFrequencyRow[]>> {
   return callInsightsRpc<SymptomFrequencyRow[]>(
     client,
@@ -177,6 +177,7 @@ export async function getSymptomFrequency(
       p_user_id: params.p_user_id,
       p_from: params.p_from,
       p_to: params.p_to,
+      p_timezone: params.p_timezone,
     },
   );
 }

--- a/packages/supabase/src/lib/episode-insights-query.ts
+++ b/packages/supabase/src/lib/episode-insights-query.ts
@@ -59,11 +59,11 @@ export interface SymptomFrequencyRow {
   occurrence_count: number;
 }
 
-async function callInsightsRpc<TData>(
+async function callInsightsRpc<TRow>(
   client: AbstrackSupabaseClient,
   functionName: string,
   args: Record<string, unknown>,
-): Promise<PresetDataResult<TData>> {
+): Promise<PresetDataResult<TRow[]>> {
   try {
     const { data, error } = await (client as unknown as InsightsRpcClient).rpc(
       functionName,
@@ -76,7 +76,7 @@ async function callInsightsRpc<TData>(
 
     return {
       ok: true,
-      data: data as TData,
+      data: (data ?? []) as TRow[],
     };
   } catch (cause) {
     return { ok: false, error: toPresetDataError(cause) };
@@ -94,7 +94,7 @@ export async function getEpisodeSummary(
   client: AbstrackSupabaseClient,
   params: EpisodeInsightsRangeParams,
 ): Promise<PresetDataResult<EpisodeSummaryRow | null>> {
-  const result = await callInsightsRpc<unknown[]>(
+  const result = await callInsightsRpc<EpisodeSummaryRow>(
     client,
     'get_episode_summary',
     {
@@ -109,7 +109,7 @@ export async function getEpisodeSummary(
     return result;
   }
 
-  const [row] = (result.data ?? []) as EpisodeSummaryRow[];
+  const [row] = result.data;
   return { ok: true, data: row ?? null };
 }
 
@@ -124,7 +124,7 @@ export async function getEpisodeWeekCounts(
   client: AbstrackSupabaseClient,
   params: EpisodeInsightsRangeParams,
 ): Promise<PresetDataResult<EpisodeWeekCountRow[]>> {
-  return callInsightsRpc<EpisodeWeekCountRow[]>(
+  return callInsightsRpc<EpisodeWeekCountRow>(
     client,
     'get_episode_week_counts',
     {
@@ -147,7 +147,7 @@ export async function getEpisodeStartHourDistribution(
   client: AbstrackSupabaseClient,
   params: EpisodeInsightsRangeParams,
 ): Promise<PresetDataResult<EpisodeStartHourDistributionRow[]>> {
-  return callInsightsRpc<EpisodeStartHourDistributionRow[]>(
+  return callInsightsRpc<EpisodeStartHourDistributionRow>(
     client,
     'get_episode_start_hour_distribution',
     {
@@ -170,14 +170,10 @@ export async function getSymptomFrequency(
   client: AbstrackSupabaseClient,
   params: EpisodeInsightsRangeParams,
 ): Promise<PresetDataResult<SymptomFrequencyRow[]>> {
-  return callInsightsRpc<SymptomFrequencyRow[]>(
-    client,
-    'get_symptom_frequency',
-    {
-      p_user_id: params.p_user_id,
-      p_from: params.p_from,
-      p_to: params.p_to,
-      p_timezone: params.p_timezone,
-    },
-  );
+  return callInsightsRpc<SymptomFrequencyRow>(client, 'get_symptom_frequency', {
+    p_user_id: params.p_user_id,
+    p_from: params.p_from,
+    p_to: params.p_to,
+    p_timezone: params.p_timezone,
+  });
 }

--- a/packages/supabase/src/lib/episode-insights-query.ts
+++ b/packages/supabase/src/lib/episode-insights-query.ts
@@ -59,6 +59,16 @@ export interface SymptomFrequencyRow {
   occurrence_count: number;
 }
 
+/**
+ * Combined overview payload used by patient and practitioner insights surfaces.
+ */
+export interface EpisodeInsightsOverviewData {
+  summary: EpisodeSummaryRow | null;
+  weekCounts: EpisodeWeekCountRow[];
+  symptomFrequencies: SymptomFrequencyRow[];
+  startHourDistribution: EpisodeStartHourDistributionRow[];
+}
+
 async function callInsightsRpc<TRow>(
   client: AbstrackSupabaseClient,
   functionName: string,
@@ -176,4 +186,51 @@ export async function getSymptomFrequency(
     p_to: params.p_to,
     p_timezone: params.p_timezone,
   });
+}
+
+/**
+ * Loads the complete episode insights overview payload used by the web and practitioner apps.
+ *
+ * @param client - Supabase client with the caller JWT.
+ * @param params - User, range, and IANA timezone parameters shared by the overview RPCs.
+ * @returns Overview summary, heatmap buckets, symptom frequencies, and start-hour distribution.
+ */
+export async function loadEpisodeInsightsOverview(
+  client: AbstrackSupabaseClient,
+  params: EpisodeInsightsRangeParams,
+): Promise<PresetDataResult<EpisodeInsightsOverviewData>> {
+  const [
+    summaryResult,
+    weekCountsResult,
+    symptomFrequencyResult,
+    startHourDistributionResult,
+  ] = await Promise.all([
+    getEpisodeSummary(client, params),
+    getEpisodeWeekCounts(client, params),
+    getSymptomFrequency(client, params),
+    getEpisodeStartHourDistribution(client, params),
+  ]);
+
+  if (!summaryResult.ok) {
+    return summaryResult;
+  }
+  if (!weekCountsResult.ok) {
+    return weekCountsResult;
+  }
+  if (!symptomFrequencyResult.ok) {
+    return symptomFrequencyResult;
+  }
+  if (!startHourDistributionResult.ok) {
+    return startHourDistributionResult;
+  }
+
+  return {
+    ok: true,
+    data: {
+      summary: summaryResult.data,
+      weekCounts: weekCountsResult.data,
+      symptomFrequencies: symptomFrequencyResult.data,
+      startHourDistribution: startHourDistributionResult.data,
+    },
+  };
 }

--- a/packages/supabase/src/lib/episode-insights-query.ts
+++ b/packages/supabase/src/lib/episode-insights-query.ts
@@ -1,0 +1,182 @@
+import type { Uuid } from '@abstrack/types';
+import { toPresetDataError } from './preset-data-error.js';
+import type { PresetDataResult } from './preset-data.js';
+import type { AbstrackSupabaseClient } from './supabase-client-type.js';
+
+type InsightsRpcClient = {
+  rpc(
+    fn: string,
+    args: Record<string, unknown>,
+  ): Promise<{ data: unknown; error: unknown }>;
+};
+
+/**
+ * Shared range arguments for episode insights RPCs that bucket or summarize in a timezone.
+ */
+export interface EpisodeInsightsRangeParams {
+  p_user_id: Uuid;
+  p_from: string;
+  p_to: string;
+  p_timezone: string;
+}
+
+/**
+ * Summary metrics returned by `get_episode_summary`.
+ */
+export interface EpisodeSummaryRow {
+  total_episode_count: number;
+  abs_episode_count: number;
+  other_episode_count: number;
+  average_episodes_per_week: number | null;
+  longest_episode_free_streak_days: number | null;
+  current_episode_free_streak_days: number | null;
+  average_episode_duration_hours: number | null;
+}
+
+/**
+ * One weekly episode-count bucket for the overview heatmap.
+ */
+export interface EpisodeWeekCountRow {
+  week_start: string;
+  episode_type: 'ABS' | 'Other';
+  episode_count: number;
+}
+
+/**
+ * One hourly episode-start count for the overview start-time chart.
+ */
+export interface EpisodeStartHourDistributionRow {
+  hour_of_day: number;
+  episode_type: 'ABS' | 'Other';
+  episode_count: number;
+}
+
+/**
+ * One aggregated symptom-frequency row for the selected period.
+ */
+export interface SymptomFrequencyRow {
+  symptom_name: string;
+  occurrence_count: number;
+}
+
+async function callInsightsRpc<TData>(
+  client: AbstrackSupabaseClient,
+  functionName: string,
+  args: Record<string, unknown>,
+): Promise<PresetDataResult<TData>> {
+  try {
+    const { data, error } = await (client as unknown as InsightsRpcClient).rpc(
+      functionName,
+      args,
+    );
+
+    if (error) {
+      return { ok: false, error: toPresetDataError(error) };
+    }
+
+    return {
+      ok: true,
+      data: data as TData,
+    };
+  } catch (cause) {
+    return { ok: false, error: toPresetDataError(cause) };
+  }
+}
+
+/**
+ * Loads overview summary metrics for episodes in the selected period.
+ *
+ * @param client - Supabase client with the caller JWT.
+ * @param params - User, range, and IANA timezone parameters for the RPC.
+ * @returns One summary row, or `null` if the RPC returned no rows.
+ */
+export async function getEpisodeSummary(
+  client: AbstrackSupabaseClient,
+  params: EpisodeInsightsRangeParams,
+): Promise<PresetDataResult<EpisodeSummaryRow | null>> {
+  const result = await callInsightsRpc<unknown[]>(
+    client,
+    'get_episode_summary',
+    {
+      p_user_id: params.p_user_id,
+      p_from: params.p_from,
+      p_to: params.p_to,
+      p_timezone: params.p_timezone,
+    },
+  );
+
+  if (!result.ok) {
+    return result;
+  }
+
+  const [row] = (result.data ?? []) as EpisodeSummaryRow[];
+  return { ok: true, data: row ?? null };
+}
+
+/**
+ * Loads weekly episode counts grouped by episode type for the overview heatmap.
+ *
+ * @param client - Supabase client with the caller JWT.
+ * @param params - User, range, and IANA timezone parameters for the RPC.
+ * @returns Weekly buckets ordered by week start.
+ */
+export async function getEpisodeWeekCounts(
+  client: AbstrackSupabaseClient,
+  params: EpisodeInsightsRangeParams,
+): Promise<PresetDataResult<EpisodeWeekCountRow[]>> {
+  return callInsightsRpc<EpisodeWeekCountRow[]>(
+    client,
+    'get_episode_week_counts',
+    {
+      p_user_id: params.p_user_id,
+      p_from: params.p_from,
+      p_to: params.p_to,
+      p_timezone: params.p_timezone,
+    },
+  );
+}
+
+/**
+ * Loads hourly episode-start counts grouped by episode type.
+ *
+ * @param client - Supabase client with the caller JWT.
+ * @param params - User, range, and IANA timezone parameters for the RPC.
+ * @returns Hour-of-day buckets ordered by hour.
+ */
+export async function getEpisodeStartHourDistribution(
+  client: AbstrackSupabaseClient,
+  params: EpisodeInsightsRangeParams,
+): Promise<PresetDataResult<EpisodeStartHourDistributionRow[]>> {
+  return callInsightsRpc<EpisodeStartHourDistributionRow[]>(
+    client,
+    'get_episode_start_hour_distribution',
+    {
+      p_user_id: params.p_user_id,
+      p_from: params.p_from,
+      p_to: params.p_to,
+      p_timezone: params.p_timezone,
+    },
+  );
+}
+
+/**
+ * Loads symptom counts for episode symptoms recorded in the selected period.
+ *
+ * @param client - Supabase client with the caller JWT.
+ * @param params - User and selected period bounds (`p_to` exclusive).
+ * @returns Symptom counts ordered from most to least frequent.
+ */
+export async function getSymptomFrequency(
+  client: AbstrackSupabaseClient,
+  params: Pick<EpisodeInsightsRangeParams, 'p_user_id' | 'p_from' | 'p_to'>,
+): Promise<PresetDataResult<SymptomFrequencyRow[]>> {
+  return callInsightsRpc<SymptomFrequencyRow[]>(
+    client,
+    'get_symptom_frequency',
+    {
+      p_user_id: params.p_user_id,
+      p_from: params.p_from,
+      p_to: params.p_to,
+    },
+  );
+}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -32,6 +32,14 @@ export {
   type InsightComposedChartProps,
 } from './lib/InsightComposedChart.js';
 export {
+  InsightsSummarySection,
+  type InsightsStartHourDistributionRow,
+  type InsightsSummaryMetrics,
+  type InsightsSummarySectionProps,
+  type InsightsSymptomFrequencyRow,
+  type InsightsWeekCountRow,
+} from './lib/InsightsSummarySection.js';
+export {
   pivotChartSeriesBucketRows,
   type ChartSeriesBucketRowInput,
 } from './lib/insight-composed-chart-utils.js';

--- a/packages/ui/src/insights-web.ts
+++ b/packages/ui/src/insights-web.ts
@@ -27,6 +27,14 @@ export {
   type InsightComposedChartProps,
 } from './lib/InsightComposedChart.js';
 export {
+  InsightsSummarySection,
+  type InsightsStartHourDistributionRow,
+  type InsightsSummaryMetrics,
+  type InsightsSummarySectionProps,
+  type InsightsSymptomFrequencyRow,
+  type InsightsWeekCountRow,
+} from './lib/InsightsSummarySection.js';
+export {
   pivotChartSeriesBucketRows,
   type ChartSeriesBucketRowInput,
 } from './lib/insight-composed-chart-utils.js';

--- a/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
@@ -177,17 +177,31 @@ describe('InsightSeriesPicker', () => {
     });
 
     expect(
-      within(slotThree).queryByRole('option', { name: 'Heart rate' }),
+      within(slotThree).queryByRole('option', { name: /Heart rate/i }),
     ).not.toBeInTheDocument();
     expect(
-      within(slotThree).queryByRole('option', { name: 'Brain fog' }),
+      within(slotThree).queryByRole('option', { name: /Brain fog/i }),
     ).not.toBeInTheDocument();
     expect(
-      within(slotThree).getByRole('option', { name: 'Vomiting' }),
+      within(slotThree).getByRole('option', { name: /Vomiting/i }),
     ).toBeInTheDocument();
     expect(
       within(slotThree).getByRole('option', { name: /Blood pressure/i }),
     ).toBeInTheDocument();
+  });
+
+  it('shows observation counts and observed date range in series options', () => {
+    render(<ControlledPicker />);
+
+    const option = within(
+      screen.getByLabelText('Data series 1', { selector: 'select' }),
+    ).getByRole('option', {
+      name: /Blood glucose/i,
+    });
+
+    expect(option.textContent).toContain('Blood glucose (mmol/L)');
+    expect(option.textContent).toContain('5 obs');
+    expect(option.textContent).toContain('to');
   });
 
   it('hides extra slots when the parent clears value externally', () => {

--- a/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.spec.tsx
@@ -116,6 +116,17 @@ function ControlledPicker({
   );
 }
 
+function seriesAt(
+  row: ChartableManifestRow,
+  slotIndex: number,
+): SelectedSeries {
+  const series = createSelectedSeriesFromManifestRow(row, slotIndex);
+  if (!series) {
+    throw new Error(`Expected chartable fixture for ${row.series_id}`);
+  }
+  return series;
+}
+
 describe('InsightSeriesPicker', () => {
   it('auto-selects bp_band and hides the chart-type dropdown for blood pressure', () => {
     const onChangeSpy = vi.fn();
@@ -163,10 +174,7 @@ describe('InsightSeriesPicker', () => {
   it('omits series that would introduce a third distinct value unit from later slots', () => {
     render(
       <ControlledPicker
-        initial={[
-          createSelectedSeriesFromManifestRow(bacRow, 0)!,
-          createSelectedSeriesFromManifestRow(glucoseRow, 1)!,
-        ]}
+        initial={[seriesAt(bacRow, 0), seriesAt(glucoseRow, 1)]}
       />,
     );
 
@@ -202,6 +210,68 @@ describe('InsightSeriesPicker', () => {
     expect(option.textContent).toContain('Blood glucose (mmol/L)');
     expect(option.textContent).toContain('5 obs');
     expect(option.textContent).toContain('to');
+  });
+
+  it('formats observed date ranges in the provided timezone', () => {
+    const originalDateTimeFormat = Intl.DateTimeFormat;
+    function dateTimeFormatMock(
+      this: Intl.DateTimeFormat,
+      locales?: string | string[],
+      options?: Intl.DateTimeFormatOptions,
+    ) {
+      return new originalDateTimeFormat(locales, options);
+    }
+    const dateTimeFormatSpy = vi
+      .spyOn(Intl, 'DateTimeFormat')
+      .mockImplementation(dateTimeFormatMock as typeof Intl.DateTimeFormat);
+    const timezoneManifest = [
+      {
+        ...glucoseRow,
+        first_observed_at: '2026-01-01T23:30:00Z',
+        last_observed_at: '2026-02-01T00:30:00Z',
+      },
+    ] satisfies ChartManifestRow[];
+
+    try {
+      render(
+        <InsightSeriesPicker
+          manifest={timezoneManifest}
+          value={[]}
+          onChange={vi.fn()}
+          timeZone="Pacific/Auckland"
+        />,
+      );
+
+      const option = within(
+        screen.getByLabelText('Data series 1', { selector: 'select' }),
+      ).getByRole('option', {
+        name: /Blood glucose/i,
+      });
+
+      const startLabel = new originalDateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+        timeZone: 'Pacific/Auckland',
+      }).format(new Date('2026-01-01T23:30:00Z'));
+      const endLabel = new originalDateTimeFormat(undefined, {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        timeZone: 'Pacific/Auckland',
+      }).format(new Date('2026-02-01T00:30:00Z'));
+
+      expect(option.textContent).toContain(`${startLabel} to ${endLabel}`);
+      expect(
+        dateTimeFormatSpy.mock.calls.some(
+          ([, options]) =>
+            options?.timeZone === 'Pacific/Auckland' &&
+            options?.month === 'short' &&
+            options?.day === 'numeric',
+        ),
+      ).toBe(true);
+    } finally {
+      dateTimeFormatSpy.mockRestore();
+    }
   });
 
   it('hides extra slots when the parent clears value externally', () => {
@@ -550,13 +620,6 @@ describe('InsightSeriesPicker', () => {
 
   it('calls onChange on mount when the controlled value exceeds three series', () => {
     const onChange = vi.fn();
-    const seriesAt = (row: ChartableManifestRow, slotIndex: number) => {
-      const series = createSelectedSeriesFromManifestRow(row, slotIndex);
-      if (!series) {
-        throw new Error(`Expected chartable fixture for ${row.series_id}`);
-      }
-      return series;
-    };
     const oversizedValue: SelectedSeries[] = [
       seriesAt(glucoseRow, 0),
       seriesAt(severityRow, 1),
@@ -584,13 +647,6 @@ describe('InsightSeriesPicker', () => {
 
   it('clamps onChange to three series when chart type changes with an oversized value', () => {
     const onChange = vi.fn();
-    const seriesAt = (row: ChartableManifestRow, slotIndex: number) => {
-      const series = createSelectedSeriesFromManifestRow(row, slotIndex);
-      if (!series) {
-        throw new Error(`Expected chartable fixture for ${row.series_id}`);
-      }
-      return series;
-    };
     const oversizedValue: SelectedSeries[] = [
       seriesAt(glucoseRow, 0),
       seriesAt(severityRow, 1),

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -130,6 +130,43 @@ function findManifestRow(
   return manifest.find((row) => row.series_id === seriesId);
 }
 
+function formatObservationRange(
+  firstObservedAt: string,
+  lastObservedAt: string,
+): string {
+  const first = new Date(firstObservedAt);
+  const last = new Date(lastObservedAt);
+  if (Number.isNaN(first.getTime()) || Number.isNaN(last.getTime())) {
+    return 'Date range unavailable';
+  }
+
+  const sameYear = first.getFullYear() === last.getFullYear();
+  const start = first.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    ...(sameYear ? {} : { year: 'numeric' }),
+  });
+  const end = last.toLocaleDateString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    year: 'numeric',
+  });
+
+  return `${start} to ${end}`;
+}
+
+function manifestOptionLabel(row: ChartableManifestRow): string {
+  const seriesLabel = row.unit ? `${row.label} (${row.unit})` : row.label;
+  const observationLabel = `${row.observation_count.toLocaleString()} obs`;
+  const rangeLabel = formatObservationRange(
+    row.first_observed_at,
+    row.last_observed_at,
+  );
+  return [seriesLabel, observationLabel, rangeLabel]
+    .filter(Boolean)
+    .join(' · ');
+}
+
 /**
  * Accessible label for the slot remove/clear control.
  * Slot 1 clears in place; slots 2–3 remove the slot from view.
@@ -380,8 +417,7 @@ export function InsightSeriesPicker({
                   <option value="">Select a series…</option>
                   {slotOptions.map((option) => (
                     <option key={option.series_id} value={option.series_id}>
-                      {option.label}
-                      {option.unit ? ` (${option.unit})` : ''}
+                      {manifestOptionLabel(option)}
                     </option>
                   ))}
                 </PickerSelect>

--- a/packages/ui/src/lib/InsightSeriesPicker.tsx
+++ b/packages/ui/src/lib/InsightSeriesPicker.tsx
@@ -133,6 +133,7 @@ function findManifestRow(
 function formatObservationRange(
   firstObservedAt: string,
   lastObservedAt: string,
+  timeZone?: string,
 ): string {
   const first = new Date(firstObservedAt);
   const last = new Date(lastObservedAt);
@@ -140,27 +141,38 @@ function formatObservationRange(
     return 'Date range unavailable';
   }
 
-  const sameYear = first.getFullYear() === last.getFullYear();
-  const start = first.toLocaleDateString(undefined, {
+  const formatOptions = (includeYear: boolean): Intl.DateTimeFormatOptions => ({
     month: 'short',
     day: 'numeric',
-    ...(sameYear ? {} : { year: 'numeric' }),
+    ...(includeYear ? { year: 'numeric' } : {}),
+    ...(timeZone ? { timeZone } : {}),
   });
-  const end = last.toLocaleDateString(undefined, {
-    month: 'short',
-    day: 'numeric',
+  const yearFormat = new Intl.DateTimeFormat(undefined, {
     year: 'numeric',
+    ...(timeZone ? { timeZone } : {}),
   });
+  const sameYear = yearFormat.format(first) === yearFormat.format(last);
+  const start = new Intl.DateTimeFormat(
+    undefined,
+    formatOptions(!sameYear),
+  ).format(first);
+  const end = new Intl.DateTimeFormat(undefined, formatOptions(true)).format(
+    last,
+  );
 
   return `${start} to ${end}`;
 }
 
-function manifestOptionLabel(row: ChartableManifestRow): string {
+function manifestOptionLabel(
+  row: ChartableManifestRow,
+  timeZone?: string,
+): string {
   const seriesLabel = row.unit ? `${row.label} (${row.unit})` : row.label;
   const observationLabel = `${row.observation_count.toLocaleString()} obs`;
   const rangeLabel = formatObservationRange(
     row.first_observed_at,
     row.last_observed_at,
+    timeZone,
   );
   return [seriesLabel, observationLabel, rangeLabel]
     .filter(Boolean)
@@ -222,6 +234,7 @@ export function InsightSeriesPicker({
   manifest,
   value,
   onChange,
+  timeZone,
   highContrast = false,
 }: InsightSeriesPickerProps) {
   const seriesValue = useMemo(() => clampSeriesValue(value), [value]);
@@ -417,7 +430,7 @@ export function InsightSeriesPicker({
                   <option value="">Select a series…</option>
                   {slotOptions.map((option) => (
                     <option key={option.series_id} value={option.series_id}>
-                      {manifestOptionLabel(option)}
+                      {manifestOptionLabel(option, timeZone)}
                     </option>
                   ))}
                 </PickerSelect>

--- a/packages/ui/src/lib/InsightSeriesPicker.types.ts
+++ b/packages/ui/src/lib/InsightSeriesPicker.types.ts
@@ -54,6 +54,8 @@ export interface InsightSeriesPickerProps {
   manifest: ChartManifestRow[];
   value: SelectedSeries[];
   onChange: (series: SelectedSeries[]) => void;
+  /** IANA timezone for manifest observation date labels; defaults to the viewer locale zone. */
+  timeZone?: string;
   /** Stronger borders and text for high-contrast presentation. */
   highContrast?: boolean;
 }

--- a/packages/ui/src/lib/InsightsSummarySection.spec.tsx
+++ b/packages/ui/src/lib/InsightsSummarySection.spec.tsx
@@ -126,7 +126,7 @@ describe('InsightsSummarySection', () => {
           ([, options]) =>
             options?.month === 'short' &&
             options?.day === 'numeric' &&
-            !('timeZone' in options),
+            options?.timeZone == null,
         ),
       ).toBe(true);
     } finally {

--- a/packages/ui/src/lib/InsightsSummarySection.spec.tsx
+++ b/packages/ui/src/lib/InsightsSummarySection.spec.tsx
@@ -1,5 +1,5 @@
 import { render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { InsightsSummarySection } from './InsightsSummarySection.js';
 
 describe('InsightsSummarySection', () => {
@@ -86,5 +86,51 @@ describe('InsightsSummarySection', () => {
     expect(
       screen.getByText('No episode or symptom data in this date range yet.'),
     ).toBeInTheDocument();
+  });
+
+  it('formats the selected period label using local calendar dates', () => {
+    const originalDateTimeFormat = Intl.DateTimeFormat;
+    function dateTimeFormatMock(
+      this: Intl.DateTimeFormat,
+      locales?: string | string[],
+      options?: Intl.DateTimeFormatOptions,
+    ) {
+      return new originalDateTimeFormat(locales, options);
+    }
+    const dateTimeFormatSpy = vi
+      .spyOn(Intl, 'DateTimeFormat')
+      .mockImplementation(dateTimeFormatMock as typeof Intl.DateTimeFormat);
+
+    try {
+      render(
+        <InsightsSummarySection
+          dateRange={dateRange}
+          timeZone="Pacific/Auckland"
+          summary={{
+            total_episode_count: 0,
+            abs_episode_count: 0,
+            other_episode_count: 0,
+            average_episodes_per_week: 0,
+            longest_episode_free_streak_days: 31,
+            current_episode_free_streak_days: 31,
+            average_episode_duration_hours: null,
+          }}
+          weekCounts={[]}
+          symptomFrequencies={[]}
+          startHourDistribution={[]}
+        />,
+      );
+
+      expect(
+        dateTimeFormatSpy.mock.calls.some(
+          ([, options]) =>
+            options?.month === 'short' &&
+            options?.day === 'numeric' &&
+            !('timeZone' in options),
+        ),
+      ).toBe(true);
+    } finally {
+      dateTimeFormatSpy.mockRestore();
+    }
   });
 });

--- a/packages/ui/src/lib/InsightsSummarySection.spec.tsx
+++ b/packages/ui/src/lib/InsightsSummarySection.spec.tsx
@@ -133,4 +133,44 @@ describe('InsightsSummarySection', () => {
       dateTimeFormatSpy.mockRestore();
     }
   });
+
+  it('wraps long episode calendars within the card width', () => {
+    render(
+      <InsightsSummarySection
+        dateRange={{
+          from: new Date(2025, 2, 1),
+          to: new Date(2026, 2, 31),
+        }}
+        timeZone="America/New_York"
+        summary={{
+          total_episode_count: 6,
+          abs_episode_count: 2,
+          other_episode_count: 4,
+          average_episodes_per_week: 1.4,
+          longest_episode_free_streak_days: 8,
+          current_episode_free_streak_days: 3,
+          average_episode_duration_hours: 9.1,
+        }}
+        weekCounts={[
+          {
+            week_start: '2025-03-03T05:00:00.000Z',
+            episode_type: 'Other',
+            episode_count: 1,
+          },
+          {
+            week_start: '2026-03-16T04:00:00.000Z',
+            episode_type: 'ABS',
+            episode_count: 1,
+          },
+        ]}
+        symptomFrequencies={[]}
+        startHourDistribution={[]}
+      />,
+    );
+
+    expect(
+      screen.getByTitle(/Other \/ vomiting: 1 episode in week of/i)
+        .parentElement,
+    ).toHaveClass('flex', 'max-w-full', 'flex-wrap', 'gap-1');
+  });
 });

--- a/packages/ui/src/lib/InsightsSummarySection.spec.tsx
+++ b/packages/ui/src/lib/InsightsSummarySection.spec.tsx
@@ -1,0 +1,90 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { InsightsSummarySection } from './InsightsSummarySection.js';
+
+describe('InsightsSummarySection', () => {
+  const dateRange = {
+    from: new Date(2026, 2, 1),
+    to: new Date(2026, 2, 31),
+  };
+
+  it('renders summary cards, callouts, and charts when overview data exists', () => {
+    render(
+      <InsightsSummarySection
+        dateRange={dateRange}
+        timeZone="America/New_York"
+        summary={{
+          total_episode_count: 6,
+          abs_episode_count: 2,
+          other_episode_count: 4,
+          average_episodes_per_week: 1.4,
+          longest_episode_free_streak_days: 8,
+          current_episode_free_streak_days: 3,
+          average_episode_duration_hours: 9.1,
+        }}
+        weekCounts={[
+          {
+            week_start: '2026-03-02T05:00:00.000Z',
+            episode_type: 'Other',
+            episode_count: 1,
+          },
+          {
+            week_start: '2026-03-16T04:00:00.000Z',
+            episode_type: 'ABS',
+            episode_count: 1,
+          },
+          {
+            week_start: '2026-03-16T04:00:00.000Z',
+            episode_type: 'Other',
+            episode_count: 3,
+          },
+        ]}
+        symptomFrequencies={[
+          { symptom_name: 'Nausea', occurrence_count: 6 },
+          { symptom_name: 'Abdominal pain', occurrence_count: 4 },
+        ]}
+        startHourDistribution={[
+          { hour_of_day: 5, episode_type: 'Other', episode_count: 4 },
+          { hour_of_day: 6, episode_type: 'Other', episode_count: 1 },
+          { hour_of_day: 15, episode_type: 'ABS', episode_count: 2 },
+        ]}
+      />,
+    );
+
+    expect(
+      screen.getByRole('heading', { name: 'Overview' }),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Total episodes')).toBeInTheDocument();
+    expect(screen.getByText('Episode calendar')).toBeInTheDocument();
+    expect(screen.getByText('Symptom frequency')).toBeInTheDocument();
+    expect(screen.getByText('When episodes start')).toBeInTheDocument();
+    expect(screen.getAllByText('Pattern callout').length).toBeGreaterThan(0);
+    expect(screen.getByText('Nausea')).toBeInTheDocument();
+  });
+
+  it('renders the empty state when the selected period has no overview data', () => {
+    render(
+      <InsightsSummarySection
+        dateRange={dateRange}
+        timeZone="America/New_York"
+        summary={{
+          total_episode_count: 0,
+          abs_episode_count: 0,
+          other_episode_count: 0,
+          average_episodes_per_week: 0,
+          longest_episode_free_streak_days: 31,
+          current_episode_free_streak_days: 31,
+          average_episode_duration_hours: null,
+        }}
+        weekCounts={[]}
+        symptomFrequencies={[]}
+        startHourDistribution={[]}
+      />,
+    );
+
+    expect(screen.getByText('No overview yet')).toBeInTheDocument();
+    expect(
+      screen.getByText('No episode or symptom data in this date range yet.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/packages/ui/src/lib/InsightsSummarySection.tsx
+++ b/packages/ui/src/lib/InsightsSummarySection.tsx
@@ -77,7 +77,14 @@ function formatEpisodeTypeLabel(episodeType: EpisodeType): string {
   return episodeType === 'ABS' ? 'ABS' : 'Other / vomiting';
 }
 
-function formatCompactDate(date: Date, timeZone: string): string {
+function formatCalendarDate(date: Date): string {
+  return new Intl.DateTimeFormat(undefined, {
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+}
+
+function formatCompactDateInTimeZone(date: Date, timeZone: string): string {
   return new Intl.DateTimeFormat(undefined, {
     timeZone,
     month: 'short',
@@ -85,11 +92,8 @@ function formatCompactDate(date: Date, timeZone: string): string {
   }).format(date);
 }
 
-function formatRangeLabel(range: InsightDateRange, timeZone: string): string {
-  return `${formatCompactDate(range.from, timeZone)} to ${formatCompactDate(
-    range.to,
-    timeZone,
-  )}`;
+function formatRangeLabel(range: InsightDateRange): string {
+  return `${formatCalendarDate(range.from)} to ${formatCalendarDate(range.to)}`;
 }
 
 function toStartOfWeek(date: Date): Date {
@@ -152,7 +156,7 @@ function buildHeatmapCells(
     weeks.push({
       weekKey: key,
       weekStart: new Date(cursor),
-      label: formatCompactDate(cursor, timeZone),
+      label: formatCalendarDate(cursor),
       count: countsByWeek.get(key) ?? 0,
     });
     cursor.setDate(cursor.getDate() + 7);
@@ -310,7 +314,7 @@ function deriveClusterCallout(
     return null;
   }
 
-  const weekLabel = formatCompactDate(
+  const weekLabel = formatCompactDateInTimeZone(
     new Date(busiestWeek.weekStart),
     timeZone,
   );
@@ -436,9 +440,7 @@ export function InsightsSummarySection({
         >
           Overview
         </h2>
-        <p className="text-sm text-app-muted">
-          {formatRangeLabel(dateRange, timeZone)}
-        </p>
+        <p className="text-sm text-app-muted">{formatRangeLabel(dateRange)}</p>
       </div>
 
       {loading ? (
@@ -580,7 +582,6 @@ export function InsightsSummarySection({
               role="img"
               aria-label={`Episode calendar from ${formatRangeLabel(
                 dateRange,
-                timeZone,
               )}. ${formatEpisodeTypeLabel('Other')} episodes appear in ${
                 otherHeatmap.filter((cell) => cell.count > 0).length
               } weeks. ABS episodes appear in ${

--- a/packages/ui/src/lib/InsightsSummarySection.tsx
+++ b/packages/ui/src/lib/InsightsSummarySection.tsx
@@ -1,0 +1,808 @@
+import type { CSSProperties } from 'react';
+import type { InsightDateRange } from './InsightDateRangePicker.js';
+
+const OTHER_EPISODE_RGB = '29, 78, 216';
+const ABS_EPISODE_RGB = '234, 88, 12';
+
+type EpisodeType = 'ABS' | 'Other';
+
+type HeatmapCell = {
+  weekKey: string;
+  weekStart: Date;
+  label: string;
+  count: number;
+};
+
+type TimeBucketSummary = {
+  label: string;
+  otherCount: number;
+  absCount: number;
+};
+
+/**
+ * One overview summary row rendered in the insights header cards.
+ */
+export interface InsightsSummaryMetrics {
+  total_episode_count: number;
+  abs_episode_count: number;
+  other_episode_count: number;
+  average_episodes_per_week: number | null;
+  longest_episode_free_streak_days: number | null;
+  current_episode_free_streak_days: number | null;
+  average_episode_duration_hours: number | null;
+}
+
+/**
+ * One weekly episode-count bucket used by the overview heatmap.
+ */
+export interface InsightsWeekCountRow {
+  week_start: string;
+  episode_type: EpisodeType;
+  episode_count: number;
+}
+
+/**
+ * One hourly episode-start bucket used by the time-of-day chart.
+ */
+export interface InsightsStartHourDistributionRow {
+  hour_of_day: number;
+  episode_type: EpisodeType;
+  episode_count: number;
+}
+
+/**
+ * One ranked symptom-frequency row used by the overview symptom chart.
+ */
+export interface InsightsSymptomFrequencyRow {
+  symptom_name: string;
+  occurrence_count: number;
+}
+
+/**
+ * Props for the curated insights overview section shared by patient and practitioner web apps.
+ */
+export interface InsightsSummarySectionProps {
+  dateRange: InsightDateRange;
+  timeZone: string;
+  summary: InsightsSummaryMetrics | null;
+  weekCounts: InsightsWeekCountRow[];
+  symptomFrequencies: InsightsSymptomFrequencyRow[];
+  startHourDistribution: InsightsStartHourDistributionRow[];
+  loading?: boolean;
+  error?: string | null;
+  emptyMessage?: string;
+}
+
+function formatEpisodeTypeLabel(episodeType: EpisodeType): string {
+  return episodeType === 'ABS' ? 'ABS' : 'Other / vomiting';
+}
+
+function formatCompactDate(date: Date, timeZone: string): string {
+  return new Intl.DateTimeFormat(undefined, {
+    timeZone,
+    month: 'short',
+    day: 'numeric',
+  }).format(date);
+}
+
+function formatRangeLabel(range: InsightDateRange, timeZone: string): string {
+  return `${formatCompactDate(range.from, timeZone)} to ${formatCompactDate(
+    range.to,
+    timeZone,
+  )}`;
+}
+
+function toStartOfWeek(date: Date): Date {
+  const copy = new Date(date);
+  copy.setHours(0, 0, 0, 0);
+  const mondayOffset = (copy.getDay() + 6) % 7;
+  copy.setDate(copy.getDate() - mondayOffset);
+  return copy;
+}
+
+function toEndOfWeek(date: Date): Date {
+  const copy = toStartOfWeek(date);
+  copy.setDate(copy.getDate() + 6);
+  return copy;
+}
+
+function dateKey(date: Date): string {
+  const year = date.getFullYear();
+  const month = `${date.getMonth() + 1}`.padStart(2, '0');
+  const day = `${date.getDate()}`.padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+function timeZoneDateKey(iso: string, timeZone: string): string {
+  const formatter = new Intl.DateTimeFormat('en-CA', {
+    timeZone,
+    year: 'numeric',
+    month: '2-digit',
+    day: '2-digit',
+  });
+  const parts = formatter.formatToParts(new Date(iso));
+  const year = parts.find((part) => part.type === 'year')?.value ?? '0000';
+  const month = parts.find((part) => part.type === 'month')?.value ?? '01';
+  const day = parts.find((part) => part.type === 'day')?.value ?? '01';
+  return `${year}-${month}-${day}`;
+}
+
+function buildHeatmapCells(
+  range: InsightDateRange,
+  weekCounts: InsightsWeekCountRow[],
+  episodeType: EpisodeType,
+  timeZone: string,
+): HeatmapCell[] {
+  const countsByWeek = new Map<string, number>();
+  for (const row of weekCounts) {
+    if (row.episode_type !== episodeType) {
+      continue;
+    }
+    countsByWeek.set(
+      timeZoneDateKey(row.week_start, timeZone),
+      row.episode_count,
+    );
+  }
+
+  const weeks: HeatmapCell[] = [];
+  const cursor = toStartOfWeek(range.from);
+  const end = toEndOfWeek(range.to);
+  while (cursor <= end) {
+    const key = dateKey(cursor);
+    weeks.push({
+      weekKey: key,
+      weekStart: new Date(cursor),
+      label: formatCompactDate(cursor, timeZone),
+      count: countsByWeek.get(key) ?? 0,
+    });
+    cursor.setDate(cursor.getDate() + 7);
+  }
+  return weeks;
+}
+
+function heatmapCellStyle(
+  count: number,
+  maxCount: number,
+  rgb: string,
+): CSSProperties {
+  if (count <= 0 || maxCount <= 0) {
+    return {
+      backgroundColor: 'rgba(148, 163, 184, 0.18)',
+    };
+  }
+
+  const opacity = Math.max(0.2, Math.min(0.9, count / maxCount));
+  return {
+    backgroundColor: `rgba(${rgb}, ${opacity})`,
+  };
+}
+
+function buildMonthMarkers(range: InsightDateRange): string[] {
+  const markers: string[] = [];
+  const cursor = new Date(range.from);
+  cursor.setHours(0, 0, 0, 0);
+  const end = new Date(range.to);
+  end.setHours(0, 0, 0, 0);
+
+  while (cursor <= end) {
+    const label = cursor.toLocaleDateString(undefined, { month: 'short' });
+    if (markers.at(-1) !== label) {
+      markers.push(label);
+    }
+    cursor.setMonth(cursor.getMonth() + 1, 1);
+  }
+
+  return markers;
+}
+
+function buildTimeBuckets(
+  rows: InsightsStartHourDistributionRow[],
+): TimeBucketSummary[] {
+  const buckets = [
+    { label: '12-4a', minHour: 0, maxHour: 3 },
+    { label: '4-8a', minHour: 4, maxHour: 7 },
+    { label: '8-12p', minHour: 8, maxHour: 11 },
+    { label: '12-4p', minHour: 12, maxHour: 15 },
+    { label: '4-8p', minHour: 16, maxHour: 19 },
+    { label: '8-12a', minHour: 20, maxHour: 23 },
+  ];
+
+  return buckets.map((bucket) => {
+    let otherCount = 0;
+    let absCount = 0;
+    for (const row of rows) {
+      if (
+        row.hour_of_day < bucket.minHour ||
+        row.hour_of_day > bucket.maxHour
+      ) {
+        continue;
+      }
+      if (row.episode_type === 'ABS') {
+        absCount += row.episode_count;
+      } else {
+        otherCount += row.episode_count;
+      }
+    }
+
+    return {
+      label: bucket.label,
+      otherCount,
+      absCount,
+    };
+  });
+}
+
+function derivePeakTimeCallout(
+  rows: InsightsStartHourDistributionRow[],
+): string | null {
+  const buckets = buildTimeBuckets(rows);
+  const candidates: Array<{
+    episodeType: EpisodeType;
+    count: number;
+    share: number;
+    label: string;
+  }> = [];
+
+  const otherTotal = buckets.reduce(
+    (sum, bucket) => sum + bucket.otherCount,
+    0,
+  );
+  const absTotal = buckets.reduce((sum, bucket) => sum + bucket.absCount, 0);
+
+  for (const bucket of buckets) {
+    if (otherTotal > 0) {
+      candidates.push({
+        episodeType: 'Other',
+        count: bucket.otherCount,
+        share: bucket.otherCount / otherTotal,
+        label: bucket.label,
+      });
+    }
+    if (absTotal > 0) {
+      candidates.push({
+        episodeType: 'ABS',
+        count: bucket.absCount,
+        share: bucket.absCount / absTotal,
+        label: bucket.label,
+      });
+    }
+  }
+
+  candidates.sort(
+    (left, right) => right.share - left.share || right.count - left.count,
+  );
+  const winner = candidates[0];
+  if (!winner || winner.count < 2 || winner.share < 0.45) {
+    return null;
+  }
+
+  return `${formatEpisodeTypeLabel(winner.episodeType)} episodes most often started around ${winner.label}.`;
+}
+
+function deriveClusterCallout(
+  weekCounts: InsightsWeekCountRow[],
+  timeZone: string,
+): string | null {
+  const weeklyTotals = new Map<
+    string,
+    { weekStart: string; total: number; absCount: number }
+  >();
+
+  for (const row of weekCounts) {
+    const key = timeZoneDateKey(row.week_start, timeZone);
+    const current = weeklyTotals.get(key) ?? {
+      weekStart: row.week_start,
+      total: 0,
+      absCount: 0,
+    };
+    current.total += row.episode_count;
+    if (row.episode_type === 'ABS') {
+      current.absCount += row.episode_count;
+    }
+    weeklyTotals.set(key, current);
+  }
+
+  const busiestWeek = [...weeklyTotals.values()].sort(
+    (left, right) => right.total - left.total || right.absCount - left.absCount,
+  )[0];
+
+  if (!busiestWeek || busiestWeek.total < 3) {
+    return null;
+  }
+
+  const weekLabel = formatCompactDate(
+    new Date(busiestWeek.weekStart),
+    timeZone,
+  );
+  const absSuffix =
+    busiestWeek.absCount > 0
+      ? `, including ${busiestWeek.absCount} ABS episode${busiestWeek.absCount === 1 ? '' : 's'}`
+      : '';
+
+  return `Busiest week: ${weekLabel} had ${busiestWeek.total} episode${busiestWeek.total === 1 ? '' : 's'}${absSuffix}.`;
+}
+
+function deriveStreakCallout(
+  summary: InsightsSummaryMetrics | null,
+): string | null {
+  if (!summary) {
+    return null;
+  }
+
+  const longest = summary.longest_episode_free_streak_days ?? 0;
+  const current = summary.current_episode_free_streak_days ?? 0;
+
+  if (longest <= 0 && current <= 0) {
+    return null;
+  }
+
+  if (current >= longest && current > 0) {
+    return `Current streak: ${current} day${current === 1 ? '' : 's'} without an episode in this period.`;
+  }
+
+  return `Longest episode-free stretch lasted ${longest} day${longest === 1 ? '' : 's'} in this period.`;
+}
+
+function buildCallouts(
+  summary: InsightsSummaryMetrics | null,
+  weekCounts: InsightsWeekCountRow[],
+  startHourDistribution: InsightsStartHourDistributionRow[],
+  timeZone: string,
+): string[] {
+  return [
+    deriveClusterCallout(weekCounts, timeZone),
+    derivePeakTimeCallout(startHourDistribution),
+    deriveStreakCallout(summary),
+  ].filter((value): value is string => value != null);
+}
+
+function formatMetricValue(
+  value: number | null | undefined,
+  suffix = '',
+): string {
+  if (value == null || Number.isNaN(value)) {
+    return '—';
+  }
+  return `${value.toLocaleString(undefined, {
+    maximumFractionDigits: 1,
+  })}${suffix}`;
+}
+
+function pluralizeDays(days: number | null | undefined): string {
+  if (days == null) {
+    return '—';
+  }
+  return `${days.toLocaleString()} day${days === 1 ? '' : 's'}`;
+}
+
+/**
+ * Curated insights overview with summary cards, auto-generated pattern callouts, a weekly heatmap,
+ * symptom ranking, and episode start-time distribution. This sits above the custom chart builder.
+ *
+ * @param props - Selected date range, overview query results, and load state.
+ * @returns Shared patient/practitioner overview content.
+ */
+export function InsightsSummarySection({
+  dateRange,
+  timeZone,
+  summary,
+  weekCounts,
+  symptomFrequencies,
+  startHourDistribution,
+  loading = false,
+  error = null,
+  emptyMessage = 'No episode or symptom data in this date range yet.',
+}: InsightsSummarySectionProps) {
+  const hasData =
+    (summary?.total_episode_count ?? 0) > 0 ||
+    symptomFrequencies.length > 0 ||
+    startHourDistribution.length > 0;
+
+  const otherHeatmap = buildHeatmapCells(
+    dateRange,
+    weekCounts,
+    'Other',
+    timeZone,
+  );
+  const absHeatmap = buildHeatmapCells(dateRange, weekCounts, 'ABS', timeZone);
+  const maxOtherCount = Math.max(0, ...otherHeatmap.map((cell) => cell.count));
+  const maxAbsCount = Math.max(0, ...absHeatmap.map((cell) => cell.count));
+  const timeBuckets = buildTimeBuckets(startHourDistribution);
+  const maxTimeBucketCount = Math.max(
+    0,
+    ...timeBuckets.flatMap((bucket) => [bucket.otherCount, bucket.absCount]),
+  );
+  const strongestSymptomCount = Math.max(
+    0,
+    ...symptomFrequencies.map((row) => row.occurrence_count),
+  );
+  const callouts = buildCallouts(
+    summary,
+    weekCounts,
+    startHourDistribution,
+    timeZone,
+  );
+  const monthMarkers = buildMonthMarkers(dateRange);
+
+  return (
+    <section aria-labelledby="insights-overview-heading" className="space-y-6">
+      <div className="space-y-1">
+        <p className="text-xs font-semibold uppercase tracking-[0.16em] text-app-muted">
+          Selected period
+        </p>
+        <h2
+          id="insights-overview-heading"
+          className="text-xl font-semibold tracking-tight text-app-ink"
+        >
+          Overview
+        </h2>
+        <p className="text-sm text-app-muted">
+          {formatRangeLabel(dateRange, timeZone)}
+        </p>
+      </div>
+
+      {loading ? (
+        <section
+          className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]"
+          aria-busy="true"
+          aria-label="Loading insights overview"
+        >
+          <div className="flex items-center gap-3">
+            <div
+              className="h-5 w-5 shrink-0 animate-spin rounded-full border-2 border-app-primary border-t-transparent"
+              aria-hidden
+            />
+            <p className="text-sm font-medium text-app-muted">
+              Loading overview insights…
+            </p>
+          </div>
+        </section>
+      ) : null}
+
+      {!loading && error ? (
+        <section
+          className="rounded-2xl border border-red-200 bg-red-50 p-6 shadow-soft dark:border-red-900/60 dark:bg-red-950/30"
+          role="alert"
+          aria-labelledby="insights-overview-error-heading"
+        >
+          <h3
+            id="insights-overview-error-heading"
+            className="text-base font-semibold text-red-900 dark:text-red-100"
+          >
+            Could not load overview insights
+          </h3>
+          <p className="mt-2 text-sm text-red-800 dark:text-red-200">{error}</p>
+        </section>
+      ) : null}
+
+      {!loading && !error && !hasData ? (
+        <section
+          className="rounded-2xl border border-dashed border-app-border bg-app-surface/60 p-6"
+          role="status"
+        >
+          <p className="text-base font-semibold text-app-ink">
+            No overview yet
+          </p>
+          <p className="mt-2 text-sm text-app-muted">{emptyMessage}</p>
+        </section>
+      ) : null}
+
+      {!loading && !error && hasData ? (
+        <>
+          <div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-4">
+            <article className="rounded-2xl border border-app-border/90 bg-app-surface p-4 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+              <p className="text-xs font-medium uppercase tracking-wide text-app-muted">
+                Total episodes
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-app-ink">
+                {formatMetricValue(summary?.total_episode_count)}
+              </p>
+              <p className="mt-1 text-sm text-app-muted">
+                {formatMetricValue(summary?.other_episode_count)}{' '}
+                other/vomiting, {formatMetricValue(summary?.abs_episode_count)}{' '}
+                ABS
+              </p>
+            </article>
+
+            <article className="rounded-2xl border border-app-border/90 bg-app-surface p-4 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+              <p className="text-xs font-medium uppercase tracking-wide text-app-muted">
+                Avg per week
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-app-ink">
+                {formatMetricValue(summary?.average_episodes_per_week)}
+              </p>
+              <p className="mt-1 text-sm text-app-muted">
+                Episodes started during this range
+              </p>
+            </article>
+
+            <article className="rounded-2xl border border-app-border/90 bg-app-surface p-4 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+              <p className="text-xs font-medium uppercase tracking-wide text-app-muted">
+                Longest episode-free stretch
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-app-ink">
+                {pluralizeDays(summary?.longest_episode_free_streak_days)}
+              </p>
+              <p className="mt-1 text-sm text-app-muted">
+                Based on calendar days without overlap
+              </p>
+            </article>
+
+            <article className="rounded-2xl border border-app-border/90 bg-app-surface p-4 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+              <p className="text-xs font-medium uppercase tracking-wide text-app-muted">
+                Current streak
+              </p>
+              <p className="mt-2 text-2xl font-semibold text-app-ink">
+                {pluralizeDays(summary?.current_episode_free_streak_days)}
+              </p>
+              <p className="mt-1 text-sm text-app-muted">
+                Avg duration{' '}
+                {formatMetricValue(
+                  summary?.average_episode_duration_hours,
+                  'h',
+                )}
+              </p>
+            </article>
+          </div>
+
+          {callouts.length > 0 ? (
+            <div className="grid gap-3 lg:grid-cols-3">
+              {callouts.map((callout) => (
+                <article
+                  key={callout}
+                  className="rounded-2xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900 shadow-soft dark:border-amber-900/60 dark:bg-amber-950/30 dark:text-amber-100"
+                >
+                  <p className="font-medium">Pattern callout</p>
+                  <p className="mt-2 leading-relaxed">{callout}</p>
+                </article>
+              ))}
+            </div>
+          ) : null}
+
+          <article className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+            <div className="flex flex-col gap-1 sm:flex-row sm:items-end sm:justify-between">
+              <div>
+                <h3 className="text-lg font-semibold text-app-ink">
+                  Episode calendar
+                </h3>
+                <p className="mt-1 text-sm text-app-muted">
+                  Weekly density across the selected period. Darker cells mean
+                  more episodes.
+                </p>
+              </div>
+              <p className="text-xs text-app-muted">
+                {monthMarkers.join(' · ')}
+              </p>
+            </div>
+
+            <div
+              className="mt-6 space-y-4"
+              role="img"
+              aria-label={`Episode calendar from ${formatRangeLabel(
+                dateRange,
+                timeZone,
+              )}. ${formatEpisodeTypeLabel('Other')} episodes appear in ${
+                otherHeatmap.filter((cell) => cell.count > 0).length
+              } weeks. ABS episodes appear in ${
+                absHeatmap.filter((cell) => cell.count > 0).length
+              } weeks.`}
+            >
+              {[
+                {
+                  label: formatEpisodeTypeLabel('Other'),
+                  cells: otherHeatmap,
+                  maxCount: maxOtherCount,
+                  rgb: OTHER_EPISODE_RGB,
+                },
+                {
+                  label: formatEpisodeTypeLabel('ABS'),
+                  cells: absHeatmap,
+                  maxCount: maxAbsCount,
+                  rgb: ABS_EPISODE_RGB,
+                },
+              ].map((row) => (
+                <div
+                  key={row.label}
+                  className="grid gap-3 sm:grid-cols-[8rem_minmax(0,1fr)] sm:items-center"
+                >
+                  <p className="text-sm font-medium text-app-ink">
+                    {row.label}
+                  </p>
+                  <div
+                    className="grid gap-1"
+                    style={{
+                      gridTemplateColumns: `repeat(${Math.max(
+                        row.cells.length,
+                        1,
+                      )}, minmax(14px, 1fr))`,
+                    }}
+                  >
+                    {row.cells.map((cell) => (
+                      <div
+                        key={`${row.label}-${cell.weekKey}`}
+                        className="h-6 rounded-md border border-app-border/40"
+                        style={heatmapCellStyle(
+                          cell.count,
+                          row.maxCount,
+                          row.rgb,
+                        )}
+                        aria-hidden
+                        title={`${row.label}: ${cell.count} episode${
+                          cell.count === 1 ? '' : 's'
+                        } in week of ${cell.label}`}
+                      />
+                    ))}
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            <div className="mt-4 flex flex-wrap gap-4 text-xs text-app-muted">
+              <span className="inline-flex items-center gap-2">
+                <span
+                  className="h-3 w-3 rounded-sm border border-app-border/40"
+                  style={{ backgroundColor: 'rgba(148, 163, 184, 0.18)' }}
+                  aria-hidden
+                />
+                No episodes
+              </span>
+              <span className="inline-flex items-center gap-2">
+                <span
+                  className="h-3 w-3 rounded-sm border border-app-border/40"
+                  style={{ backgroundColor: `rgba(${OTHER_EPISODE_RGB}, 0.7)` }}
+                  aria-hidden
+                />
+                Other / vomiting
+              </span>
+              <span className="inline-flex items-center gap-2">
+                <span
+                  className="h-3 w-3 rounded-sm border border-app-border/40"
+                  style={{ backgroundColor: `rgba(${ABS_EPISODE_RGB}, 0.7)` }}
+                  aria-hidden
+                />
+                ABS
+              </span>
+            </div>
+          </article>
+
+          <div className="grid gap-6 xl:grid-cols-2">
+            <article className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+              <h3 className="text-lg font-semibold text-app-ink">
+                Symptom frequency
+              </h3>
+              <p className="mt-1 text-sm text-app-muted">
+                Logged symptom observations ranked by frequency for this period.
+              </p>
+
+              {symptomFrequencies.length === 0 ? (
+                <p className="mt-6 text-sm text-app-muted" role="status">
+                  No symptom observations in this date range.
+                </p>
+              ) : (
+                <div className="mt-6 space-y-4">
+                  {symptomFrequencies.map((row) => {
+                    const width =
+                      strongestSymptomCount > 0
+                        ? (row.occurrence_count / strongestSymptomCount) * 100
+                        : 0;
+                    return (
+                      <div key={row.symptom_name} className="space-y-1.5">
+                        <div className="flex items-center justify-between gap-3">
+                          <p className="text-sm font-medium text-app-ink">
+                            {row.symptom_name}
+                          </p>
+                          <p className="text-sm text-app-muted">
+                            {row.occurrence_count.toLocaleString()}
+                          </p>
+                        </div>
+                        <div
+                          className="h-2.5 overflow-hidden rounded-full bg-app-bg"
+                          aria-hidden
+                        >
+                          <div
+                            className="h-full rounded-full"
+                            style={{
+                              width: `${width}%`,
+                              backgroundColor: `rgba(${OTHER_EPISODE_RGB}, 0.78)`,
+                            }}
+                          />
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </article>
+
+            <article className="rounded-2xl border border-app-border/90 bg-app-surface p-6 shadow-soft ring-1 ring-[color:var(--app-ring-slate)]">
+              <h3 className="text-lg font-semibold text-app-ink">
+                When episodes start
+              </h3>
+              <p className="mt-1 text-sm text-app-muted">
+                Starts grouped into four-hour windows to make time-of-day
+                patterns easier to spot.
+              </p>
+
+              {maxTimeBucketCount <= 0 ? (
+                <p className="mt-6 text-sm text-app-muted" role="status">
+                  No episode starts in this date range.
+                </p>
+              ) : (
+                <div className="mt-6 grid grid-cols-6 gap-3">
+                  {timeBuckets.map((bucket) => (
+                    <div
+                      key={bucket.label}
+                      className="flex flex-col items-center gap-3"
+                    >
+                      <div className="flex h-40 items-end gap-2">
+                        <div
+                          className="w-4 rounded-t-md"
+                          style={{
+                            height: `${Math.max(
+                              8,
+                              (bucket.otherCount / maxTimeBucketCount) * 100,
+                            )}%`,
+                            backgroundColor: `rgba(${OTHER_EPISODE_RGB}, 0.78)`,
+                            opacity: bucket.otherCount > 0 ? 1 : 0.2,
+                          }}
+                          title={`${formatEpisodeTypeLabel('Other')}: ${
+                            bucket.otherCount
+                          }`}
+                          aria-hidden
+                        />
+                        <div
+                          className="w-4 rounded-t-md"
+                          style={{
+                            height: `${Math.max(
+                              8,
+                              (bucket.absCount / maxTimeBucketCount) * 100,
+                            )}%`,
+                            backgroundColor: `rgba(${ABS_EPISODE_RGB}, 0.78)`,
+                            opacity: bucket.absCount > 0 ? 1 : 0.2,
+                          }}
+                          title={`ABS: ${bucket.absCount}`}
+                          aria-hidden
+                        />
+                      </div>
+                      <div className="space-y-1 text-center">
+                        <p className="text-xs font-medium text-app-ink">
+                          {bucket.label}
+                        </p>
+                        <p className="text-[11px] text-app-muted">
+                          {bucket.otherCount + bucket.absCount} total
+                        </p>
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+
+              <div className="mt-4 flex flex-wrap gap-4 text-xs text-app-muted">
+                <span className="inline-flex items-center gap-2">
+                  <span
+                    className="h-3 w-3 rounded-sm"
+                    style={{
+                      backgroundColor: `rgba(${OTHER_EPISODE_RGB}, 0.78)`,
+                    }}
+                    aria-hidden
+                  />
+                  Other / vomiting
+                </span>
+                <span className="inline-flex items-center gap-2">
+                  <span
+                    className="h-3 w-3 rounded-sm"
+                    style={{
+                      backgroundColor: `rgba(${ABS_EPISODE_RGB}, 0.78)`,
+                    }}
+                    aria-hidden
+                  />
+                  ABS
+                </span>
+              </div>
+            </article>
+          </div>
+        </>
+      ) : null}
+    </section>
+  );
+}

--- a/packages/ui/src/lib/InsightsSummarySection.tsx
+++ b/packages/ui/src/lib/InsightsSummarySection.tsx
@@ -604,24 +604,16 @@ export function InsightsSummarySection({
               ].map((row) => (
                 <div
                   key={row.label}
-                  className="grid gap-3 sm:grid-cols-[8rem_minmax(0,1fr)] sm:items-center"
+                  className="grid gap-3 sm:grid-cols-[8rem_minmax(0,1fr)] sm:items-start"
                 >
                   <p className="text-sm font-medium text-app-ink">
                     {row.label}
                   </p>
-                  <div
-                    className="grid gap-1"
-                    style={{
-                      gridTemplateColumns: `repeat(${Math.max(
-                        row.cells.length,
-                        1,
-                      )}, minmax(14px, 1fr))`,
-                    }}
-                  >
+                  <div className="flex max-w-full flex-wrap gap-1">
                     {row.cells.map((cell) => (
                       <div
                         key={`${row.label}-${cell.weekKey}`}
-                        className="h-6 rounded-md border border-app-border/40"
+                        className="h-6 w-3.5 shrink-0 rounded-md border border-app-border/40"
                         style={heatmapCellStyle(
                           cell.count,
                           row.maxCount,

--- a/supabase/.gitignore
+++ b/supabase/.gitignore
@@ -1,6 +1,7 @@
 # Supabase
 .branches
 .temp
+seed_temp.sql
 
 # dotenvx
 .env.keys

--- a/supabase/migrations/20260526184500_insights_overview_rpcs.sql
+++ b/supabase/migrations/20260526184500_insights_overview_rpcs.sql
@@ -360,7 +360,8 @@ GRANT EXECUTE ON FUNCTION public.get_episode_start_hour_distribution (uuid, time
 CREATE OR REPLACE FUNCTION public.get_symptom_frequency (
   p_user_id uuid,
   p_from timestamptz,
-  p_to timestamptz
+  p_to timestamptz,
+  p_timezone text
 )
 RETURNS TABLE (
   symptom_name text,
@@ -371,7 +372,24 @@ SECURITY INVOKER
 STABLE
 SET search_path = pg_catalog, public
 AS $$
+DECLARE
+  tz text := nullif(trim(p_timezone), '');
+  range_day_count integer;
 BEGIN
+  IF tz IS NULL THEN
+    RAISE EXCEPTION 'get_symptom_frequency: p_timezone must be a non-empty IANA timezone name'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM 1
+  FROM pg_timezone_names
+  WHERE name = tz;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'get_symptom_frequency: invalid IANA timezone %', tz
+      USING ERRCODE = '22023';
+  END IF;
+
   IF p_from IS NULL OR p_to IS NULL THEN
     RAISE EXCEPTION 'get_symptom_frequency: p_from and p_to must be non-null timestamps'
       USING ERRCODE = '22023';
@@ -382,7 +400,13 @@ BEGIN
       USING ERRCODE = '22023';
   END IF;
 
-  IF ((p_to::date - p_from::date))::integer > 730 THEN
+  range_day_count := (
+    ((p_to AT TIME ZONE tz) - interval '1 microsecond')::date
+    - (p_from AT TIME ZONE tz)::date
+    + 1
+  )::integer;
+
+  IF range_day_count > 730 THEN
     RAISE EXCEPTION 'get_symptom_frequency: selected range must be 730 days or fewer'
       USING ERRCODE = '22023';
   END IF;
@@ -394,7 +418,8 @@ BEGIN
       nullif(trim(es.symptom_name), '') AS symptom_label,
       CASE
         WHEN es.response_type = 'yes_no' AND es.response_boolean IS TRUE THEN 1
-        WHEN es.response_type = 'severity_scale' THEN 1
+        WHEN es.response_type = 'severity_scale'
+          AND es.response_severity IS NOT NULL THEN 1
         ELSE 0
       END AS occurrence_value
     FROM public.episode_symptoms es
@@ -414,8 +439,8 @@ BEGIN
 END;
 $$;
 
-COMMENT ON FUNCTION public.get_symptom_frequency (uuid, timestamptz, timestamptz) IS
-'Returns ranked symptom counts for the selected range. Boolean symptoms count only true responses; severity symptoms count each logged observation. SECURITY INVOKER.';
+COMMENT ON FUNCTION public.get_symptom_frequency (uuid, timestamptz, timestamptz, text) IS
+'Returns ranked symptom counts for the selected range. The 730-day cap is validated in p_timezone (IANA name) so server-side limits match the overview date picker. Boolean symptoms count only true responses; severity symptoms count each logged observation. SECURITY INVOKER.';
 
-REVOKE ALL ON FUNCTION public.get_symptom_frequency (uuid, timestamptz, timestamptz) FROM PUBLIC;
-GRANT EXECUTE ON FUNCTION public.get_symptom_frequency (uuid, timestamptz, timestamptz) TO authenticated;
+REVOKE ALL ON FUNCTION public.get_symptom_frequency (uuid, timestamptz, timestamptz, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_symptom_frequency (uuid, timestamptz, timestamptz, text) TO authenticated;

--- a/supabase/migrations/20260526184500_insights_overview_rpcs.sql
+++ b/supabase/migrations/20260526184500_insights_overview_rpcs.sql
@@ -22,6 +22,7 @@ SET search_path = pg_catalog, public
 AS $$
 DECLARE
   tz text;
+  range_day_count integer;
 BEGIN
   tz := nullif(trim(p_timezone), '');
 
@@ -46,6 +47,17 @@ BEGIN
 
   IF p_from >= p_to THEN
     RAISE EXCEPTION 'get_episode_summary: p_from must be less than p_to (p_to is exclusive)'
+      USING ERRCODE = '22023';
+  END IF;
+
+  range_day_count := (
+    ((p_to AT TIME ZONE tz) - interval '1 microsecond')::date
+    - (p_from AT TIME ZONE tz)::date
+    + 1
+  )::integer;
+
+  IF range_day_count > 730 THEN
+    RAISE EXCEPTION 'get_episode_summary: selected range must be 730 days or fewer'
       USING ERRCODE = '22023';
   END IF;
 
@@ -202,6 +214,7 @@ SET search_path = pg_catalog, public
 AS $$
 DECLARE
   tz text;
+  range_day_count integer;
 BEGIN
   tz := nullif(trim(p_timezone), '');
 
@@ -226,6 +239,17 @@ BEGIN
 
   IF p_from >= p_to THEN
     RAISE EXCEPTION 'get_episode_week_counts: p_from must be less than p_to (p_to is exclusive)'
+      USING ERRCODE = '22023';
+  END IF;
+
+  range_day_count := (
+    ((p_to AT TIME ZONE tz) - interval '1 microsecond')::date
+    - (p_from AT TIME ZONE tz)::date
+    + 1
+  )::integer;
+
+  IF range_day_count > 730 THEN
+    RAISE EXCEPTION 'get_episode_week_counts: selected range must be 730 days or fewer'
       USING ERRCODE = '22023';
   END IF;
 
@@ -272,6 +296,7 @@ SET search_path = pg_catalog, public
 AS $$
 DECLARE
   tz text;
+  range_day_count integer;
 BEGIN
   tz := nullif(trim(p_timezone), '');
 
@@ -296,6 +321,17 @@ BEGIN
 
   IF p_from >= p_to THEN
     RAISE EXCEPTION 'get_episode_start_hour_distribution: p_from must be less than p_to (p_to is exclusive)'
+      USING ERRCODE = '22023';
+  END IF;
+
+  range_day_count := (
+    ((p_to AT TIME ZONE tz) - interval '1 microsecond')::date
+    - (p_from AT TIME ZONE tz)::date
+    + 1
+  )::integer;
+
+  IF range_day_count > 730 THEN
+    RAISE EXCEPTION 'get_episode_start_hour_distribution: selected range must be 730 days or fewer'
       USING ERRCODE = '22023';
   END IF;
 
@@ -343,6 +379,11 @@ BEGIN
 
   IF p_from >= p_to THEN
     RAISE EXCEPTION 'get_symptom_frequency: p_from must be less than p_to (p_to is exclusive)'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF ((p_to::date - p_from::date))::integer > 730 THEN
+    RAISE EXCEPTION 'get_symptom_frequency: selected range must be 730 days or fewer'
       USING ERRCODE = '22023';
   END IF;
 

--- a/supabase/migrations/20260526184500_insights_overview_rpcs.sql
+++ b/supabase/migrations/20260526184500_insights_overview_rpcs.sql
@@ -76,7 +76,10 @@ BEGIN
         rb.range_start_date
       ) AS overlap_start_date,
       LEAST(
-        coalesce((e.ended_at AT TIME ZONE tz)::date, rb.range_end_date),
+        coalesce(
+          ((e.ended_at AT TIME ZONE tz) - interval '1 microsecond')::date,
+          rb.range_end_date
+        ),
         rb.range_end_date
       ) AS overlap_end_date
     FROM public.episodes e

--- a/supabase/migrations/20260526184500_insights_overview_rpcs.sql
+++ b/supabase/migrations/20260526184500_insights_overview_rpcs.sql
@@ -1,0 +1,377 @@
+-- Curated insights overview RPCs for patient and practitioner web insights surfaces.
+
+CREATE OR REPLACE FUNCTION public.get_episode_summary (
+  p_user_id uuid,
+  p_from timestamptz,
+  p_to timestamptz,
+  p_timezone text
+)
+RETURNS TABLE (
+  total_episode_count bigint,
+  abs_episode_count bigint,
+  other_episode_count bigint,
+  average_episodes_per_week numeric,
+  longest_episode_free_streak_days integer,
+  current_episode_free_streak_days integer,
+  average_episode_duration_hours numeric
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+STABLE
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  tz text;
+BEGIN
+  tz := nullif(trim(p_timezone), '');
+
+  IF tz IS NULL THEN
+    RAISE EXCEPTION 'get_episode_summary: p_timezone must be a non-empty IANA timezone name'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_timezone_names
+    WHERE name = tz
+  ) THEN
+    RAISE EXCEPTION 'get_episode_summary: invalid IANA timezone %', tz
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_from IS NULL OR p_to IS NULL THEN
+    RAISE EXCEPTION 'get_episode_summary: p_from and p_to must be non-null timestamps'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_from >= p_to THEN
+    RAISE EXCEPTION 'get_episode_summary: p_from must be less than p_to (p_to is exclusive)'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  WITH range_bounds AS (
+    SELECT
+      (p_from AT TIME ZONE tz)::date AS range_start_date,
+      GREATEST(
+        (p_from AT TIME ZONE tz)::date,
+        ((p_to AT TIME ZONE tz) - interval '1 microsecond')::date
+      ) AS range_end_date
+  ),
+  episodes_started AS (
+    SELECT
+      e.id,
+      e.episode_type,
+      e.started_at,
+      e.ended_at
+    FROM public.episodes e
+    WHERE e.user_id = p_user_id
+      AND e.started_at >= p_from
+      AND e.started_at < p_to
+  ),
+  episodes_overlapping AS (
+    SELECT
+      GREATEST(
+        (e.started_at AT TIME ZONE tz)::date,
+        rb.range_start_date
+      ) AS overlap_start_date,
+      LEAST(
+        coalesce((e.ended_at AT TIME ZONE tz)::date, rb.range_end_date),
+        rb.range_end_date
+      ) AS overlap_end_date
+    FROM public.episodes e
+    CROSS JOIN range_bounds rb
+    WHERE e.user_id = p_user_id
+      AND e.started_at < p_to
+      AND coalesce(e.ended_at, p_to) > p_from
+  ),
+  occupied_days AS (
+    SELECT DISTINCT gs::date AS occupied_date
+    FROM episodes_overlapping eo
+    CROSS JOIN LATERAL generate_series(
+      eo.overlap_start_date,
+      eo.overlap_end_date,
+      '1 day'::interval
+    ) AS gs
+    WHERE eo.overlap_start_date <= eo.overlap_end_date
+  ),
+  selected_days AS (
+    SELECT gs::date AS calendar_date
+    FROM range_bounds rb
+    CROSS JOIN LATERAL generate_series(
+      rb.range_start_date,
+      rb.range_end_date,
+      '1 day'::interval
+    ) AS gs
+  ),
+  free_days AS (
+    SELECT sd.calendar_date
+    FROM selected_days sd
+    LEFT JOIN occupied_days od
+      ON od.occupied_date = sd.calendar_date
+    WHERE od.occupied_date IS NULL
+  ),
+  free_day_groups AS (
+    SELECT
+      fd.calendar_date,
+      fd.calendar_date - row_number() OVER (ORDER BY fd.calendar_date)::integer
+        AS streak_group
+    FROM free_days fd
+  ),
+  free_day_streaks AS (
+    SELECT
+      count(*)::integer AS streak_days,
+      max(calendar_date) AS streak_end_date
+    FROM free_day_groups
+    GROUP BY streak_group
+  ),
+  period_summary AS (
+    SELECT
+      (rb.range_end_date - rb.range_start_date + 1)::integer AS period_day_count,
+      rb.range_end_date
+    FROM range_bounds rb
+  ),
+  episode_counts AS (
+    SELECT
+      count(*)::bigint AS total_episode_count,
+      count(*) FILTER (WHERE es.episode_type = 'ABS')::bigint AS abs_episode_count,
+      count(*) FILTER (WHERE es.episode_type = 'Other')::bigint AS other_episode_count
+    FROM episodes_started es
+  ),
+  duration_summary AS (
+    SELECT round(
+      avg(extract(epoch FROM (es.ended_at - es.started_at)) / 3600.0)::numeric,
+      1
+    ) AS average_episode_duration_hours
+    FROM episodes_started es
+    WHERE es.ended_at IS NOT NULL
+      AND es.ended_at > es.started_at
+  ),
+  streak_summary AS (
+    SELECT
+      coalesce((SELECT max(fds.streak_days) FROM free_day_streaks fds), 0) AS longest_episode_free_streak_days,
+      coalesce((
+        SELECT fds.streak_days
+        FROM free_day_streaks fds
+        CROSS JOIN period_summary ps
+        WHERE fds.streak_end_date = ps.range_end_date
+        ORDER BY fds.streak_days DESC
+        LIMIT 1
+      ), 0) AS current_episode_free_streak_days
+  )
+  SELECT
+    ec.total_episode_count,
+    ec.abs_episode_count,
+    ec.other_episode_count,
+    round((ec.total_episode_count::numeric * 7) / ps.period_day_count::numeric, 1)
+      AS average_episodes_per_week,
+    ss.longest_episode_free_streak_days,
+    ss.current_episode_free_streak_days,
+    ds.average_episode_duration_hours
+  FROM episode_counts ec
+  CROSS JOIN period_summary ps
+  CROSS JOIN duration_summary ds
+  CROSS JOIN streak_summary ss;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_episode_summary (uuid, timestamptz, timestamptz, text) IS
+'Returns overview metrics for episodes started within the selected range: totals by type, average episodes per week, longest/current episode-free streaks based on patient-local calendar days, and average episode duration in hours. SECURITY INVOKER.';
+
+REVOKE ALL ON FUNCTION public.get_episode_summary (uuid, timestamptz, timestamptz, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_episode_summary (uuid, timestamptz, timestamptz, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_episode_week_counts (
+  p_user_id uuid,
+  p_from timestamptz,
+  p_to timestamptz,
+  p_timezone text
+)
+RETURNS TABLE (
+  week_start timestamptz,
+  episode_type text,
+  episode_count bigint
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+STABLE
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  tz text;
+BEGIN
+  tz := nullif(trim(p_timezone), '');
+
+  IF tz IS NULL THEN
+    RAISE EXCEPTION 'get_episode_week_counts: p_timezone must be a non-empty IANA timezone name'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_timezone_names
+    WHERE name = tz
+  ) THEN
+    RAISE EXCEPTION 'get_episode_week_counts: invalid IANA timezone %', tz
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_from IS NULL OR p_to IS NULL THEN
+    RAISE EXCEPTION 'get_episode_week_counts: p_from and p_to must be non-null timestamps'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_from >= p_to THEN
+    RAISE EXCEPTION 'get_episode_week_counts: p_from must be less than p_to (p_to is exclusive)'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    (
+      date_trunc('week', e.started_at AT TIME ZONE tz)
+      AT TIME ZONE tz
+    ) AS week_start,
+    e.episode_type,
+    count(*)::bigint AS episode_count
+  FROM public.episodes e
+  WHERE e.user_id = p_user_id
+    AND e.started_at >= p_from
+    AND e.started_at < p_to
+  GROUP BY
+    date_trunc('week', e.started_at AT TIME ZONE tz) AT TIME ZONE tz,
+    e.episode_type
+  ORDER BY week_start, e.episode_type;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_episode_week_counts (uuid, timestamptz, timestamptz, text) IS
+'Returns weekly episode counts grouped by episode_type for the selected range. Buckets use date_trunc in p_timezone (IANA name) so patient and practitioner charts align to the same local week boundaries. SECURITY INVOKER.';
+
+REVOKE ALL ON FUNCTION public.get_episode_week_counts (uuid, timestamptz, timestamptz, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_episode_week_counts (uuid, timestamptz, timestamptz, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_episode_start_hour_distribution (
+  p_user_id uuid,
+  p_from timestamptz,
+  p_to timestamptz,
+  p_timezone text
+)
+RETURNS TABLE (
+  hour_of_day integer,
+  episode_type text,
+  episode_count bigint
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+STABLE
+SET search_path = pg_catalog, public
+AS $$
+DECLARE
+  tz text;
+BEGIN
+  tz := nullif(trim(p_timezone), '');
+
+  IF tz IS NULL THEN
+    RAISE EXCEPTION 'get_episode_start_hour_distribution: p_timezone must be a non-empty IANA timezone name'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_catalog.pg_timezone_names
+    WHERE name = tz
+  ) THEN
+    RAISE EXCEPTION 'get_episode_start_hour_distribution: invalid IANA timezone %', tz
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_from IS NULL OR p_to IS NULL THEN
+    RAISE EXCEPTION 'get_episode_start_hour_distribution: p_from and p_to must be non-null timestamps'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_from >= p_to THEN
+    RAISE EXCEPTION 'get_episode_start_hour_distribution: p_from must be less than p_to (p_to is exclusive)'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    extract(hour FROM (e.started_at AT TIME ZONE tz))::integer AS hour_of_day,
+    e.episode_type,
+    count(*)::bigint AS episode_count
+  FROM public.episodes e
+  WHERE e.user_id = p_user_id
+    AND e.started_at >= p_from
+    AND e.started_at < p_to
+  GROUP BY
+    extract(hour FROM (e.started_at AT TIME ZONE tz))::integer,
+    e.episode_type
+  ORDER BY hour_of_day, e.episode_type;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_episode_start_hour_distribution (uuid, timestamptz, timestamptz, text) IS
+'Returns hourly episode-start counts grouped by episode_type for the selected range. Hours are extracted in p_timezone (IANA name) so clustering callouts reflect patient-local time of day. SECURITY INVOKER.';
+
+REVOKE ALL ON FUNCTION public.get_episode_start_hour_distribution (uuid, timestamptz, timestamptz, text) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_episode_start_hour_distribution (uuid, timestamptz, timestamptz, text) TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.get_symptom_frequency (
+  p_user_id uuid,
+  p_from timestamptz,
+  p_to timestamptz
+)
+RETURNS TABLE (
+  symptom_name text,
+  occurrence_count bigint
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+STABLE
+SET search_path = pg_catalog, public
+AS $$
+BEGIN
+  IF p_from IS NULL OR p_to IS NULL THEN
+    RAISE EXCEPTION 'get_symptom_frequency: p_from and p_to must be non-null timestamps'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_from >= p_to THEN
+    RAISE EXCEPTION 'get_symptom_frequency: p_from must be less than p_to (p_to is exclusive)'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  WITH symptom_rows AS (
+    SELECT
+      lower(nullif(trim(es.symptom_name), '')) AS symptom_key,
+      nullif(trim(es.symptom_name), '') AS symptom_label,
+      CASE
+        WHEN es.response_type = 'yes_no' AND es.response_boolean IS TRUE THEN 1
+        WHEN es.response_type = 'severity_scale' THEN 1
+        ELSE 0
+      END AS occurrence_value
+    FROM public.episode_symptoms es
+    WHERE es.user_id = p_user_id
+      AND es.created_at >= p_from
+      AND es.created_at < p_to
+      AND nullif(trim(es.symptom_name), '') IS NOT NULL
+      AND es.response_type IN ('yes_no', 'severity_scale')
+  )
+  SELECT
+    min(sr.symptom_label) AS symptom_name,
+    sum(sr.occurrence_value)::bigint AS occurrence_count
+  FROM symptom_rows sr
+  GROUP BY sr.symptom_key
+  HAVING sum(sr.occurrence_value) > 0
+  ORDER BY occurrence_count DESC, symptom_name ASC;
+END;
+$$;
+
+COMMENT ON FUNCTION public.get_symptom_frequency (uuid, timestamptz, timestamptz) IS
+'Returns ranked symptom counts for the selected range. Boolean symptoms count only true responses; severity symptoms count each logged observation. SECURITY INVOKER.';
+
+REVOKE ALL ON FUNCTION public.get_symptom_frequency (uuid, timestamptz, timestamptz) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.get_symptom_frequency (uuid, timestamptz, timestamptz) TO authenticated;


### PR DESCRIPTION
Closes #219

## Summary
- add curated insights overviews to patient web and practitioner tabs with summary cards, weekly episode heatmaps, symptom frequency, episode start-time distribution, and auto-generated pattern callouts
- move the existing chart builder into a lower "Custom exploration" section, improve the series picker with observation counts and observed date ranges, and fix overview/calendar timezone and long-range layout issues
- add and harden Supabase overview RPCs plus shared query helpers for episode summaries, weekly counts, start-hour distribution, and symptom frequency, including validation and shared overview-loading logic across web and practitioner

## Testing
- [x] `pnpm vitest run -c "packages/supabase/vitest.config.mts" "packages/supabase/src/lib/episode-insights-query.spec.ts"`
- [x] `pnpm vitest run -c "packages/ui/vitest.config.mts" "packages/ui/src/lib/InsightSeriesPicker.spec.tsx" "packages/ui/src/lib/InsightsSummarySection.spec.tsx"`
- [x] `pnpm jest --config "jest.config.cts" --runInBand --runTestsByPath "src/app/(app)/insights/InsightsClient.spec.tsx"` (from `apps/web`)
- [x] `pnpm jest --config "jest.config.cts" "specs/patient-detail-insights.spec.tsx" --runInBand` (from `apps/practitioner`)
- [x] `pnpm nx run-many -t lint -p web,practitioner,@abstrack/ui,@abstrack/supabase --parallel=4`
- [x] `pnpm nx run @abstrack/supabase:build`

## Notes
- `packages/supabase/src/lib/database.types.ts` is already included in this branch; keep it aligned with the normal Supabase flow and regenerate via `db push` then `gen types --linked` for any further schema changes.