### PR TITLE
Feat/mobile background

### DIFF
--- a/apps/mobile/src/app/App.tsx
+++ b/apps/mobile/src/app/App.tsx
@@ -25,6 +25,7 @@ import {
   isAuthSessionRecoveryFailure,
 } from '../lib/supabase-wiring';
 import { AppProviders } from './components/AppProviders';
+import { AppGridBackground } from './components/AppGridBackground';
 import { SyncHealthFooter } from './components/SyncHealthFooter';
 import { ForgotPasswordScreen } from './screens/ForgotPasswordScreen';
 import { MainTabNavigator } from './navigation/MainTabNavigator';
@@ -637,14 +638,12 @@ function AppBootstrap() {
   if (initializing) {
     return (
       <PowerSyncSessionBridge session={session}>
-        <View className={`flex-1 ${nw.screenBg}`}>
+        <AppGridBackground>
           <StatusBar style={statusBarStyle} />
-          <SafeAreaView
-            className={`flex-1 items-center justify-center ${nw.screenBg}`}
-          >
+          <SafeAreaView className="flex-1 items-center justify-center">
             <ActivityIndicator size="large" color={colors.primary} />
           </SafeAreaView>
-        </View>
+        </AppGridBackground>
       </PowerSyncSessionBridge>
     );
   }

--- a/apps/mobile/src/app/components/AppGridBackground.tsx
+++ b/apps/mobile/src/app/components/AppGridBackground.tsx
@@ -49,6 +49,9 @@ export function AppGridBackground({
   const { colorScheme, colors } = useAppTheme();
   const tokens =
     colorScheme === 'dark' ? darkBackgroundTokens : lightBackgroundTokens;
+  const instanceId = React.useId().replace(/[^a-zA-Z0-9_-]/g, '');
+  const gradientId = `app-grid-gradient-${instanceId}`;
+  const patternId = `app-grid-pattern-${instanceId}`;
 
   return (
     <View style={[styles.root, { backgroundColor: colors.bg }, style]}>
@@ -60,19 +63,13 @@ export function AppGridBackground({
       >
         <Svg width="100%" height="100%" preserveAspectRatio="none">
           <Defs>
-            <LinearGradient
-              id="app-grid-gradient"
-              x1="0%"
-              y1="0%"
-              x2="0%"
-              y2="100%"
-            >
+            <LinearGradient id={gradientId} x1="0%" y1="0%" x2="0%" y2="100%">
               <Stop offset="0%" stopColor={tokens.gradientStart} />
               <Stop offset="45%" stopColor={tokens.gradientMiddle} />
               <Stop offset="100%" stopColor={tokens.gradientEnd} />
             </LinearGradient>
             <Pattern
-              id="app-grid-pattern"
+              id={patternId}
               patternUnits="userSpaceOnUse"
               width={GRID_TILE_WIDTH}
               height={GRID_TILE_HEIGHT}
@@ -91,14 +88,14 @@ export function AppGridBackground({
             y="0"
             width="100%"
             height="100%"
-            fill="url(#app-grid-gradient)"
+            fill={`url(#${gradientId})`}
           />
           <Rect
             x="0"
             y="0"
             width="100%"
             height="100%"
-            fill="url(#app-grid-pattern)"
+            fill={`url(#${patternId})`}
           />
         </Svg>
       </View>

--- a/apps/mobile/src/app/components/AppGridBackground.tsx
+++ b/apps/mobile/src/app/components/AppGridBackground.tsx
@@ -1,0 +1,103 @@
+import React from 'react';
+import { StyleSheet, View, type StyleProp, type ViewStyle } from 'react-native';
+import Svg, {
+  Defs,
+  LinearGradient,
+  Path,
+  Pattern,
+  Rect,
+  Stop,
+} from 'react-native-svg';
+import { useAppTheme } from '../theme/AppThemeContext';
+
+const GRID_TILE_WIDTH = 14;
+const GRID_TILE_HEIGHT = 24;
+
+const lightBackgroundTokens = {
+  gridLine: '#80808012',
+  gradientStart: '#f1f5f9',
+  gradientMiddle: '#f8fafc',
+  gradientEnd: '#f1f5f9',
+} as const;
+
+const darkBackgroundTokens = {
+  gridLine: '#ffffff0a',
+  gradientStart: '#0f172a',
+  gradientMiddle: '#1e293b',
+  gradientEnd: '#0f172a',
+} as const;
+
+export type AppGridBackgroundProps = {
+  children: React.ReactNode;
+  /** Optional outer container style. */
+  style?: StyleProp<ViewStyle>;
+  /** Optional style for the foreground content layer. */
+  contentStyle?: StyleProp<ViewStyle>;
+};
+
+/**
+ * Full-screen graph-paper background for mobile, matching the shared web and practitioner shell.
+ *
+ * @param props - Optional styles plus the foreground subtree rendered above the SVG background.
+ * @returns Themed background wrapper for mobile screens and modal surfaces.
+ */
+export function AppGridBackground({
+  children,
+  style,
+  contentStyle,
+}: AppGridBackgroundProps) {
+  const { colorScheme, colors } = useAppTheme();
+  const tokens =
+    colorScheme === 'dark' ? darkBackgroundTokens : lightBackgroundTokens;
+
+  return (
+    <View style={[styles.root, { backgroundColor: colors.bg }, style]}>
+      <View
+        pointerEvents="none"
+        accessibilityElementsHidden
+        importantForAccessibility="no-hide-descendants"
+        style={styles.background}
+      >
+        <Svg width="100%" height="100%" preserveAspectRatio="none">
+          <Defs>
+            <LinearGradient id="app-grid-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+              <Stop offset="0%" stopColor={tokens.gradientStart} />
+              <Stop offset="45%" stopColor={tokens.gradientMiddle} />
+              <Stop offset="100%" stopColor={tokens.gradientEnd} />
+            </LinearGradient>
+            <Pattern
+              id="app-grid-pattern"
+              patternUnits="userSpaceOnUse"
+              width={GRID_TILE_WIDTH}
+              height={GRID_TILE_HEIGHT}
+            >
+              <Path
+                d={`M ${GRID_TILE_WIDTH} 0 L 0 0 0 ${GRID_TILE_HEIGHT}`}
+                fill="none"
+                stroke={tokens.gridLine}
+                strokeWidth={1}
+              />
+            </Pattern>
+          </Defs>
+
+          <Rect x="0" y="0" width="100%" height="100%" fill="url(#app-grid-gradient)" />
+          <Rect x="0" y="0" width="100%" height="100%" fill="url(#app-grid-pattern)" />
+        </Svg>
+      </View>
+
+      <View style={[styles.content, contentStyle]}>{children}</View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  background: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  content: {
+    flex: 1,
+  },
+});

--- a/apps/mobile/src/app/components/AppGridBackground.tsx
+++ b/apps/mobile/src/app/components/AppGridBackground.tsx
@@ -60,7 +60,13 @@ export function AppGridBackground({
       >
         <Svg width="100%" height="100%" preserveAspectRatio="none">
           <Defs>
-            <LinearGradient id="app-grid-gradient" x1="0%" y1="0%" x2="0%" y2="100%">
+            <LinearGradient
+              id="app-grid-gradient"
+              x1="0%"
+              y1="0%"
+              x2="0%"
+              y2="100%"
+            >
               <Stop offset="0%" stopColor={tokens.gradientStart} />
               <Stop offset="45%" stopColor={tokens.gradientMiddle} />
               <Stop offset="100%" stopColor={tokens.gradientEnd} />
@@ -80,8 +86,20 @@ export function AppGridBackground({
             </Pattern>
           </Defs>
 
-          <Rect x="0" y="0" width="100%" height="100%" fill="url(#app-grid-gradient)" />
-          <Rect x="0" y="0" width="100%" height="100%" fill="url(#app-grid-pattern)" />
+          <Rect
+            x="0"
+            y="0"
+            width="100%"
+            height="100%"
+            fill="url(#app-grid-gradient)"
+          />
+          <Rect
+            x="0"
+            y="0"
+            width="100%"
+            height="100%"
+            fill="url(#app-grid-pattern)"
+          />
         </Svg>
       </View>
 

--- a/apps/mobile/src/app/components/AppNavigationShell.tsx
+++ b/apps/mobile/src/app/components/AppNavigationShell.tsx
@@ -4,6 +4,7 @@ import { SafeAreaView } from 'react-native-safe-area-context';
 import { NavigationShell } from '@abstrack/ui/native';
 import { useAppTheme } from '../theme/AppThemeContext';
 import { nw } from '../theme/app-nativewind-classes';
+import { AppGridBackground } from './AppGridBackground';
 
 export type AppNavigationShellProps = {
   /** Visible screen title; header semantics come from {@link NavigationShell}'s header container. */
@@ -29,32 +30,31 @@ export function AppNavigationShell({
   const { colors } = useAppTheme();
 
   return (
-    <SafeAreaView
-      className={`flex-1 ${nw.screenBg}`}
-      edges={['top', 'left', 'right']}
-    >
-      <NavigationShell
-        style={{ flex: 1, backgroundColor: colors.bg }}
-        headerStyle={{
-          backgroundColor: colors.surface,
-          borderBottomColor: colors.border,
-        }}
-        mainStyle={{ flex: 1, backgroundColor: colors.bg }}
-        header={
-          <View className="flex-row items-center justify-between gap-3">
-            <Text
-              className={`min-w-0 flex-1 text-xl font-semibold ${nw.textInk}`}
-              maxFontSizeMultiplier={2}
-              numberOfLines={1}
-            >
-              {title}
-            </Text>
-            {headerAction ? <View>{headerAction}</View> : null}
-          </View>
-        }
-      >
-        {children}
-      </NavigationShell>
+    <SafeAreaView className="flex-1" edges={['top', 'left', 'right']}>
+      <AppGridBackground>
+        <NavigationShell
+          style={{ flex: 1, backgroundColor: 'transparent' }}
+          headerStyle={{
+            backgroundColor: colors.surface,
+            borderBottomColor: colors.border,
+          }}
+          mainStyle={{ flex: 1, backgroundColor: 'transparent' }}
+          header={
+            <View className="flex-row items-center justify-between gap-3">
+              <Text
+                className={`min-w-0 flex-1 text-xl font-semibold ${nw.textInk}`}
+                maxFontSizeMultiplier={2}
+                numberOfLines={1}
+              >
+                {title}
+              </Text>
+              {headerAction ? <View>{headerAction}</View> : null}
+            </View>
+          }
+        >
+          {children}
+        </NavigationShell>
+      </AppGridBackground>
     </SafeAreaView>
   );
 }

--- a/apps/mobile/src/app/components/AppNavigationShell.tsx
+++ b/apps/mobile/src/app/components/AppNavigationShell.tsx
@@ -30,8 +30,8 @@ export function AppNavigationShell({
   const { colors } = useAppTheme();
 
   return (
-    <SafeAreaView className="flex-1" edges={['top', 'left', 'right']}>
-      <AppGridBackground>
+    <AppGridBackground>
+      <SafeAreaView className="flex-1" edges={['top', 'left', 'right']}>
         <NavigationShell
           style={{ flex: 1, backgroundColor: 'transparent' }}
           headerStyle={{
@@ -54,7 +54,7 @@ export function AppNavigationShell({
         >
           {children}
         </NavigationShell>
-      </AppGridBackground>
-    </SafeAreaView>
+      </SafeAreaView>
+    </AppGridBackground>
   );
 }

--- a/apps/mobile/src/app/components/AppSecondaryMenuButton.tsx
+++ b/apps/mobile/src/app/components/AppSecondaryMenuButton.tsx
@@ -5,6 +5,7 @@ import { useActionSheet } from '@expo/react-native-action-sheet';
 import { Ionicons } from '@expo/vector-icons';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { useAppTheme } from '../theme/AppThemeContext';
+import { buildThemedActionSheetOptions } from '../lib/build-themed-action-sheet-options';
 
 export type AppSecondaryMenuButtonProps = {
   /** Opens the standalone Manage screen. */
@@ -23,7 +24,7 @@ export function AppSecondaryMenuButton({
   onGoToManage,
   onGoToSettings,
 }: AppSecondaryMenuButtonProps) {
-  const { colors } = useAppTheme();
+  const { colorScheme, colors } = useAppTheme();
   const insets = useSafeAreaInsets();
   const { showActionSheetWithOptions } = useActionSheet();
 
@@ -34,14 +35,17 @@ export function AppSecondaryMenuButton({
       Platform.OS === 'android' ? Math.max(insets.bottom, 24) : 0;
 
     showActionSheetWithOptions(
-      {
+      buildThemedActionSheetOptions({
         title: 'Menu',
         options,
         cancelButtonIndex,
-        ...(androidBottomPad > 0
-          ? { containerStyle: { paddingBottom: androidBottomPad } }
-          : {}),
-      },
+        colors,
+        colorScheme,
+        containerStyle:
+          androidBottomPad > 0
+            ? { paddingBottom: androidBottomPad }
+            : undefined,
+      }),
       (selectedIndex?: number) => {
         if (selectedIndex === 0) {
           onGoToManage();
@@ -52,7 +56,14 @@ export function AppSecondaryMenuButton({
         }
       },
     );
-  }, [insets.bottom, onGoToManage, onGoToSettings, showActionSheetWithOptions]);
+  }, [
+    colorScheme,
+    colors,
+    insets.bottom,
+    onGoToManage,
+    onGoToSettings,
+    showActionSheetWithOptions,
+  ]);
 
   return (
     <Pressable

--- a/apps/mobile/src/app/components/AsyncScreenContainer.tsx
+++ b/apps/mobile/src/app/components/AsyncScreenContainer.tsx
@@ -54,7 +54,7 @@ export function AsyncScreenContainer({
         accessibilityRole="progressbar"
       >
         <ActivityIndicator size="large" color={colors.primary} />
-      </View>
+      </View>,
     );
   }
 
@@ -92,7 +92,7 @@ export function AsyncScreenContainer({
             </Text>
           </Pressable>
         ) : null}
-      </View>
+      </View>,
     );
   }
 

--- a/apps/mobile/src/app/components/AsyncScreenContainer.tsx
+++ b/apps/mobile/src/app/components/AsyncScreenContainer.tsx
@@ -3,6 +3,7 @@ import { ActivityIndicator, Pressable, Text, View } from 'react-native';
 import { MIN_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { useAppTheme } from '../theme/AppThemeContext';
 import { nw } from '../theme/app-nativewind-classes';
+import { AppGridBackground } from './AppGridBackground';
 
 /**
  * Async UI phase for preset (and similar) screens before data is wired.
@@ -12,6 +13,8 @@ export type AsyncScreenStatus = 'loading' | 'error' | 'ready';
 export type AsyncScreenContainerProps = {
   /** Current phase; drives which subtree renders. */
   status: AsyncScreenStatus;
+  /** When false, callers render inside an existing screen background. */
+  withBackground?: boolean;
   /** Announced while loading (spinner). */
   loadingAccessibilityLabel?: string;
   /** Short heading when `status` is `error`. */
@@ -32,6 +35,7 @@ export type AsyncScreenContainerProps = {
  */
 export function AsyncScreenContainer({
   status,
+  withBackground = true,
   loadingAccessibilityLabel = 'Loading',
   errorTitle = 'Something went wrong',
   errorMessage = 'We could not load this screen. Check your connection and try again.',
@@ -39,9 +43,11 @@ export function AsyncScreenContainer({
   children,
 }: AsyncScreenContainerProps) {
   const { colors } = useAppTheme();
+  const wrapContent = (content: React.ReactNode) =>
+    withBackground ? <AppGridBackground>{content}</AppGridBackground> : content;
 
   if (status === 'loading') {
-    return (
+    return wrapContent(
       <View
         className="flex-1 items-center justify-center"
         accessibilityLabel={loadingAccessibilityLabel}
@@ -53,7 +59,7 @@ export function AsyncScreenContainer({
   }
 
   if (status === 'error') {
-    return (
+    return wrapContent(
       <View
         className="flex-1 items-center justify-center gap-3 px-6"
         accessibilityRole="alert"
@@ -90,5 +96,5 @@ export function AsyncScreenContainer({
     );
   }
 
-  return <View className="flex-1">{children}</View>;
+  return wrapContent(<View className="flex-1">{children}</View>);
 }

--- a/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
+++ b/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
@@ -92,6 +92,9 @@ export function HomeRecentEpisodesCard({
 
       {!loading && episodes.length > 0 ? (
         <View className="gap-3" accessibilityRole="list">
+          {/* TODO(#218): Restore the per-item list role once the mobile accessibility
+              tooling follow-up lands and we can reintroduce the supported RN role
+              prop/value pair instead of the removed invalid cast. */}
           {episodes.map((episode) => (
             <View
               key={episode.id}

--- a/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
+++ b/apps/mobile/src/app/components/HomeRecentEpisodesCard.tsx
@@ -23,13 +23,6 @@ function formatInstant(iso: string): string {
   });
 }
 
-// React Native docs support `listitem`, but this repo's current types/linting still lag behind.
-// Remove this cast once the accessibility tooling catches up and accepts the role directly.
-const ACCESSIBILITY_ROLE_LISTITEM =
-  'listitem' as unknown as React.ComponentProps<
-    typeof View
-  >['accessibilityRole'];
-
 export type HomeRecentEpisodesCardProps = {
   /** Recent ended episodes to preview. */
   episodes: EpisodeRow[];
@@ -103,7 +96,6 @@ export function HomeRecentEpisodesCard({
             <View
               key={episode.id}
               className={`rounded-xl border px-4 py-3 ${nw.card}`}
-              accessibilityRole={ACCESSIBILITY_ROLE_LISTITEM}
             >
               <Text className={`text-base font-semibold ${nw.textInk}`}>
                 {episodeSummaryLine(episode)}

--- a/apps/mobile/src/app/components/ScreenShell.tsx
+++ b/apps/mobile/src/app/components/ScreenShell.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { View } from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import { nw } from '../theme/app-nativewind-classes';
+import { AppGridBackground } from './AppGridBackground';
 
 export type ScreenShellContentAlign = 'center' | 'stretch';
 
@@ -31,15 +32,16 @@ export function ScreenShell({
   const stretch = contentAlign === 'stretch';
 
   return (
-    <SafeAreaView
-      className={`flex-1 p-4 ${stretch ? '' : 'justify-center'} ${nw.screenBg}`}
-      edges={['top', 'left', 'right', 'bottom']}
-    >
-      <View
-        className={`gap-3 rounded-xl p-4 ${stretch ? 'min-h-0 w-full flex-1' : ''} ${nw.card} ${nw.cardShadow}`}
-      >
-        {children}
-      </View>
+    <SafeAreaView className="flex-1" edges={['top', 'left', 'right', 'bottom']}>
+      <AppGridBackground>
+        <View className={`flex-1 p-4 ${stretch ? '' : 'justify-center'}`}>
+          <View
+            className={`gap-3 rounded-xl p-4 ${stretch ? 'min-h-0 w-full flex-1' : ''} ${nw.card} ${nw.cardShadow}`}
+          >
+            {children}
+          </View>
+        </View>
+      </AppGridBackground>
     </SafeAreaView>
   );
 }

--- a/apps/mobile/src/app/components/ScreenShell.tsx
+++ b/apps/mobile/src/app/components/ScreenShell.tsx
@@ -32,8 +32,11 @@ export function ScreenShell({
   const stretch = contentAlign === 'stretch';
 
   return (
-    <SafeAreaView className="flex-1" edges={['top', 'left', 'right', 'bottom']}>
-      <AppGridBackground>
+    <AppGridBackground>
+      <SafeAreaView
+        className="flex-1"
+        edges={['top', 'left', 'right', 'bottom']}
+      >
         <View className={`flex-1 p-4 ${stretch ? '' : 'justify-center'}`}>
           <View
             className={`gap-3 rounded-xl p-4 ${stretch ? 'min-h-0 w-full flex-1' : ''} ${nw.card} ${nw.cardShadow}`}
@@ -41,7 +44,7 @@ export function ScreenShell({
             {children}
           </View>
         </View>
-      </AppGridBackground>
-    </SafeAreaView>
+      </SafeAreaView>
+    </AppGridBackground>
   );
 }

--- a/apps/mobile/src/app/components/episode-templates/PresetOptionSheetField.tsx
+++ b/apps/mobile/src/app/components/episode-templates/PresetOptionSheetField.tsx
@@ -5,6 +5,7 @@ import { useActionSheet } from '@expo/react-native-action-sheet';
 import { Ionicons } from '@expo/vector-icons';
 import { announce } from '@abstrack/ui/native';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
+import { buildThemedActionSheetOptions } from '../../lib/build-themed-action-sheet-options';
 import { useAppTheme } from '../../theme/AppThemeContext';
 import { nw } from '../../theme/app-nativewind-classes';
 
@@ -40,7 +41,7 @@ export function PresetOptionSheetField({
   disabled = false,
   hint = 'Tap to see a list of choices.',
 }: PresetOptionSheetFieldProps) {
-  const { colors } = useAppTheme();
+  const { colorScheme, colors } = useAppTheme();
   const insets = useSafeAreaInsets();
   const { showActionSheetWithOptions } = useActionSheet();
 
@@ -67,15 +68,18 @@ export function PresetOptionSheetField({
       Platform.OS === 'android' ? Math.max(insets.bottom, 24) : 0;
 
     showActionSheetWithOptions(
-      {
+      buildThemedActionSheetOptions({
         title: label,
         message: hint,
         options: sheetOptions,
         cancelButtonIndex,
-        ...(androidBottomPad > 0
-          ? { containerStyle: { paddingBottom: androidBottomPad } }
-          : {}),
-      },
+        colors,
+        colorScheme,
+        containerStyle:
+          androidBottomPad > 0
+            ? { paddingBottom: androidBottomPad }
+            : undefined,
+      }),
       (selectedIndex?: number) => {
         if (selectedIndex == null || selectedIndex === cancelButtonIndex) {
           return;
@@ -87,6 +91,8 @@ export function PresetOptionSheetField({
       },
     );
   }, [
+    colorScheme,
+    colors,
     disabled,
     hint,
     insets.bottom,

--- a/apps/mobile/src/app/lib/build-themed-action-sheet-options.ts
+++ b/apps/mobile/src/app/lib/build-themed-action-sheet-options.ts
@@ -1,0 +1,68 @@
+import type { AppColorScheme } from '../theme/AppThemeContext';
+import type { AppThemeColors } from '../theme/app-colors';
+
+export type ThemedActionSheetConfig = {
+  title?: string;
+  message?: string;
+  options: string[];
+  cancelButtonIndex?: number;
+  destructiveButtonIndex?: number | number[];
+  disabledButtonIndices?: number[];
+  colors: AppThemeColors;
+  colorScheme: AppColorScheme;
+  containerStyle?: {
+    paddingBottom?: number;
+  };
+};
+
+/**
+ * Builds action-sheet options that follow the app's semantic light/dark tokens.
+ *
+ * Android/Web use the library's custom sheet, so these styles theme the container,
+ * separators, and text directly. iOS still uses the native sheet, but
+ * `userInterfaceStyle` and tint colors keep it aligned with the selected appearance.
+ *
+ * @param config - Base sheet content plus semantic app colors and optional container padding.
+ * @returns Action sheet options object suitable for `showActionSheetWithOptions`.
+ */
+export function buildThemedActionSheetOptions({
+  title,
+  message,
+  options,
+  cancelButtonIndex,
+  destructiveButtonIndex,
+  disabledButtonIndices,
+  colors,
+  colorScheme,
+  containerStyle,
+}: ThemedActionSheetConfig) {
+  return {
+    title,
+    message,
+    options,
+    cancelButtonIndex,
+    destructiveButtonIndex,
+    disabledButtonIndices,
+    userInterfaceStyle: colorScheme,
+    tintColor: colors.ink,
+    cancelButtonTintColor: colors.primary,
+    destructiveColor: colors.error,
+    textStyle: {
+      color: colors.ink,
+    },
+    titleTextStyle: {
+      color: colors.muted,
+    },
+    messageTextStyle: {
+      color: colors.muted,
+    },
+    showSeparators: true,
+    containerStyle: {
+      backgroundColor: colors.surface,
+      ...containerStyle,
+    },
+    separatorStyle: {
+      backgroundColor: colors.border,
+    },
+  };
+}

--- a/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
+++ b/apps/mobile/src/app/screens/EpisodeStartScreen.tsx
@@ -666,6 +666,7 @@ export function EpisodeStartScreen() {
         {!blockingActiveEpisode ? (
           <AsyncScreenContainer
             status={status}
+            withBackground={false}
             loadingAccessibilityLabel={
               submitting ? 'Starting episode' : 'Loading episode templates'
             }

--- a/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/HealthMarkerPromptScreen.tsx
@@ -1395,6 +1395,7 @@ export function HealthMarkerPromptScreen() {
         ) : (
           <AsyncScreenContainer
             status={status}
+            withBackground={false}
             loadingAccessibilityLabel="Loading health marker list"
             errorTitle="Could not load health markers"
             errorMessage={errorMessage ?? undefined}

--- a/apps/mobile/src/app/screens/SymptomPresetEditorScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPresetEditorScreen.tsx
@@ -323,7 +323,10 @@ export function SymptomPresetEditorScreen() {
         }}
         accessibilityViewIsModal
       >
-        <SafeAreaView className="flex-1" edges={['top', 'left', 'right', 'bottom']}>
+        <SafeAreaView
+          className="flex-1"
+          edges={['top', 'left', 'right', 'bottom']}
+        >
           <AppGridBackground>
             <View
               className="flex-row items-center justify-between border-b px-4 py-3"

--- a/apps/mobile/src/app/screens/SymptomPresetEditorScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPresetEditorScreen.tsx
@@ -323,11 +323,11 @@ export function SymptomPresetEditorScreen() {
         }}
         accessibilityViewIsModal
       >
-        <SafeAreaView
-          className="flex-1"
-          edges={['top', 'left', 'right', 'bottom']}
-        >
-          <AppGridBackground>
+        <AppGridBackground>
+          <SafeAreaView
+            className="flex-1"
+            edges={['top', 'left', 'right', 'bottom']}
+          >
             <View
               className="flex-row items-center justify-between border-b px-4 py-3"
               style={{
@@ -387,8 +387,8 @@ export function SymptomPresetEditorScreen() {
                 </Pressable>
               ))}
             </ScrollView>
-          </AppGridBackground>
-        </SafeAreaView>
+          </SafeAreaView>
+        </AppGridBackground>
       </Modal>
     </AsyncScreenContainer>
   );

--- a/apps/mobile/src/app/screens/SymptomPresetEditorScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPresetEditorScreen.tsx
@@ -15,6 +15,7 @@ import { announce } from '@abstrack/ui/native';
 import { COMFORTABLE_TOUCH_TARGET_DP } from '@abstrack/ui/native';
 import { useSymptomPresetEditor } from '../../lib/symptom-presets/use-symptom-preset-editor';
 import { AsyncScreenContainer } from '../components/AsyncScreenContainer';
+import { AppGridBackground } from '../components/AppGridBackground';
 import { SymptomLineCard } from '../components/symptom-presets/SymptomLineCard';
 import { SymptomResponseTypePicker } from '../components/symptom-presets/SymptomResponseTypePicker';
 import type { SymptomPresetsStackParamList } from '../navigation/types';
@@ -322,69 +323,68 @@ export function SymptomPresetEditorScreen() {
         }}
         accessibilityViewIsModal
       >
-        <SafeAreaView
-          className={`flex-1 ${nw.screenBg}`}
-          edges={['top', 'left', 'right', 'bottom']}
-        >
-          <View
-            className="flex-row items-center justify-between border-b px-4 py-3"
-            style={{
-              borderColor: colors.border,
-              minHeight: COMFORTABLE_TOUCH_TARGET_DP,
-            }}
-          >
-            <Text
-              className={`flex-1 text-lg font-semibold ${nw.textInk}`}
-              maxFontSizeMultiplier={2}
-            >
-              Pick a suggestion
-            </Text>
-            <Pressable
-              accessibilityRole="button"
-              accessibilityLabel="Close suggestions"
-              onPress={() => {
-                setSuggestionsOpen(false);
-              }}
-              hitSlop={12}
+        <SafeAreaView className="flex-1" edges={['top', 'left', 'right', 'bottom']}>
+          <AppGridBackground>
+            <View
+              className="flex-row items-center justify-between border-b px-4 py-3"
               style={{
-                minWidth: COMFORTABLE_TOUCH_TARGET_DP,
+                borderColor: colors.border,
                 minHeight: COMFORTABLE_TOUCH_TARGET_DP,
-                alignItems: 'center',
-                justifyContent: 'center',
               }}
             >
-              <Text className={`text-[17px] font-semibold ${nw.textPrimary}`}>
-                Done
+              <Text
+                className={`flex-1 text-lg font-semibold ${nw.textInk}`}
+                maxFontSizeMultiplier={2}
+              >
+                Pick a suggestion
               </Text>
-            </Pressable>
-          </View>
-          <ScrollView
-            className="flex-1 px-4 pt-3"
-            contentContainerStyle={{ paddingBottom: 32 }}
-            keyboardShouldPersistTaps="handled"
-          >
-            {ALL_ABS_SYMPTOM_SUGGESTIONS.map((suggestion) => (
               <Pressable
-                key={suggestion}
                 accessibilityRole="button"
-                accessibilityLabel={`Use suggestion ${suggestion}`}
+                accessibilityLabel="Close suggestions"
                 onPress={() => {
-                  setNewSymptomName(suggestion);
-                  announce(`Filled symptom name: ${suggestion}`);
                   setSuggestionsOpen(false);
                 }}
-                className={`mb-3 rounded-xl border px-4 py-4 active:opacity-90 ${nw.card}`}
-                style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP + 8 }}
+                hitSlop={12}
+                style={{
+                  minWidth: COMFORTABLE_TOUCH_TARGET_DP,
+                  minHeight: COMFORTABLE_TOUCH_TARGET_DP,
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                }}
               >
-                <Text
-                  className={`text-[17px] ${nw.textInk}`}
-                  maxFontSizeMultiplier={2}
-                >
-                  {suggestion}
+                <Text className={`text-[17px] font-semibold ${nw.textPrimary}`}>
+                  Done
                 </Text>
               </Pressable>
-            ))}
-          </ScrollView>
+            </View>
+            <ScrollView
+              className="flex-1 px-4 pt-3"
+              contentContainerStyle={{ paddingBottom: 32 }}
+              keyboardShouldPersistTaps="handled"
+            >
+              {ALL_ABS_SYMPTOM_SUGGESTIONS.map((suggestion) => (
+                <Pressable
+                  key={suggestion}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Use suggestion ${suggestion}`}
+                  onPress={() => {
+                    setNewSymptomName(suggestion);
+                    announce(`Filled symptom name: ${suggestion}`);
+                    setSuggestionsOpen(false);
+                  }}
+                  className={`mb-3 rounded-xl border px-4 py-4 active:opacity-90 ${nw.card}`}
+                  style={{ minHeight: COMFORTABLE_TOUCH_TARGET_DP + 8 }}
+                >
+                  <Text
+                    className={`text-[17px] ${nw.textInk}`}
+                    maxFontSizeMultiplier={2}
+                  >
+                    {suggestion}
+                  </Text>
+                </Pressable>
+              ))}
+            </ScrollView>
+          </AppGridBackground>
         </SafeAreaView>
       </Modal>
     </AsyncScreenContainer>

--- a/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
+++ b/apps/mobile/src/app/screens/SymptomPromptScreen.tsx
@@ -1529,6 +1529,7 @@ export function SymptomPromptScreen() {
 
         <AsyncScreenContainer
           status={status}
+          withBackground={false}
           loadingAccessibilityLabel="Loading symptom list"
           errorTitle="Could not load symptoms"
           errorMessage={errorMessage ?? undefined}


### PR DESCRIPTION
Closes #225

## Summary
- add a reusable native `AppGridBackground` so mobile matches the web and practitioner graph/grid background in light and dark mode
- wire the shared mobile shells, async states, and the symptom preset suggestions modal to use the new background without double-wrapping existing screen layouts
- remove the temporary `accessibilityRole="listitem"` usage from the recent episodes card to avoid the Android runtime accessibility error after login
- theme the mobile action sheets with app light/dark tokens so the top-right menu and preset pickers no longer show a white sheet in dark mode

## Test plan
- [x] Run `pnpm exec tsc -p apps/mobile/tsconfig.json --noEmit`
- [x] Check edited files with lints
- [ ] Launch mobile and verify the graph background appears correctly in light mode
- [ ] Launch mobile and verify the graph background appears correctly in dark mode
- [ ] Open the top-right app menu in dark mode and confirm the action sheet uses dark surface/text/separator colors
- [ ] Open a preset picker in dark mode and confirm the action sheet uses dark surface/text/separator colors
- [ ] Log in on Android and confirm the `Invalid accessibility role value: listitem` popup no longer appears