### PR TITLE
fix(practitioner): align MFA device trust with user web (30d/1y, restore JWT sync)

### DIFF
--- a/apps/practitioner/specs/login-page.spec.tsx
+++ b/apps/practitioner/specs/login-page.spec.tsx
@@ -6,7 +6,7 @@ import {
   tryRestoreTrustedMfaSession,
   saveMfaTrustBundle,
   clearMfaTrustBundle,
-  getTrustedUntilMsAfterVerification,
+  getTrustedUntilMsForDuration,
 } from '../src/lib/practitioner-device-trust';
 
 jest.mock('@abstrack/supabase/browser', () => ({
@@ -22,7 +22,11 @@ jest.mock('../src/lib/practitioner-device-trust', () => {
     tryRestoreTrustedMfaSession: jest.fn(),
     saveMfaTrustBundle: jest.fn(),
     clearMfaTrustBundle: jest.fn(),
-    getTrustedUntilMsAfterVerification: jest.fn(() => Date.now() + 86_400_000),
+    getTrustedUntilMsForDuration: jest.fn((duration: string) =>
+      duration === '1_year'
+        ? Date.now() + 365 * 86_400_000
+        : Date.now() + 30 * 86_400_000,
+    ),
   };
 });
 
@@ -40,7 +44,7 @@ const mockedGetClient = jest.mocked(getSupabaseBrowserClient);
 const mockedTryRestore = jest.mocked(tryRestoreTrustedMfaSession);
 const mockedSaveBundle = jest.mocked(saveMfaTrustBundle);
 const mockedClearBundle = jest.mocked(clearMfaTrustBundle);
-const mockedTrustedUntil = jest.mocked(getTrustedUntilMsAfterVerification);
+const mockedTrustedUntil = jest.mocked(getTrustedUntilMsForDuration);
 
 const USER_ID = '00000000-0000-0000-0000-000000000042';
 const FACTOR_ID = 'factor-totp-1';
@@ -184,6 +188,10 @@ function createLoginSupabaseMock(options?: {
     error: mfaSessionOpts?.error ?? null,
   };
   const getSession = jest.fn().mockResolvedValue(verifyPhaseGetSessionResult);
+  const refreshSession = jest.fn().mockResolvedValue({
+    error: null,
+    data: { session: defaultMfaSession },
+  });
   const signOut = jest.fn().mockResolvedValue({ error: null });
 
   const challenge = jest.fn().mockResolvedValue({
@@ -210,6 +218,7 @@ function createLoginSupabaseMock(options?: {
       signInWithPassword,
       getUser,
       getSession,
+      refreshSession,
       signOut,
       mfa: {
         listFactors,
@@ -322,9 +331,33 @@ describe('LoginPage MFA state machine', () => {
 
     await waitFor(() => {
       expect(mockedTryRestore).toHaveBeenCalledWith(expect.anything(), USER_ID);
+      expect(client.auth.refreshSession).toHaveBeenCalled();
       expect(mockPush).toHaveBeenCalledWith('/patients');
     });
     expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
+  });
+
+  it('does not show MFA when trust restore succeeds but JWT aal2 never appears', async () => {
+    mockedTryRestore.mockResolvedValue({ status: 'restored' });
+    const { client } = createLoginSupabaseMock({
+      assuranceFirst: { currentLevel: 'aal1', nextLevel: 'aal2' },
+      sessionAccessToken: makeUnsignedJwtForTest({ aal: 'aal1' }),
+    });
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(
+      () => {
+        expect(getVisibleFormError().textContent).toContain(
+          'saved device sign-in could not be confirmed',
+        );
+      },
+      { timeout: 5_000 },
+    );
+    expect(screen.queryByLabelText(/Authenticator code/i)).toBeNull();
+    expect(mockPush).not.toHaveBeenCalledWith('/patients');
   });
 
   it('navigates to /patients when session is already AAL2', async () => {
@@ -368,7 +401,7 @@ describe('LoginPage MFA state machine', () => {
     expect(mockedClearBundle).toHaveBeenCalled();
   });
 
-  it('credentials → MFA verify → /patients and saves trust bundle when remember device is checked', async () => {
+  it('credentials → MFA verify → /patients and saves trust bundle for 30 days', async () => {
     const { client, mfa } = createLoginSupabaseMock();
     mockedGetClient.mockReturnValue(client as never);
 
@@ -379,7 +412,7 @@ describe('LoginPage MFA state machine', () => {
       expect(screen.getByLabelText(/Authenticator code/i)).toBeTruthy();
     });
 
-    fireEvent.click(screen.getByLabelText(/Trust this device for 30 days/i));
+    fireEvent.click(screen.getByLabelText(/Do not ask again for 30 days/i));
     fireEvent.change(screen.getByLabelText(/Authenticator code/i), {
       target: { value: '123456' },
     });
@@ -397,8 +430,36 @@ describe('LoginPage MFA state machine', () => {
       challengeId: 'challenge-id',
       code: '123456',
     });
+    expect(mockedTrustedUntil).toHaveBeenCalledWith('30_days');
     expect(mockedSaveBundle).toHaveBeenCalled();
     expect(mockedClearBundle).not.toHaveBeenCalled();
+  });
+
+  it('saves trust bundle for 1 year when that option is selected', async () => {
+    const { client } = createLoginSupabaseMock();
+    mockedGetClient.mockReturnValue(client as never);
+
+    renderLogin();
+    await submitCredentials();
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Authenticator code/i)).toBeTruthy();
+    });
+
+    fireEvent.click(screen.getByLabelText(/Do not ask again for 1 year/i));
+    fireEvent.change(screen.getByLabelText(/Authenticator code/i), {
+      target: { value: '123456' },
+    });
+    fireEvent.click(
+      screen.getByRole('button', { name: /Verify and continue/i }),
+    );
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/patients');
+    });
+
+    expect(mockedTrustedUntil).toHaveBeenCalledWith('1_year');
+    expect(mockedSaveBundle).toHaveBeenCalled();
   });
 
   it('credentials → MFA verify challenges the selected factor when multiple verified TOTP factors exist', async () => {

--- a/apps/practitioner/src/app/login/page.tsx
+++ b/apps/practitioner/src/app/login/page.tsx
@@ -12,6 +12,7 @@ import { useRouter } from 'next/navigation';
 import {
   useCallback,
   useEffect,
+  useId,
   useMemo,
   useRef,
   useState,
@@ -19,10 +20,11 @@ import {
 } from 'react';
 import {
   clearMfaTrustBundle,
-  getTrustedUntilMsAfterVerification,
+  getTrustedUntilMsForDuration,
   isPractitionerMfaDeviceTrustEnabled,
   saveMfaTrustBundle,
   tryRestoreTrustedMfaSession,
+  type PractitionerMfaDeviceTrustDuration,
 } from '../../lib/practitioner-device-trust';
 import {
   looksLikeTotpSetupPayload,
@@ -31,6 +33,9 @@ import {
 } from '../../lib/mfa-user-messages';
 
 type LoginStep = 'credentials' | 'mfa_verify';
+
+/** Whether to skip TOTP on later sign-ins from this browser, and for how long. */
+type DeviceTrustChoice = 'none' | PractitionerMfaDeviceTrustDuration;
 
 /** Verified TOTP row from `auth.mfa.listFactors()` — `friendly_name` is optional in API payloads. */
 type ListedTotpFactor = {
@@ -60,6 +65,14 @@ function buildMfaFactorChoices(factors: ListedTotpFactor[]): Array<{
 /** Max polls when waiting for the access token JWT to include `aal: aal2` after assurance reports AAL2. */
 const JWT_AAL2_SYNC_MAX_ATTEMPTS = 8;
 const JWT_AAL2_SYNC_DELAY_MS = 75;
+/** Longer poll after trust-bundle restore — JWT `aal` can lag behind assurance. */
+const JWT_AAL2_SYNC_AFTER_RESTORE_MAX_ATTEMPTS = 32;
+const JWT_AAL2_SYNC_AFTER_RESTORE_DELAY_MS = 100;
+
+type JwtAal2SyncOptions = {
+  maxAttempts?: number;
+  delayMs?: number;
+};
 
 /**
  * Patient routes gate on JWT `aal` via `hasMfaAssuranceAal2` (see `resolvePractitionerAppGate` in
@@ -73,23 +86,26 @@ const JWT_AAL2_SYNC_DELAY_MS = 75;
  *
  * @param supabase - Browser Supabase client.
  * @param sessionHint - Optional session to parse before polling (same shape as `getSession().data.session`).
+ * @param options - Optional poll limits (defaults match post-MFA verify timing).
  * @returns The session whose `access_token` parses to AAL2, or `null` if still stale / missing.
  */
 async function waitForSessionWithJwtAal2(
   supabase: ReturnType<typeof getSupabaseBrowserClient>,
   sessionHint?: Session | null,
+  options?: JwtAal2SyncOptions,
 ): Promise<Session | null> {
+  const maxAttempts = options?.maxAttempts ?? JWT_AAL2_SYNC_MAX_ATTEMPTS;
+  const delayMs = options?.delayMs ?? JWT_AAL2_SYNC_DELAY_MS;
+
   if (sessionHint?.access_token != null) {
     const hintClaims = parseAbstrackAccessTokenClaims(sessionHint.access_token);
     if (hasMfaAssuranceAal2(hintClaims)) {
       return sessionHint;
     }
   }
-  for (let attempt = 0; attempt < JWT_AAL2_SYNC_MAX_ATTEMPTS; attempt++) {
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
     if (attempt > 0) {
-      await new Promise((resolve) =>
-        setTimeout(resolve, JWT_AAL2_SYNC_DELAY_MS),
-      );
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
     const { data, error } = await supabase.auth.getSession();
     if (error || data.session?.access_token == null) {
@@ -105,8 +121,8 @@ async function waitForSessionWithJwtAal2(
 
 /**
  * Practitioner email/password login with MFA step-up and optional device trust (browser storage).
- * Successful verification with “Trust this device” unchecked clears any stored bundle so trust
- * matches the checkbox for this sign-in. If there is no verified TOTP factor, any existing bundle
+ * Successful verification with “Remember this device” set to ask every time clears any stored
+ * bundle so trust matches the choice for this sign-in. If there is no verified TOTP factor, any existing bundle
  * is cleared before redirecting to practitioner home for TOTP enrollment so stale tokens are not kept in storage.
  * After email/password authentication succeeds, password state is cleared immediately so the secret
  * is not retained through MFA or device-trust checks.
@@ -145,6 +161,7 @@ async function waitForSessionWithJwtAal2(
  * @returns Login UI.
  */
 export default function LoginPage() {
+  const formId = useId();
   const router = useRouter();
   const supabase = useMemo(() => getSupabaseBrowserClient(), []);
   const deviceTrustFeatureEnabled = useMemo(
@@ -155,7 +172,8 @@ export default function LoginPage() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [verifyCode, setVerifyCode] = useState('');
-  const [rememberDevice, setRememberDevice] = useState(false);
+  const [deviceTrustChoice, setDeviceTrustChoice] =
+    useState<DeviceTrustChoice>('none');
   const [mfaFactorId, setMfaFactorId] = useState<string | null>(null);
   /** Populated when entering MFA verify so multiple enrolled TOTP factors can be chosen by label. */
   const [mfaFactorChoices, setMfaFactorChoices] = useState<
@@ -183,7 +201,7 @@ export default function LoginPage() {
    */
   useEffect(() => {
     if (!deviceTrustFeatureEnabled) {
-      setRememberDevice(false);
+      setDeviceTrustChoice('none');
     }
   }, [deviceTrustFeatureEnabled]);
 
@@ -229,7 +247,7 @@ export default function LoginPage() {
     (options?: { clearPassword?: boolean; message?: string }) => {
       setStep('credentials');
       setVerifyCode('');
-      setRememberDevice(false);
+      setDeviceTrustChoice('none');
       setMfaFactorId(null);
       setMfaFactorChoices([]);
       setStatus(null);
@@ -323,13 +341,25 @@ export default function LoginPage() {
         user.id,
       );
       if (restoreOutcome.status === 'restored') {
-        const sessionWithJwtAal2 = await waitForSessionWithJwtAal2(supabase);
+        await supabase.auth.refreshSession();
+        const sessionWithJwtAal2 = await waitForSessionWithJwtAal2(
+          supabase,
+          null,
+          {
+            maxAttempts: JWT_AAL2_SYNC_AFTER_RESTORE_MAX_ATTEMPTS,
+            delayMs: JWT_AAL2_SYNC_AFTER_RESTORE_DELAY_MS,
+          },
+        );
         if (sessionWithJwtAal2 != null) {
           router.push('/patients');
           router.refresh();
           return;
         }
-        /* Else: JWT `aal` may still lag; fall through to session/assurance checks. */
+        resetToCredentials({
+          message:
+            'Your saved device sign-in could not be confirmed on this browser. Enter your email and password, then your authenticator code if prompted.',
+        });
+        return;
       }
       if (restoreOutcome.status === 'signed_out') {
         router.refresh();
@@ -524,10 +554,10 @@ export default function LoginPage() {
           return;
         }
 
-        if (deviceTrustFeatureEnabled && rememberDevice) {
+        if (deviceTrustFeatureEnabled && deviceTrustChoice !== 'none') {
           saveMfaTrustBundle(
             sessionWithJwtAal2,
-            getTrustedUntilMsAfterVerification(),
+            getTrustedUntilMsForDuration(deviceTrustChoice),
           );
         } else {
           clearMfaTrustBundle();
@@ -727,15 +757,48 @@ export default function LoginPage() {
             </div>
 
             {deviceTrustFeatureEnabled ? (
-              <label className="flex items-start gap-2 text-sm text-app-muted">
-                <input
-                  type="checkbox"
-                  className="mt-1 h-4 w-4 rounded border-app-border text-app-primary focus:ring-app-ring"
-                  checked={rememberDevice}
-                  onChange={(event) => setRememberDevice(event.target.checked)}
-                />
-                <span>Trust this device for 30 days.</span>
-              </label>
+              <fieldset className="space-y-2 rounded-md border border-app-border/80 p-3">
+                <legend className="px-1 text-sm font-medium text-app-ink">
+                  Remember this device
+                </legend>
+                <p className="text-xs text-app-muted">
+                  Skip the authenticator code on later sign-ins from this
+                  browser. Sign out everywhere in Settings to require a code
+                  again sooner.
+                </p>
+                <div className="space-y-2 text-sm text-app-muted">
+                  <label className="flex items-start gap-2">
+                    <input
+                      type="radio"
+                      name={`${formId}-device-trust`}
+                      className="mt-1 h-4 w-4 border-app-border"
+                      checked={deviceTrustChoice === 'none'}
+                      onChange={() => setDeviceTrustChoice('none')}
+                    />
+                    <span>Ask every time I sign in on this device</span>
+                  </label>
+                  <label className="flex items-start gap-2">
+                    <input
+                      type="radio"
+                      name={`${formId}-device-trust`}
+                      className="mt-1 h-4 w-4 border-app-border"
+                      checked={deviceTrustChoice === '30_days'}
+                      onChange={() => setDeviceTrustChoice('30_days')}
+                    />
+                    <span>Do not ask again for 30 days</span>
+                  </label>
+                  <label className="flex items-start gap-2">
+                    <input
+                      type="radio"
+                      name={`${formId}-device-trust`}
+                      className="mt-1 h-4 w-4 border-app-border"
+                      checked={deviceTrustChoice === '1_year'}
+                      onChange={() => setDeviceTrustChoice('1_year')}
+                    />
+                    <span>Do not ask again for 1 year</span>
+                  </label>
+                </div>
+              </fieldset>
             ) : null}
 
             <button

--- a/apps/practitioner/src/lib/practitioner-device-trust-duration.spec.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust-duration.spec.ts
@@ -1,0 +1,28 @@
+import {
+  getTrustedUntilMsForDuration,
+  getTrustedUntilMsAfterVerification,
+} from './practitioner-device-trust';
+
+describe('getTrustedUntilMsForDuration', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2026-05-22T12:00:00.000Z'));
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('adds 30 days for 30_days', () => {
+    const expected =
+      Date.parse('2026-05-22T12:00:00.000Z') + 30 * 24 * 60 * 60 * 1000;
+    expect(getTrustedUntilMsForDuration('30_days')).toBe(expected);
+    expect(getTrustedUntilMsAfterVerification()).toBe(expected);
+  });
+
+  it('adds 365 days for 1_year', () => {
+    const expected =
+      Date.parse('2026-05-22T12:00:00.000Z') + 365 * 24 * 60 * 60 * 1000;
+    expect(getTrustedUntilMsForDuration('1_year')).toBe(expected);
+  });
+});

--- a/apps/practitioner/src/lib/practitioner-device-trust.ts
+++ b/apps/practitioner/src/lib/practitioner-device-trust.ts
@@ -47,6 +47,23 @@ export const PRACTITIONER_MFA_TRUST_BUNDLE_STORAGE_KEY =
   'abstrack.practitioner.mfaTrustBundle.v1';
 
 const THIRTY_DAYS_MS = 30 * 24 * 60 * 60 * 1000;
+const ONE_YEAR_MS = 365 * 24 * 60 * 60 * 1000;
+
+/** Practitioner-selected window to skip TOTP on this browser after a successful MFA sign-in. */
+export type PractitionerMfaDeviceTrustDuration = '30_days' | '1_year';
+
+/**
+ * Absolute expiry timestamp for a device-trust bundle from the chosen duration.
+ *
+ * @param duration - `30_days` or `1_year`.
+ * @returns Milliseconds since epoch when trust expires.
+ */
+export function getTrustedUntilMsForDuration(
+  duration: PractitionerMfaDeviceTrustDuration,
+): number {
+  const windowMs = duration === '1_year' ? ONE_YEAR_MS : THIRTY_DAYS_MS;
+  return Date.now() + windowMs;
+}
 
 /**
  * Whether practitioner MFA “trusted device” (localStorage token bundle) is allowed for this build.
@@ -798,6 +815,11 @@ export async function practitionerSignOut(
   }
 }
 
+/**
+ * Default trust window (30 days) for callers that do not expose duration choice.
+ *
+ * @returns Milliseconds since epoch when trust expires.
+ */
 export function getTrustedUntilMsAfterVerification(): number {
-  return Date.now() + THIRTY_DAYS_MS;
+  return getTrustedUntilMsForDuration('30_days');
 }


### PR DESCRIPTION
Closes #188

## Summary

- Fixes practitioner “remember this device” so a saved trust bundle is not discarded when JWT `aal: aal2` lags after a successful restore (previously fell through to the TOTP step).
- Matches user web MFA device-trust UX: radio choices for ask every time, 30 days, or 1 year.
- Adds `getTrustedUntilMsForDuration` / `PractitionerMfaDeviceTrustDuration` in `practitioner-device-trust.ts`.

## Test plan

- [ ] Sign in → TOTP → choose **Do not ask again for 30 days** → **Log out** (header, not Settings “everywhere”) → sign in with password only → lands on `/patients` without TOTP
- [ ] Repeat with **1 year** option; confirm bundle expiry uses the selected window
- [ ] Choose **Ask every time** → verify no bundle is saved; next sign-in prompts for TOTP
- [ ] **Back to sign in** on MFA step still requires TOTP on next login (full sign-out revokes bundle)